### PR TITLE
fix: use resolved SERENA_BIN for health check instead of uvx

### DIFF
--- a/scripts/setup_serena.sh
+++ b/scripts/setup_serena.sh
@@ -363,8 +363,8 @@ SERENA_HEALTH_OK="false"
 for _health_attempt in $(seq 1 "${SERENA_HEALTH_MAX_RETRIES}"); do
 	echo "Validating Serena MCP server startup (attempt ${_health_attempt}/${SERENA_HEALTH_MAX_RETRIES})..."
 	HEALTH_EXIT=0
-	timeout 30s uvx --from "git+https://github.com/oraios/serena@${SERENA_VERSION}" \
-		serena start-mcp-server --context "${SERENA_CONTEXT}" --mode one-shot --mode "${SERENA_MODE}" \
+	timeout 30s "${SERENA_BIN}" \
+		start-mcp-server --context "${SERENA_CONTEXT}" --mode one-shot --mode "${SERENA_MODE}" \
 		--project-from-cwd --enable-web-dashboard false --open-web-dashboard false </dev/null >"${HEALTH_LOG}" 2>&1 || HEALTH_EXIT=$?
 	if [ "${HEALTH_EXIT}" -eq 0 ] || [ "${HEALTH_EXIT}" -eq 124 ]; then
 		# Exit 0 = clean exit; Exit 124 = timeout killed a still-running server (expected).


### PR DESCRIPTION
## Summary
- The health check in `setup_serena.sh` step 8 was still invoking Serena through `uvx`, while the MCP config (step 6) now uses the resolved direct binary path (`$SERENA_BIN`)
- This inconsistency means the health check validates a different code path than what Codex actually uses at runtime
- Uses `"${SERENA_BIN}"` consistently for both the MCP config and the health check

## Test plan
- [x] Ran `setup_serena.sh` locally — health check passes using the direct binary
- [x] Verified `codex exec` with Serena MCP: `mcp: serena ready` (both stdin pipe and argument modes)
- [x] Confirmed `codex mcp list` shows the correct direct binary path

https://claude.ai/code/session_01SwxKyzzkGkpkjUimF5Bv5z