### PR TITLE
Fix cancel workflow 404 by adding --method GET to gh api calls

### DIFF
--- a/.github/workflows/cancel_on_pr_close.yml
+++ b/.github/workflows/cancel_on_pr_close.yml
@@ -32,6 +32,7 @@ jobs:
             | flatten}'
           queued_runs_json="$(
             gh api \
+              --method GET \
               "repos/${REPOSITORY}/actions/runs" \
               --paginate \
               -f status=queued \
@@ -40,6 +41,7 @@ jobs:
           )"
           in_progress_runs_json="$(
             gh api \
+              --method GET \
               "repos/${REPOSITORY}/actions/runs" \
               --paginate \
               -f status=in_progress \


### PR DESCRIPTION
## Summary

- Fix HTTP 404 error in `cancel_on_pr_close.yml` workflow by adding `--method GET` to `gh api` calls
- `gh api` defaults to POST when `-f` parameters are present, but the `/actions/runs` endpoint only supports GET, causing the 404

## Test plan

- [ ] Merge a PR with active workflow runs and verify the cancel workflow completes successfully instead of failing with 404

https://claude.ai/code/session_01BHSDBEzcCFNiJ8nL9M5E5f