### PR TITLE
fix: unconditionally delete workflow artifacts before commit

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -647,20 +647,12 @@ jobs:
             exit 0
           fi
 
-          # Remove workflow-generated/fetched artifacts so they are not committed.
-          # This list must cover ALL files fetched from coding-workflows by ANY
-          # reusable workflow so that caller repos never accidentally commit them.
+          # Remove ALL workflow-generated/fetched artifacts unconditionally so
+          # they are never committed to caller repos.
           rm -f ./pre_assembled_static.txt
-          for f in codex_system_instructions.md ai_pipeline.md unattended_llm_system_instructions.md agents.md; do
-            [ -n "$(git ls-files "${f}")" ] || rm -f "${f}"
-          done
-          for f in setup_serena.sh git_ref_health_check.sh serena_efficiency_report.py generate_symbol_diff_summary.py; do
-            [ -n "$(git ls-files "scripts/${f}")" ] || rm -f "scripts/${f}"
-          done
-          # Remove .serena/ directory created by setup_serena.sh (if not already tracked)
-          if [ -d .serena ] && [ -z "$(git ls-files .serena)" ]; then
-            rm -rf .serena
-          fi
+          rm -f codex_system_instructions.md ai_pipeline.md unattended_llm_system_instructions.md agents.md
+          rm -f scripts/setup_serena.sh scripts/git_ref_health_check.sh scripts/serena_efficiency_report.py scripts/generate_symbol_diff_summary.py
+          rm -rf .serena
 
           git config user.name "codex-bot"
           git config user.email "codex@users.noreply.github.com"

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1823,20 +1823,12 @@ jobs:
             git clean -f -d -- .github/workflows || true
           fi
 
-          # Remove workflow-generated/fetched artifacts so they are not committed.
-          # This list must cover ALL files fetched from coding-workflows by ANY
-          # reusable workflow so that caller repos never accidentally commit them.
+          # Remove ALL workflow-generated/fetched artifacts unconditionally so
+          # they are never committed to caller repos.
           rm -f ./pre_assembled_static.txt
-          for f in codex_system_instructions.md ai_pipeline.md unattended_llm_system_instructions.md agents.md; do
-            [ -n "$(git ls-files "${f}")" ] || rm -f "${f}"
-          done
-          for f in setup_serena.sh git_ref_health_check.sh serena_efficiency_report.py generate_symbol_diff_summary.py; do
-            [ -n "$(git ls-files "scripts/${f}")" ] || rm -f "scripts/${f}"
-          done
-          # Remove .serena/ directory created by setup_serena.sh (if not already tracked)
-          if [ -d .serena ] && [ -z "$(git ls-files .serena)" ]; then
-            rm -rf .serena
-          fi
+          rm -f codex_system_instructions.md ai_pipeline.md unattended_llm_system_instructions.md agents.md
+          rm -f scripts/setup_serena.sh scripts/git_ref_health_check.sh scripts/serena_efficiency_report.py scripts/generate_symbol_diff_summary.py
+          rm -rf .serena
 
           git config user.name "codex-bot"
           git config user.email "codex@users.noreply.github.com"
@@ -2121,20 +2113,12 @@ jobs:
             git checkout -- .github/workflows || true
           fi
 
-          # Remove workflow-generated/fetched artifacts so they are not committed.
-          # This list must cover ALL files fetched from coding-workflows by ANY
-          # reusable workflow so that caller repos never accidentally commit them.
+          # Remove ALL workflow-generated/fetched artifacts unconditionally so
+          # they are never committed to caller repos.
           rm -f ./pre_assembled_static.txt
-          for f in codex_system_instructions.md ai_pipeline.md unattended_llm_system_instructions.md agents.md; do
-            [ -n "$(git ls-files "${f}")" ] || rm -f "${f}"
-          done
-          for f in setup_serena.sh git_ref_health_check.sh serena_efficiency_report.py generate_symbol_diff_summary.py; do
-            [ -n "$(git ls-files "scripts/${f}")" ] || rm -f "scripts/${f}"
-          done
-          # Remove .serena/ directory created by setup_serena.sh (if not already tracked)
-          if [ -d .serena ] && [ -z "$(git ls-files .serena)" ]; then
-            rm -rf .serena
-          fi
+          rm -f codex_system_instructions.md ai_pipeline.md unattended_llm_system_instructions.md agents.md
+          rm -f scripts/setup_serena.sh scripts/git_ref_health_check.sh scripts/serena_efficiency_report.py scripts/generate_symbol_diff_summary.py
+          rm -rf .serena
 
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "codex-bot"


### PR DESCRIPTION
## Summary

- Replace conditional `git ls-files` cleanup checks with unconditional `rm -f` / `rm -rf` in all 3 commit points across `review_autofix.yml` (2 locations) and `implement.yml` (1 location)
- Prevents `.serena/project.yml`, `scripts/setup_serena.sh`, and other fetched CI artifacts from ever being committed to caller repos

## Problem

The old cleanup logic only removed files that weren't tracked by git:
```bash
[ -n "$(git ls-files "${f}")" ] || rm -f "${f}"
```
This meant if a caller repo happened to track any of these files, they'd survive cleanup and get pushed with AI changes. Since these files are always fetched fresh from `coding-workflows` during CI, they should never be committed regardless.

## Test plan

- [ ] Trigger a review_autofix workflow on a caller repo and verify no `.serena/` or `scripts/setup_serena.sh` files appear in the commit
- [ ] Trigger an implement workflow and verify the same
- [ ] Verify the AI autofix and conflict resolution paths still work correctly

https://claude.ai/code/session_01GBjNhn7DganMaEizthCwZM