### PR TITLE
Improve Serena MCP setup robustness and configuration

### DIFF
--- a/scripts/setup_serena.sh
+++ b/scripts/setup_serena.sh
@@ -63,6 +63,14 @@ echo "Setting up Serena MCP server (version=${SERENA_VERSION}, mode=${SERENA_MOD
 
 warn_and_exit() {
 	echo "::warning::Serena setup failed: $1 — workflow will fall back to file-based editing."
+	# Remove the Serena MCP server block from Codex config so that
+	# required=true doesn't prevent Codex from starting at all.
+	CODEX_CFG="${HOME}/.codex/config.toml"
+	if [ -f "${CODEX_CFG}" ] && grep -q '\[mcp_servers\.serena\]' "${CODEX_CFG}"; then
+		# Delete from [mcp_servers.serena] to the next section header or EOF
+		sed -i '/^\[mcp_servers\.serena\]/,/^\[/{/^\[mcp_servers\.serena\]/d;/^\[/!d;}' "${CODEX_CFG}"
+		echo "Removed Serena MCP server from ${CODEX_CFG} to allow Codex to start without it."
+	fi
 	exit 0
 }
 
@@ -205,7 +213,8 @@ fi
 # ── 5. Create global Serena config ───────────────────────────────────────────
 
 mkdir -p ~/.serena
-cat > ~/.serena/serena_config.yml <<'SERENA_GLOBAL_EOF'
+PROJECT_ROOT="$(pwd)"
+cat > ~/.serena/serena_config.yml <<SERENA_GLOBAL_EOF
 language_backend: LSP
 gui_log_window: false
 web_dashboard: false
@@ -215,6 +224,8 @@ log_level: 20
 tool_timeout: 240
 default_modes:
   - editing
+projects:
+  - path: "${PROJECT_ROOT}"
 SERENA_GLOBAL_EOF
 
 # ── 6. Append Serena MCP server to Codex config.toml ─────────────────────────


### PR DESCRIPTION
## Summary
This PR enhances the Serena MCP server setup script to be more resilient to failures and to properly configure the project root in the global Serena configuration.

## Key Changes
- **Graceful failure handling**: When Serena setup fails, the script now removes the Serena MCP server block from the Codex configuration file to prevent startup failures caused by `required=true` constraints. This allows Codex to continue functioning with file-based editing as a fallback.
- **Project root configuration**: The setup script now captures the current working directory as `PROJECT_ROOT` and includes it in the generated Serena global configuration file, enabling Serena to be aware of the project context.
- **Configuration file generation fix**: Changed the heredoc delimiter from a quoted string (`<<'SERENA_GLOBAL_EOF'`) to an unquoted string (`<<SERENA_GLOBAL_EOF`) to allow variable expansion (specifically `${PROJECT_ROOT}`) within the generated configuration file.

## Implementation Details
- The `warn_and_exit()` function now includes logic to safely remove the `[mcp_servers.serena]` section from `~/.codex/config.toml` using `sed` if the file exists and contains that section.
- The Serena global configuration now includes a `projects` section with the current project path, allowing Serena to operate within the correct project context.

https://claude.ai/code/session_01LNmZrBMF3AdYwEeeExiT8H