### PR TITLE
Implement iteration limit for autofix loop prevention

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -502,20 +502,36 @@ jobs:
           echo "CAN_PUSH=true" >> "$GITHUB_ENV"
           echo "TARGET_BRANCH=${HEAD_REF}" >> "$GITHUB_ENV"
 
-      - name: Check for autofix re-trigger
+      - name: Count autofix iterations
         id: retrigger_guard
+        env:
+          MAX_AUTOFIX_ITERATIONS: ${{ vars.MAX_AUTOFIX_ITERATIONS || '3' }}
         run: |
           set -euo pipefail
-          HEAD_MSG="$(git log -1 --format='%s' HEAD 2>/dev/null || true)"
-          if echo "${HEAD_MSG}" | grep -q '^\[ai-autofix\]'; then
-            echo "Head commit is an autofix commit — skipping review/editor to avoid re-trigger loop."
-            echo "is_autofix_retrigger=true" >> "$GITHUB_OUTPUT"
+
+          # Count consecutive [ai-autofix] commits from HEAD backwards.
+          autofix_count=0
+          while true; do
+            msg="$(git log -1 --format='%s' "HEAD~${autofix_count}" 2>/dev/null || true)"
+            if echo "${msg}" | grep -q '^\[ai-autofix\]'; then
+              autofix_count=$((autofix_count + 1))
+            else
+              break
+            fi
+          done
+
+          echo "Consecutive autofix commits: ${autofix_count} (max: ${MAX_AUTOFIX_ITERATIONS})"
+          echo "autofix_iteration=${autofix_count}" >> "$GITHUB_OUTPUT"
+
+          if [ "${autofix_count}" -ge "${MAX_AUTOFIX_ITERATIONS}" ]; then
+            echo "Max autofix iterations reached — skipping review/editor."
+            echo "max_iterations_reached=true" >> "$GITHUB_OUTPUT"
           else
-            echo "is_autofix_retrigger=false" >> "$GITHUB_OUTPUT"
+            echo "max_iterations_reached=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Generate diff context
-        if: steps.retrigger_guard.outputs.is_autofix_retrigger != 'true'
+        if: steps.retrigger_guard.outputs.max_iterations_reached != 'true'
         run: |
           set -euo pipefail
 
@@ -677,7 +693,7 @@ jobs:
           } > "${RUNTIME_CONTEXT_DIR}/run_logs_best_effort.txt" || true
 
       - name: Run reviewer models
-        if: steps.retrigger_guard.outputs.is_autofix_retrigger != 'true'
+        if: steps.retrigger_guard.outputs.max_iterations_reached != 'true'
         id: reviewers
         run: |
           set -euo pipefail
@@ -1302,7 +1318,7 @@ jobs:
           echo "REVIEWERS_SUCCESSFUL=${reviewers_successful}" >> "$GITHUB_ENV"
 
       - name: Filter reviewer issues by consensus
-        if: steps.retrigger_guard.outputs.is_autofix_retrigger != 'true'
+        if: steps.retrigger_guard.outputs.max_iterations_reached != 'true'
         run: |
           set -euo pipefail
 
@@ -1342,14 +1358,14 @@ jobs:
           } > "${REVIEWER_CONSENSUS_FILE}"
 
       - name: Switch reasoning effort for editor
-        if: steps.retrigger_guard.outputs.is_autofix_retrigger != 'true'
+        if: steps.retrigger_guard.outputs.max_iterations_reached != 'true'
         run: |
           set -euo pipefail
           sed -i "s/model_reasoning_effort = \"${REVIEWER_REASONING_EFFORT}\"/model_reasoning_effort = \"${EDITOR_REASONING_EFFORT}\"/" ~/.codex/config.toml
           echo "Updated reasoning effort from ${REVIEWER_REASONING_EFFORT} to ${EDITOR_REASONING_EFFORT} for editor phase"
 
       - name: Apply fixes with editor model
-        if: steps.retrigger_guard.outputs.is_autofix_retrigger != 'true'
+        if: steps.retrigger_guard.outputs.max_iterations_reached != 'true'
         run: |
           set -euo pipefail
 
@@ -1866,7 +1882,7 @@ jobs:
             }
 
       - name: Commit changes
-        if: steps.retrigger_guard.outputs.is_autofix_retrigger != 'true'
+        if: steps.retrigger_guard.outputs.max_iterations_reached != 'true'
         id: commit_changes
         run: |
           set -euo pipefail
@@ -2038,7 +2054,7 @@ jobs:
           fi
 
       - name: Post editor summary comment
-        if: always() && steps.retrigger_guard.outputs.is_autofix_retrigger != 'true'
+        if: always() && steps.retrigger_guard.outputs.max_iterations_reached != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
@@ -2097,7 +2113,7 @@ jobs:
 
 
       - name: Detect merge conflicts
-        if: success() && steps.retrigger_guard.outputs.is_autofix_retrigger != 'true' && steps.commit_changes.outputs.did_commit != 'true' && env.CAN_PUSH == 'true'
+        if: success() && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && steps.commit_changes.outputs.did_commit != 'true' && env.CAN_PUSH == 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
@@ -2136,7 +2152,7 @@ jobs:
           fi
 
       - name: Resolve merge conflicts with Codex
-        if: success() && steps.retrigger_guard.outputs.is_autofix_retrigger != 'true' && steps.commit_changes.outputs.did_commit != 'true' && env.CAN_PUSH == 'true' && env.MERGE_CONFLICT == 'true'
+        if: success() && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && steps.commit_changes.outputs.did_commit != 'true' && env.CAN_PUSH == 'true' && env.MERGE_CONFLICT == 'true'
         run: |
           set -euo pipefail
 
@@ -2247,7 +2263,7 @@ jobs:
             --data-urlencode "text=${MSG}"
 
       - name: Mark linked issues ready to merge
-        if: success() && (steps.retrigger_guard.outputs.is_autofix_retrigger == 'true' || (steps.commit_changes.outputs.did_commit != 'true' && env.MERGE_CONFLICT != 'true'))
+        if: success() && (steps.retrigger_guard.outputs.max_iterations_reached == 'true' || (steps.commit_changes.outputs.did_commit != 'true' && env.MERGE_CONFLICT != 'true'))
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           REPOSITORY: ${{ github.repository }}
@@ -2294,7 +2310,7 @@ jobs:
           fi
 
       - name: Telegram success
-        if: success() && (steps.retrigger_guard.outputs.is_autofix_retrigger == 'true' || (steps.commit_changes.outputs.did_commit != 'true' && env.MERGE_CONFLICT != 'true'))
+        if: success() && (steps.retrigger_guard.outputs.max_iterations_reached == 'true' || (steps.commit_changes.outputs.did_commit != 'true' && env.MERGE_CONFLICT != 'true'))
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `AUTO_IMPLEMENT_ON_CLEAR_PLAN` | No | `true` | plan | Auto-trigger implementation when plan is clear |
 | `ALLOW_WORKFLOW_EDITS` | No | `false` | review_autofix | Allow AI edits to `.github/workflows` files |
 | `ENABLE_AUTO_MERGE` | No | `false` | review_autofix, orchestrate_poll | Auto-merge PRs (squash) when review passes. Requires "Allow auto-merge" in repo settings. |
+| `MAX_AUTOFIX_ITERATIONS` | No | `3` | review_autofix | Maximum consecutive autofix rounds before the review loop stops and marks the PR ready to merge. |
 | `TG_ADMIN_CHAT_ID` | No | — | clarify, plan, implement, review_autofix | Telegram chat ID for notifications (pair with `TG_BOT_SECRET`) |
 | `SERENA_VERSION` | No | `main` | clarify, plan, implement, review_autofix | Version/branch of the Serena MCP server |
 | `SERENA_LANGUAGES` | No | `""` (empty) | clarify, plan, implement, review_autofix | Languages for Serena symbol analysis |
@@ -260,6 +261,7 @@ See [`workflow-templates/`](workflow-templates/) in this repository for ready-to
 | `AUTO_IMPLEMENT_ON_CLEAR_PLAN` | `true` | Auto-approve clear plans |
 | `ALLOW_WORKFLOW_EDITS` | `false` | Allow AI edits to workflow files |
 | `ENABLE_AUTO_MERGE` | `false` | Auto-merge PRs (squash) when review passes and checks are green |
+| `MAX_AUTOFIX_ITERATIONS` | `3` | Maximum consecutive autofix rounds before stopping |
 | `AI_MEMORY_BRANCH` | `ai-memory` | Branch used for persistent AI memory |
 | `AI_MEMORY_ROOT` | `ai-memory` | Memory root path used by workflows |
 | `AI_MEMORY_RETRIEVAL_PROFILES` | `ai-memory/config/retrieval_profiles.v1.json` | Retrieval role config |


### PR DESCRIPTION
## Summary
Replace the simple autofix re-trigger detection with a configurable iteration counter that limits consecutive autofix rounds. This prevents infinite loops while allowing multiple fix attempts up to a configurable maximum.

## Key Changes
- **Refactored autofix guard logic**: Changed from binary "is this an autofix commit?" check to counting consecutive `[ai-autofix]` commits from HEAD backwards
- **Added configurable limit**: Introduced `MAX_AUTOFIX_ITERATIONS` variable (default: 3) to control maximum consecutive autofix rounds
- **Updated condition logic**: Changed all workflow step conditions from `is_autofix_retrigger` to `max_iterations_reached` to better reflect the new behavior
- **Updated documentation**: Added `MAX_AUTOFIX_ITERATIONS` to both the configuration variables table and the workflow defaults table in README.md

## Implementation Details
- The iteration counter walks backwards through git history, counting consecutive commits with `[ai-autofix]` prefix
- When the count reaches or exceeds `MAX_AUTOFIX_ITERATIONS`, the workflow skips review/editor phases and marks the PR ready to merge
- This allows the system to attempt multiple fixes while preventing runaway loops
- All 8 conditional steps that previously checked `is_autofix_retrigger` now check `max_iterations_reached` with appropriate logic (negation for skip conditions, direct comparison for success conditions)

https://claude.ai/code/session_017uLtKy5xGZr8MjQnyj7B2t