### PR TITLE
Fix reviewer heartbeat race condition causing crashes

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1068,12 +1068,17 @@ jobs:
             while [ "${attempt}" -le 3 ]; do
               tmp_output="$(mktemp)"
               tmp_stderr="$(mktemp)"
-              # Use heartbeat file per reviewer to track activity
+              # Use heartbeat file per reviewer to track activity.
+              # IMPORTANT: writes use atomic rename (write to .tmp then mv)
+              # to avoid a race where the watchdog reads an empty file
+              # mid-truncate and computes now-0 = epoch → false idle kill.
               local hb_file
               hb_file="$(mktemp /tmp/heartbeat_reviewer.XXXXXX)"
               date +%s > "${hb_file}"
               local start_time
               start_time="$(date +%s)"
+              local codex_pid_file
+              codex_pid_file="$(mktemp /tmp/codex_pid_reviewer.XXXXXX)"
 
               # Background watchdog for this reviewer attempt
               (
@@ -1081,13 +1086,22 @@ jobs:
                   sleep 10
                   now="$(date +%s)"
                   last="$(cat "${hb_file}" 2>/dev/null || echo "$now")"
+                  # Guard against empty/corrupt reads: if last is not numeric, treat as now
+                  if ! [[ "${last}" =~ ^[0-9]+$ ]]; then last="${now}"; fi
                   if [ $(( now - last )) -ge "${reviewer_idle_timeout}" ]; then
                     echo "Reviewer ${model} killed — no output for $(( now - last ))s (idle limit: ${reviewer_idle_timeout}s)." | tee -a "${log_file}" >&2
+                    # Actually kill the codex process
+                    local cpid
+                    cpid="$(cat "${codex_pid_file}" 2>/dev/null || true)"
+                    if [ -n "${cpid}" ]; then kill -TERM "${cpid}" 2>/dev/null; sleep 5; kill -KILL "${cpid}" 2>/dev/null; fi
                     rm -f "${hb_file}"
                     exit 142
                   fi
                   if [ $(( now - start_time )) -ge "${reviewer_max_wall}" ]; then
                     echo "Reviewer ${model} killed — max wall time ${reviewer_max_wall}s exceeded." | tee -a "${log_file}" >&2
+                    local cpid
+                    cpid="$(cat "${codex_pid_file}" 2>/dev/null || true)"
+                    if [ -n "${cpid}" ]; then kill -TERM "${cpid}" 2>/dev/null; sleep 5; kill -KILL "${cpid}" 2>/dev/null; fi
                     rm -f "${hb_file}"
                     exit 143
                   fi
@@ -1095,16 +1109,24 @@ jobs:
               ) &
               local wd_pid=$!
 
-              codex exec --model "${model}" --full-auto "$(cat "${REVIEWER_PROMPT_FILE}")" > "${tmp_output}" 2> >(
+              # Run codex in a wrapper subshell so we can capture its PID
+              # for the watchdog to kill on timeout.
+              (
+                exec codex exec --model "${model}" --full-auto "$(cat "${REVIEWER_PROMPT_FILE}")"
+              ) > "${tmp_output}" 2> >(
                 while IFS= read -r line || [ -n "$line" ]; do
-                  date +%s > "${hb_file}" 2>/dev/null
+                  # Atomic heartbeat update: write to tmp then rename
+                  printf '%s' "$(date +%s)" > "${hb_file}.tmp" && mv -f "${hb_file}.tmp" "${hb_file}" 2>/dev/null
                   printf '%s\n' "$line"
                 done > "${tmp_stderr}"
-              )
+              ) &
+              local codex_bg_pid=$!
+              echo "${codex_bg_pid}" > "${codex_pid_file}"
+              wait "${codex_bg_pid}" 2>/dev/null
               local cmd_rc=$?
 
               kill "${wd_pid}" 2>/dev/null; wait "${wd_pid}" 2>/dev/null
-              rm -f "${hb_file}"
+              rm -f "${hb_file}" "${hb_file}.tmp" "${codex_pid_file}"
 
               if [ "${cmd_rc}" -eq 0 ]; then
                 cat "${tmp_stderr}" >> "${log_file}"
@@ -1567,7 +1589,7 @@ jobs:
           _HEARTBEAT_START_TIME="$(date +%s)"
           _HB_IDLE="${HEARTBEAT_IDLE_TIMEOUT:-900}"
           _HB_WALL="${HEARTBEAT_MAX_WALL:-10800}"
-          heartbeat_touch() { [ -n "${HEARTBEAT_FILE}" ] && date +%s > "${HEARTBEAT_FILE}"; }
+          heartbeat_touch() { [ -n "${HEARTBEAT_FILE}" ] && printf '%s' "$(date +%s)" > "${HEARTBEAT_FILE}.tmp" && mv -f "${HEARTBEAT_FILE}.tmp" "${HEARTBEAT_FILE}" 2>/dev/null; }
           heartbeat_tee() {
             local outfile="${1:-}"
             if [ -n "$outfile" ]; then
@@ -1578,9 +1600,11 @@ jobs:
           }
           heartbeat_stop() {
             [ -n "${HEARTBEAT_WATCHDOG_PID:-}" ] && kill "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null && wait "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null; HEARTBEAT_WATCHDOG_PID=""
-            [ -n "${HEARTBEAT_FILE:-}" ] && rm -f "${HEARTBEAT_FILE}"; HEARTBEAT_FILE=""
+            [ -n "${HEARTBEAT_FILE:-}" ] && rm -f "${HEARTBEAT_FILE}" "${HEARTBEAT_FILE}.tmp"; HEARTBEAT_FILE=""
           }
           ( while true; do sleep 10; now="$(date +%s)"; last="$(cat "${HEARTBEAT_FILE}" 2>/dev/null || echo "$now")"
+            # Guard against empty/corrupt reads from race condition
+            [[ "${last}" =~ ^[0-9]+$ ]] || last="${now}"
             [ $(( now - last )) -ge "${_HB_IDLE}" ] && echo "" >&2 && echo "::error::heartbeat: no output for $(( now - last ))s (limit: ${_HB_IDLE}s) — terminating" >&2 && kill -TERM "$$" 2>/dev/null && sleep 10 && kill -KILL "$$" 2>/dev/null && exit 142
             [ $(( now - _HEARTBEAT_START_TIME )) -ge "${_HB_WALL}" ] && echo "" >&2 && echo "::error::heartbeat: max wall time ${_HB_WALL}s exceeded — terminating" >&2 && kill -TERM "$$" 2>/dev/null && sleep 10 && kill -KILL "$$" 2>/dev/null && exit 143
           done ) &


### PR DESCRIPTION
## Summary

- **Fix heartbeat race condition**: `date +%s > file` truncates before writing; if the watchdog `cat`s between truncate and write, it reads empty → 0 → `now - 0 = epoch ≈ 1.7B seconds` → immediate false idle-timeout kill. Fixed by using atomic write-to-tmp-then-mv.
- **Fix watchdog not killing codex**: The reviewer watchdog only `exit`ed its subshell but never killed the actual `codex exec` process. Now stores the codex PID and sends SIGTERM/SIGKILL on timeout.
- **Add non-numeric guard**: If heartbeat value is empty/corrupt despite atomic writes, treat it as current time instead of 0.
- **Applied same fixes to editor heartbeat** for consistency.

## Root cause from logs

```
Reviewer moonshotai/kimi-k2.5 killed — no output for 1774341846s (idle limit: 900s).
```

`1774341846` is the Unix epoch timestamp (~March 2026), meaning `last` was read as empty → evaluated to 0 in bash arithmetic → `now - 0 = now`.

## Test plan

- [ ] Verify workflow YAML is valid (validated locally with `yaml.safe_load`)
- [ ] Run review workflow on a test PR and confirm reviewers no longer get false idle-timeout kills
- [ ] Confirm watchdog actually terminates codex on real timeout scenarios

https://claude.ai/code/session_01Gxy3tK8snLTzojY11nWfYp