### PR TITLE
Protect shared repo files from being committed in caller repos

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -609,14 +609,20 @@ jobs:
             exit 0
           fi
 
-          # Remove workflow-generated/fetched artifacts so they are not committed
+          # Remove workflow-generated/fetched artifacts so they are not committed.
+          # This list must cover ALL files fetched from coding-workflows by ANY
+          # reusable workflow so that caller repos never accidentally commit them.
           rm -f ./pre_assembled_static.txt
-          for f in codex_system_instructions.md ai_pipeline.md agents.md; do
+          for f in codex_system_instructions.md ai_pipeline.md unattended_llm_system_instructions.md agents.md; do
             [ -n "$(git ls-files "${f}")" ] || rm -f "${f}"
           done
-          for f in setup_serena.sh git_ref_health_check.sh serena_efficiency_report.py; do
+          for f in setup_serena.sh git_ref_health_check.sh serena_efficiency_report.py generate_symbol_diff_summary.py; do
             [ -n "$(git ls-files "scripts/${f}")" ] || rm -f "scripts/${f}"
           done
+          # Remove .serena/ directory created by setup_serena.sh (if not already tracked)
+          if [ -d .serena ] && [ -z "$(git ls-files .serena)" ]; then
+            rm -rf .serena
+          fi
 
           git config user.name "codex-bot"
           git config user.email "codex@users.noreply.github.com"

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1692,14 +1692,20 @@ jobs:
             git clean -f -d -- .github/workflows || true
           fi
 
-          # Remove workflow-generated/fetched artifacts so they are not committed
+          # Remove workflow-generated/fetched artifacts so they are not committed.
+          # This list must cover ALL files fetched from coding-workflows by ANY
+          # reusable workflow so that caller repos never accidentally commit them.
           rm -f ./pre_assembled_static.txt
-          for f in codex_system_instructions.md ai_pipeline.md agents.md; do
+          for f in codex_system_instructions.md ai_pipeline.md unattended_llm_system_instructions.md agents.md; do
             [ -n "$(git ls-files "${f}")" ] || rm -f "${f}"
           done
           for f in setup_serena.sh git_ref_health_check.sh serena_efficiency_report.py generate_symbol_diff_summary.py; do
             [ -n "$(git ls-files "scripts/${f}")" ] || rm -f "scripts/${f}"
           done
+          # Remove .serena/ directory created by setup_serena.sh (if not already tracked)
+          if [ -d .serena ] && [ -z "$(git ls-files .serena)" ]; then
+            rm -rf .serena
+          fi
 
           git config user.name "codex-bot"
           git config user.email "codex@users.noreply.github.com"
@@ -1984,14 +1990,20 @@ jobs:
             git checkout -- .github/workflows || true
           fi
 
-          # Remove workflow-generated/fetched artifacts so they are not committed
+          # Remove workflow-generated/fetched artifacts so they are not committed.
+          # This list must cover ALL files fetched from coding-workflows by ANY
+          # reusable workflow so that caller repos never accidentally commit them.
           rm -f ./pre_assembled_static.txt
-          for f in codex_system_instructions.md ai_pipeline.md agents.md; do
+          for f in codex_system_instructions.md ai_pipeline.md unattended_llm_system_instructions.md agents.md; do
             [ -n "$(git ls-files "${f}")" ] || rm -f "${f}"
           done
           for f in setup_serena.sh git_ref_health_check.sh serena_efficiency_report.py generate_symbol_diff_summary.py; do
             [ -n "$(git ls-files "scripts/${f}")" ] || rm -f "scripts/${f}"
           done
+          # Remove .serena/ directory created by setup_serena.sh (if not already tracked)
+          if [ -d .serena ] && [ -z "$(git ls-files .serena)" ]; then
+            rm -rf .serena
+          fi
 
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "codex-bot"


### PR DESCRIPTION
## Summary
- **Add `unattended_llm_system_instructions.md`** to cleanup lists in both `implement.yml` and `review_autofix.yml` — this file was fetched by review_autofix but never removed before `git add -A`, so it could be committed to caller repos
- **Add `.serena/` directory cleanup** — `setup_serena.sh` creates `.serena/project.yml` at runtime, which was not being removed before commits
- **Standardize cleanup lists** across all 3 commit points (implement.yml, review_autofix main commit, review_autofix conflict-resolution commit) so they all cover the full set of fetched files
- **Add `generate_symbol_diff_summary.py`** to implement.yml cleanup defensively

## Test plan
- [ ] Verify implement.yml cleanup section removes all fetched artifacts before `git add -A`
- [ ] Verify review_autofix.yml main commit cleanup removes all fetched artifacts
- [ ] Verify review_autofix.yml conflict-resolution commit cleanup removes all fetched artifacts
- [ ] Confirm `.serena/` directory is cleaned up when not already tracked by the caller repo
- [ ] Confirm files already tracked by caller repos (via `git ls-files` check) are preserved

https://claude.ai/code/session_017CJpAVwXiHP1v9TRz6fNN4