### PR TITLE
Fetch canonical instruction files from coding-workflows

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -60,6 +60,11 @@ jobs:
                 "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
               chmod +x "scripts/${f}"
             done
+            # Always use the canonical instruction files from coding-workflows
+            for f in codex_system_instructions.md ai_pipeline.md; do
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}"
+            done
           fi
 
       - name: Create runtime workspace

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -157,6 +157,11 @@ jobs:
           # NOTE: github.workflow_ref resolves to the *caller* workflow, not
           # this reusable workflow, so we cannot derive the source repo from it.
           wf_source="${{ github.repository_owner }}/coding-workflows"
+          # Detect external context before scripts are fetched
+          is_external="false"
+          if [ ! -f scripts/setup_serena.sh ]; then
+            is_external="true"
+          fi
           mkdir -p scripts
           for f in setup_serena.sh git_ref_health_check.sh serena_efficiency_report.py; do
             if [ ! -f "scripts/${f}" ]; then
@@ -165,6 +170,13 @@ jobs:
               chmod +x "scripts/${f}"
             fi
           done
+          # Always use the canonical instruction files from coding-workflows
+          if [ "$is_external" = "true" ]; then
+            for f in codex_system_instructions.md ai_pipeline.md; do
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}"
+            done
+          fi
 
       - name: Fetch issue metadata
         if: env.SKIP_IMPLEMENT != 'true'

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -92,6 +92,11 @@ jobs:
                 "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
               chmod +x "scripts/${f}"
             done
+            # Always use the canonical instruction files from coding-workflows
+            for f in codex_system_instructions.md ai_pipeline.md; do
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}"
+            done
           fi
 
       - name: Create runtime workspace

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -72,6 +72,11 @@ jobs:
                 "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
               chmod +x "scripts/${f}"
             done
+            # Always use the canonical instruction files from coding-workflows
+            for f in unattended_llm_system_instructions.md codex_system_instructions.md; do
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}"
+            done
           fi
 
       - name: Validate PR number input


### PR DESCRIPTION
## Summary
This change ensures that instruction files used by the workflow automation system are always fetched from the canonical `coding-workflows` repository, maintaining consistency across all workflow executions.

## Key Changes
- **implement.yml**: Added detection of external context and conditional fetching of `codex_system_instructions.md` and `ai_pipeline.md` from the stable branch of coding-workflows
- **clarify.yml**: Added unconditional fetching of `codex_system_instructions.md` and `ai_pipeline.md` from coding-workflows
- **plan.yml**: Added unconditional fetching of `codex_system_instructions.md` and `ai_pipeline.md` from coding-workflows
- **review_autofix.yml**: Added unconditional fetching of `unattended_llm_system_instructions.md` and `codex_system_instructions.md` from coding-workflows

## Implementation Details
- All instruction files are fetched from the `stable` branch of the `coding-workflows` repository using the GitHub API
- The `implement.yml` workflow includes logic to detect whether it's running in an external context (by checking for the presence of `scripts/setup_serena.sh`) before fetching instruction files
- Other workflows fetch instruction files unconditionally as part of their setup process
- Files are fetched using `gh api` with the `application/vnd.github.raw+json` accept header to retrieve raw content

https://claude.ai/code/session_01Uhmsdo2mweWZrYviZoeq3t