### PR TITLE
Release v1.1.0: Add CI workflow and stabilization fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,26 @@ Versioning follows [Semantic Versioning](https://semver.org/) per `docs/release-
 
 ## [Unreleased]
 
+## [v1.1.0] - 2026-03-22
+
 ### Fixed
 - `memory_maintenance.yml`: replaced inline Python with CLI command to fix branch-safe persistence
 - `review_autofix.yml`: fixed ghost reference to removed `ai-auto-review-and-edit.yml`
 - `ai_pipeline.md`: updated stale workflow name references to current names
 - `research/`: updated pre-refactoring workflow names to current names
 - `docs/compatibility-matrix.md`: corrected misleading setup-runtime action references
+- `cancel_on_pr_close.yml`: fixed 404 due to incorrect workflow reference
+- `ci.yml`: fixed JSON validation step failing when `schemas/` dir doesn't exist
 
 ### Added
 - `ci.yml`: basic CI workflow with YAML lint, Python syntax check, JSON validation, and shell lint
 - `CHANGELOG.md`: release tracking per `docs/release-policy.md`
+- README quickstart section with full secrets/vars reference and all workflow wrappers
+- Serena MCP integration across all workflows
+- Internal caller workflows so all AI workflows run on this repo
+- Comprehensive repository audit report
+
+### Changed
+- Disabled URL previews in all Telegram notifications
+- Consolidated `TG_ADMIN_USERID` and `TG_ADMIN_CHAT_ID` into single variable
+- Added yamllint config to disable line-length, document-start, and truthy rules

--- a/scripts/mark-stable.sh
+++ b/scripts/mark-stable.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Mark the current main branch as stable.
+# Usage: ./scripts/mark-stable.sh v1.1.0
+set -euo pipefail
+
+VERSION_TAG="${1:?Usage: $0 <version-tag>  (e.g. v1.1.0)}"
+
+echo "Tagging origin/main as ${VERSION_TAG} and updating stable pointer..."
+git fetch origin main
+git tag -f "${VERSION_TAG}" origin/main
+git tag -f stable "${VERSION_TAG}"
+git push origin "${VERSION_TAG}"
+git push -f origin stable
+echo "Done. ${VERSION_TAG} is now the stable release."


### PR DESCRIPTION
## Summary
This PR releases v1.1.0 with a new CI workflow, multiple bug fixes, and repository improvements. It includes a release automation script and comprehensive changelog updates.

## Key Changes

**New Features:**
- Added `ci.yml` workflow with YAML linting, Python syntax checking, JSON validation, and shell script linting
- Created `scripts/mark-stable.sh` release automation script to tag and push stable releases
- Added README quickstart section with secrets/variables reference and workflow wrappers
- Integrated Serena MCP across all workflows
- Created internal caller workflows for AI workflow execution on this repository
- Generated comprehensive repository audit report

**Bug Fixes:**
- Fixed `memory_maintenance.yml` by replacing inline Python with CLI command for branch-safe persistence
- Fixed ghost reference to removed `ai-auto-review-and-edit.yml` in `review_autofix.yml`
- Updated stale workflow name references in `ai_pipeline.md` and `research/` directory
- Corrected misleading setup-runtime action references in `docs/compatibility-matrix.md`
- Fixed 404 error in `cancel_on_pr_close.yml` due to incorrect workflow reference
- Fixed `ci.yml` JSON validation step failing when `schemas/` directory doesn't exist

**Configuration Changes:**
- Disabled URL previews in all Telegram notifications
- Consolidated `TG_ADMIN_USERID` and `TG_ADMIN_CHAT_ID` into single variable
- Added yamllint configuration to disable line-length, document-start, and truthy rules

## Notable Implementation Details
- The `mark-stable.sh` script uses `set -euo pipefail` for safety and requires a version tag argument (e.g., v1.1.0)
- The script manages both a version-specific tag and a floating `stable` tag, with force-push capability for the stable pointer
- CHANGELOG.md now tracks releases per the documented release policy with semantic versioning

https://claude.ai/code/session_019PxTVZQHHVmG7tzBeYHJB2