### PR TITLE
Add explicit checkout step before orchestrator integration tests

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -422,6 +422,11 @@ jobs:
           exit 1
 
       # ── Phase 5: Orchestrator script integration test ──────────
+      - name: Checkout repository for integration tests
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
       - name: "Phase 5: Orchestrator script integration test"
         id: orchestrator-scripts
         run: |


### PR DESCRIPTION
## Summary
Added an explicit repository checkout step before running the orchestrator script integration tests in the CI workflow to ensure the correct branch state is available for testing.

## Key Changes
- Added a new checkout action step that explicitly checks out the `main` branch before the orchestrator script integration test phase
- This checkout step runs immediately before the "Phase 5: Orchestrator script integration test" step

## Implementation Details
The new checkout step uses `actions/checkout@v5` with an explicit `ref: main` parameter. This ensures that the integration tests run against a known, consistent state of the repository, which may be necessary if previous workflow steps modified the working directory or if the workflow needs to guarantee it's testing against the main branch specifically.

https://claude.ai/code/session_01XqWjD9kNTCyycJNH2U58oL