### PR TITLE
Prevent workflow-generated artifacts from being committed

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -607,6 +607,15 @@ jobs:
             exit 0
           fi
 
+          # Remove workflow-generated/fetched artifacts so they are not committed
+          rm -f ./pre_assembled_static.txt
+          for f in codex_system_instructions.md ai_pipeline.md agents.md; do
+            [ -n "$(git ls-files "${f}")" ] || rm -f "${f}"
+          done
+          for f in setup_serena.sh git_ref_health_check.sh serena_efficiency_report.py; do
+            [ -n "$(git ls-files "scripts/${f}")" ] || rm -f "scripts/${f}"
+          done
+
           git config user.name "codex-bot"
           git config user.email "codex@users.noreply.github.com"
           git add -A

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1690,6 +1690,15 @@ jobs:
             git clean -f -d -- .github/workflows || true
           fi
 
+          # Remove workflow-generated/fetched artifacts so they are not committed
+          rm -f ./pre_assembled_static.txt
+          for f in codex_system_instructions.md ai_pipeline.md agents.md; do
+            [ -n "$(git ls-files "${f}")" ] || rm -f "${f}"
+          done
+          for f in setup_serena.sh git_ref_health_check.sh serena_efficiency_report.py; do
+            [ -n "$(git ls-files "scripts/${f}")" ] || rm -f "scripts/${f}"
+          done
+
           git config user.name "codex-bot"
           git config user.email "codex@users.noreply.github.com"
           git add -A
@@ -1966,6 +1975,15 @@ jobs:
             echo "Discarding workflow-file edits from conflict resolver."
             git checkout -- .github/workflows || true
           fi
+
+          # Remove workflow-generated/fetched artifacts so they are not committed
+          rm -f ./pre_assembled_static.txt
+          for f in codex_system_instructions.md ai_pipeline.md agents.md; do
+            [ -n "$(git ls-files "${f}")" ] || rm -f "${f}"
+          done
+          for f in setup_serena.sh git_ref_health_check.sh serena_efficiency_report.py; do
+            [ -n "$(git ls-files "scripts/${f}")" ] || rm -f "scripts/${f}"
+          done
 
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "codex-bot"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 __pycache__/
+*.pyc
 
 .serena/
+
+# Workflow-generated artifacts (created at repo root during CI runs)
+pre_assembled_static.txt


### PR DESCRIPTION
## Summary
This PR adds safeguards to prevent temporary workflow-generated and fetched artifacts from being accidentally committed to the repository. These artifacts are created during CI runs but should not be part of the permanent codebase.

## Key Changes
- **Updated `.gitignore`**: Added entries to ignore workflow-generated artifacts:
  - `pre_assembled_static.txt` - temporary static assembly file
  - `*.pyc` - Python bytecode files
  
- **Updated CI workflows** (`review_autofix.yml`, `implement.yml`): Added cleanup logic before committing changes to remove:
  - `pre_assembled_static.txt` from repo root
  - Documentation files: `codex_system_instructions.md`, `ai_pipeline.md`, `agents.md` (only if not tracked in git)
  - Script files in `scripts/`: `setup_serena.sh`, `git_ref_health_check.sh`, `serena_efficiency_report.py` (only if not tracked in git)

## Implementation Details
The cleanup uses conditional checks (`git ls-files`) to only remove files that are not part of the repository's tracked files. This ensures that legitimate tracked files with the same names are preserved, while temporary artifacts generated during workflow execution are cleaned up before the commit step.

https://claude.ai/code/session_017naa1C69FDDo6Rtuj1pNmY