### PR TITLE
Add workflow script fetching for reusable workflow support

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -42,6 +42,24 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
 
+      - name: Fetch workflow support scripts
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          # When called as a reusable workflow from another repo, the caller's
+          # repo is checked out and this repo's scripts/ directory is absent.
+          if [ ! -f scripts/setup_serena.sh ]; then
+            wf_source="$(echo "${{ github.workflow_ref }}" | sed 's|/\.github/.*||')"
+            wf_ref="$(echo "${{ github.workflow_ref }}" | sed 's|.*@||')"
+            mkdir -p scripts
+            for f in setup_serena.sh git_ref_health_check.sh; do
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/scripts/${f}?ref=${wf_ref}" > "scripts/${f}"
+              chmod +x "scripts/${f}"
+            done
+          fi
+
       - name: Create runtime workspace
         run: |
           set -euo pipefail

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -148,6 +148,25 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
 
+      - name: Fetch workflow support scripts
+        if: env.SKIP_IMPLEMENT != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          # When called as a reusable workflow from another repo, the caller's
+          # repo is checked out and this repo's scripts/ directory is absent.
+          if [ ! -f scripts/setup_serena.sh ]; then
+            wf_source="$(echo "${{ github.workflow_ref }}" | sed 's|/\.github/.*||')"
+            wf_ref="$(echo "${{ github.workflow_ref }}" | sed 's|.*@||')"
+            mkdir -p scripts
+            for f in setup_serena.sh git_ref_health_check.sh; do
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/scripts/${f}?ref=${wf_ref}" > "scripts/${f}"
+              chmod +x "scripts/${f}"
+            done
+          fi
+
       - name: Fetch issue metadata
         if: env.SKIP_IMPLEMENT != 'true'
         env:

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -57,6 +57,24 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
 
+      - name: Fetch workflow support scripts
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          # When called as a reusable workflow from another repo, the caller's
+          # repo is checked out and this repo's scripts/ directory is absent.
+          if [ ! -f scripts/setup_serena.sh ]; then
+            wf_source="$(echo "${{ github.workflow_ref }}" | sed 's|/\.github/.*||')"
+            wf_ref="$(echo "${{ github.workflow_ref }}" | sed 's|.*@||')"
+            mkdir -p scripts
+            for f in setup_serena.sh git_ref_health_check.sh; do
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/scripts/${f}?ref=${wf_ref}" > "scripts/${f}"
+              chmod +x "scripts/${f}"
+            done
+          fi
+
       - name: Create runtime workspace
         run: |
           set -euo pipefail

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -54,6 +54,24 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
 
+      - name: Fetch workflow support scripts
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          # When called as a reusable workflow from another repo, the caller's
+          # repo is checked out and this repo's scripts/ directory is absent.
+          if [ ! -f scripts/setup_serena.sh ]; then
+            wf_source="$(echo "${{ github.workflow_ref }}" | sed 's|/\.github/.*||')"
+            wf_ref="$(echo "${{ github.workflow_ref }}" | sed 's|.*@||')"
+            mkdir -p scripts
+            for f in setup_serena.sh git_ref_health_check.sh; do
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/scripts/${f}?ref=${wf_ref}" > "scripts/${f}"
+              chmod +x "scripts/${f}"
+            done
+          fi
+
       - name: Validate PR number input
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
This change adds a new step to multiple GitHub Actions workflows to dynamically fetch required support scripts when the workflows are used as reusable workflows from other repositories.

## Key Changes
- Added "Fetch workflow support scripts" step to four workflows:
  - `implement.yml`
  - `clarify.yml`
  - `plan.yml`
  - `review_autofix.yml`

- The new step:
  - Checks if `scripts/setup_serena.sh` exists locally
  - If missing (indicating the workflow is being called from another repo), it fetches both `setup_serena.sh` and `git_ref_health_check.sh` from the source workflow repository
  - Uses GitHub API to retrieve the scripts at the correct workflow reference
  - Makes the fetched scripts executable

## Implementation Details
- Uses `github.workflow_ref` to determine the source repository and reference
- Extracts the repository path and git reference using `sed` commands
- Leverages the GitHub CLI (`gh api`) with raw content accept header to fetch scripts
- Includes proper error handling with `set -euo pipefail`
- Authenticates using `GH_PAT` token for API access
- The `implement.yml` step includes an additional conditional check (`if: env.SKIP_IMPLEMENT != 'true'`) to respect the skip flag

This enables these workflows to be used as reusable workflows while maintaining access to their required support scripts.

https://claude.ai/code/session_018kc2QNUZ96saeLH8D2DjtZ