### PR TITLE
Fix grep -c arithmetic error in E2E smoke test review polling

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -337,8 +337,13 @@ jobs:
                     --jq '.jobs[0].id // empty' 2>/dev/null || echo "")
                   if [ -n "$JOB_ID" ]; then
                     LOG_CONTENT=$(gh api "repos/${TEST_REPO}/actions/jobs/${JOB_ID}/logs" 2>/dev/null || echo "")
-                    SUCCEEDED=$(echo "$LOG_CONTENT" | grep -c "Reviewer .* succeeded" || echo "0")
-                    FAILED_R=$(echo "$LOG_CONTENT" | grep -c "Reviewer .* failed after" || echo "0")
+                    SUCCEEDED=$(echo "$LOG_CONTENT" | grep -c "Reviewer .* succeeded" || true)
+                    FAILED_R=$(echo "$LOG_CONTENT" | grep -c "Reviewer .* failed after" || true)
+                    # Sanitize: grep -c may produce empty output on binary/corrupt logs
+                    SUCCEEDED="${SUCCEEDED:-0}"; SUCCEEDED="${SUCCEEDED##*$'\n'}"
+                    FAILED_R="${FAILED_R:-0}"; FAILED_R="${FAILED_R##*$'\n'}"
+                    [[ "$SUCCEEDED" =~ ^[0-9]+$ ]] || SUCCEEDED=0
+                    [[ "$FAILED_R" =~ ^[0-9]+$ ]] || FAILED_R=0
                     TOTAL_DONE=$((SUCCEEDED + FAILED_R))
                     # Check: succeeded > 50% of finished reviewers, and at least 3 succeeded
                     if [ "$SUCCEEDED" -ge 3 ] && [ $((SUCCEEDED * 2)) -gt "$TOTAL_DONE" ]; then


### PR DESCRIPTION
grep -c outputs "0" but exits with code 1 when no matches are found.
The `|| echo "0"` fallback then appends a second "0", producing "0\n0"
which causes a bash arithmetic syntax error on the TOTAL_DONE line.

Fix: use `|| true` and add sanitization to handle edge cases with
binary log content or unexpected grep output.

https://claude.ai/code/session_01J5pcvygVqfazzhVP3uuUgv