### PR TITLE
Fix review-blocked detection when issue also has ai:merged label

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -565,7 +565,7 @@ jobs:
           gh api "repos/${TEST_REPO}/issues/${ISSUE_NUMBER}/labels" \
             -f "labels[]=ai:review-blocked" >/dev/null 2>&1 || true
           # Remove other ai: phase labels to simulate a clean review-blocked state
-          for label in ai:done ai:ready-to-merge ai:implementing; do
+          for label in ai:done ai:ready-to-merge ai:implementing ai:merged; do
             gh api "repos/${TEST_REPO}/issues/${ISSUE_NUMBER}/labels/${label}" \
               -X DELETE 2>/dev/null || true
           done

--- a/scripts/orchestrate_lib.py
+++ b/scripts/orchestrate_lib.py
@@ -366,7 +366,11 @@ def cmd_check_wave_status(args: argparse.Namespace) -> int:
 		gh_num = str(issue.get("github_issue", ""))
 		labels = issue_labels.get(gh_num, [])
 
-		if "ai:merged" in labels:
+		if "ai:review-blocked" in labels:
+			status = "review-blocked"
+			any_review_blocked = True
+			all_merged = False
+		elif "ai:merged" in labels:
 			status = "merged"
 		elif "ai:closed" in labels:
 			status = "closed"
@@ -374,10 +378,6 @@ def cmd_check_wave_status(args: argparse.Namespace) -> int:
 		elif "ai:implementation-failed" in labels:
 			status = "implementation-failed"
 			any_failed = True
-			all_merged = False
-		elif "ai:review-blocked" in labels:
-			status = "review-blocked"
-			any_review_blocked = True
 			all_merged = False
 		elif "ai:ready-to-merge" in labels:
 			status = "ready-to-merge"


### PR DESCRIPTION
The e2e-smoke-test Phase 6 was hanging because check-wave-status in
orchestrate_lib.py checked ai:merged before ai:review-blocked. When
Phase 6 added ai:review-blocked to an already-merged issue, the poller
saw "merged" and declared the project complete without handling the
review-blocked signal.

Two fixes:
- orchestrate_lib.py: check ai:review-blocked first in the elif chain
  so it takes priority as an active intervention signal
- test-and-mark-stable.yml: also strip ai:merged in Phase 6 setup so
  the simulation starts from a clean review-blocked state

https://claude.ai/code/session_01XQzH28t4EUZL1QPCiLg5na