### PR TITLE
Fix missing TG notification for plan clarification

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -595,6 +595,30 @@ jobs:
           gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
             -f body="$(cat "${PLAN_COMMENT_FILE}")"
 
+      - name: Telegram clarification notification
+        if: env.SKIP_PLAN != 'true' && steps.parse_plan.outputs.needs_clarification == 'true'
+        env:
+          TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
+          TG_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
+        run: |
+          set -euo pipefail
+
+          CHAT_ID="${TG_CHAT_ID:-}"
+          if [ -z "${TG_BOT_SECRET:-}" ] || [ -z "${CHAT_ID}" ]; then
+            echo "Warning: Telegram clarification notification skipped (missing TG_BOT_SECRET or chat_id)"
+            exit 0
+          fi
+
+          MSG="Plan needs clarification for issue ${ISSUE_URL}"
+          RESPONSE="$(curl -sS -X POST \
+            "https://api.telegram.org/bot${TG_BOT_SECRET}/sendMessage" \
+            -d "chat_id=${CHAT_ID}" \
+            -d "disable_web_page_preview=true" \
+            --data-urlencode "text=${MSG}")"
+          if ! printf '%s' "${RESPONSE}" | jq -e '.ok == true' >/dev/null 2>&1; then
+            echo "::warning::Telegram clarification notification failed: ${RESPONSE}"
+          fi
+
       - name: Post implementation plan
         if: env.SKIP_PLAN != 'true' && steps.parse_plan.outputs.needs_clarification != 'true'
         env:


### PR DESCRIPTION
## Summary

- When the plan stage determines clarification is needed, it posts questions to GitHub but **does not send a Telegram notification**, causing issues to silently stall until manually checked
- Adds a "Telegram clarification notification" step in `plan.yml` that fires when `needs_clarification == 'true'`, matching the existing pattern in `clarify.yml`
- Message sent: "Plan needs clarification for issue {URL}"

## Test plan

- [ ] Trigger the plan workflow on an issue that requires clarification and verify a TG message is received
- [ ] Verify existing plan notification (clear plan) still works as before
- [ ] Verify failure notifications are unaffected

https://claude.ai/code/session_01QneSWQAGKhLnDnkUt8rEJh