### PR TITLE
Fix markdown formatting in orchestrate workflow issue output

### DIFF
--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -516,7 +516,7 @@ jobs:
 
           The following issues have been created and are entering the AI pipeline:
 
-          $(echo "${WAVE1_ISSUES}" | jq -r '.issues[] | "- #\(.github_issue) (\`.id\`\(.id)\`)"')
+          $(echo "${WAVE1_ISSUES}" | jq -r '.issues[] | "- #\(.github_issue) (`\(.id)`)"')
 
           The orchestrator poller will monitor progress and dispatch subsequent waves when dependencies are met."
 


### PR DESCRIPTION
## Summary
Fixed incorrect markdown backtick escaping in the GitHub Actions orchestrate workflow that formats issue output for the AI pipeline.

## Changes
- Corrected the jq filter expression in the WAVE1_ISSUES output formatting
- Changed from `\`.id\`\(.id)\`` (incorrect escaped backticks) to `` `\(.id)` `` (proper markdown inline code formatting)
- This ensures issue IDs are properly displayed as inline code in the workflow output message

## Details
The original expression had malformed backtick escaping that would render incorrectly in the GitHub Actions workflow output. The fix uses standard markdown inline code syntax to properly format the issue ID values extracted from the JSON response.

https://claude.ai/code/session_01QDiDkSWhj3KEsRbv8sSasn