### PR TITLE
Speed up smoke tests and fix Telegram notifications

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -414,14 +414,33 @@ jobs:
           echo "BASE_BRANCH=${BASE_REF}" >> "$GITHUB_ENV"
 
       - name: Detect smoke test and tune LLM settings
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           set -euo pipefail
           PR_TITLE=$(jq -r '.title // ""' "${PR_PAYLOAD_FILE}")
           PR_BODY=$(jq -r '.body // ""' "${PR_PAYLOAD_FILE}")
 
-          # Detect E2E smoke test PRs by title or linked issue title
+          IS_SMOKE=false
+
+          # Direct match on PR title/body
           if echo "${PR_TITLE}" | grep -qi '\[E2E Smoke Test\]' \
              || echo "${PR_BODY}" | grep -qi '\[E2E Smoke Test\]'; then
+            IS_SMOKE=true
+          fi
+
+          # Check linked issue title (PR body often contains "issue #N" or issue URL)
+          if [ "$IS_SMOKE" = "false" ]; then
+            ISSUE_NUM=$(echo "${PR_BODY}" | grep -oP '(?:issues/|issue\s*#)(\d+)' | head -1 | grep -oP '\d+' || true)
+            if [ -n "$ISSUE_NUM" ]; then
+              ISSUE_TITLE=$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUM}" --jq '.title // ""' 2>/dev/null || echo "")
+              if echo "${ISSUE_TITLE}" | grep -qi '\[E2E Smoke Test\]'; then
+                IS_SMOKE=true
+              fi
+            fi
+          fi
+
+          if [ "$IS_SMOKE" = "true" ]; then
             echo "🔬 Smoke test PR detected — switching to low reasoning effort and reduced reviewer set"
             echo "REVIEWER_REASONING_EFFORT=low" >> "$GITHUB_ENV"
             echo "EDITOR_REASONING_EFFORT=low" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

- **Smoke test detection in `review_autofix.yml`**: Auto-detects smoke test PRs by resolving the linked issue number from the PR body and checking the issue title for `[E2E Smoke Test]`. When detected, overrides reasoning effort to `low` for both reviewers and editors, and reduces reviewer models from 7 to 2 fast ones (gemini-3-flash, gpt-5-mini).
- **Combined Telegram notification**: Moved TG alerts from the `e2e-smoke-test` job to a new `notify` job that runs after all jobs (`e2e-smoke-test`, `validate`, `release`) with `if: always()`. Previously, failures in `validate` or `release` produced no alert.
- **Faster polling**: `phase_timeout` 30→15 min, `POLL_INTERVAL` 30→10s, job timeout 150→75 min, review initial sleep 15→5s.

## Test plan

- [ ] Run E2E smoke test and verify review phase uses only 2 models with low reasoning
- [ ] Verify smoke test completes in ~5-8 minutes instead of 30+
- [ ] Verify Telegram alert fires after all jobs complete (including on validate/release failure)
- [ ] Verify normal (non-smoke-test) PRs still use full 7 models with xhigh reasoning

https://claude.ai/code/session_01RTYrZP8YEzbBG5Pp2tTfvy