### PR TITLE
Exclude node_modules from git commits in CI workflows

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -691,7 +691,8 @@ jobs:
 
           git config user.name "codex-bot"
           git config user.email "codex@users.noreply.github.com"
-          git add -A
+          git rm -r --cached node_modules 2>/dev/null || true
+          git add -A -- ':!node_modules'
           git commit -m "AI implementation for issue #${ISSUE_NUMBER}"
           echo "did_commit=true" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1964,7 +1964,8 @@ jobs:
 
           git config user.name "codex-bot"
           git config user.email "codex@users.noreply.github.com"
-          git add -A
+          git rm -r --cached node_modules 2>/dev/null || true
+          git add -A -- ':!node_modules'
 
           if git diff --cached --quiet; then
             echo "No repository changes to commit."
@@ -2270,7 +2271,8 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "codex-bot"
             git config user.email "codex@users.noreply.github.com"
-            git add -A
+            git rm -r --cached node_modules 2>/dev/null || true
+            git add -A -- ':!node_modules'
             git commit -m "[ai-autofix] resolve merge conflicts"
             git remote set-url origin https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}
             git push origin "HEAD:${TARGET_BRANCH}"

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@ __pycache__/
 
 .serena/
 
+node_modules/
+
 # Workflow-generated artifacts (created at repo root during CI runs)
 pre_assembled_static.txt


### PR DESCRIPTION
## Summary
This PR prevents the `node_modules` directory from being committed to the repository by updating git staging commands in CI workflows and adding `node_modules/` to `.gitignore`.

## Key Changes
- **Updated `.gitignore`**: Added `node_modules/` to prevent accidental commits of dependencies
- **Modified CI workflows** (`review_autofix.yml` and `implement.yml`): 
  - Changed `git add -A` to explicitly exclude `node_modules` using `git add -A -- ':!node_modules'`
  - Added `git rm -r --cached node_modules` to remove any previously staged `node_modules` directory before staging changes
  - Applied to both the main autofix job and the merge conflict resolution job in `review_autofix.yml`, and the implementation job in `implement.yml`

## Implementation Details
The solution uses two complementary approaches:
1. `git rm -r --cached node_modules 2>/dev/null || true` - Safely removes `node_modules` from the git index if it was previously tracked, with error suppression
2. `git add -A -- ':!node_modules'` - Stages all changes while explicitly excluding the `node_modules` directory from being added

This ensures that even if `node_modules` exists in the working directory, it won't be included in commits made by the bot during automated workflows.

https://claude.ai/code/session_01KYYns3dqdvhSWANRs8MRjr