### PR TITLE
Fix Serena cache warm check to use --help instead of --version

### DIFF
--- a/scripts/setup_serena.sh
+++ b/scripts/setup_serena.sh
@@ -83,7 +83,7 @@ fi
 # ── 2. Warm Serena cache ─────────────────────────────────────────────────────
 
 echo "Warming Serena uvx cache..."
-if ! uvx --from "git+https://github.com/oraios/serena@${SERENA_VERSION}" serena --version 2>/dev/null; then
+if ! uvx --from "git+https://github.com/oraios/serena@${SERENA_VERSION}" serena --help >/dev/null 2>&1; then
 	warn_and_exit "Serena cache warm failed"
 fi
 


### PR DESCRIPTION
## Summary
Updated the Serena cache warm-up verification in the setup script to use the `--help` flag instead of `--version` for more reliable command validation.

## Key Changes
- Changed the cache warm verification command from `serena --version` to `serena --help`
- Updated output redirection from `2>/dev/null` to `>/dev/null 2>&1` for consistent stderr and stdout suppression

## Implementation Details
The `--help` flag is a more robust way to verify that a command is available and functional, as it's a standard convention across CLI tools. This change makes the cache warm check more reliable and consistent with common practices for validating command availability during setup procedures.

https://claude.ai/code/session_01ELZX7yzVuq2CXsReRDP9gJ