### PR TITLE
fix: skip clarify workflow for orchestrator tracking issues

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -14,7 +14,7 @@ name: AI Clarify (Reusable)
 jobs:
   clarify:
     if: >-
-      (github.event_name == 'issues' && github.event.action == 'opened') ||
+      (github.event_name == 'issues' && github.event.action == 'opened' && !contains(toJson(github.event.issue.labels.*.name), 'ai:orchestrator-tracking')) ||
       (github.event_name == 'issue_comment' && github.event.action == 'created' && github.event.issue.pull_request == null && github.event.comment.user.type == 'User' && contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && startsWith(github.event.comment.body, '/reclarify'))
     runs-on: ubuntu-latest
     timeout-minutes: 120


### PR DESCRIPTION
## Summary

- Skip the clarify workflow for issues labeled `ai:orchestrator-tracking`. The tracking issue is a project status dashboard, not an implementation task — running clarify on it wastes an LLM call and can trigger nonsensical plan/implement runs downstream.
- One-line change: added `!contains(toJson(github.event.issue.labels.*.name), 'ai:orchestrator-tracking')` to the `issues.opened` guard in `clarify.yml`.
- The `/reclarify` path is unchanged — no one would `/reclarify` a tracking issue.

## Test plan

- [ ] Create an orchestrator tracking issue (with `ai:orchestrator-tracking` label) — verify clarify does not run
- [ ] Create a normal issue — verify clarify runs as before
- [ ] Run `/reclarify` on a normal issue — verify it still works

https://claude.ai/code/session_01JMMrQ6nAZwpfs7kyL2emSR