### PR TITLE
fix: resolve Serena MCP failures — use direct binary instead of uvx

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -67,14 +67,16 @@ jobs:
           # NOTE: github.workflow_ref resolves to the *caller* workflow, not
           # this reusable workflow, so we cannot derive the source repo from it.
           wf_source="${{ github.repository_owner }}/coding-workflows"
-          if [ ! -f scripts/setup_serena.sh ]; then
-            mkdir -p scripts
-            for f in setup_serena.sh git_ref_health_check.sh; do
-              gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
-              chmod +x "scripts/${f}"
-            done
-          fi
+          # ALWAYS fetch canonical scripts from coding-workflows, even if the
+          # caller repo ships its own scripts/ directory. Stale caller-repo
+          # scripts (e.g. writing to mcp.json instead of config.toml) cause
+          # silent MCP failures ("mcp startup: no servers").
+          mkdir -p scripts
+          for f in setup_serena.sh git_ref_health_check.sh; do
+            gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
+            chmod +x "scripts/${f}"
+          done
           # Always use the canonical instruction files from coding-workflows
           # (must be outside the if-block so they're fetched even when the
           # caller repo ships its own scripts/ directory)

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -157,13 +157,14 @@ jobs:
           # NOTE: github.workflow_ref resolves to the *caller* workflow, not
           # this reusable workflow, so we cannot derive the source repo from it.
           wf_source="${{ github.repository_owner }}/coding-workflows"
+          # ALWAYS fetch canonical scripts from coding-workflows, even if the
+          # caller repo ships its own scripts/ directory. Stale caller-repo
+          # scripts cause silent MCP failures.
           mkdir -p scripts
           for f in setup_serena.sh git_ref_health_check.sh serena_efficiency_report.py; do
-            if [ ! -f "scripts/${f}" ]; then
-              gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
-              chmod +x "scripts/${f}"
-            fi
+            gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
+            chmod +x "scripts/${f}"
           done
           # Always use the canonical instruction files from coding-workflows
           # (must not be gated on is_external — caller repos that ship their

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -85,14 +85,15 @@ jobs:
           # NOTE: github.workflow_ref resolves to the *caller* workflow, not
           # this reusable workflow, so we cannot derive the source repo from it.
           wf_source="${{ github.repository_owner }}/coding-workflows"
-          if [ ! -f scripts/setup_serena.sh ]; then
-            mkdir -p scripts
-            for f in setup_serena.sh git_ref_health_check.sh; do
-              gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
-              chmod +x "scripts/${f}"
-            done
-          fi
+          # ALWAYS fetch canonical scripts from coding-workflows, even if the
+          # caller repo ships its own scripts/ directory. Stale caller-repo
+          # scripts cause silent MCP failures.
+          mkdir -p scripts
+          for f in setup_serena.sh git_ref_health_check.sh; do
+            gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
+            chmod +x "scripts/${f}"
+          done
           # Always use the canonical instruction files from coding-workflows
           # (must be outside the if-block so they're fetched even when the
           # caller repo ships its own scripts/ directory)

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -65,14 +65,15 @@ jobs:
           # NOTE: github.workflow_ref resolves to the *caller* workflow, not
           # this reusable workflow, so we cannot derive the source repo from it.
           wf_source="${{ github.repository_owner }}/coding-workflows"
-          if [ ! -f scripts/setup_serena.sh ]; then
-            mkdir -p scripts
-            for f in setup_serena.sh git_ref_health_check.sh generate_symbol_diff_summary.py serena_efficiency_report.py; do
-              gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
-              chmod +x "scripts/${f}"
-            done
-          fi
+          # ALWAYS fetch canonical scripts from coding-workflows, even if the
+          # caller repo ships its own scripts/ directory. Stale caller-repo
+          # scripts cause silent MCP failures.
+          mkdir -p scripts
+          for f in setup_serena.sh git_ref_health_check.sh generate_symbol_diff_summary.py serena_efficiency_report.py; do
+            gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
+            chmod +x "scripts/${f}"
+          done
           # Always use the canonical instruction files from coding-workflows
           # (must be outside the if-block so they're fetched even when the
           # caller repo ships its own scripts/ directory)

--- a/scripts/setup_serena.sh
+++ b/scripts/setup_serena.sh
@@ -261,6 +261,11 @@ SERENA_GLOBAL_EOF
 # Codex CLI reads MCP servers from [mcp_servers.<name>] tables in config.toml,
 # NOT from a separate mcp.json file. Append to the existing config.toml that
 # the workflow creates earlier.
+#
+# IMPORTANT: Codex's process spawning does NOT work reliably with `uvx` as the
+# MCP server command. The `uvx` launcher adds a process indirection layer that
+# causes Codex MCP handshake timeouts. Instead, we resolve the actual `serena`
+# binary from the uvx cache (which was warmed in step 2) and use it directly.
 
 CODEX_CONFIG="${HOME}/.codex/config.toml"
 mkdir -p ~/.codex
@@ -269,41 +274,47 @@ if [ ! -f "${CODEX_CONFIG}" ]; then
 	touch "${CODEX_CONFIG}"
 fi
 
-# Resolve uvx to an absolute path so the Codex sandbox can find it
-# regardless of its PATH. This is the most common cause of
-# "mcp startup: no servers" — uvx is on PATH in the shell but not
-# inside the Codex sandbox environment.
-UVX_PATH="$(command -v uvx 2>/dev/null || true)"
-if [ -z "${UVX_PATH}" ]; then
-	echo "::warning::uvx not found in PATH — Serena MCP server may fail to start in Codex sandbox."
-	UVX_PATH="uvx"
-elif [ "${UVX_PATH#/}" = "${UVX_PATH}" ]; then
-	echo "::warning::uvx resolved to non-absolute path '${UVX_PATH}' — sandbox startup may fail."
+# Resolve the actual serena binary from the uvx cache.
+# The cache was warmed in step 2, so the binary should be available.
+# Using the direct binary avoids the uvx process indirection that causes
+# Codex MCP handshake timeouts ("mcp startup: no servers" / timeout).
+SERENA_BIN="$(uvx --from "git+https://github.com/oraios/serena@${SERENA_VERSION}" which serena 2>/dev/null || true)"
+if [ -z "${SERENA_BIN}" ] || [ ! -x "${SERENA_BIN}" ]; then
+	# Fallback: try to find the binary in the uvx cache
+	SERENA_BIN="$(find "${HOME}/.cache/uv" -name "serena" -type f -executable 2>/dev/null | head -1 || true)"
 fi
-echo "Resolved uvx path: ${UVX_PATH}"
+if [ -z "${SERENA_BIN}" ] || [ ! -x "${SERENA_BIN}" ]; then
+	warn_and_exit "Could not resolve serena binary path from uvx cache"
+fi
+echo "Resolved serena binary: ${SERENA_BIN}"
 
-# Build the env_vars list: forward critical environment variables so the
-# Codex sandbox subprocess can locate uvx dependencies and caches.
-# Without these, the sandbox strips PATH/HOME/UV_CACHE_DIR and the MCP
-# server process fails silently ("mcp startup: no servers").
-ENV_VARS_LINE='env_vars = ["PATH", "HOME", "TMPDIR"'
+# Build the [mcp_servers.serena.env] sub-table with explicit key=value pairs.
+# This is the canonical format that `codex mcp add --env` uses.
+# Forward critical environment variables so the Codex sandbox subprocess
+# can locate dependencies and caches.
+ENV_BLOCK='[mcp_servers.serena.env]'
+ENV_BLOCK="${ENV_BLOCK}\nHOME = \"${HOME}\""
+ENV_BLOCK="${ENV_BLOCK}\nPATH = \"${PATH}\""
+if [ -n "${TMPDIR:-}" ]; then
+	ENV_BLOCK="${ENV_BLOCK}\nTMPDIR = \"${TMPDIR}\""
+fi
 if [ -n "${UV_CACHE_DIR:-}" ]; then
-	ENV_VARS_LINE="${ENV_VARS_LINE}, \"UV_CACHE_DIR\""
+	ENV_BLOCK="${ENV_BLOCK}\nUV_CACHE_DIR = \"${UV_CACHE_DIR}\""
 fi
 if [ -n "${PYTHONDONTWRITEBYTECODE:-}" ]; then
-	ENV_VARS_LINE="${ENV_VARS_LINE}, \"PYTHONDONTWRITEBYTECODE\""
+	ENV_BLOCK="${ENV_BLOCK}\nPYTHONDONTWRITEBYTECODE = \"${PYTHONDONTWRITEBYTECODE}\""
 fi
-ENV_VARS_LINE="${ENV_VARS_LINE}]"
 
 cat >> "${CODEX_CONFIG}" <<MCP_EOF
 
 [mcp_servers.serena]
-command = "${UVX_PATH}"
-args = ["--from", "git+https://github.com/oraios/serena@${SERENA_VERSION}", "serena", "start-mcp-server", "--context", "${SERENA_CONTEXT}", "--mode", "one-shot", "--mode", "${SERENA_MODE}", "--project-from-cwd", "--enable-web-dashboard", "false", "--open-web-dashboard", "false"]
-${ENV_VARS_LINE}
+command = "${SERENA_BIN}"
+args = ["start-mcp-server", "--context", "${SERENA_CONTEXT}", "--mode", "one-shot", "--mode", "${SERENA_MODE}", "--project-from-cwd", "--enable-web-dashboard", "false", "--open-web-dashboard", "false"]
 startup_timeout_sec = 30
 tool_timeout_sec = 240
 required = true
+
+$(printf '%b' "${ENV_BLOCK}")
 MCP_EOF
 
 echo "Serena MCP server appended to ${CODEX_CONFIG}"


### PR DESCRIPTION
## Summary

- **Fix Serena MCP "no servers" / timeout failures** by using the direct `serena` binary instead of `uvx` as the MCP server command. Codex CLI v0.114.0's process spawning doesn't work reliably through the `uvx` launcher indirection — the MCP handshake consistently times out even though Serena responds correctly when invoked directly.
- **Always fetch canonical scripts from coding-workflows** in all 4 workflow files, removing the `if [ ! -f scripts/setup_serena.sh ]` guard that allowed stale caller-repo scripts (e.g. ones still writing to `mcp.json`) to silently break MCP integration.
- **Switch env config format** from `env_vars = [...]` to the canonical `[mcp_servers.serena.env]` sub-table format (matches what `codex mcp add --env` produces).

## Investigation details

Local testing confirmed:
- `uvx` as MCP command → **always times out** (30s, 60s, any timeout)
- Direct `serena` binary as MCP command → **connects in <2s** (`mcp: serena ready`)
- Both produce identical results when invoked via pipe outside of Codex
- The `uvx` process indirection layer is incompatible with Codex's MCP process spawning
- Codex v0.114.0 reads MCP config from `config.toml` only — `mcp.json` is completely ignored

## Test plan

- [ ] Verify `setup_serena.sh` resolves serena binary path after cache warm
- [ ] Verify `codex mcp list` shows serena with correct command/env
- [ ] Verify `codex exec` shows `mcp: serena ready` (not timeout)
- [ ] Trigger clarify workflow on a caller repo to confirm end-to-end MCP connectivity
- [ ] Update `stable` tag after merge to propagate fix to all caller repos

https://claude.ai/code/session_01SwxKyzzkGkpkjUimF5Bv5z