### PR TITLE
Add missing internal wrapper for orchestrate-clarify-respond

### DIFF
--- a/.github/workflows/internal-orchestrate-clarify-respond.yml
+++ b/.github/workflows/internal-orchestrate-clarify-respond.yml
@@ -1,0 +1,14 @@
+name: "Internal: AI Orchestrate Clarify Respond"
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  respond:
+    uses: ./.github/workflows/orchestrate_clarify_respond.yml
+    secrets: inherit


### PR DESCRIPTION
The orchestrator pipeline creates child issues that go through the
clarify phase, but the auto-answer workflow was never wired up in
this repository. Without the internal wrapper, clarification questions
on orchestrator-managed issues sit unanswered indefinitely.

https://claude.ai/code/session_01LMUo4aRX6X8t7pJuZYGMNv