### PR TITLE
fix: revert ai:planning label on plan workflow failure/timeout

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -749,6 +749,18 @@ jobs:
             } >> "$GITHUB_ENV"
           fi
 
+      - name: Revert label on planning failure
+        if: failure() || cancelled()
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          ISSUE_LABELS_JSON="$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}" --jq '[.labels[].name]')"
+          if printf '%s' "${ISSUE_LABELS_JSON}" | jq -e 'index("ai:planning") != null' >/dev/null; then
+            gh api -X POST "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/labels" -f labels[]='ai:clarification' >/dev/null
+            gh api -X DELETE "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/labels/ai:planning" >/dev/null 2>&1 || true
+          fi
+
       - name: Comment on issue failure
         if: failure() || cancelled()
         env:


### PR DESCRIPTION
When the plan workflow fails or times out, the issue gets stuck with the
ai:planning label. No workflow re-triggers planning, so the issue is
effectively dead. This matches the implement workflow's existing pattern
of reverting the label on failure, allowing the issue to re-enter the
pipeline via the clarification phase.

https://claude.ai/code/session_011w2ph8NPuA1bp4YANkmdjH