### PR TITLE
Send Telegram alerts on workflow timeout/cancellation

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -600,17 +600,22 @@ jobs:
           fi
 
       - name: Comment on issue failure
-        if: failure()
+        if: failure() || cancelled()
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           set -euo pipefail
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ "${{ job.status }}" = "cancelled" ]; then
+            REASON="AI clarification workflow was cancelled/timed out for ${ISSUE_URL}. Run: ${RUN_URL}"
+          else
+            REASON="AI clarification workflow failed for ${ISSUE_URL}. Run: ${RUN_URL}"
+          fi
           gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
-            -f body="AI clarification workflow failed for ${ISSUE_URL}. Run: ${RUN_URL}"
+            -f body="${REASON}"
 
       - name: Telegram failure notification
-        if: failure()
+        if: failure() || cancelled()
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
@@ -624,7 +629,11 @@ jobs:
           fi
 
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MSG="AI clarification failed for #${ISSUE_NUMBER}: ${ISSUE_TITLE}"
+          if [ "${{ job.status }}" = "cancelled" ]; then
+            MSG="AI clarification cancelled/timed out for #${ISSUE_NUMBER}: ${ISSUE_TITLE}"
+          else
+            MSG="AI clarification failed for #${ISSUE_NUMBER}: ${ISSUE_TITLE}"
+          fi
           MSG+=$'\n'
           MSG+="${ISSUE_URL}"
           MSG+=$'\n'

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -835,7 +835,7 @@ jobs:
           gh api -X DELETE "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/labels/ai:implementing" >/dev/null 2>&1 || true
 
       - name: Comment on issue failure
-        if: failure()
+        if: failure() || cancelled()
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
@@ -846,11 +846,16 @@ jobs:
             gh api -X DELETE "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/labels/ai:implementing" >/dev/null 2>&1 || true
           fi
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ "${{ job.status }}" = "cancelled" ]; then
+            REASON="AI implementation workflow was cancelled/timed out for ${ISSUE_URL}. Run: ${RUN_URL}"
+          else
+            REASON="AI implementation workflow failed for ${ISSUE_URL}. Run: ${RUN_URL}"
+          fi
           gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
-            -f body="AI implementation workflow failed for ${ISSUE_URL}. Run: ${RUN_URL}"
+            -f body="${REASON}"
 
       - name: Telegram failure notification
-        if: failure()
+        if: failure() || cancelled()
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
@@ -864,7 +869,11 @@ jobs:
           fi
 
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MSG="AI implementation workflow failed for issue ${ISSUE_URL}"
+          if [ "${{ job.status }}" = "cancelled" ]; then
+            MSG="AI implementation workflow cancelled/timed out for issue ${ISSUE_URL}"
+          else
+            MSG="AI implementation workflow failed for issue ${ISSUE_URL}"
+          fi
           MSG+=$'\n'
           MSG+="Run: ${RUN_URL}"
           RESPONSE="$(curl -sS -X POST \
@@ -877,7 +886,7 @@ jobs:
           fi
 
       - name: Exit safely
-        if: failure()
+        if: failure() || cancelled()
         run: exit 0
 
       - name: Cleanup temporary artifacts

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -755,15 +755,21 @@ jobs:
           fi
 
       - name: Capture planning failure context
-        if: failure()
+        if: failure() || cancelled()
         run: |
           set -euo pipefail
-          {
-            echo "PLAN_FAILURE_CONTEXT=AI Plan phase failed before posting the implementation plan."
-          } >> "$GITHUB_ENV"
+          if [ "${{ job.status }}" = "cancelled" ]; then
+            {
+              echo "PLAN_FAILURE_CONTEXT=AI Plan phase was cancelled or timed out before posting the implementation plan."
+            } >> "$GITHUB_ENV"
+          else
+            {
+              echo "PLAN_FAILURE_CONTEXT=AI Plan phase failed before posting the implementation plan."
+            } >> "$GITHUB_ENV"
+          fi
 
       - name: Comment on issue failure
-        if: failure()
+        if: failure() || cancelled()
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
@@ -774,7 +780,7 @@ jobs:
             -f body=$'AI planning workflow failed.\n\nWorkflow: AI Plan\nIssue: #'"${ISSUE_NUMBER}"$'\nIssue URL: '"${ISSUE_URL}"$'\nContext: '"${PLAN_FAILURE_CONTEXT}"$'\nHint: '"${FAILED_STEP_HINT}"$'\nRun: '"${RUN_URL}"
 
       - name: Telegram failure notification
-        if: failure()
+        if: failure() || cancelled()
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
@@ -789,7 +795,11 @@ jobs:
 
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           FAILED_STEP_HINT="Check the AI Plan run logs and inspect the first failed step."
-          MSG="AI planning workflow failed."
+          if [ "${{ job.status }}" = "cancelled" ]; then
+            MSG="AI planning workflow cancelled/timed out."
+          else
+            MSG="AI planning workflow failed."
+          fi
           MSG+=$'\n'
           MSG+="Workflow: AI Plan"
           MSG+=$'\n'
@@ -812,5 +822,5 @@ jobs:
           fi
 
       - name: Exit safely
-        if: failure()
+        if: failure() || cancelled()
         run: exit 0

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2168,14 +2168,18 @@ jobs:
             --data-urlencode "text=${MSG}"
 
       - name: Telegram failure
-        if: failure()
+        if: failure() || cancelled()
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
         run: |
           PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUMBER}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MSG="$(printf 'PR autofix failed\nPR: %s\nRun: %s' "${PR_URL}" "${RUN_URL}")"
+          if [ "${{ job.status }}" = "cancelled" ]; then
+            MSG="$(printf 'PR autofix cancelled/timed out\nPR: %s\nRun: %s' "${PR_URL}" "${RUN_URL}")"
+          else
+            MSG="$(printf 'PR autofix failed\nPR: %s\nRun: %s' "${PR_URL}" "${RUN_URL}")"
+          fi
           curl -sS -X POST \
             "https://api.telegram.org/bot${TG_BOT_SECRET}/sendMessage" \
             -d "chat_id=${TG_CHAT_ID}" \


### PR DESCRIPTION
## Summary

- GitHub Actions sets job status to `cancelled` (not `failed`) when a job hits `timeout-minutes`, so notification steps using `if: failure()` never fired on timeouts
- Changed all failure notification steps across all 4 core workflows (clarify, plan, implement, review_autofix) to use `if: failure() || cancelled()`
- Messages now distinguish between failures and cancellations/timeouts for clearer alerting

## Test plan

- [ ] Verify a workflow that times out (hits `timeout-minutes`) now sends a Telegram alert with "cancelled/timed out" in the message
- [ ] Verify a workflow that fails normally still sends the existing failure Telegram alert
- [ ] Verify issue comments are also posted on cancellation/timeout
- [ ] Verify label restoration (e.g. `ai:awaiting-approval`) still works on cancellation

https://claude.ai/code/session_01Ti6BAMntCQUc8oQ2fpF6E3