### PR TITLE
Document concurrency configuration warning for reusable workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ jobs:
     secrets: inherit
 ```
 
+> **Warning — do NOT add a top-level `concurrency` block to this wrapper.**
+> The reusable workflow already manages concurrency at the job level. Adding a
+> workflow-level `concurrency` group with the same key (e.g.
+> `pr-autofix-${{ github.event.pull_request.number }}`) causes a deadlock:
+> the caller holds the lock while the called job waits for it, and GitHub
+> Actions cancels the run. If you need to customize the concurrency group,
+> do so only inside the reusable workflow, not in the caller.
+
 **`.github/workflows/ai-issue-pr-status.yml`** — Syncs issue labels when PRs are merged/closed
 ```yaml
 name: AI Issue PR Status


### PR DESCRIPTION
## Summary
Added documentation warning about concurrency configuration when using the reusable workflow wrapper to prevent potential deadlocks in GitHub Actions.

## Changes
- Added a warning block in README.md explaining why a top-level `concurrency` block should NOT be added to the caller workflow
- Documented the deadlock scenario: when both the caller and reusable workflow define concurrency with the same key, the caller holds the lock while the called job waits for it, causing GitHub Actions to cancel the run
- Clarified that concurrency customization should only be done inside the reusable workflow itself, not in the caller

## Details
This is a documentation-only change that helps users avoid a common misconfiguration that would result in workflow failures. The warning is placed immediately after the example workflow configuration to catch users before they make this mistake.

https://claude.ai/code/session_011jW8SQvwY9SJ6ENYkphjHn