### PR TITLE
fix: use timeline API for linked PR detection in plan workflow

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -181,10 +181,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           set -euo pipefail
-          # Use search API to find open PRs that mention this issue (catches both
-          # cross-references and commit-message links, unlike the timeline API)
-          LINKED_PR_COUNT="$(gh pr list --repo "${{ github.repository }}" \
-            --search "#${ISSUE_NUMBER}" --state open --json number --jq 'length')"
+          # Use the issue timeline API to find PRs that are actually
+          # cross-referenced to this issue (not just text matches).
+          # The previous gh pr list --search approach produced false positives
+          # when unrelated PRs happened to mention the issue number.
+          LINKED_PR_COUNT="$(gh api --paginate \
+            "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/timeline" \
+            --jq '
+              [.[]
+               | select(.event == "cross-referenced")
+               | select(.source.issue.pull_request != null)
+               | select(.source.issue.state == "open")
+              ] | length
+            ')"
           if [ "${LINKED_PR_COUNT}" -gt 0 ]; then
             echo "Issue #${ISSUE_NUMBER} already has at least one open PR. Skipping planning run."
             echo "SKIP_PLAN=true" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- The plan workflow's "Skip when issue already has a PR" step used `gh pr list --search "#<number>"`, a broad text search that matches any open PR mentioning the issue number anywhere in title/body
- This caused false positives — planning was skipped even when no PR was actually linked to the issue (e.g. issue #2233 had no PR but workflow skipped)
- Replaced with the issue timeline API (`/issues/{number}/timeline`) which only returns PRs genuinely cross-referenced to the issue, filtered to open state

## Test plan
- [ ] Trigger the plan workflow on an issue that has no linked PR — should proceed with planning
- [ ] Trigger the plan workflow on an issue that has an actual linked open PR — should skip correctly
- [ ] Verify the timeline API call works with paginated results for issues with long histories

https://claude.ai/code/session_019WLaZQMfh99dbEfUTdFiFC