### PR TITLE
Add model catalog to orchestrator workflows to fix judge activation

### DIFF
--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -138,6 +138,14 @@ jobs:
           gh api -H 'Accept: application/vnd.github.raw+json' \
             "repos/${wf_source}/contents/.github/ai/orchestrate_schema.v1.json?ref=stable" > ".github/ai/orchestrate_schema.v1.json"
           # Fetch canonical instruction files
+          # Model catalog: try stable first, fall back to local copy from checkout.
+          if gh api -H 'Accept: application/vnd.github.raw+json' \
+            "repos/${wf_source}/contents/scripts/codex_model_catalog.json?ref=stable" > "scripts/codex_model_catalog.json.tmp" 2>/dev/null; then
+            mv "scripts/codex_model_catalog.json.tmp" "scripts/codex_model_catalog.json"
+          else
+            rm -f "scripts/codex_model_catalog.json.tmp"
+            echo "Model catalog not on stable tag yet; using local copy."
+          fi
           for f in codex_system_instructions.md ai_pipeline.md; do
             if [ ! -f "${f}" ]; then
               gh api -H 'Accept: application/vnd.github.raw+json' \
@@ -149,11 +157,15 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ~/.codex
+          CATALOG_PATH="$(pwd)/scripts/codex_model_catalog.json"
           {
             echo 'web_search = "live"'
             echo 'model_provider = "openrouter"'
             echo "model = \"${MODEL_EDITOR}\""
             echo "model_reasoning_effort = \"${MODEL_REASONING_EFFORT}\""
+            if [ -f "${CATALOG_PATH}" ]; then
+              echo "model_catalog_json = \"${CATALOG_PATH}\""
+            fi
             echo
             echo '[model_providers.openrouter]'
             echo 'name = "OpenRouter"'

--- a/.github/workflows/orchestrate_clarify_respond.yml
+++ b/.github/workflows/orchestrate_clarify_respond.yml
@@ -96,6 +96,14 @@ jobs:
               "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
             chmod +x "scripts/${f}"
           done
+          # Model catalog: try stable first, fall back to local copy from checkout.
+          if gh api -H 'Accept: application/vnd.github.raw+json' \
+            "repos/${wf_source}/contents/scripts/codex_model_catalog.json?ref=stable" > "scripts/codex_model_catalog.json.tmp" 2>/dev/null; then
+            mv "scripts/codex_model_catalog.json.tmp" "scripts/codex_model_catalog.json"
+          else
+            rm -f "scripts/codex_model_catalog.json.tmp"
+            echo "Model catalog not on stable tag yet; using local copy."
+          fi
           # Fetch the clarify-respond prompt
           PROMPT_SOURCE="prompts/mode-clarify-respond.txt"
           mkdir -p prompts
@@ -149,11 +157,15 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ~/.codex
+          CATALOG_PATH="$(pwd)/scripts/codex_model_catalog.json"
           {
             echo 'web_search = "live"'
             echo 'model_provider = "openrouter"'
             echo "model = \"${MODEL_EDITOR}\""
             echo "model_reasoning_effort = \"${MODEL_REASONING_EFFORT}\""
+            if [ -f "${CATALOG_PATH}" ]; then
+              echo "model_catalog_json = \"${CATALOG_PATH}\""
+            fi
             echo
             echo '[model_providers.openrouter]'
             echo 'name = "OpenRouter"'

--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -117,6 +117,14 @@ jobs:
           done
           gh api -H 'Accept: application/vnd.github.raw+json' \
             "repos/${wf_source}/contents/.github/ai/orchestrate_schema.v1.json?ref=stable" > ".github/ai/orchestrate_schema.v1.json"
+          # Model catalog: try stable first, fall back to local copy from checkout.
+          if gh api -H 'Accept: application/vnd.github.raw+json' \
+            "repos/${wf_source}/contents/scripts/codex_model_catalog.json?ref=stable" > "scripts/codex_model_catalog.json.tmp" 2>/dev/null; then
+            mv "scripts/codex_model_catalog.json.tmp" "scripts/codex_model_catalog.json"
+          else
+            rm -f "scripts/codex_model_catalog.json.tmp"
+            echo "Model catalog not on stable tag yet; using local copy."
+          fi
           for f in codex_system_instructions.md ai_pipeline.md; do
             if [ ! -f "${f}" ]; then
               gh api -H 'Accept: application/vnd.github.raw+json' \

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -171,11 +171,15 @@ for tidx in $(seq 0 $(( COUNT - 1 ))); do
 
     # Ensure codex config exists for the judge
     mkdir -p ~/.codex
+    CATALOG_PATH="$(pwd)/scripts/codex_model_catalog.json"
     {
       echo 'web_search = "live"'
       echo 'model_provider = "openrouter"'
       echo "model = \"${MODEL_EDITOR}\""
       echo "model_reasoning_effort = \"${MODEL_REASONING_EFFORT_JUDGE}\""
+      if [ -f "${CATALOG_PATH}" ]; then
+        echo "model_catalog_json = \"${CATALOG_PATH}\""
+      fi
       echo
       echo '[model_providers.openrouter]'
       echo 'name = "OpenRouter"'
@@ -617,11 +621,15 @@ ORCHESTRATOR_STATE_V1 -->"
 
   # Setup Codex config for judge
   mkdir -p ~/.codex
+  CATALOG_PATH="$(pwd)/scripts/codex_model_catalog.json"
   {
     echo 'web_search = "live"'
     echo 'model_provider = "openrouter"'
     echo "model = \"${MODEL_EDITOR}\""
     echo "model_reasoning_effort = \"${MODEL_REASONING_EFFORT_JUDGE}\""
+    if [ -f "${CATALOG_PATH}" ]; then
+      echo "model_catalog_json = \"${CATALOG_PATH}\""
+    fi
     echo
     echo '[model_providers.openrouter]'
     echo 'name = "OpenRouter"'


### PR DESCRIPTION
The codex model catalog (codex_model_catalog.json) was added to
review_autofix.yml in faca3d5 but never propagated to the orchestrator
workflows. Without the catalog, codex can't resolve metadata for
non-OpenAI models routed through OpenRouter, causing the judge to
produce empty output and silently fail on every poll cycle.

This fixes the review-blocked judge not activating for PR #210 / issue
#208 by adding the catalog fetch + config reference to:
- orchestrate_poll.yml (fetch step)
- orchestrate_poll_process.sh (both codex config blocks)
- orchestrate.yml (fetch step + config)
- orchestrate_clarify_respond.yml (fetch step + config)

https://claude.ai/code/session_01KN2bfUcWXn75ZweTuBNsRq