### PR TITLE
Fix heartbeat_stop exit code 143 causing successful runs to fail

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -419,7 +419,7 @@ jobs:
             fi
           }
           heartbeat_stop() {
-            [ -n "${HEARTBEAT_WATCHDOG_PID:-}" ] && kill "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null && wait "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null; HEARTBEAT_WATCHDOG_PID=""
+            [ -n "${HEARTBEAT_WATCHDOG_PID:-}" ] && { kill "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null; wait "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null || true; }; HEARTBEAT_WATCHDOG_PID=""
             [ -n "${HEARTBEAT_FILE:-}" ] && rm -f "${HEARTBEAT_FILE}"; HEARTBEAT_FILE=""
           }
           ( while true; do sleep 10; now="$(date +%s)"; last="$(cat "${HEARTBEAT_FILE}" 2>/dev/null || echo "$now")"

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -476,7 +476,7 @@ jobs:
             fi
           }
           heartbeat_stop() {
-            [ -n "${HEARTBEAT_WATCHDOG_PID:-}" ] && kill "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null && wait "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null; HEARTBEAT_WATCHDOG_PID=""
+            [ -n "${HEARTBEAT_WATCHDOG_PID:-}" ] && { kill "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null; wait "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null || true; }; HEARTBEAT_WATCHDOG_PID=""
             [ -n "${HEARTBEAT_FILE:-}" ] && rm -f "${HEARTBEAT_FILE}"; HEARTBEAT_FILE=""
           }
           ( while true; do sleep 10; now="$(date +%s)"; last="$(cat "${HEARTBEAT_FILE}" 2>/dev/null || echo "$now")"

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -525,7 +525,7 @@ jobs:
             fi
           }
           heartbeat_stop() {
-            [ -n "${HEARTBEAT_WATCHDOG_PID:-}" ] && kill "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null && wait "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null; HEARTBEAT_WATCHDOG_PID=""
+            [ -n "${HEARTBEAT_WATCHDOG_PID:-}" ] && { kill "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null; wait "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null || true; }; HEARTBEAT_WATCHDOG_PID=""
             [ -n "${HEARTBEAT_FILE:-}" ] && rm -f "${HEARTBEAT_FILE}"; HEARTBEAT_FILE=""
           }
           ( while true; do sleep 10; now="$(date +%s)"; last="$(cat "${HEARTBEAT_FILE}" 2>/dev/null || echo "$now")"

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1599,7 +1599,7 @@ jobs:
             fi
           }
           heartbeat_stop() {
-            [ -n "${HEARTBEAT_WATCHDOG_PID:-}" ] && kill "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null && wait "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null; HEARTBEAT_WATCHDOG_PID=""
+            [ -n "${HEARTBEAT_WATCHDOG_PID:-}" ] && { kill "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null; wait "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null || true; }; HEARTBEAT_WATCHDOG_PID=""
             [ -n "${HEARTBEAT_FILE:-}" ] && rm -f "${HEARTBEAT_FILE}" "${HEARTBEAT_FILE}.tmp"; HEARTBEAT_FILE=""
           }
           ( while true; do sleep 10; now="$(date +%s)"; last="$(cat "${HEARTBEAT_FILE}" 2>/dev/null || echo "$now")"


### PR DESCRIPTION
## Summary

- Fixes `heartbeat_stop()` in all 4 workflow files where `wait` on a killed watchdog returns exit code 143 (SIGTERM), which under `set -euo pipefail` fails the entire step even when Codex succeeded
- Changes `kill && wait` to `{ kill; wait || true; }` to suppress the expected non-zero exit from the terminated watchdog process
- Affected files: `clarify.yml`, `plan.yml`, `implement.yml`, `review_autofix.yml`

## Root cause

The E2E smoke test on issue #63 showed Codex clarify returning `STATUS: CLEAR` successfully, but the step failed with exit code 143. The `wait` command returns the exit status of the waited-for process — since the watchdog was killed by SIGTERM, `wait` returns 143, and `set -e` propagates this as a step failure.

## Test plan

- [ ] Re-run the E2E smoke test and verify the clarify step completes successfully
- [ ] Verify the downstream steps (post CLEAR comment, auto-post `/answer`) execute after clarify succeeds

https://claude.ai/code/session_01G7SJRH3yFKx5EmiuDmT3sK