### PR TITLE
Add fallback to main branch for workflow dependency fetches

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -75,8 +75,12 @@ jobs:
           # silent MCP failures ("mcp startup: no servers").
           mkdir -p scripts
           for f in setup_serena.sh git_ref_health_check.sh tg_helpers.sh; do
-            gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
+            if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}" 2>/dev/null; then
+              echo "::warning::${f} not found on stable; falling back to main"
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/scripts/${f}?ref=main" > "scripts/${f}"
+            fi
             chmod +x "scripts/${f}"
           done
           # Always use the canonical instruction files from coding-workflows
@@ -84,8 +88,12 @@ jobs:
           # caller repo ships its own scripts/ directory)
           for f in codex_system_instructions.md ai_pipeline.md; do
             if [ ! -f "${f}" ]; then
-              gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}"
+              if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}" 2>/dev/null; then
+                echo "::warning::${f} not found on stable; falling back to main"
+                gh api -H 'Accept: application/vnd.github.raw+json' \
+                  "repos/${wf_source}/contents/${f}?ref=main" > "${f}"
+              fi
             fi
           done
 

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -174,8 +174,12 @@ jobs:
           # scripts cause silent MCP failures.
           mkdir -p scripts
           for f in setup_serena.sh git_ref_health_check.sh serena_efficiency_report.py tg_helpers.sh; do
-            gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
+            if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}" 2>/dev/null; then
+              echo "::warning::${f} not found on stable; falling back to main"
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/scripts/${f}?ref=main" > "scripts/${f}"
+            fi
             chmod +x "scripts/${f}"
             if [ "${is_self_repo}" = "false" ]; then
               echo "scripts/${f}" >> "${FETCHED_MANIFEST}"
@@ -186,8 +190,12 @@ jobs:
           # own scripts/ still need these canonical md files)
           for f in codex_system_instructions.md ai_pipeline.md; do
             if [ ! -f "${f}" ]; then
-              gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}"
+              if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}" 2>/dev/null; then
+                echo "::warning::${f} not found on stable; falling back to main"
+                gh api -H 'Accept: application/vnd.github.raw+json' \
+                  "repos/${wf_source}/contents/${f}?ref=main" > "${f}"
+              fi
               if [ "${is_self_repo}" = "false" ]; then
                 echo "${f}" >> "${FETCHED_MANIFEST}"
               fi
@@ -731,8 +739,12 @@ jobs:
           # artifacts to keep them out of caller repos.
           wf_source="${{ github.repository_owner }}/coding-workflows"
           mkdir -p scripts
-          gh api -H 'Accept: application/vnd.github.raw+json' \
-            "repos/${wf_source}/contents/scripts/git_ref_health_check.sh?ref=stable" > scripts/git_ref_health_check.sh
+          if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+            "repos/${wf_source}/contents/scripts/git_ref_health_check.sh?ref=stable" > scripts/git_ref_health_check.sh 2>/dev/null; then
+            echo "::warning::git_ref_health_check.sh not found on stable; falling back to main"
+            gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/scripts/git_ref_health_check.sh?ref=main" > scripts/git_ref_health_check.sh
+          fi
           chmod +x scripts/git_ref_health_check.sh
 
           bash scripts/git_ref_health_check.sh repair

--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -125,18 +125,30 @@ jobs:
           wf_source="${{ github.repository_owner }}/coding-workflows"
           mkdir -p scripts
           for f in setup_serena.sh git_ref_health_check.sh orchestrate_lib.py tg_helpers.sh; do
-            gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
+            if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}" 2>/dev/null; then
+              echo "::warning::${f} not found on stable; falling back to main"
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/scripts/${f}?ref=main" > "scripts/${f}"
+            fi
             chmod +x "scripts/${f}"
           done
           # Fetch prompt template
           mkdir -p prompts
-          gh api -H 'Accept: application/vnd.github.raw+json' \
-            "repos/${wf_source}/contents/prompts/mode-orchestrate.txt?ref=stable" > "prompts/mode-orchestrate.txt"
+          if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+            "repos/${wf_source}/contents/prompts/mode-orchestrate.txt?ref=stable" > "prompts/mode-orchestrate.txt" 2>/dev/null; then
+            echo "::warning::mode-orchestrate.txt not found on stable; falling back to main"
+            gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/prompts/mode-orchestrate.txt?ref=main" > "prompts/mode-orchestrate.txt"
+          fi
           # Fetch schema for reference in prompt
           mkdir -p .github/ai
-          gh api -H 'Accept: application/vnd.github.raw+json' \
-            "repos/${wf_source}/contents/.github/ai/orchestrate_schema.v1.json?ref=stable" > ".github/ai/orchestrate_schema.v1.json"
+          if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+            "repos/${wf_source}/contents/.github/ai/orchestrate_schema.v1.json?ref=stable" > ".github/ai/orchestrate_schema.v1.json" 2>/dev/null; then
+            echo "::warning::orchestrate_schema.v1.json not found on stable; falling back to main"
+            gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/.github/ai/orchestrate_schema.v1.json?ref=main" > ".github/ai/orchestrate_schema.v1.json"
+          fi
           # Fetch canonical instruction files
           # Model catalog: try stable first, fall back to local copy from checkout.
           if gh api -H 'Accept: application/vnd.github.raw+json' \
@@ -148,8 +160,12 @@ jobs:
           fi
           for f in codex_system_instructions.md ai_pipeline.md; do
             if [ ! -f "${f}" ]; then
-              gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}"
+              if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}" 2>/dev/null; then
+                echo "::warning::${f} not found on stable; falling back to main"
+                gh api -H 'Accept: application/vnd.github.raw+json' \
+                  "repos/${wf_source}/contents/${f}?ref=main" > "${f}"
+              fi
             fi
           done
 

--- a/.github/workflows/orchestrate_clarify_respond.yml
+++ b/.github/workflows/orchestrate_clarify_respond.yml
@@ -92,8 +92,12 @@ jobs:
           wf_source="shubhodeep1/coding-workflows"
           mkdir -p scripts
           for f in setup_serena.sh tg_helpers.sh; do
-            gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
+            if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}" 2>/dev/null; then
+              echo "::warning::${f} not found on stable; falling back to main"
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/scripts/${f}?ref=main" > "scripts/${f}"
+            fi
             chmod +x "scripts/${f}"
           done
           # Model catalog: try stable first, fall back to local copy from checkout.
@@ -108,8 +112,12 @@ jobs:
           PROMPT_SOURCE="prompts/mode-clarify-respond.txt"
           mkdir -p prompts
           if [ ! -f "${PROMPT_SOURCE}" ]; then
-            gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/${PROMPT_SOURCE}?ref=stable" > "${PROMPT_SOURCE}"
+            if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/${PROMPT_SOURCE}?ref=stable" > "${PROMPT_SOURCE}" 2>/dev/null; then
+              echo "::warning::${PROMPT_SOURCE} not found on stable; falling back to main"
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/${PROMPT_SOURCE}?ref=main" > "${PROMPT_SOURCE}"
+            fi
           fi
 
       - name: Create runtime workspace

--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -107,16 +107,28 @@ jobs:
           wf_source="${{ github.repository_owner }}/coding-workflows"
           mkdir -p scripts prompts .github/ai
           for f in setup_serena.sh git_ref_health_check.sh orchestrate_lib.py orchestrate_poll_process.sh tg_helpers.sh; do
-            gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
+            if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}" 2>/dev/null; then
+              echo "::warning::${f} not found on stable; falling back to main"
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/scripts/${f}?ref=main" > "scripts/${f}"
+            fi
             chmod +x "scripts/${f}"
           done
           for pf in mode-judge.txt mode-judge-review-blocked.txt; do
-            gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/prompts/${pf}?ref=stable" > "prompts/${pf}"
+            if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/prompts/${pf}?ref=stable" > "prompts/${pf}" 2>/dev/null; then
+              echo "::warning::${pf} not found on stable; falling back to main"
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/prompts/${pf}?ref=main" > "prompts/${pf}"
+            fi
           done
-          gh api -H 'Accept: application/vnd.github.raw+json' \
-            "repos/${wf_source}/contents/.github/ai/orchestrate_schema.v1.json?ref=stable" > ".github/ai/orchestrate_schema.v1.json"
+          if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+            "repos/${wf_source}/contents/.github/ai/orchestrate_schema.v1.json?ref=stable" > ".github/ai/orchestrate_schema.v1.json" 2>/dev/null; then
+            echo "::warning::orchestrate_schema.v1.json not found on stable; falling back to main"
+            gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/.github/ai/orchestrate_schema.v1.json?ref=main" > ".github/ai/orchestrate_schema.v1.json"
+          fi
           # Model catalog: try stable first, fall back to local copy from checkout.
           if gh api -H 'Accept: application/vnd.github.raw+json' \
             "repos/${wf_source}/contents/scripts/codex_model_catalog.json?ref=stable" > "scripts/codex_model_catalog.json.tmp" 2>/dev/null; then
@@ -127,8 +139,12 @@ jobs:
           fi
           for f in codex_system_instructions.md ai_pipeline.md; do
             if [ ! -f "${f}" ]; then
-              gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}"
+              if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}" 2>/dev/null; then
+                echo "::warning::${f} not found on stable; falling back to main"
+                gh api -H 'Accept: application/vnd.github.raw+json' \
+                  "repos/${wf_source}/contents/${f}?ref=main" > "${f}"
+              fi
             fi
           done
 

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -19,7 +19,8 @@ jobs:
       (
         (
           github.event.comment.user.type == 'User' &&
-          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+          startsWith(github.event.comment.body, '/answer')
         ) ||
         (
           github.event.comment.user.type == 'Bot' &&
@@ -99,8 +100,12 @@ jobs:
           # Only fetch scripts actually used by the plan workflow.
           # git_ref_health_check.sh is only needed by implement/edit workflows.
           for f in setup_serena.sh tg_helpers.sh; do
-            gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
+            if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}" 2>/dev/null; then
+              echo "::warning::${f} not found on stable; falling back to main"
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/scripts/${f}?ref=main" > "scripts/${f}"
+            fi
             chmod +x "scripts/${f}"
           done
           # Always use the canonical instruction files from coding-workflows
@@ -108,8 +113,12 @@ jobs:
           # caller repo ships its own scripts/ directory)
           for f in codex_system_instructions.md ai_pipeline.md; do
             if [ ! -f "${f}" ]; then
-              gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}"
+              if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}" 2>/dev/null; then
+                echo "::warning::${f} not found on stable; falling back to main"
+                gh api -H 'Accept: application/vnd.github.raw+json' \
+                  "repos/${wf_source}/contents/${f}?ref=main" > "${f}"
+              fi
             fi
           done
 

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -76,8 +76,12 @@ jobs:
           # scripts cause silent MCP failures.
           mkdir -p scripts
           for f in setup_serena.sh git_ref_health_check.sh generate_symbol_diff_summary.py serena_efficiency_report.py tg_helpers.sh; do
-            gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}"
+            if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}" 2>/dev/null; then
+              echo "::warning::${f} not found on stable; falling back to main"
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/scripts/${f}?ref=main" > "scripts/${f}"
+            fi
             chmod +x "scripts/${f}"
           done
           # Model catalog: try stable first, fall back to local copy from checkout.
@@ -96,8 +100,12 @@ jobs:
           # caller repo ships its own scripts/ directory)
           for f in unattended_llm_system_instructions.md codex_system_instructions.md; do
             if [ ! -f "${f}" ]; then
-              gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}"
+              if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}" 2>/dev/null; then
+                echo "::warning::${f} not found on stable; falling back to main"
+                gh api -H 'Accept: application/vnd.github.raw+json' \
+                  "repos/${wf_source}/contents/${f}?ref=main" > "${f}"
+              fi
             fi
           done
           # Fetch judge prompt for review-blocked judge feature
@@ -2297,8 +2305,12 @@ jobs:
           if [ ! -f scripts/git_ref_health_check.sh ]; then
             wf_source="${{ github.repository_owner }}/coding-workflows"
             mkdir -p scripts
-            gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/git_ref_health_check.sh?ref=stable" > scripts/git_ref_health_check.sh
+            if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/scripts/git_ref_health_check.sh?ref=stable" > scripts/git_ref_health_check.sh 2>/dev/null; then
+              echo "::warning::git_ref_health_check.sh not found on stable; falling back to main"
+              gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/scripts/git_ref_health_check.sh?ref=main" > scripts/git_ref_health_check.sh
+            fi
             chmod +x scripts/git_ref_health_check.sh
           fi
           bash scripts/git_ref_health_check.sh repair


### PR DESCRIPTION
## Summary
This change adds resilience to workflow dependency fetching by implementing a fallback mechanism. When fetching scripts, prompts, and configuration files from the `coding-workflows` repository, the workflows now attempt to fetch from the `stable` branch first, and if that fails, automatically fall back to the `main` branch with a warning message.

## Key Changes
- **Consistent fallback pattern**: Applied across all workflow files (orchestrate.yml, orchestrate_poll.yml, implement.yml, review_autofix.yml, plan.yml, clarify.yml, orchestrate_clarify_respond.yml)
- **Error handling**: Wrapped all `gh api` calls that fetch external dependencies with conditional checks that suppress stderr (`2>/dev/null`) and provide fallback logic
- **User visibility**: Added `::warning::` messages to GitHub Actions logs when fallback occurs, making it clear which files were fetched from `main` instead of `stable`
- **Scope**: Applied to all dependency types:
  - Shell scripts (setup_serena.sh, git_ref_health_check.sh, tg_helpers.sh, etc.)
  - Python scripts (orchestrate_lib.py, serena_efficiency_report.py, etc.)
  - Prompt templates (mode-orchestrate.txt, mode-judge.txt, etc.)
  - Configuration files (orchestrate_schema.v1.json, codex_system_instructions.md, ai_pipeline.md)
- **Plan workflow enhancement**: Added additional condition to require `/answer` prefix for non-bot user comments in the plan workflow trigger

## Implementation Details
- Each `gh api` call now follows the pattern: `if ! command 2>/dev/null; then fallback; fi`
- Fallback always targets the `main` branch as the secondary source
- Warning messages include the specific filename for easy identification
- No changes to the actual dependency fetching logic, only error handling and fallback behavior

https://claude.ai/code/session_01SyuBrQYwZvBbDBfxQfMcpX