### PR TITLE
Fix git staging to properly handle untracked files

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -692,7 +692,8 @@ jobs:
           git config user.name "codex-bot"
           git config user.email "codex@users.noreply.github.com"
           git rm -r --cached node_modules 2>/dev/null || true
-          git add -A -- ':!node_modules'
+          git add -u -- ':!node_modules'
+          git ls-files --others --exclude-standard -z -- ':!node_modules' | xargs -0 -r git add --
           git commit -m "AI implementation for issue #${ISSUE_NUMBER}"
           echo "did_commit=true" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1965,7 +1965,8 @@ jobs:
           git config user.name "codex-bot"
           git config user.email "codex@users.noreply.github.com"
           git rm -r --cached node_modules 2>/dev/null || true
-          git add -A -- ':!node_modules'
+          git add -u -- ':!node_modules'
+          git ls-files --others --exclude-standard -z -- ':!node_modules' | xargs -0 -r git add --
 
           if git diff --cached --quiet; then
             echo "No repository changes to commit."
@@ -2272,7 +2273,8 @@ jobs:
             git config user.name "codex-bot"
             git config user.email "codex@users.noreply.github.com"
             git rm -r --cached node_modules 2>/dev/null || true
-            git add -A -- ':!node_modules'
+            git add -u -- ':!node_modules'
+            git ls-files --others --exclude-standard -z -- ':!node_modules' | xargs -0 -r git add --
             git commit -m "[ai-autofix] resolve merge conflicts"
             git remote set-url origin https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}
             git push origin "HEAD:${TARGET_BRANCH}"


### PR DESCRIPTION
## Summary
Updated git staging commands in CI workflows to properly handle both modified and untracked files while excluding node_modules directory.

## Key Changes
- Replaced `git add -A` with a two-step approach:
  - `git add -u` to stage modified and deleted files (excluding node_modules)
  - `git ls-files --others --exclude-standard` piped to `git add` to stage untracked files (excluding node_modules)
- Applied changes across three workflow files:
  - `.github/workflows/review_autofix.yml` (2 occurrences)
  - `.github/workflows/implement.yml` (1 occurrence)

## Implementation Details
The new approach uses `git add -u` for tracked file changes and explicitly lists untracked files using `git ls-files --others --exclude-standard`, which respects .gitignore rules. The `-z` flag with `xargs -0` ensures proper handling of filenames with special characters. This provides more explicit control over which files are staged while maintaining the exclusion of node_modules across both tracked and untracked files.

https://claude.ai/code/session_01GXGFC3Mj2RMf78D4e7EAdS