### PR TITLE
Fix workflow script sourcing to use hardcoded repo path

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -49,13 +49,14 @@ jobs:
           set -euo pipefail
           # When called as a reusable workflow from another repo, the caller's
           # repo is checked out and this repo's scripts/ directory is absent.
+          # NOTE: github.workflow_ref resolves to the *caller* workflow, not
+          # this reusable workflow, so we cannot derive the source repo from it.
           if [ ! -f scripts/setup_serena.sh ]; then
-            wf_source="$(echo "${{ github.workflow_ref }}" | sed 's|/\.github/.*||')"
-            wf_ref="$(echo "${{ github.workflow_ref }}" | sed 's|.*@||')"
+            wf_source="${{ github.repository_owner }}/coding-workflows"
             mkdir -p scripts
             for f in setup_serena.sh git_ref_health_check.sh; do
               gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/scripts/${f}?ref=${wf_ref}" > "scripts/${f}"
+                "repos/${wf_source}/contents/scripts/${f}" > "scripts/${f}"
               chmod +x "scripts/${f}"
             done
           fi

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -156,13 +156,14 @@ jobs:
           set -euo pipefail
           # When called as a reusable workflow from another repo, the caller's
           # repo is checked out and this repo's scripts/ directory is absent.
+          # NOTE: github.workflow_ref resolves to the *caller* workflow, not
+          # this reusable workflow, so we cannot derive the source repo from it.
           if [ ! -f scripts/setup_serena.sh ]; then
-            wf_source="$(echo "${{ github.workflow_ref }}" | sed 's|/\.github/.*||')"
-            wf_ref="$(echo "${{ github.workflow_ref }}" | sed 's|.*@||')"
+            wf_source="${{ github.repository_owner }}/coding-workflows"
             mkdir -p scripts
             for f in setup_serena.sh git_ref_health_check.sh; do
               gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/scripts/${f}?ref=${wf_ref}" > "scripts/${f}"
+                "repos/${wf_source}/contents/scripts/${f}" > "scripts/${f}"
               chmod +x "scripts/${f}"
             done
           fi

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -64,13 +64,14 @@ jobs:
           set -euo pipefail
           # When called as a reusable workflow from another repo, the caller's
           # repo is checked out and this repo's scripts/ directory is absent.
+          # NOTE: github.workflow_ref resolves to the *caller* workflow, not
+          # this reusable workflow, so we cannot derive the source repo from it.
           if [ ! -f scripts/setup_serena.sh ]; then
-            wf_source="$(echo "${{ github.workflow_ref }}" | sed 's|/\.github/.*||')"
-            wf_ref="$(echo "${{ github.workflow_ref }}" | sed 's|.*@||')"
+            wf_source="${{ github.repository_owner }}/coding-workflows"
             mkdir -p scripts
             for f in setup_serena.sh git_ref_health_check.sh; do
               gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/scripts/${f}?ref=${wf_ref}" > "scripts/${f}"
+                "repos/${wf_source}/contents/scripts/${f}" > "scripts/${f}"
               chmod +x "scripts/${f}"
             done
           fi

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -61,13 +61,14 @@ jobs:
           set -euo pipefail
           # When called as a reusable workflow from another repo, the caller's
           # repo is checked out and this repo's scripts/ directory is absent.
+          # NOTE: github.workflow_ref resolves to the *caller* workflow, not
+          # this reusable workflow, so we cannot derive the source repo from it.
           if [ ! -f scripts/setup_serena.sh ]; then
-            wf_source="$(echo "${{ github.workflow_ref }}" | sed 's|/\.github/.*||')"
-            wf_ref="$(echo "${{ github.workflow_ref }}" | sed 's|.*@||')"
+            wf_source="${{ github.repository_owner }}/coding-workflows"
             mkdir -p scripts
             for f in setup_serena.sh git_ref_health_check.sh; do
               gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/scripts/${f}?ref=${wf_ref}" > "scripts/${f}"
+                "repos/${wf_source}/contents/scripts/${f}" > "scripts/${f}"
               chmod +x "scripts/${f}"
             done
           fi


### PR DESCRIPTION
## Summary
Fixed the reusable workflow scripts sourcing logic across all workflow files to use a hardcoded repository path instead of attempting to derive it from `github.workflow_ref`, which resolves to the caller's workflow rather than the reusable workflow itself.

## Key Changes
- Replaced dynamic `github.workflow_ref` parsing with hardcoded `${{ github.repository_owner }}/coding-workflows` path in all four workflow files (clarify.yml, implement.yml, plan.yml, review_autofix.yml)
- Removed the `wf_ref` variable extraction since the API call now fetches from the default branch instead of a specific ref
- Simplified the `gh api` call by removing the `?ref=${wf_ref}` query parameter
- Added clarifying comments explaining why `github.workflow_ref` cannot be used for this purpose

## Implementation Details
The previous approach attempted to extract the source repository and ref from `github.workflow_ref`, but this context variable resolves to the *caller's* workflow when using reusable workflows, not the reusable workflow itself. This made it impossible to reliably determine the correct source repository and ref.

The fix hardcodes the expected source as `{owner}/coding-workflows` and fetches scripts from the default branch, which is a more reliable and maintainable approach for this use case.

https://claude.ai/code/session_01X1Y5gLXwi8PUs3G5vdqKam