### PR TITLE
Fix awaiting approval label restoration logic in implement workflow

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -885,8 +885,8 @@ jobs:
           gh api -X POST "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/labels" -f labels[]='ai:done' >/dev/null
           gh api -X DELETE "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/labels/ai:implementing" >/dev/null 2>&1 || true
 
-      - name: Restore awaiting approval label on no-op implementation
-        if: env.SKIP_IMPLEMENT != 'true' && steps.commit_changes.outputs.did_commit == 'false'
+      - name: Restore awaiting approval label on skipped implementation
+        if: env.SKIP_IMPLEMENT == 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |


### PR DESCRIPTION
## Summary
Fixed the conditional logic for restoring the "awaiting approval" label in the implement workflow to correctly trigger when implementation is skipped.

## Key Changes
- Updated the step condition from `env.SKIP_IMPLEMENT != 'true' && steps.commit_changes.outputs.did_commit == 'false'` to `env.SKIP_IMPLEMENT == 'true'`
- Updated the step name from "Restore awaiting approval label on no-op implementation" to "Restore awaiting approval label on skipped implementation" for clarity

## Details
The previous logic was contradictory - it would only restore the label when `SKIP_IMPLEMENT` was NOT true, which is the opposite of the intended behavior. The corrected condition now properly restores the "awaiting approval" label when the implementation is actually skipped (i.e., when `SKIP_IMPLEMENT == 'true'`).

https://claude.ai/code/session_01XrGPr3bhYyDFzdjapTdsm4