### PR TITLE
Fix YAML formatting in Serena setup script language block

### DIFF
--- a/scripts/setup_serena.sh
+++ b/scripts/setup_serena.sh
@@ -423,9 +423,11 @@ else
 	# files). Replace the languages block with the freshly detected set so
 	# Serena indexes all file types and provides accurate symbol resolution.
 	# Use awk to replace the languages: block in-place.
+	# Note: command substitution strips trailing newlines, so we append \n
+	# to ensure the last language entry doesn't merge with the next YAML key.
 	_NEW_LANGS="$(printf '%b' "${LANG_YAML}")"
 	awk -v new_langs="${_NEW_LANGS}" '
-		/^languages:/ { print; printf "%s", new_langs; skip=1; next }
+		/^languages:/ { print; printf "%s\n", new_langs; skip=1; next }
 		skip && /^[^ ]/ { skip=0 }
 		skip && /^  - / { next }
 		!skip { print }


### PR DESCRIPTION
## Summary
Fixed a YAML formatting issue in the Serena setup script where the languages block was not properly terminated with a newline, causing the last language entry to merge with the next YAML key.

## Key Changes
- Added newline character (`\n`) to the `printf` statement when inserting the new languages block into the YAML configuration
- Updated the comment to clarify that command substitution strips trailing newlines and explain why the newline is necessary

## Implementation Details
The issue occurred because `printf '%b'` without an explicit newline at the end would cause the last language entry to be concatenated directly with the following YAML key on the same line, breaking the YAML structure. By changing `printf "%s"` to `printf "%s\n"`, we ensure proper YAML formatting where each block is properly separated.

https://claude.ai/code/session_01Sk1WwHJvosddHsZGBVDGNF