### PR TITLE
Add adaptive progress-aware watchdog for editor and budget-aware retries

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -131,6 +131,7 @@ jobs:
           mkdir -p "${PREVIOUS_REVIEWS_DIR}" "${RUNTIME_CONTEXT_DIR}"
 
           {
+            echo "JOB_START_EPOCH=$(date +%s)"
             echo "RUNTIME_DIR=${RUNTIME_DIR}"
             echo "PREVIOUS_REVIEWS_DIR=${PREVIOUS_REVIEWS_DIR}"
             echo "RUNTIME_CONTEXT_DIR=${RUNTIME_CONTEXT_DIR}"
@@ -1756,15 +1757,113 @@ jobs:
 
           rm -f "${EDITOR_SUMMARY_FILE}"
 
-          # No per-attempt heartbeat for the editor: GPT with high thinking
-          # can legitimately go quiet for extended periods during reasoning.
-          # The job-level timeout-minutes (180) is the safety net.
+          # ── Adaptive progress-aware watchdog for the editor ──────────
+          # Unlike the reviewer heartbeat (15 min idle kill), the editor uses
+          # a longer idle threshold (20 min) because high-thinking models can
+          # legitimately go quiet during extended reasoning.  Before killing
+          # an idle process the watchdog probes /proc/<pid>/fd for active
+          # network sockets — if the process still has open connections it is
+          # likely waiting on an API response, so the idle window is extended.
+          #
+          # The retry loop is budget-aware: before each attempt it calculates
+          # the remaining time until the job deadline and skips attempts that
+          # cannot complete within the remaining budget.
+          # ──────────────────────────────────────────────────────────────────
+
+          EDITOR_IDLE_TIMEOUT="${EDITOR_IDLE_TIMEOUT:-1200}"   # 20 min
+          EDITOR_MAX_WALL="${EDITOR_MAX_WALL:-3300}"            # 55 min
+          EDITOR_MIN_ATTEMPT_SECS="${EDITOR_MIN_ATTEMPT_SECS:-300}"  # 5 min minimum
+          JOB_TIMEOUT_SECS=$((180 * 60))
+          JOB_DEADLINE=$(( ${JOB_START_EPOCH:-$(date +%s)} + JOB_TIMEOUT_SECS ))
 
           attempt=1
           while [ "${attempt}" -le 3 ]; do
+            now_epoch="$(date +%s)"
+            remaining=$(( JOB_DEADLINE - now_epoch ))
+            if [ "${remaining}" -lt "${EDITOR_MIN_ATTEMPT_SECS}" ]; then
+              echo "Skipping editor attempt ${attempt}: only ${remaining}s remain before job deadline (need ${EDITOR_MIN_ATTEMPT_SECS}s minimum)."
+              break
+            fi
+            # Cap this attempt's wall time to the lesser of EDITOR_MAX_WALL
+            # and the remaining budget minus a 2-min buffer for cleanup steps.
+            attempt_wall="${EDITOR_MAX_WALL}"
+            budget_cap=$(( remaining - 120 ))
+            if [ "${budget_cap}" -lt "${attempt_wall}" ]; then
+              attempt_wall="${budget_cap}"
+              echo "Editor attempt ${attempt}: capping wall time to ${attempt_wall}s (budget-limited, ${remaining}s remain)."
+            fi
+
             tmp_output="$(mktemp)"
             tmp_err="$(mktemp)"
-            if timeout 3300 codex exec --model "${MODEL_EDITOR}" --full-auto < "${EDITOR_PROMPT_FILE}" > "${tmp_output}" 2>"${tmp_err}"; then
+
+            # ── Heartbeat file for progress tracking ──
+            hb_file="$(mktemp /tmp/heartbeat_editor.XXXXXX)"
+            printf '%s' "$(date +%s)" > "${hb_file}.tmp" && mv -f "${hb_file}.tmp" "${hb_file}"
+            editor_start="$(date +%s)"
+            codex_pid_file="$(mktemp /tmp/codex_pid_editor.XXXXXX)"
+
+            # ── Background watchdog: heartbeat + network-activity aware ──
+            (
+              while true; do
+                sleep 15
+                wd_now="$(date +%s)"
+                last="$(cat "${hb_file}" 2>/dev/null || echo "${wd_now}")"
+                if ! [[ "${last}" =~ ^[0-9]+$ ]]; then last="${wd_now}"; fi
+                idle_secs=$(( wd_now - last ))
+                wall_secs=$(( wd_now - editor_start ))
+
+                # Hard wall-time limit (budget-aware)
+                if [ "${wall_secs}" -ge "${attempt_wall}" ]; then
+                  echo "Editor killed — wall time ${attempt_wall}s exceeded (attempt ${attempt})." >&2
+                  cpid="$(cat "${codex_pid_file}" 2>/dev/null || true)"
+                  if [ -n "${cpid}" ]; then kill -TERM "${cpid}" 2>/dev/null; sleep 5; kill -KILL "${cpid}" 2>/dev/null; fi
+                  rm -f "${hb_file}"
+                  exit 143
+                fi
+
+                # Idle check with network-activity probe
+                if [ "${idle_secs}" -ge "${EDITOR_IDLE_TIMEOUT}" ]; then
+                  cpid="$(cat "${codex_pid_file}" 2>/dev/null || true)"
+                  net_active=false
+                  if [ -n "${cpid}" ] && [ -d "/proc/${cpid}/fd" ]; then
+                    sock_count="$(find "/proc/${cpid}/fd" -lname 'socket:*' 2>/dev/null | head -20 | wc -l || echo 0)"
+                    if [ "${sock_count}" -gt 0 ]; then
+                      net_active=true
+                    fi
+                  fi
+                  if [ "${net_active}" = true ]; then
+                    echo "Editor idle for ${idle_secs}s but has ${sock_count} active socket(s) — likely waiting on API, extending." >&2
+                    # Reset heartbeat to grant another idle window
+                    printf '%s' "$(date +%s)" > "${hb_file}.tmp" && mv -f "${hb_file}.tmp" "${hb_file}" 2>/dev/null
+                  else
+                    echo "Editor killed — no output for ${idle_secs}s and no active network connections (idle limit: ${EDITOR_IDLE_TIMEOUT}s, attempt ${attempt})." >&2
+                    if [ -n "${cpid}" ]; then kill -TERM "${cpid}" 2>/dev/null; sleep 5; kill -KILL "${cpid}" 2>/dev/null; fi
+                    rm -f "${hb_file}"
+                    exit 142
+                  fi
+                fi
+              done
+            ) &
+            wd_pid=$!
+
+            # Run codex with stderr-based heartbeat tracking
+            (
+              exec codex exec --model "${MODEL_EDITOR}" --full-auto < "${EDITOR_PROMPT_FILE}"
+            ) > "${tmp_output}" 2> >(
+              while IFS= read -r line || [ -n "$line" ]; do
+                printf '%s' "$(date +%s)" > "${hb_file}.tmp" && mv -f "${hb_file}.tmp" "${hb_file}" 2>/dev/null
+                printf '%s\n' "$line"
+              done > "${tmp_err}"
+            ) &
+            codex_bg_pid=$!
+            echo "${codex_bg_pid}" > "${codex_pid_file}"
+            cmd_rc=0
+            wait "${codex_bg_pid}" 2>/dev/null || cmd_rc=$?
+
+            kill "${wd_pid}" 2>/dev/null; wait "${wd_pid}" 2>/dev/null || true
+            rm -f "${hb_file}" "${hb_file}.tmp" "${codex_pid_file}"
+
+            if [ "${cmd_rc}" -eq 0 ]; then
               cp "${tmp_err}" "${PREVIOUS_REVIEWS_DIR}/editor_attempt_${attempt}.err" 2>/dev/null || true
               if [ -s "${tmp_output}" ] && grep -q '^Changes made:' "${tmp_output}"                 && grep -q '^Already satisfied (suggested but already present):' "${tmp_output}"                 && grep -q '^Ignored suggestions (with short reason):' "${tmp_output}"                 && grep -q '^Reviewer files processed:' "${tmp_output}"                 && grep -q '^Review file issue audit:' "${tmp_output}"                 && ! grep -qiE "I can.?t execute this|need to read|allow read/write shell commands|cannot proceed under the current constraints" "${tmp_output}"; then
                 reviewer_validation_ok=true

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -31,11 +31,19 @@ name: Test & Mark Stable Release
         default: false
       phase_timeout:
         description: >
-          Max minutes to wait for each workflow phase (clarify, plan, implement, review).
+          Max minutes to wait for each workflow phase (clarify, plan, implement).
           Increase for repos with large codebases or slow LLM providers.
         required: false
         type: number
         default: 60
+      review_timeout:
+        description: >
+          Max minutes to wait for the review & autofix phase specifically.
+          Review runs longer than other phases (multiple reviewer models +
+          editor). Falls back to phase_timeout when not set.
+        required: false
+        type: number
+        default: 90
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -100,7 +108,7 @@ jobs:
     needs: [resolve-version]
     if: ${{ !inputs.skip_e2e }}
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    timeout-minutes: 120
     concurrency:
       group: e2e-smoke-test-${{ inputs.test_repo || github.repository }}
       cancel-in-progress: false
@@ -110,6 +118,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_PAT }}
       TEST_REPO: ${{ inputs.test_repo || github.repository }}
       PHASE_TIMEOUT: ${{ inputs.phase_timeout || 15 }}
+      REVIEW_TIMEOUT: ${{ inputs.review_timeout || inputs.phase_timeout || 90 }}
       POLL_INTERVAL: 10
 
     steps:
@@ -325,8 +334,9 @@ jobs:
         run: |
           set -euo pipefail
           echo "Waiting for review workflow on PR #${PR_NUMBER}..."
-          TIMEOUT_SECS=$((PHASE_TIMEOUT * 60))
+          TIMEOUT_SECS=$((REVIEW_TIMEOUT * 60))
           ELAPSED=0
+          echo "Review timeout: ${REVIEW_TIMEOUT} minutes (${TIMEOUT_SECS}s)"
 
           # Give the review workflow a moment to start
           sleep 5

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `SERENA_DISABLED` | No | `false` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll | Disable the Serena MCP server |
 | `WORKFLOW_ORCHESTRATE_MODEL` | No | (falls back to `WORKFLOW_EDITOR_MODEL`) | orchestrate, orchestrate_poll | Model override for orchestrator decomposer and judge |
 | `ORCHESTRATE_POLL_INTERVAL` | No | `10` | orchestrate | Reserved poll interval setting (current poll cadence is controlled by the poller wrapper cron schedule) |
+| `EDITOR_IDLE_TIMEOUT` | No | `1200` | review_autofix | Editor watchdog idle timeout in seconds. The editor is killed if it produces no output for this long and has no active network connections. |
+| `EDITOR_MAX_WALL` | No | `3300` | review_autofix | Maximum wall-clock seconds per editor attempt. Budget-aware: auto-capped to remaining job time minus a 2-min buffer. |
+| `EDITOR_MIN_ATTEMPT_SECS` | No | `300` | review_autofix | Minimum remaining job budget (seconds) required to start an editor attempt. Prevents futile retries near the job deadline. |
 
 **Thinking levels** — control the model's reasoning effort per phase. Valid values: `xhigh`, `high`, `medium`, `low`. Defaults are tuned per phase: `medium` for clarify (gap analysis doesn't need deep reasoning), `xhigh` for plan (architectural decisions benefit from maximum reasoning), `high` for implement (follows an existing plan), and `xhigh` for review (last line of defense for catching bugs).
 
@@ -356,6 +359,9 @@ See [`workflow-templates/`](workflow-templates/) in this repository for ready-to
 | `THINKING_LEVEL_ORCHESTRATE` | `xhigh` | Reasoning effort for project decomposition |
 | `THINKING_LEVEL_JUDGE` | `xhigh` | Reasoning effort for judge evaluation |
 | `ORCHESTRATE_POLL_INTERVAL` | `10` | Reserved poll interval setting (current poll cadence is controlled by the poller wrapper cron schedule) |
+| `EDITOR_IDLE_TIMEOUT` | `1200` | Editor watchdog idle timeout (seconds); killed if no output and no active network connections |
+| `EDITOR_MAX_WALL` | `3300` | Max wall-clock seconds per editor attempt; auto-capped to remaining job budget |
+| `EDITOR_MIN_ATTEMPT_SECS` | `300` | Minimum job budget (seconds) required to start an editor attempt |
 | `TOOL_CALL_BUDGET_ORCHESTRATE` | `40` | Tool call budget for decomposer |
 | `TOOL_CALL_BUDGET_JUDGE` | `60` | Tool call budget for judge (needs deep repo inspection) |
 | `TOKEN_WARN_THRESHOLD_ORCHESTRATE` | `200000` | Token warning threshold for orchestration |


### PR DESCRIPTION
The editor step in review_autofix could hang indefinitely because it used
a bare `timeout 3300` with no heartbeat monitoring. When the codex process
got stuck (dead stream, hung MCP tool, zombie child), the only safety net
was the 180-min job timeout — far too late for the smoke test's 60-min
review window.

Changes:

1. **Editor heartbeat watchdog** (review_autofix.yml):
   - Replaces `timeout 3300` with a background watchdog matching the
     reviewer pattern but tuned for the editor's extended-thinking behavior.
   - 20-min idle threshold (vs reviewer's 15 min) with a secondary
     network-activity probe: before killing an idle process, the watchdog
     checks /proc/<pid>/fd for active sockets. If connections exist, the
     process is likely waiting on an API response and gets an extension.
   - Hard wall-time cap per attempt (default 55 min), auto-reduced to
     fit within remaining job budget.

2. **Budget-aware retry loop** (review_autofix.yml):
   - Records JOB_START_EPOCH at workspace init and computes a deadline.
   - Before each editor attempt, checks remaining time. Skips attempts
     that cannot complete within the budget (default minimum: 5 min).
   - Caps per-attempt wall time to remaining budget minus 2-min buffer
     for cleanup steps. Prevents 3×55 min = 165 min exhausting the
     180-min job timeout.

3. **Configurable smoke test review timeout** (test-and-mark-stable.yml):
   - Adds `review_timeout` input (default 90 min) separate from
     `phase_timeout` (used for clarify/plan/implement).
   - Increases job timeout-minutes from 75 to 120 to accommodate.

New env vars: EDITOR_IDLE_TIMEOUT, EDITOR_MAX_WALL, EDITOR_MIN_ATTEMPT_SECS.

https://claude.ai/code/session_01MouqBpp5jWdCJhagEWEp3M