### PR TITLE
fix: update Codex wire_api from "chat" to "responses"

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -171,7 +171,7 @@ jobs:
             echo 'name = "OpenRouter"'
             echo 'base_url = "https://openrouter.ai/api/v1"'
             echo 'env_key = "OPENROUTER_API_KEY"'
-            echo 'wire_api = "chat"'
+            echo 'wire_api = "responses"'
             echo 'stream_idle_timeout_ms = 600000'
             echo 'stream_max_retries = 5'
             echo 'request_max_retries = 3'

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -329,7 +329,7 @@ jobs:
             echo 'name = "OpenRouter"'
             echo 'base_url = "https://openrouter.ai/api/v1"'
             echo 'env_key = "OPENROUTER_API_KEY"'
-            echo 'wire_api = "chat"'
+            echo 'wire_api = "responses"'
             echo 'stream_idle_timeout_ms = 600000'
             echo 'stream_max_retries = 5'
             echo 'request_max_retries = 3'

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -315,7 +315,7 @@ jobs:
             echo 'name = "OpenRouter"'
             echo 'base_url = "https://openrouter.ai/api/v1"'
             echo 'env_key = "OPENROUTER_API_KEY"'
-            echo 'wire_api = "chat"'
+            echo 'wire_api = "responses"'
             echo 'stream_idle_timeout_ms = 600000'
             echo 'stream_max_retries = 5'
             echo 'request_max_retries = 3'


### PR DESCRIPTION
## Summary
- Codex v0.114.0 dropped support for `wire_api = "chat"` in config.toml, causing all three workflows (clarify, plan, implement) to fail with: `Error loading config.toml: wire_api = "chat" is no longer supported`
- Updated `wire_api` from `"chat"` to `"responses"` in clarify.yml, plan.yml, and implement.yml to match review_autofix.yml which was already correct

## Test plan
- [ ] Re-run the clarify workflow on an issue to verify it no longer fails at the Codex config loading step
- [ ] Verify plan and implement workflows also pass with the updated config

https://claude.ai/code/session_01ByxdPykeNrCo8EbqST9e3H