### PR TITLE
Fix heartbeat race condition causing spurious idle timeouts

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -427,7 +427,7 @@ jobs:
           _HEARTBEAT_START_TIME="$(date +%s)"
           _HB_IDLE="${HEARTBEAT_IDLE_TIMEOUT:-900}"
           _HB_WALL="${HEARTBEAT_MAX_WALL:-7200}"
-          heartbeat_touch() { [ -n "${HEARTBEAT_FILE}" ] && date +%s > "${HEARTBEAT_FILE}"; }
+          heartbeat_touch() { [ -n "${HEARTBEAT_FILE}" ] && printf '%s' "$(date +%s)" > "${HEARTBEAT_FILE}.tmp" && mv -f "${HEARTBEAT_FILE}.tmp" "${HEARTBEAT_FILE}" 2>/dev/null; }
           heartbeat_tee() {
             local outfile="${1:-}"
             if [ -n "$outfile" ]; then
@@ -438,9 +438,11 @@ jobs:
           }
           heartbeat_stop() {
             [ -n "${HEARTBEAT_WATCHDOG_PID:-}" ] && { kill "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null; wait "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null || true; }; HEARTBEAT_WATCHDOG_PID=""
-            [ -n "${HEARTBEAT_FILE:-}" ] && rm -f "${HEARTBEAT_FILE}"; HEARTBEAT_FILE=""
+            [ -n "${HEARTBEAT_FILE:-}" ] && rm -f "${HEARTBEAT_FILE}" "${HEARTBEAT_FILE}.tmp"; HEARTBEAT_FILE=""
           }
           ( while true; do sleep 10; now="$(date +%s)"; last="$(cat "${HEARTBEAT_FILE}" 2>/dev/null || echo "$now")"
+            # Guard against empty/corrupt reads from race condition
+            [[ "${last}" =~ ^[0-9]+$ ]] || last="${now}"
             [ $(( now - last )) -ge "${_HB_IDLE}" ] && echo "" >&2 && echo "::error::heartbeat: no output for $(( now - last ))s (limit: ${_HB_IDLE}s) — terminating" >&2 && kill -TERM "$$" 2>/dev/null && sleep 10 && kill -KILL "$$" 2>/dev/null && exit 142
             [ $(( now - _HEARTBEAT_START_TIME )) -ge "${_HB_WALL}" ] && echo "" >&2 && echo "::error::heartbeat: max wall time ${_HB_WALL}s exceeded — terminating" >&2 && kill -TERM "$$" 2>/dev/null && sleep 10 && kill -KILL "$$" 2>/dev/null && exit 143
           done ) &

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -466,7 +466,7 @@ jobs:
           _HEARTBEAT_START_TIME="$(date +%s)"
           _HB_IDLE="${HEARTBEAT_IDLE_TIMEOUT:-900}"
           _HB_WALL="${HEARTBEAT_MAX_WALL:-10800}"
-          heartbeat_touch() { [ -n "${HEARTBEAT_FILE}" ] && date +%s > "${HEARTBEAT_FILE}"; }
+          heartbeat_touch() { [ -n "${HEARTBEAT_FILE}" ] && printf '%s' "$(date +%s)" > "${HEARTBEAT_FILE}.tmp" && mv -f "${HEARTBEAT_FILE}.tmp" "${HEARTBEAT_FILE}" 2>/dev/null; }
           heartbeat_tee() {
             local outfile="${1:-}"
             if [ -n "$outfile" ]; then
@@ -477,9 +477,11 @@ jobs:
           }
           heartbeat_stop() {
             [ -n "${HEARTBEAT_WATCHDOG_PID:-}" ] && { kill "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null; wait "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null || true; }; HEARTBEAT_WATCHDOG_PID=""
-            [ -n "${HEARTBEAT_FILE:-}" ] && rm -f "${HEARTBEAT_FILE}"; HEARTBEAT_FILE=""
+            [ -n "${HEARTBEAT_FILE:-}" ] && rm -f "${HEARTBEAT_FILE}" "${HEARTBEAT_FILE}.tmp"; HEARTBEAT_FILE=""
           }
           ( while true; do sleep 10; now="$(date +%s)"; last="$(cat "${HEARTBEAT_FILE}" 2>/dev/null || echo "$now")"
+            # Guard against empty/corrupt reads from race condition
+            [[ "${last}" =~ ^[0-9]+$ ]] || last="${now}"
             [ $(( now - last )) -ge "${_HB_IDLE}" ] && echo "" >&2 && echo "::error::heartbeat: no output for $(( now - last ))s (limit: ${_HB_IDLE}s) — terminating" >&2 && kill -TERM "$$" 2>/dev/null && sleep 10 && kill -KILL "$$" 2>/dev/null && exit 142
             [ $(( now - _HEARTBEAT_START_TIME )) -ge "${_HB_WALL}" ] && echo "" >&2 && echo "::error::heartbeat: max wall time ${_HB_WALL}s exceeded — terminating" >&2 && kill -TERM "$$" 2>/dev/null && sleep 10 && kill -KILL "$$" 2>/dev/null && exit 143
           done ) &

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -515,7 +515,7 @@ jobs:
           _HEARTBEAT_START_TIME="$(date +%s)"
           _HB_IDLE="${HEARTBEAT_IDLE_TIMEOUT:-900}"
           _HB_WALL="${HEARTBEAT_MAX_WALL:-7200}"
-          heartbeat_touch() { [ -n "${HEARTBEAT_FILE}" ] && date +%s > "${HEARTBEAT_FILE}"; }
+          heartbeat_touch() { [ -n "${HEARTBEAT_FILE}" ] && printf '%s' "$(date +%s)" > "${HEARTBEAT_FILE}.tmp" && mv -f "${HEARTBEAT_FILE}.tmp" "${HEARTBEAT_FILE}" 2>/dev/null; }
           heartbeat_tee() {
             local outfile="${1:-}"
             if [ -n "$outfile" ]; then
@@ -526,9 +526,11 @@ jobs:
           }
           heartbeat_stop() {
             [ -n "${HEARTBEAT_WATCHDOG_PID:-}" ] && { kill "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null; wait "${HEARTBEAT_WATCHDOG_PID}" 2>/dev/null || true; }; HEARTBEAT_WATCHDOG_PID=""
-            [ -n "${HEARTBEAT_FILE:-}" ] && rm -f "${HEARTBEAT_FILE}"; HEARTBEAT_FILE=""
+            [ -n "${HEARTBEAT_FILE:-}" ] && rm -f "${HEARTBEAT_FILE}" "${HEARTBEAT_FILE}.tmp"; HEARTBEAT_FILE=""
           }
           ( while true; do sleep 10; now="$(date +%s)"; last="$(cat "${HEARTBEAT_FILE}" 2>/dev/null || echo "$now")"
+            # Guard against empty/corrupt reads from race condition
+            [[ "${last}" =~ ^[0-9]+$ ]] || last="${now}"
             [ $(( now - last )) -ge "${_HB_IDLE}" ] && echo "" >&2 && echo "::error::heartbeat: no output for $(( now - last ))s (limit: ${_HB_IDLE}s) — terminating" >&2 && kill -TERM "$$" 2>/dev/null && sleep 10 && kill -KILL "$$" 2>/dev/null && exit 142
             [ $(( now - _HEARTBEAT_START_TIME )) -ge "${_HB_WALL}" ] && echo "" >&2 && echo "::error::heartbeat: max wall time ${_HB_WALL}s exceeded — terminating" >&2 && kill -TERM "$$" 2>/dev/null && sleep 10 && kill -KILL "$$" 2>/dev/null && exit 143
           done ) &


### PR DESCRIPTION
## Summary
- Fix non-atomic heartbeat file writes in `clarify.yml`, `implement.yml`, and `plan.yml` that cause a race condition between the writer (`heartbeat_touch`) and the reader (watchdog loop)
- The `>` operator truncates the file before writing; if the watchdog reads during that window, it gets an empty string → bash treats it as `0` → `now - 0 ≈ 1.7 billion seconds` → exceeds 900s idle limit → process killed immediately
- Applied the same atomic temp-file + `mv` pattern and numeric validation guard already present in `review_autofix.yml`

## Root Cause

The implement workflow failed with:
```
heartbeat: no output for 1774411856s (limit: 900s) — terminating
```

The ~1.7B second value is the current Unix epoch, meaning `last` was read as empty/0 due to the race condition in `heartbeat_touch()`.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/implement.yml` | Atomic heartbeat write + numeric guard |
| `.github/workflows/clarify.yml` | Atomic heartbeat write + numeric guard |
| `.github/workflows/plan.yml` | Atomic heartbeat write + numeric guard |

## Test plan
- [x] Validated heartbeat logic locally (atomic write, empty guard, corrupt guard all pass)
- [x] YAML syntax validated for all three files
- [ ] Verify next implement/clarify/plan workflow run no longer hits spurious idle timeout

https://claude.ai/code/session_014VF2czqzmkg8w9kDXyTe4d