### PR TITLE
Fix E2E deep verify false failure on spurious re-trigger runs

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -141,7 +141,7 @@ jobs:
               echo "✓ Clarify phase completed — issue moved to planning"
               # Capture the clarify workflow run ID
               CLARIFY_RUN_ID=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=10&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq '[.workflow_runs[] | select(.name | test("Clarif"; "i")) | select(.status == "completed")] | sort_by(.created_at) | last.id // empty' 2>/dev/null || echo "")
+                --jq '[.workflow_runs[] | select(.name | test("Clarif"; "i")) | select(.status == "completed")] | sort_by(.created_at) | .[0].id // empty' 2>/dev/null || echo "")
               echo "run_id=${CLARIFY_RUN_ID}" >> "$GITHUB_OUTPUT"
               echo "status=success" >> "$GITHUB_OUTPUT"
               exit 0
@@ -185,7 +185,7 @@ jobs:
             if echo "$LABELS" | grep -q 'ai:awaiting-approval'; then
               echo "✓ Plan phase completed — awaiting approval"
               PLAN_RUN_ID=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=10&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq '[.workflow_runs[] | select(.name | test("Plan"; "i")) | select(.status == "completed")] | sort_by(.created_at) | last.id // empty' 2>/dev/null || echo "")
+                --jq '[.workflow_runs[] | select(.name | test("Plan"; "i")) | select(.status == "completed")] | sort_by(.created_at) | .[0].id // empty' 2>/dev/null || echo "")
               echo "run_id=${PLAN_RUN_ID}" >> "$GITHUB_OUTPUT"
               echo "status=success" >> "$GITHUB_OUTPUT"
               exit 0
@@ -195,7 +195,7 @@ jobs:
             if echo "$LABELS" | grep -q 'ai:implementing'; then
               echo "✓ Plan phase completed with auto-approval — already implementing"
               PLAN_RUN_ID=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=10&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq '[.workflow_runs[] | select(.name | test("Plan"; "i")) | select(.status == "completed")] | sort_by(.created_at) | last.id // empty' 2>/dev/null || echo "")
+                --jq '[.workflow_runs[] | select(.name | test("Plan"; "i")) | select(.status == "completed")] | sort_by(.created_at) | .[0].id // empty' 2>/dev/null || echo "")
               echo "run_id=${PLAN_RUN_ID}" >> "$GITHUB_OUTPUT"
               echo "status=auto_approved" >> "$GITHUB_OUTPUT"
               exit 0
@@ -244,7 +244,7 @@ jobs:
             if [ -n "$PR_NUMBER" ]; then
               echo "✓ Implementation PR #${PR_NUMBER} created"
               IMPL_RUN_ID=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=10&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq '[.workflow_runs[] | select(.name | test("Implement"; "i")) | select(.status == "completed")] | sort_by(.created_at) | last.id // empty' 2>/dev/null || echo "")
+                --jq '[.workflow_runs[] | select(.name | test("Implement"; "i")) | select(.status == "completed")] | sort_by(.created_at) | .[0].id // empty' 2>/dev/null || echo "")
               echo "run_id=${IMPL_RUN_ID}" >> "$GITHUB_OUTPUT"
               echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
               echo "status=success" >> "$GITHUB_OUTPUT"
@@ -374,6 +374,18 @@ jobs:
 
             # Fetch all jobs and their steps
             JOBS_JSON=$(gh api "repos/${TEST_REPO}/actions/runs/${run_id}/jobs?per_page=100" 2>/dev/null || echo '{"jobs":[]}')
+
+            # Check if all jobs in this run were skipped (spurious re-trigger where
+            # the reusable workflow's job-level if: condition was false). This commonly
+            # happens when a comment event re-triggers internal-clarify.yml or
+            # internal-implement.yml but the reusable workflow skips the job.
+            TOTAL_JOBS=$(echo "$JOBS_JSON" | jq '.jobs | length')
+            SKIPPED_JOBS=$(echo "$JOBS_JSON" | jq '[.jobs[] | select(.conclusion == "skipped")] | length')
+            if [ "$TOTAL_JOBS" -gt 0 ] && [ "$SKIPPED_JOBS" -eq "$TOTAL_JOBS" ]; then
+              echo "  │  ⊘ All ${TOTAL_JOBS} job(s) were skipped (spurious re-trigger) — OK"
+              echo "  └─"
+              return 0
+            fi
 
             # Iterate every step in every job
             STEP_COUNT=$(echo "$JOBS_JSON" | jq '[.jobs[].steps[]] | length')


### PR DESCRIPTION
## Summary

- **Root cause**: The E2E smoke test's deep verify step captured the wrong workflow run IDs for Clarify and Implement phases. Comment events (e.g., `/answer`, `/approved`) re-trigger `internal-clarify.yml` and `internal-implement.yml`, but the reusable workflow's job-level `if:` condition evaluates to false, producing a completed run with all jobs **skipped** and zero steps. The jq filter used `last` (most recent), which picked these skipped runs instead of the actual working runs.
- **Fix 1**: Change run ID capture from `last` to `.[0]` (earliest completed run after issue creation) for Clarify, Plan, and Implement phases — the first completed run is the one that actually did the work.
- **Fix 2**: Add skipped-job detection in `check_all_steps()` — when all jobs in a run have `conclusion=skipped`, treat it as OK (spurious re-trigger) instead of marking `deep_passed=false`.

## Test plan

- [ ] Re-run the E2E smoke test (`Test & Mark Stable Release` workflow) and verify the Internals check passes
- [ ] Verify that actual failures (e.g., a step with `conclusion=failure`) are still correctly detected

https://claude.ai/code/session_01Sftxmm4u5EKeQZDQwCVe6J