### PR TITLE
Fix Serena config YAML format for projects list

### DIFF
--- a/scripts/setup_serena.sh
+++ b/scripts/setup_serena.sh
@@ -225,7 +225,7 @@ tool_timeout: 240
 default_modes:
   - editing
 projects:
-  - path: "${PROJECT_ROOT}"
+  - "${PROJECT_ROOT}"
 SERENA_GLOBAL_EOF
 
 # ── 6. Append Serena MCP server to Codex config.toml ─────────────────────────


### PR DESCRIPTION
## Summary
Fixed the YAML configuration format in the Serena setup script by removing unnecessary `path:` key from the projects list entry.

## Changes
- Simplified the projects configuration from `- path: "${PROJECT_ROOT}"` to `- "${PROJECT_ROOT}"` in the Serena global configuration block
- This change aligns the YAML structure with the expected format for the projects list, treating it as a simple list of strings rather than a list of objects with a `path` property

## Details
The modification corrects the YAML syntax in `scripts/setup_serena.sh` to ensure the projects configuration is properly formatted. The projects list should contain direct string values representing project root paths, not key-value pairs.

https://claude.ai/code/session_018p3jKhtAbxdzEzE94ao7TA