### PR TITLE
Fix review workflow re-trigger loop causing smoke test timeout

### DIFF
--- a/.github/workflows/internal-review.yml
+++ b/.github/workflows/internal-review.yml
@@ -10,7 +10,32 @@ permissions:
   issues: write
 
 jobs:
+  # Gate: skip review when the triggering commit was pushed by the review
+  # workflow itself (commit message starts with "[ai-autofix]"). Without this
+  # guard, each autofix push fires a `synchronize` event that re-triggers the
+  # review, creating an infinite loop.
+  check-skip:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.check.outputs.skip }}
+    steps:
+      - name: Check if head commit is an autofix commit
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          COMMIT_MSG=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}" \
+            --jq '.commit.message' 2>/dev/null || echo "")
+          if echo "$COMMIT_MSG" | head -1 | grep -q '^\[ai-autofix\]'; then
+            echo "Head commit is an autofix commit — skipping review to avoid re-trigger loop"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
   review:
+    needs: [check-skip]
+    if: needs.check-skip.outputs.should_skip != 'true'
     uses: ./.github/workflows/review_autofix.yml
     with:
       allow_workflow_edits: ${{ vars.ALLOW_WORKFLOW_EDITS == 'true' }}


### PR DESCRIPTION
## Summary

- The review workflow (`internal-review.yml`) triggers on `pull_request: synchronize`, which fires when new commits are pushed to the PR branch
- When the review workflow pushes `[ai-autofix]` commits, this re-triggers itself in an infinite loop
- The smoke test in `test-and-mark-stable.yml` times out (30min) waiting for the review to complete because new review runs keep spawning (observed: run `23525618855` → run `23526032709`)
- **Fix:** Add a `check-skip` gate job that inspects the head commit message — if it starts with `[ai-autofix]`, the review job is skipped, breaking the loop

## Test plan

- [ ] Run the "Test & Mark Stable Release" workflow and verify the review phase completes without timeout
- [ ] Verify that normal PRs (non-autofix commits) still trigger the review workflow
- [ ] Verify that autofix commits pushed by the review workflow do NOT re-trigger a new review run

https://claude.ai/code/session_01GVisP849cCwqKedYZKeZRa