### PR TITLE
Ensure orchestrator tracking label exists before creating issues

### DIFF
--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -319,6 +319,20 @@ jobs:
           # Compute waves for logging
           python3 scripts/orchestrate_lib.py compute-waves --input-file "${DECOMPOSITION_FILE}"
 
+      - name: Ensure orchestrator labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          # The consumer repo may not have the ai:orchestrator-tracking label yet.
+          # gh issue create --label fails if the label does not exist, so create it
+          # idempotently first.
+          gh label create "ai:orchestrator-tracking" \
+            --repo "${{ github.repository }}" \
+            --color "a2eeef" \
+            --description "Orchestrator project tracking issue" \
+            2>/dev/null || true
+
       - name: Create tracking issue
         id: tracking_issue
         env:


### PR DESCRIPTION
## Summary
Added a pre-flight check to ensure the `ai:orchestrator-tracking` GitHub label exists before attempting to create tracking issues. This prevents failures when the orchestrator workflow runs against repositories that don't yet have this label defined.

## Changes
- Added a new workflow step that idempotently creates the `ai:orchestrator-tracking` label if it doesn't already exist
- The label is created with a light blue color (`a2eeef`) and descriptive text
- Uses `gh label create` with error suppression (`2>/dev/null || true`) to gracefully handle cases where the label already exists
- Runs before the "Create tracking issue" step to ensure the label is available

## Implementation Details
- The step uses the `GH_PAT` secret for authentication to ensure proper permissions
- The `set -euo pipefail` ensures the script fails fast on any unexpected errors while allowing the label creation command to fail gracefully
- This approach is idempotent and safe to run multiple times without side effects

https://claude.ai/code/session_015shCxwQpkQp65ecJy88nT6