### PR TITLE
Add CLAUDE.md based on codex_system_instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,215 @@
+# CLAUDE.md — Project Instructions
+
+These instructions are **mandatory** and must be followed **before any action**.
+
+---
+
+## PRE-TASK MANDATORY CONTEXT LOADING
+
+Before any task, read:
+- `README.md`
+- `agents.md`
+- all `/db/contracts/*.yml` (or `.json`) relevant to collections that may be touched
+
+If any are missing or unclear: **STOP and ask using the mandatory Q/A format.**
+Never assume undocumented behavior.
+
+---
+
+## 0. Prime Directive (NON-NEGOTIABLE)
+
+If you are **not 100% certain** the outcome matches the user's expectations:
+**STOP. ASK. DO NOT PROCEED.** — even if the task looks trivial or the intent seems obvious.
+
+---
+
+## 1. Core Priorities (Strict Order)
+
+1. Security
+2. Correctness & safety
+3. Backward compatibility
+4. Operational clarity
+5. Performance
+6. Speed
+
+---
+
+## 2. Always-On Ask-First Mode
+
+Ambiguity is a **hard stop**.
+
+Before asking questions:
+- Restate your understanding of the task
+- Study the repo to avoid avoidable questions
+- Identify all blocking uncertainties
+
+Ask clarifying questions **before** modifying code, schemas, configs, scripts, docs, migrations, or infrastructure.
+
+### Clarification Batching
+Ask **all known questions in a single batch**. Follow-ups only if answers introduce new ambiguity.
+
+### Mandatory Question Format
+
+Use stable identifiers `Q1`, `Q2`, etc. with letter-only answers (`A`, `B`, `C`, or `A+C`).
+
+**Format:**
+
+> **Q1: \<question\>**
+>
+> Choices:
+> - **A** — \<description\> (RECOMMENDED)
+> - **B** — \<description\>
+> - **C** — \<description\>
+>
+> Reply: `Q1: A`
+
+Rules:
+- One decision per Q-ID. Never bundle multiple decisions.
+- Mark at least one option `(RECOMMENDED)`.
+- Do NOT use numeric question numbering (1, 2, 3) — only Q-IDs.
+- If multiple selections allowed, state explicitly.
+
+### When to Ask
+
+Ask if **any** of these are unclear:
+- **Scope:** which repo/module/service, runtime vs batch, prod/staging/dev
+- **Behavior:** expected behavior, edge cases, failure handling, safety constraints
+- **Interfaces:** API/CLI/env vars, backward compatibility, logging/observability
+- **Data/MongoDB:** collections, uniqueness rules, index contracts
+- **Operations:** timing, concurrency, rollback/recovery
+
+### Forbidden
+- Guessing intent or applying "reasonable defaults" without confirmation
+- Silent refactors, cleanups, or speculative fixes
+
+---
+
+## 3. Production Code Assumptions
+
+All code is production-bound. Verify: logic correctness, error paths, race conditions, idempotency, deployment safety.
+
+---
+
+## 4. Environment Variables
+
+- Always provide defaults for new env vars unless explicitly told otherwise.
+- Preserve all existing env var names.
+
+---
+
+## 5. Minimal Change Set
+
+- Do NOT change formats, types, or unrelated logic.
+- Do NOT reformat files unless required for the fix.
+- Do NOT create test scripts unless asked.
+- Extend existing mechanisms — never compete with them.
+
+---
+
+## 6. Backward Compatibility / Naming Immutability
+
+NEVER rename, remove, or repurpose existing identifiers (variables, functions, classes, modules, CLI flags, env vars, URL paths, JSON/DB fields, index/event/metric names, log keys) without asking first and detailing current usage.
+
+All renames are **breaking changes**. If a new name is needed:
+- Add alongside the old one, accept both inputs, preserve old outputs, document aliases.
+
+---
+
+## 7. Output Requirements
+
+In every final response:
+- List all files changed with line ranges of major logic changes (skip formatting-only)
+- If behavior changes: update `README.md` / `agents.md` with env vars, DB behavior, indexes, operational steps, failure modes
+
+---
+
+## 8. Debugging & Diagnostics
+
+If a problem's cause is unclear: add **diagnostic logging first**, not speculative fixes.
+Logging must be structured, searchable, with context keys.
+
+---
+
+## 9. Code Style
+
+- **Tabs** for indentation
+- Opening braces on a **new line**
+
+---
+
+## 10. MongoDB Rules
+
+### A) DB Contract
+One contract per collection at `/db/contracts/<collection>.yml`. Must include: collection name, indexes (keys, uniqueness, partials, collation), purpose, business invariants, write entrypoints. Any query/write change must update the contract.
+
+### B) Index Registry
+Single shared index module (e.g. `ensureIndexes`). No ad-hoc `createIndex` calls.
+
+### C) Runtime Index Creation
+Use distributed lock via `_locks` collection with lease expiry. Compare indexes by name+keys+options. Never silently drop/recreate in prod.
+
+### D) Unique Index Safety
+Explicit null/missing/empty rules. Prefer partial unique indexes. Preflight duplicate detection. Treat E11000 as expected in races.
+
+### E) Idempotency
+Require idempotency keys backed by unique indexes. Prefer atomic upserts.
+
+### F) Transactions
+Use sparingly, retry transient errors, keep scope minimal.
+
+### G) Query/Index Alignment
+Every query must have a matching index or documented justification.
+
+### H) Operational Safety
+Document index timing, expected output, failure modes, rollout considerations.
+
+---
+
+## 11. Task Checklist Completion Gate
+
+When a user provides a task list for execution, convert it to a checklist.
+
+Rules:
+- Track and update checklist visibly in conversation
+- Mark items complete only after work is done or user confirms
+- Map every task; never skip or silently drop items
+- Complete all non-PR items before creating a PR (unless user approves splitting)
+- If blocked: report failure, keep item open, await direction
+
+---
+
+## 12. PR Review Mode
+
+When reviewing PR feedback: apply only explicitly requested changes.
+
+### Intent Preservation (NON-NEGOTIABLE)
+- Do NOT deviate from original project intent
+- Do NOT introduce new goals, scope, abstractions, or behaviors unless approved
+- Treat existing implementation as intentional
+
+### Ambiguous Feedback
+If feedback could change behavior, broaden/narrow scope, or alter semantics: **STOP and ask (Q/A format)** before acting.
+
+### Forbidden
+- "Improving" design beyond the comment
+- Refactoring for elegance or style
+- Applying suggestions that conflict with existing behavior without surfacing the conflict
+
+### Acceptance Criteria
+After changes: original intent preserved, behavior unchanged unless approved, backward compatible, no new assumptions, changes traceable to PR comments. If no changes needed: reply "No changes are needed."
+
+---
+
+## 13. Repository Hygiene
+
+- Never write into `.git/**` (no artifacts, caches, or bytecode).
+- Set `PYTHONDONTWRITEBYTECODE=1` for Python tooling on repo files.
+- Treat `__pycache__`/`*.pyc` under `.git/` as invalid state.
+
+---
+
+## FINAL REMINDER
+
+If uncertainty exists: **ASK (multiple-choice). DO NOT EXECUTE.**
+
+Accuracy > speed. Safety > convenience. Backward compatibility is mandatory.


### PR DESCRIPTION
Adapts the existing codex_system_instructions.md into a CLAUDE.md file
for Claude Code. Removes Serena/MCP-specific and Codex-specific sections
while preserving all project rules: ask-first mode, production code
assumptions, minimal change set, backward compatibility, MongoDB rules,
code style, and repository hygiene.

https://claude.ai/code/session_01YM5KPeWFuUa9TKt1fYQmmk