### PR TITLE
Refactor workflow setup to use standard actions instead of custom runtime

### DIFF
--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -47,18 +47,66 @@ jobs:
           fetch-depth: 1
           token: ${{ secrets.GH_PAT }}
 
-      - name: Setup runtime
-        uses: ./.github/actions/setup-runtime
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          runtime_prefix: codex-orchestrate
-          required_env_csv: OPENROUTER_API_KEY
+          node-version: "22"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Codex CLI and core tools
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          npm install -g "@openai/codex@v0.114.0" --no-audit --no-fund
+
+          missing_tools=()
+          for tool in jq curl gh; do
+            command -v "$tool" >/dev/null 2>&1 || missing_tools+=("$tool")
+          done
+
+          if [ "${#missing_tools[@]}" -gt 0 ]; then
+            if ! command -v apt-get >/dev/null 2>&1; then
+              echo "Missing tools (${missing_tools[*]}), but apt-get is unavailable on this runner" >&2
+              exit 1
+            fi
+
+            apt_cmd=(apt-get)
+            if command -v sudo >/dev/null 2>&1; then
+              apt_cmd=(sudo apt-get)
+            elif [ "$(id -u)" -ne 0 ]; then
+              echo "Missing tools (${missing_tools[*]}), but sudo is unavailable and the current user is not root" >&2
+              exit 1
+            fi
+
+            "${apt_cmd[@]}" update
+            if ! "${apt_cmd[@]}" install -y "${missing_tools[@]}"; then
+              echo "apt-get install failed for: ${missing_tools[*]}" >&2
+              exit 1
+            fi
+          fi
+
+          echo "PYTHONDONTWRITEBYTECODE=1" >> "$GITHUB_ENV"
+
+      - name: Validate required environment variables
+        shell: bash
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+            echo "Missing required environment variables: OPENROUTER_API_KEY" >&2
+            exit 1
+          fi
 
       - name: Create runtime workspace
         run: |
           set -euo pipefail
-          RUNTIME_DIR="/tmp/codex-orchestrate-${GITHUB_RUN_ID}"
+          RUNTIME_DIR="/tmp/codex-orchestrate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           mkdir -p "${RUNTIME_DIR}"
           {
             echo "RUNTIME_DIR=${RUNTIME_DIR}"

--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -31,18 +31,66 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
 
-      - name: Setup runtime
-        uses: ./.github/actions/setup-runtime
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          runtime_prefix: codex-orchestrate-poll
-          required_env_csv: OPENROUTER_API_KEY
+          node-version: "22"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Codex CLI and core tools
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          npm install -g "@openai/codex@v0.114.0" --no-audit --no-fund
+
+          missing_tools=()
+          for tool in jq curl gh; do
+            command -v "$tool" >/dev/null 2>&1 || missing_tools+=("$tool")
+          done
+
+          if [ "${#missing_tools[@]}" -gt 0 ]; then
+            if ! command -v apt-get >/dev/null 2>&1; then
+              echo "Missing tools (${missing_tools[*]}), but apt-get is unavailable on this runner" >&2
+              exit 1
+            fi
+
+            apt_cmd=(apt-get)
+            if command -v sudo >/dev/null 2>&1; then
+              apt_cmd=(sudo apt-get)
+            elif [ "$(id -u)" -ne 0 ]; then
+              echo "Missing tools (${missing_tools[*]}), but sudo is unavailable and the current user is not root" >&2
+              exit 1
+            fi
+
+            "${apt_cmd[@]}" update
+            if ! "${apt_cmd[@]}" install -y "${missing_tools[@]}"; then
+              echo "apt-get install failed for: ${missing_tools[*]}" >&2
+              exit 1
+            fi
+          fi
+
+          echo "PYTHONDONTWRITEBYTECODE=1" >> "$GITHUB_ENV"
+
+      - name: Validate required environment variables
+        shell: bash
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+            echo "Missing required environment variables: OPENROUTER_API_KEY" >&2
+            exit 1
+          fi
 
       - name: Create runtime workspace
         run: |
           set -euo pipefail
-          RUNTIME_DIR="/tmp/codex-orchestrate-poll-${GITHUB_RUN_ID}"
+          RUNTIME_DIR="/tmp/codex-orchestrate-poll-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           mkdir -p "${RUNTIME_DIR}"
           {
             echo "RUNTIME_DIR=${RUNTIME_DIR}"


### PR DESCRIPTION
## Summary
Replaced the custom `setup-runtime` action with explicit setup steps using standard GitHub Actions for Node.js and Python, along with inline tooling installation and validation logic.

## Key Changes
- **Removed custom action**: Replaced `./.github/actions/setup-runtime` with explicit setup steps in both `orchestrate.yml` and `orchestrate_poll.yml` workflows
- **Added Node.js setup**: Integrated `actions/setup-node@v4` with Node.js 22
- **Added Python setup**: Integrated `actions/setup-python@v5` with Python 3.12
- **Inline tool installation**: Created bash script to install Codex CLI (`@openai/codex@v0.114.0`) and verify required tools (jq, curl, gh) with fallback apt-get installation
- **Explicit environment validation**: Replaced implicit validation with explicit bash script that checks for `OPENROUTER_API_KEY` presence
- **Improved runtime directory naming**: Updated `RUNTIME_DIR` to include `${GITHUB_RUN_ATTEMPT}` suffix for better isolation of retry attempts
- **Added Python environment flag**: Set `PYTHONDONTWRITEBYTECODE=1` to prevent bytecode generation

## Implementation Details
- Both workflows now follow identical setup patterns for consistency
- Tool installation includes proper error handling with informative messages
- Gracefully handles different runner environments (with/without sudo, with/without apt-get)
- Environment variable validation is now explicit and testable rather than delegated to a custom action

https://claude.ai/code/session_01RZEs4P9v5fBozngbAuoP74