### PR TITLE
Fix indentation of RETRY_EOF marker in workflow

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -520,7 +520,7 @@ jobs:
           described in the plan. Do NOT just describe the changes — execute them by
           writing to disk. Proceed now.
 
-RETRY_EOF
+          RETRY_EOF
                 cat "${CODEX_PROMPT_FILE}"
               } > "${PROMPT_FILE_TO_USE}"
             fi


### PR DESCRIPTION
## Summary
Fixed incorrect indentation of the `RETRY_EOF` marker in the GitHub Actions workflow file.

## Changes
- Corrected the indentation of `RETRY_EOF` from column 0 to column 10 (matching the surrounding heredoc content indentation)

## Details
The `RETRY_EOF` marker was not properly indented relative to the heredoc content it terminates. This fix ensures consistent indentation within the workflow file and prevents potential parsing issues with the heredoc syntax.

https://claude.ai/code/session_01RZsNMcjdFTkRzVxeoh1zNR