### PR TITLE
Improve GitHub Actions token handling and permissions

### DIFF
--- a/.github/workflows/cancel_on_pr_close.yml
+++ b/.github/workflows/cancel_on_pr_close.yml
@@ -11,7 +11,7 @@ jobs:
   cancel-active-runs:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
       REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/internal-cancel-on-pr-close.yml
+++ b/.github/workflows/internal-cancel-on-pr-close.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   actions: write
+  contents: read
 
 jobs:
   cancel:


### PR DESCRIPTION
## Summary
Enhanced GitHub Actions workflow configurations to improve token handling and explicitly declare required permissions.

## Key Changes
- **Token fallback mechanism**: Updated `cancel_on_pr_close.yml` to use a Personal Access Token (GH_PAT) as the primary token source, with a fallback to the default GITHUB_TOKEN if GH_PAT is not available
- **Explicit permissions**: Added `contents: read` permission to `internal-cancel-on-pr-close.yml` to explicitly declare the required permission for the workflow

## Implementation Details
The token change allows workflows to use a more privileged Personal Access Token when available (useful for cross-repository operations or when additional permissions are needed), while maintaining backward compatibility by falling back to the standard GITHUB_TOKEN. The explicit permission declaration follows GitHub's security best practice of principle of least privilege by clearly stating what permissions the workflow requires.

https://claude.ai/code/session_01XCYVSL8uECM5Ct3QWBSXwD