### PR TITLE
Enable cancellation of in-progress e2e smoke tests

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -111,7 +111,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
       group: e2e-smoke-test-${{ inputs.test_repo || github.repository }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     outputs:
       test_passed: ${{ steps.verify.outputs.passed }}
     env:


### PR DESCRIPTION
## Summary
Updated the e2e smoke test workflow to allow cancellation of in-progress test runs when a new run is triggered for the same concurrency group.

## Changes
- Changed `cancel-in-progress` from `false` to `true` in the e2e-smoke-test job concurrency settings

## Details
This change enables the workflow to automatically cancel any previously running e2e smoke tests in the same concurrency group when a new test run is initiated. This helps reduce resource consumption and provides faster feedback by preventing multiple concurrent test runs from executing simultaneously for the same repository/test configuration.

https://claude.ai/code/session_01QaHfdLXdgTtZuRhosA5sDd