### PR TITLE
Fix E2E internals false failure on run ID capture

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -141,7 +141,7 @@ jobs:
               echo "✓ Clarify phase completed — issue moved to planning"
               # Capture the clarify workflow run ID
               CLARIFY_RUN_ID=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=10&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq '[.workflow_runs[] | select(.name | test("Clarif"; "i")) | select(.status == "completed")] | sort_by(.created_at) | .[0].id // empty' 2>/dev/null || echo "")
+                --jq '[.workflow_runs[] | select(.name | test("Clarif"; "i"))] | sort_by(.created_at) | last | .id // empty' 2>/dev/null || echo "")
               echo "run_id=${CLARIFY_RUN_ID}" >> "$GITHUB_OUTPUT"
               echo "status=success" >> "$GITHUB_OUTPUT"
               exit 0
@@ -185,7 +185,7 @@ jobs:
             if echo "$LABELS" | grep -q 'ai:awaiting-approval'; then
               echo "✓ Plan phase completed — awaiting approval"
               PLAN_RUN_ID=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=10&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq '[.workflow_runs[] | select(.name | test("Plan"; "i")) | select(.status == "completed")] | sort_by(.created_at) | .[0].id // empty' 2>/dev/null || echo "")
+                --jq '[.workflow_runs[] | select(.name | test("Plan"; "i"))] | sort_by(.created_at) | last | .id // empty' 2>/dev/null || echo "")
               echo "run_id=${PLAN_RUN_ID}" >> "$GITHUB_OUTPUT"
               echo "status=success" >> "$GITHUB_OUTPUT"
               exit 0
@@ -195,7 +195,7 @@ jobs:
             if echo "$LABELS" | grep -q 'ai:implementing'; then
               echo "✓ Plan phase completed with auto-approval — already implementing"
               PLAN_RUN_ID=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=10&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq '[.workflow_runs[] | select(.name | test("Plan"; "i")) | select(.status == "completed")] | sort_by(.created_at) | .[0].id // empty' 2>/dev/null || echo "")
+                --jq '[.workflow_runs[] | select(.name | test("Plan"; "i"))] | sort_by(.created_at) | last | .id // empty' 2>/dev/null || echo "")
               echo "run_id=${PLAN_RUN_ID}" >> "$GITHUB_OUTPUT"
               echo "status=auto_approved" >> "$GITHUB_OUTPUT"
               exit 0
@@ -244,7 +244,7 @@ jobs:
             if [ -n "$PR_NUMBER" ]; then
               echo "✓ Implementation PR #${PR_NUMBER} created"
               IMPL_RUN_ID=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=10&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq '[.workflow_runs[] | select(.name | test("Implement"; "i")) | select(.status == "completed")] | sort_by(.created_at) | .[0].id // empty' 2>/dev/null || echo "")
+                --jq '[.workflow_runs[] | select(.name | test("Implement"; "i"))] | sort_by(.created_at) | last | .id // empty' 2>/dev/null || echo "")
               echo "run_id=${IMPL_RUN_ID}" >> "$GITHUB_OUTPUT"
               echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
               echo "status=success" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Fixes the `Internals: FAILED` false positive in E2E smoke tests (e.g. run #23487910602, issue #71)
- Root cause: run ID capture queries filtered for `status == "completed"`, but workflows are often still running post-steps when the phase label is detected — causing `PLAN_RUN_ID` to be empty
- Removes the `completed` status filter from all 4 run ID capture queries (Clarify, Plan x2, Implement)
- Also switches from `.[0]` (oldest) to `last` (newest) to prefer the real run over spurious re-triggers

## Test plan

- [ ] Re-run the E2E smoke test (`Test & Mark Stable Release` workflow) and verify Internals passes
- [ ] Confirm all 5 checks (Clarify, Plan, Implement, Review, Internals) show PASSED

https://claude.ai/code/session_015fsq5nL7y4fRT4uSnFt4Ej