### PR TITLE
Auto-increment version in release workflows

### DIFF
--- a/.github/workflows/mark-stable.yml
+++ b/.github/workflows/mark-stable.yml
@@ -44,6 +44,10 @@ jobs:
           INPUT_VERSION="${{ inputs.version_tag }}"
 
           if [ -n "$INPUT_VERSION" ]; then
+            if [[ ! "$INPUT_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Provided version '${INPUT_VERSION}' is invalid; must match vX.Y.Z"
+              exit 1
+            fi
             echo "Using user-provided version: ${INPUT_VERSION}"
             echo "version=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -67,6 +67,10 @@ jobs:
           INPUT_VERSION="${{ inputs.version_tag }}"
 
           if [ -n "$INPUT_VERSION" ]; then
+            if [[ ! "$INPUT_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Provided version '${INPUT_VERSION}' is invalid; must match vX.Y.Z"
+              exit 1
+            fi
             echo "Using user-provided version: ${INPUT_VERSION}"
             echo "version=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
             exit 0
@@ -690,6 +694,7 @@ jobs:
     needs: [resolve-version, e2e-smoke-test]
     if: >-
       always() &&
+      needs.resolve-version.result == 'success' &&
       (needs.e2e-smoke-test.result == 'success' || needs.e2e-smoke-test.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
Add a resolve-version job to both mark-stable.yml and
test-and-mark-stable.yml that automatically computes the next patch
version from the latest vX.Y.Z tag when the version_tag input is left
blank. Users can still manually specify a version to override the
auto-increment.

https://claude.ai/code/session_015KqEtxXoMqRi5hxruRfc11