### PR TITLE
Disable web page previews in Telegram notifications

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -269,6 +269,7 @@ jobs:
           HTTP_OUTPUT="$(curl -sS -w '\n%{http_code}' -X POST \
             "https://api.telegram.org/bot${TG_BOT_SECRET}/sendMessage" \
             -d "chat_id=${CHAT_ID}" \
+            -d "disable_web_page_preview=true" \
             --data-urlencode "text=${MSG}")"
           CURL_EXIT="${?}"
           set -e
@@ -313,6 +314,7 @@ jobs:
           HTTP_OUTPUT="$(curl -sS -w '\n%{http_code}' -X POST \
             "https://api.telegram.org/bot${TG_BOT_SECRET}/sendMessage" \
             -d "chat_id=${CHAT_ID}" \
+            -d "disable_web_page_preview=true" \
             --data-urlencode "text=${MSG}")"
           CURL_EXIT="${?}"
           set -e

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -129,6 +129,7 @@ jobs:
           RESPONSE="$(curl -sS -X POST \
             "https://api.telegram.org/bot${TG_BOT_SECRET}/sendMessage" \
             -d "chat_id=${CHAT_ID}" \
+            -d "disable_web_page_preview=true" \
             --data-urlencode "text=${MSG}")"
           if ! printf '%s' "${RESPONSE}" | jq -e '.ok == true' >/dev/null 2>&1; then
             echo "::warning::Telegram duplicate PR notification failed: ${RESPONSE}"
@@ -611,6 +612,7 @@ jobs:
           RESPONSE="$(curl -sS -X POST \
             "https://api.telegram.org/bot${TG_BOT_SECRET}/sendMessage" \
             -d "chat_id=${CHAT_ID}" \
+            -d "disable_web_page_preview=true" \
             --data-urlencode "text=${MSG}")"
           if ! printf '%s' "${RESPONSE}" | jq -e '.ok == true' >/dev/null 2>&1; then
             echo "::warning::Telegram failure notification failed: ${RESPONSE}"

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -471,6 +471,7 @@ jobs:
           RESPONSE="$(curl -sS -X POST \
             "https://api.telegram.org/bot${TG_BOT_SECRET}/sendMessage" \
             -d "chat_id=${CHAT_ID}" \
+            -d "disable_web_page_preview=true" \
             --data-urlencode "text=${MSG}")"
           if ! printf '%s' "${RESPONSE}" | jq -e '.ok == true' >/dev/null 2>&1; then
             echo "::warning::Telegram plan notification failed: ${RESPONSE}"
@@ -527,6 +528,7 @@ jobs:
           RESPONSE="$(curl -sS -X POST \
             "https://api.telegram.org/bot${TG_BOT_SECRET}/sendMessage" \
             -d "chat_id=${CHAT_ID}" \
+            -d "disable_web_page_preview=true" \
             --data-urlencode "text=${MSG}")"
           if ! printf '%s' "${RESPONSE}" | jq -e '.ok == true' >/dev/null 2>&1; then
             echo "::warning::Telegram failure notification failed: ${RESPONSE}"

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1902,6 +1902,7 @@ jobs:
           curl -sS -X POST \
             "https://api.telegram.org/bot${TG_BOT_SECRET}/sendMessage" \
             -d "chat_id=${TG_CHAT_ID}" \
+            -d "disable_web_page_preview=true" \
             --data-urlencode "text=${MSG}"
 
       - name: Mark linked issues ready to merge
@@ -1942,6 +1943,7 @@ jobs:
           curl -sS -X POST \
             "https://api.telegram.org/bot${TG_BOT_SECRET}/sendMessage" \
             -d "chat_id=${TG_CHAT_ID}" \
+            -d "disable_web_page_preview=true" \
             --data-urlencode "text=${MSG}"
 
       - name: Telegram failure
@@ -1956,6 +1958,7 @@ jobs:
           curl -sS -X POST \
             "https://api.telegram.org/bot${TG_BOT_SECRET}/sendMessage" \
             -d "chat_id=${TG_CHAT_ID}" \
+            -d "disable_web_page_preview=true" \
             --data-urlencode "text=${MSG}"
 
       - name: Cleanup temporary artifacts


### PR DESCRIPTION
## Summary
This change adds the `disable_web_page_preview=true` parameter to all Telegram bot API calls across multiple GitHub Actions workflows to prevent link previews from being generated in notification messages.

## Key Changes
- Added `disable_web_page_preview=true` parameter to Telegram `sendMessage` API calls in:
  - `.github/workflows/review_autofix.yml` (3 occurrences)
  - `.github/workflows/clarify.yml` (2 occurrences)
  - `.github/workflows/implement.yml` (2 occurrences)
  - `.github/workflows/plan.yml` (2 occurrences)

## Implementation Details
The parameter is added as a separate `-d` flag in the curl POST requests to the Telegram Bot API endpoint. This ensures that when notification messages containing URLs are sent to Telegram, the platform will not attempt to generate and display web page previews, resulting in cleaner and more concise notifications.

https://claude.ai/code/session_018bAtGrtYUMhqo4JMehdCAQ