### PR TITLE
Always fetch canonical instruction files from coding-workflows

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -52,20 +52,24 @@ jobs:
           # repo is checked out and this repo's scripts/ directory is absent.
           # NOTE: github.workflow_ref resolves to the *caller* workflow, not
           # this reusable workflow, so we cannot derive the source repo from it.
+          wf_source="${{ github.repository_owner }}/coding-workflows"
           if [ ! -f scripts/setup_serena.sh ]; then
-            wf_source="${{ github.repository_owner }}/coding-workflows"
             mkdir -p scripts
             for f in setup_serena.sh git_ref_health_check.sh; do
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
               chmod +x "scripts/${f}"
             done
-            # Always use the canonical instruction files from coding-workflows
-            for f in codex_system_instructions.md ai_pipeline.md; do
+          fi
+          # Always use the canonical instruction files from coding-workflows
+          # (must be outside the if-block so they're fetched even when the
+          # caller repo ships its own scripts/ directory)
+          for f in codex_system_instructions.md ai_pipeline.md; do
+            if [ ! -f "${f}" ]; then
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/${f}?ref=stable" > "${f}"
-            done
-          fi
+            fi
+          done
 
       - name: Create runtime workspace
         run: |

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -157,11 +157,6 @@ jobs:
           # NOTE: github.workflow_ref resolves to the *caller* workflow, not
           # this reusable workflow, so we cannot derive the source repo from it.
           wf_source="${{ github.repository_owner }}/coding-workflows"
-          # Detect external context before scripts are fetched
-          is_external="false"
-          if [ ! -f scripts/setup_serena.sh ]; then
-            is_external="true"
-          fi
           mkdir -p scripts
           for f in setup_serena.sh git_ref_health_check.sh serena_efficiency_report.py; do
             if [ ! -f "scripts/${f}" ]; then
@@ -171,12 +166,14 @@ jobs:
             fi
           done
           # Always use the canonical instruction files from coding-workflows
-          if [ "$is_external" = "true" ]; then
-            for f in codex_system_instructions.md ai_pipeline.md; do
+          # (must not be gated on is_external — caller repos that ship their
+          # own scripts/ still need these canonical md files)
+          for f in codex_system_instructions.md ai_pipeline.md; do
+            if [ ! -f "${f}" ]; then
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/${f}?ref=stable" > "${f}"
-            done
-          fi
+            fi
+          done
 
       - name: Fetch issue metadata
         if: env.SKIP_IMPLEMENT != 'true'

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -84,20 +84,24 @@ jobs:
           # repo is checked out and this repo's scripts/ directory is absent.
           # NOTE: github.workflow_ref resolves to the *caller* workflow, not
           # this reusable workflow, so we cannot derive the source repo from it.
+          wf_source="${{ github.repository_owner }}/coding-workflows"
           if [ ! -f scripts/setup_serena.sh ]; then
-            wf_source="${{ github.repository_owner }}/coding-workflows"
             mkdir -p scripts
             for f in setup_serena.sh git_ref_health_check.sh; do
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
               chmod +x "scripts/${f}"
             done
-            # Always use the canonical instruction files from coding-workflows
-            for f in codex_system_instructions.md ai_pipeline.md; do
+          fi
+          # Always use the canonical instruction files from coding-workflows
+          # (must be outside the if-block so they're fetched even when the
+          # caller repo ships its own scripts/ directory)
+          for f in codex_system_instructions.md ai_pipeline.md; do
+            if [ ! -f "${f}" ]; then
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/${f}?ref=stable" > "${f}"
-            done
-          fi
+            fi
+          done
 
       - name: Create runtime workspace
         run: |

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -64,20 +64,24 @@ jobs:
           # repo is checked out and this repo's scripts/ directory is absent.
           # NOTE: github.workflow_ref resolves to the *caller* workflow, not
           # this reusable workflow, so we cannot derive the source repo from it.
+          wf_source="${{ github.repository_owner }}/coding-workflows"
           if [ ! -f scripts/setup_serena.sh ]; then
-            wf_source="${{ github.repository_owner }}/coding-workflows"
             mkdir -p scripts
             for f in setup_serena.sh git_ref_health_check.sh; do
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
               chmod +x "scripts/${f}"
             done
-            # Always use the canonical instruction files from coding-workflows
-            for f in unattended_llm_system_instructions.md codex_system_instructions.md; do
+          fi
+          # Always use the canonical instruction files from coding-workflows
+          # (must be outside the if-block so they're fetched even when the
+          # caller repo ships its own scripts/ directory)
+          for f in unattended_llm_system_instructions.md codex_system_instructions.md; do
+            if [ ! -f "${f}" ]; then
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/${f}?ref=stable" > "${f}"
-            done
-          fi
+            fi
+          done
 
       - name: Validate PR number input
         run: |


### PR DESCRIPTION
## Summary
This change ensures that canonical instruction files (codex_system_instructions.md, ai_pipeline.md, etc.) are always fetched from the coding-workflows repository, regardless of whether the caller repository ships its own scripts/ directory.

## Key Changes
- **implement.yml**: Removed the `is_external` flag logic that gated instruction file fetching. Now instruction files are always fetched unconditionally, with a check to skip if they already exist locally.
- **clarify.yml, plan.yml, review_autofix.yml**: Moved `wf_source` variable declaration outside the conditional block and restructured the instruction file fetching logic to always execute, with individual file existence checks to avoid unnecessary API calls.

## Implementation Details
- The `wf_source` variable is now declared at the beginning of the setup step in all workflows, making it available for both script and instruction file fetching.
- Instruction file fetching is now decoupled from the scripts/ directory detection. This ensures that caller repositories that ship their own scripts/ directory still receive the canonical instruction files from coding-workflows.
- Added existence checks (`if [ ! -f "${f}" ]`) before fetching each instruction file to prevent overwriting existing files and reduce unnecessary API calls.
- Updated comments to clarify that instruction files must be fetched outside the conditional block.

This change improves consistency across all reusable workflows and ensures that canonical instruction files are always available, which is critical for proper AI pipeline operation.

https://claude.ai/code/session_012H621LD1jRtGyM6yqprrui