### PR TITLE
Replace blanket job timeouts with heartbeat-based activity monitoring

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'issues' && github.event.action == 'opened') ||
       (github.event_name == 'issue_comment' && github.event.action == 'created' && github.event.issue.pull_request == null && github.event.comment.user.type == 'User' && contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && startsWith(github.event.comment.body, '/reclarify'))
     runs-on: ubuntu-latest
-    timeout-minutes: 55
+    timeout-minutes: 120
     concurrency:
       # NOTE: cancel-in-progress: true means if a /reclarify comment arrives
       # while a clarification run is already in progress, the old run is killed
@@ -403,18 +403,28 @@ jobs:
             cat "${ISSUE_CONTEXT_FILE}"
           } > "${CODEX_PROMPT_FILE}"
 
+          # Heartbeat-based timeout: kill only if no output for 15 min
+          source "${GITHUB_WORKSPACE}/scripts/heartbeat_exec.sh"
+          heartbeat_start --idle-timeout "${HEARTBEAT_IDLE_TIMEOUT:-900}" --max-wall "${HEARTBEAT_MAX_WALL:-7200}"
+
           # Pass prompt via stdin to avoid ARG_MAX limits with large context files
           max_attempts=3
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "Codex clarify attempt ${attempt}/${max_attempts}..."
-            if cat "${CODEX_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --full-auto > "${CODEX_OUTPUT_FILE}" 2> >(tee "${RUNTIME_DIR}/codex_log.txt" >&2); then
+            if cat "${CODEX_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --full-auto > "${CODEX_OUTPUT_FILE}" 2> >(heartbeat_tee "${RUNTIME_DIR}/codex_log.txt" >&2); then
               if grep -q '[^[:space:]]' "${CODEX_OUTPUT_FILE}"; then
                 echo "Codex clarify succeeded on attempt ${attempt}."
                 break
               fi
               echo "::warning::Codex returned empty output on attempt ${attempt}."
             else
-              echo "::warning::Codex exited with code $? on attempt ${attempt}."
+              rc=$?
+              if [ "$rc" -eq 142 ]; then
+                echo "::error::Codex clarify killed — no output activity (idle timeout)."
+                heartbeat_stop
+                exit 1
+              fi
+              echo "::warning::Codex exited with code $rc on attempt ${attempt}."
             fi
             if [ "${attempt}" -lt "${max_attempts}" ]; then
               sleep_secs=$(( 10 * (2 ** (attempt - 1)) + RANDOM % 10 ))
@@ -422,9 +432,12 @@ jobs:
               sleep "${sleep_secs}"
             else
               echo "::error::Codex clarify failed after ${max_attempts} attempts."
+              heartbeat_stop
               exit 1
             fi
           done
+
+          heartbeat_stop
 
       - name: Write run summary
         if: always()

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -35,7 +35,7 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    timeout-minutes: 180
     concurrency:
       group: ai-implement-${{ github.repository }}-${{ github.event.issue.number }}
       cancel-in-progress: false
@@ -459,17 +459,28 @@ jobs:
             cat "${IMPLEMENTATION_CONTEXT_FILE}"
           } > "${CODEX_PROMPT_FILE}"
 
+          # Heartbeat-based timeout: kill only if no output for 15 min,
+          # with a 3-hour hard ceiling (instead of blanket 75-min wall clock).
+          source "${GITHUB_WORKSPACE}/scripts/heartbeat_exec.sh"
+          heartbeat_start --idle-timeout "${HEARTBEAT_IDLE_TIMEOUT:-900}" --max-wall "${HEARTBEAT_MAX_WALL:-10800}"
+
           max_attempts=2
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "Codex implement attempt ${attempt}/${max_attempts}..."
-            if cat "${CODEX_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --full-auto > "${CODEX_OUTPUT_FILE}" 2> >(tee "${RUNTIME_DIR}/codex_log.txt" >&2); then
+            if cat "${CODEX_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --full-auto > "${CODEX_OUTPUT_FILE}" 2> >(heartbeat_tee "${RUNTIME_DIR}/codex_log.txt" >&2); then
               if grep -q '[^[:space:]]' "${CODEX_OUTPUT_FILE}"; then
                 echo "Codex implement succeeded on attempt ${attempt}."
                 break
               fi
               echo "::warning::Codex returned empty output on attempt ${attempt}."
             else
-              echo "::warning::Codex exited with code $? on attempt ${attempt}."
+              rc=$?
+              if [ "$rc" -eq 142 ]; then
+                echo "::error::Codex implement killed — no output activity (idle timeout)."
+                heartbeat_stop
+                exit 1
+              fi
+              echo "::warning::Codex exited with code $rc on attempt ${attempt}."
             fi
             if [ "${attempt}" -lt "${max_attempts}" ]; then
               sleep_secs=$((10 * (2 ** (attempt - 1))))
@@ -477,9 +488,12 @@ jobs:
               sleep "${sleep_secs}"
             else
               echo "::error::Codex implement failed after ${max_attempts} attempts."
+              heartbeat_stop
               exit 1
             fi
           done
+
+          heartbeat_stop
 
       - name: Write run summary
         if: env.SKIP_IMPLEMENT != 'true' && always()

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -29,7 +29,7 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 55
+    timeout-minutes: 120
     env:
       ISSUE_NUMBER: ${{ github.event.issue.number }}
       ISSUE_URL: ${{ github.event.issue.html_url }}
@@ -509,17 +509,27 @@ jobs:
             cat "${PLANNING_CONTEXT_FILE}"
           } > "${CODEX_PROMPT_FILE}"
 
+          # Heartbeat-based timeout: kill only if no output for 15 min
+          source "${GITHUB_WORKSPACE}/scripts/heartbeat_exec.sh"
+          heartbeat_start --idle-timeout "${HEARTBEAT_IDLE_TIMEOUT:-900}" --max-wall "${HEARTBEAT_MAX_WALL:-7200}"
+
           max_attempts=3
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "Codex planning attempt ${attempt}/${max_attempts}..."
-            if cat "${CODEX_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --full-auto > "${CODEX_OUTPUT_FILE}" 2> >(tee "${RUNTIME_DIR}/codex_log.txt" >&2); then
+            if cat "${CODEX_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --full-auto > "${CODEX_OUTPUT_FILE}" 2> >(heartbeat_tee "${RUNTIME_DIR}/codex_log.txt" >&2); then
               if grep -q '[^[:space:]]' "${CODEX_OUTPUT_FILE}"; then
                 echo "Codex planning succeeded on attempt ${attempt}."
                 break
               fi
               echo "::warning::Codex returned empty output on attempt ${attempt}."
             else
-              echo "::warning::Codex exited with code $? on attempt ${attempt}."
+              rc=$?
+              if [ "$rc" -eq 142 ]; then
+                echo "::error::Codex planning killed — no output activity (idle timeout)."
+                heartbeat_stop
+                exit 1
+              fi
+              echo "::warning::Codex exited with code $rc on attempt ${attempt}."
             fi
             if [ "${attempt}" -lt "${max_attempts}" ]; then
               sleep_secs=$((10 * (2 ** (attempt - 1))))
@@ -527,9 +537,12 @@ jobs:
               sleep "${sleep_secs}"
             else
               echo "::error::Codex planning failed after ${max_attempts} attempts."
+              heartbeat_stop
               exit 1
             fi
           done
+
+          heartbeat_stop
 
       - name: Write run summary
         if: env.SKIP_PLAN != 'true' && always()

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -39,7 +39,7 @@ env:
 jobs:
   codex-agent:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 180
     if: ${{ github.event_name == 'workflow_dispatch' || (!github.event.pull_request.draft && !contains(github.event.pull_request.title || '', '[skip ai]') && !contains(github.event.pull_request.body || '', '[skip ai]')) }}
 
     env:
@@ -1053,21 +1053,62 @@ jobs:
             cat "${REVIEWER_PROMPT_BODY_FILE}"
           } > "${REVIEWER_PROMPT_FILE}"
 
+          # Source heartbeat utilities for activity-based timeouts
+          source "${GITHUB_WORKSPACE}/scripts/heartbeat_exec.sh"
+
           run_reviewer() {
             local model="$1"
             local safe_name="$2"
             local output_file="${PREVIOUS_REVIEWS_DIR}/review_${safe_name}.txt"
             local status_file="${PREVIOUS_REVIEWS_DIR}/status_${safe_name}.txt"
             local log_file="${PREVIOUS_REVIEWS_DIR}/review_${safe_name}.log"
-            local reviewer_timeout_seconds=1800
+            local reviewer_idle_timeout="${HEARTBEAT_IDLE_TIMEOUT:-900}"
+            local reviewer_max_wall="${HEARTBEAT_MAX_WALL:-7200}"
             local attempt=1
 
             : > "${log_file}"
             while [ "${attempt}" -le 3 ]; do
               tmp_output="$(mktemp)"
               tmp_stderr="$(mktemp)"
-              if timeout --signal=TERM --kill-after=30s "${reviewer_timeout_seconds}s" \
-                codex exec --model "${model}" --full-auto "$(cat "${REVIEWER_PROMPT_FILE}")" > "${tmp_output}" 2> "${tmp_stderr}"; then
+              # Use heartbeat file per reviewer to track activity
+              local hb_file
+              hb_file="$(mktemp /tmp/heartbeat_reviewer.XXXXXX)"
+              date +%s > "${hb_file}"
+              local start_time
+              start_time="$(date +%s)"
+
+              # Background watchdog for this reviewer attempt
+              (
+                while true; do
+                  sleep 10
+                  now="$(date +%s)"
+                  last="$(cat "${hb_file}" 2>/dev/null || echo "$now")"
+                  if [ $(( now - last )) -ge "${reviewer_idle_timeout}" ]; then
+                    echo "Reviewer ${model} killed — no output for $(( now - last ))s (idle limit: ${reviewer_idle_timeout}s)." | tee -a "${log_file}" >&2
+                    rm -f "${hb_file}"
+                    exit 142
+                  fi
+                  if [ $(( now - start_time )) -ge "${reviewer_max_wall}" ]; then
+                    echo "Reviewer ${model} killed — max wall time ${reviewer_max_wall}s exceeded." | tee -a "${log_file}" >&2
+                    rm -f "${hb_file}"
+                    exit 143
+                  fi
+                done
+              ) &
+              local wd_pid=$!
+
+              codex exec --model "${model}" --full-auto "$(cat "${REVIEWER_PROMPT_FILE}")" > "${tmp_output}" 2> >(
+                while IFS= read -r line || [ -n "$line" ]; do
+                  date +%s > "${hb_file}" 2>/dev/null
+                  printf '%s\n' "$line"
+                done > "${tmp_stderr}"
+              )
+              local cmd_rc=$?
+
+              kill "${wd_pid}" 2>/dev/null; wait "${wd_pid}" 2>/dev/null
+              rm -f "${hb_file}"
+
+              if [ "${cmd_rc}" -eq 0 ]; then
                 cat "${tmp_stderr}" >> "${log_file}"
                 if [ -s "${tmp_output}" ]; then
                   mv "${tmp_output}" "${output_file}"
@@ -1078,13 +1119,8 @@ jobs:
                 fi
                 echo "Reviewer ${model} produced empty output on attempt ${attempt}." | tee -a "${log_file}"
               else
-                rc=$?
                 cat "${tmp_stderr}" >> "${log_file}"
-                if [ "${rc}" -eq 124 ]; then
-                  echo "Reviewer ${model} timed out after ${reviewer_timeout_seconds}s on attempt ${attempt}." | tee -a "${log_file}"
-                else
-                  echo "Reviewer ${model} execution failed on attempt ${attempt} (exit=${rc})." | tee -a "${log_file}"
-                fi
+                echo "Reviewer ${model} execution failed on attempt ${attempt} (exit=${cmd_rc})." | tee -a "${log_file}"
               fi
 
               if [ -s "${tmp_stderr}" ]; then
@@ -1520,11 +1556,15 @@ jobs:
           echo "Editor prompt sha256: $(sha256sum "${EDITOR_PROMPT_FILE}" | awk '{print $1}')"
 
           rm -f "${EDITOR_SUMMARY_FILE}"
+
+          # Heartbeat-based timeout for editor
+          heartbeat_start --idle-timeout "${HEARTBEAT_IDLE_TIMEOUT:-900}" --max-wall "${HEARTBEAT_MAX_WALL:-10800}"
+
           attempt=1
           while [ "${attempt}" -le 3 ]; do
             tmp_output="$(mktemp)"
             tmp_err="$(mktemp)"
-            if codex exec --model "${MODEL_EDITOR}" --full-auto "$(cat "${EDITOR_PROMPT_FILE}")" > "${tmp_output}" 2>"${tmp_err}"; then
+            if codex exec --model "${MODEL_EDITOR}" --full-auto "$(cat "${EDITOR_PROMPT_FILE}")" > "${tmp_output}" 2> >(heartbeat_tee "${tmp_err}" >/dev/null); then
               cp "${tmp_err}" "${PREVIOUS_REVIEWS_DIR}/editor_attempt_${attempt}.err" 2>/dev/null || true
               if [ -s "${tmp_output}" ] && grep -q '^Changes made:' "${tmp_output}"                 && grep -q '^Already satisfied (suggested but already present):' "${tmp_output}"                 && grep -q '^Ignored suggestions (with short reason):' "${tmp_output}"                 && grep -q '^Reviewer files processed:' "${tmp_output}"                 && grep -q '^Review file issue audit:' "${tmp_output}"                 && ! grep -qiE "I can.?t execute this|need to read|allow read/write shell commands|cannot proceed under the current constraints" "${tmp_output}"; then
                 reviewer_validation_ok=true
@@ -1614,6 +1654,8 @@ jobs:
             attempt=$((attempt + 1))
             sleep 2
           done
+
+          heartbeat_stop
 
           cat > "${EDITOR_SUMMARY_FILE}" <<'__EDITOR_SUMMARY__'
           Changes made:

--- a/scripts/heartbeat_exec.sh
+++ b/scripts/heartbeat_exec.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# heartbeat_exec.sh — Activity-based timeout wrapper for long-running processes.
+#
+# Monitors a heartbeat file and kills the watched process group if no
+# output activity is detected for IDLE_TIMEOUT seconds.  The caller is
+# responsible for updating the heartbeat file (e.g. via the
+# heartbeat_tee helper function below).
+#
+# Usage:
+#   source scripts/heartbeat_exec.sh   # import functions
+#
+# Functions provided:
+#   heartbeat_start [--idle-timeout SECS] [--max-wall SECS]
+#       Starts the background watchdog.  Sets HEARTBEAT_FILE env var.
+#       Returns the watchdog PID in HEARTBEAT_WATCHDOG_PID.
+#
+#   heartbeat_stop
+#       Stops the watchdog and cleans up.
+#
+#   heartbeat_tee FILE
+#       Reads stdin, writes to FILE, copies to stdout, and touches
+#       the heartbeat file on every line.  Use in process substitution:
+#         cmd 2> >(heartbeat_tee logfile.txt >&2)
+#
+#   heartbeat_touch
+#       Manually update the heartbeat timestamp (e.g. after a meaningful event).
+#
+# Defaults (override via env or flags):
+#   HEARTBEAT_IDLE_TIMEOUT  — idle seconds before kill  (default: 900 = 15 min)
+#   HEARTBEAT_MAX_WALL      — max wall-clock seconds    (default: 10800 = 3 h)
+
+HEARTBEAT_IDLE_TIMEOUT="${HEARTBEAT_IDLE_TIMEOUT:-900}"
+HEARTBEAT_MAX_WALL="${HEARTBEAT_MAX_WALL:-10800}"
+HEARTBEAT_FILE=""
+HEARTBEAT_WATCHDOG_PID=""
+_HEARTBEAT_START_TIME=""
+
+heartbeat_touch() {
+  [ -n "${HEARTBEAT_FILE}" ] && date +%s > "${HEARTBEAT_FILE}"
+}
+
+heartbeat_tee() {
+  # Usage: heartbeat_tee [OUTPUT_FILE]
+  # Reads stdin line-by-line, writes to OUTPUT_FILE (if given) and stdout,
+  # and updates the heartbeat timestamp on each line.
+  local outfile="${1:-}"
+  if [ -n "$outfile" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+      heartbeat_touch
+      printf '%s\n' "$line"
+      printf '%s\n' "$line" >> "$outfile"
+    done
+  else
+    while IFS= read -r line || [ -n "$line" ]; do
+      heartbeat_touch
+      printf '%s\n' "$line"
+    done
+  fi
+}
+
+heartbeat_start() {
+  local idle_timeout="${HEARTBEAT_IDLE_TIMEOUT}"
+  local max_wall="${HEARTBEAT_MAX_WALL}"
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --idle-timeout) idle_timeout="$2"; shift 2 ;;
+      --max-wall)     max_wall="$2";     shift 2 ;;
+      *)              shift ;;
+    esac
+  done
+
+  HEARTBEAT_FILE="$(mktemp /tmp/heartbeat.XXXXXX)"
+  date +%s > "${HEARTBEAT_FILE}"
+  _HEARTBEAT_START_TIME="$(date +%s)"
+
+  # Get the caller's process group so we can kill the whole step on timeout
+  local watch_pgid="$$"
+
+  (
+    while true; do
+      sleep 10
+
+      now="$(date +%s)"
+      last_activity="$(cat "${HEARTBEAT_FILE}" 2>/dev/null || echo "$now")"
+
+      idle_secs=$(( now - last_activity ))
+      wall_secs=$(( now - _HEARTBEAT_START_TIME ))
+
+      if [ "$idle_secs" -ge "$idle_timeout" ]; then
+        echo "" >&2
+        echo "::error::heartbeat_exec: no output for ${idle_secs}s (limit: ${idle_timeout}s) — terminating" >&2
+        kill -TERM -"${watch_pgid}" 2>/dev/null || kill -TERM "${watch_pgid}" 2>/dev/null
+        sleep 10
+        kill -KILL -"${watch_pgid}" 2>/dev/null || kill -KILL "${watch_pgid}" 2>/dev/null
+        exit 142
+      fi
+
+      if [ "$wall_secs" -ge "$max_wall" ]; then
+        echo "" >&2
+        echo "::error::heartbeat_exec: max wall time ${max_wall}s exceeded — terminating" >&2
+        kill -TERM -"${watch_pgid}" 2>/dev/null || kill -TERM "${watch_pgid}" 2>/dev/null
+        sleep 10
+        kill -KILL -"${watch_pgid}" 2>/dev/null || kill -KILL "${watch_pgid}" 2>/dev/null
+        exit 143
+      fi
+    done
+  ) &
+  HEARTBEAT_WATCHDOG_PID=$!
+
+  echo "heartbeat_exec: watchdog started (idle=${idle_timeout}s, max_wall=${max_wall}s, pid=${HEARTBEAT_WATCHDOG_PID})"
+}
+
+heartbeat_stop() {
+  if [ -n "${HEARTBEAT_WATCHDOG_PID}" ]; then
+    kill "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null
+    wait "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null
+    HEARTBEAT_WATCHDOG_PID=""
+  fi
+  if [ -n "${HEARTBEAT_FILE}" ]; then
+    rm -f "${HEARTBEAT_FILE}"
+    HEARTBEAT_FILE=""
+  fi
+}


### PR DESCRIPTION
## Summary

- **Problem**: Large multi-step implement jobs were being killed at 75 minutes even while actively producing output, causing wasted compute and failed tasks
- **Solution**: Replace fixed wall-clock `timeout-minutes` with heartbeat-based monitoring that only kills processes with no output activity for 15 minutes
- **New `scripts/heartbeat_exec.sh`**: Provides `heartbeat_start`, `heartbeat_stop`, `heartbeat_tee`, and `heartbeat_touch` functions that workflows source to monitor codex exec output activity

### Timeout changes

| Workflow | Old `timeout-minutes` | New `timeout-minutes` (safety ceiling) | Idle timeout (kills on no output) |
|---|---|---|---|
| `implement.yml` | 75 min | 180 min | 15 min (configurable) |
| `plan.yml` | 55 min | 120 min | 15 min (configurable) |
| `clarify.yml` | 55 min | 120 min | 15 min (configurable) |
| `review_autofix.yml` | 90 min | 180 min | 15 min (configurable) |

### How it works

1. Workflows `source scripts/heartbeat_exec.sh` before the codex exec loop
2. `heartbeat_start` launches a background watchdog that checks a timestamp file every 10s
3. Codex stderr is piped through `heartbeat_tee` which updates the timestamp on every line of output
4. If no output for `HEARTBEAT_IDLE_TIMEOUT` seconds (default 900 = 15 min), the process is killed
5. A hard wall ceiling (`HEARTBEAT_MAX_WALL`) remains as a safety net

### Configurable via env vars

- `HEARTBEAT_IDLE_TIMEOUT` — seconds of no output before kill (default: 900)
- `HEARTBEAT_MAX_WALL` — absolute max wall-clock seconds (default: 10800 for implement/review, 7200 for plan/clarify)

## Test plan

- [ ] Verify implement workflow runs to completion on a large task that previously timed out at 75 min
- [ ] Verify a stuck/hung codex process (no output) gets killed after 15 min idle
- [ ] Verify heartbeat_exec.sh syntax with `bash -n` and confirm functions source correctly
- [ ] Confirm YAML validity of all modified workflow files
- [ ] Test that retry logic still works correctly when codex fails on first attempt

https://claude.ai/code/session_01HeCxYU8yjFqpEzXZiyzPEZ