### PR TITLE
Make thinking levels configurable per workflow phase

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -30,7 +30,7 @@ jobs:
       ISSUE_NUMBER: ${{ github.event.issue.number }}
       ISSUE_URL: ${{ github.event.issue.html_url }}
       MODEL_EDITOR: ${{ vars.WORKFLOW_EDITOR_MODEL || 'openai/gpt-5.3-codex' }}
-      MODEL_REASONING_EFFORT: xhigh
+      MODEL_REASONING_EFFORT: ${{ vars.THINKING_LEVEL_CLARIFY || 'xhigh' }}
 
     steps:
       - name: Log trigger context

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -13,7 +13,7 @@ name: AI Implement
 
 env:
   MODEL_EDITOR: ${{ vars.WORKFLOW_EDITOR_MODEL || 'openai/gpt-5.3-codex' }}
-  MODEL_REASONING_EFFORT: xhigh
+  MODEL_REASONING_EFFORT: ${{ vars.THINKING_LEVEL_IMPLEMENT || 'xhigh' }}
 
 jobs:
   implement:

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -35,7 +35,7 @@ jobs:
       ISSUE_URL: ${{ github.event.issue.html_url }}
       SKIP_PLAN: "false"
       MODEL_EDITOR: ${{ vars.WORKFLOW_EDITOR_MODEL || 'openai/gpt-5.3-codex' }}
-      MODEL_REASONING_EFFORT: xhigh
+      MODEL_REASONING_EFFORT: ${{ vars.THINKING_LEVEL_PLAN || 'xhigh' }}
       AUTO_IMPLEMENT_ON_CLEAR_PLAN: ${{ vars.AUTO_IMPLEMENT_ON_CLEAR_PLAN || 'false' }}
       PLAN_FAILURE_CONTEXT: "Planning run did not complete."
 

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -34,7 +34,7 @@ env:
     qwen/qwen3.5-397b-a17b
     openai/gpt-5-mini
   MODEL_EDITOR: ${{ vars.WORKFLOW_EDITOR_MODEL || 'openai/gpt-5.3-codex' }}
-  MODEL_REASONING_EFFORT: xhigh
+  MODEL_REASONING_EFFORT: ${{ vars.THINKING_LEVEL_REVIEW || 'xhigh' }}
 
 jobs:
   codex-agent:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `SERENA_LANGUAGES` | No | `""` (empty) | clarify, plan, implement, review_autofix | Languages for Serena symbol analysis |
 | `SERENA_DISABLED` | No | `false` | clarify, plan, implement, review_autofix | Disable the Serena MCP server |
 
+**Thinking levels** — control the model's reasoning effort per phase. Valid values: `xhigh`, `high`, `medium`, `low`. Higher levels produce more thorough analysis but use more tokens. Lower levels are faster and cheaper, suitable for straightforward tasks.
+
+| Variable | Default | Used By | Description |
+|---|---|---|---|
+| `THINKING_LEVEL_CLARIFY` | `xhigh` | clarify | Reasoning effort for the clarification phase |
+| `THINKING_LEVEL_PLAN` | `xhigh` | plan | Reasoning effort for the planning phase |
+| `THINKING_LEVEL_IMPLEMENT` | `xhigh` | implement | Reasoning effort for the implementation phase |
+| `THINKING_LEVEL_REVIEW` | `xhigh` | review_autofix | Reasoning effort for the review & autofix phase |
+
 **Tool call budgets** — soft limits on the number of MCP + shell tool calls per phase. The LLM treats these as guidelines; it may exceed them for large refactors that span many files.
 
 | Variable | Default | Used By | Description |
@@ -242,6 +251,10 @@ See `workflow-templates/` in consumer repos for all wrapper examples.
 | `AI_MEMORY_ROOT` | `ai-memory` | Memory root path used by workflows |
 | `AI_MEMORY_RETRIEVAL_PROFILES` | `ai-memory/config/retrieval_profiles.v1.json` | Retrieval role config |
 | `AI_MEMORY_ENABLED` | `true` | Enable/disable memory operations |
+| `THINKING_LEVEL_CLARIFY` | `xhigh` | Reasoning effort for clarification (`xhigh`, `high`, `medium`, `low`) |
+| `THINKING_LEVEL_PLAN` | `xhigh` | Reasoning effort for planning |
+| `THINKING_LEVEL_IMPLEMENT` | `xhigh` | Reasoning effort for implementation |
+| `THINKING_LEVEL_REVIEW` | `xhigh` | Reasoning effort for review & autofix |
 | `TOOL_CALL_BUDGET_CLARIFY` | `15` | Tool call budget for clarification |
 | `TOOL_CALL_BUDGET_PLAN` | `40` | Tool call budget for planning |
 | `TOOL_CALL_BUDGET_IMPLEMENT` | `50` | Tool call budget for implementation |


### PR DESCRIPTION
## Summary

- Replace hardcoded `xhigh` reasoning effort in all 4 core workflows with configurable GitHub Actions variables
- Add `THINKING_LEVEL_CLARIFY`, `THINKING_LEVEL_PLAN`, `THINKING_LEVEL_IMPLEMENT`, and `THINKING_LEVEL_REVIEW` variables, all defaulting to `xhigh`
- Document the new variables in the README (both in the detailed Quickstart section and the summary table)

## Changes

| File | Change |
|---|---|
| `clarify.yml` | `MODEL_REASONING_EFFORT: xhigh` → `${{ vars.THINKING_LEVEL_CLARIFY \|\| 'xhigh' }}` |
| `plan.yml` | `MODEL_REASONING_EFFORT: xhigh` → `${{ vars.THINKING_LEVEL_PLAN \|\| 'xhigh' }}` |
| `implement.yml` | `MODEL_REASONING_EFFORT: xhigh` → `${{ vars.THINKING_LEVEL_IMPLEMENT \|\| 'xhigh' }}` |
| `review_autofix.yml` | `MODEL_REASONING_EFFORT: xhigh` → `${{ vars.THINKING_LEVEL_REVIEW \|\| 'xhigh' }}` |
| `README.md` | New "Thinking levels" section with variable table + summary table entries |

## Test plan

- [ ] Verify workflows run correctly with no variables set (should default to `xhigh`)
- [ ] Set one variable (e.g. `THINKING_LEVEL_CLARIFY=medium`) and verify it takes effect in the Codex config
- [ ] Confirm README renders correctly on GitHub

https://claude.ai/code/session_01F8s6cAvBFFLJVLZ4LuqakC