### PR TITLE
Fix issue label updates in cross-repository workflows

### DIFF
--- a/.github/workflows/issue_pr_status.yml
+++ b/.github/workflows/issue_pr_status.yml
@@ -38,6 +38,6 @@ jobs:
           while IFS= read -r issue_number; do
             [ -n "${issue_number}" ] || continue
             echo "Updating issue #${issue_number} with label ${FINAL_LABEL}"
-            gh issue edit "${issue_number}" --remove-label 'ai:done' --remove-label 'ai:implementing' --remove-label 'ai:awaiting-approval' --remove-label 'ai:planning' --remove-label 'ai:clarification' --remove-label 'ai:ready-to-merge' --remove-label 'ai:merged' --remove-label 'ai:closed' || true
-            gh issue edit "${issue_number}" --add-label "${FINAL_LABEL}"
+            gh issue edit "${issue_number}" -R "${REPOSITORY}" --remove-label 'ai:done' --remove-label 'ai:implementing' --remove-label 'ai:awaiting-approval' --remove-label 'ai:planning' --remove-label 'ai:clarification' --remove-label 'ai:ready-to-merge' --remove-label 'ai:merged' --remove-label 'ai:closed' || true
+            gh issue edit "${issue_number}" -R "${REPOSITORY}" --add-label "${FINAL_LABEL}"
           done <<< "${ISSUE_NUMBERS}"


### PR DESCRIPTION
## Summary
Updated the GitHub CLI commands in the issue/PR status workflow to explicitly specify the repository context when editing issue labels, ensuring the workflow functions correctly in cross-repository scenarios.

## Key Changes
- Added `-R "${REPOSITORY}"` flag to both `gh issue edit` commands that manage issue labels
- This ensures label operations target the correct repository when the workflow runs in a different repository context

## Implementation Details
The workflow was previously relying on implicit repository context, which could cause label updates to fail or target the wrong repository. By explicitly passing the `REPOSITORY` variable via the `-R` flag to the GitHub CLI, the commands now reliably update issues in the intended repository regardless of the workflow's execution context.

https://claude.ai/code/session_0185v1R8dfFUjnarKjCrSU4m