### PR TITLE
Replace wall-clock timeout with activity-based idle timeout

### DIFF
--- a/.github/workflows/internal-validate.yml
+++ b/.github/workflows/internal-validate.yml
@@ -14,7 +14,7 @@ on:
         type: string
         default: "docker-compose.yml"
       validation_timeout:
-        description: Validation timeout in minutes
+        description: Validation idle timeout in minutes (killed after this long with no output)
         required: false
         type: string
         default: "15"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ name: AI Validate (Reusable)
         type: string
         default: "docker-compose.yml"
       validation_timeout:
-        description: "Validation timeout in minutes"
+        description: "Validation idle timeout in minutes (killed after this long with no output)"
         required: false
         type: string
         default: "15"
@@ -242,7 +242,7 @@ jobs:
             echo "| Reasoning effort | \`${MODEL_REASONING_EFFORT}\` |"
             printf '| Tracking issue | `%s` |\n' "${SUMMARY_TRACKING_ISSUE}"
             printf '| Compose fallback | `%s` |\n' "${SUMMARY_COMPOSE_FILE}"
-            printf '| Timeout (minutes) | `%s` |\n' "${SUMMARY_TIMEOUT}"
+            printf '| Idle timeout (minutes) | `%s` |\n' "${SUMMARY_TIMEOUT}"
             printf '| Status | `%s` |\n' "${SUMMARY_STATUS}"
             printf '| Summary | %s |\n' "${summary_text_escaped}"
             if [ -n "${SUMMARY_FAILURE_TEXT}" ]; then

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ on:
         type: string
         default: "docker-compose.yml"
       validation_timeout:
-        description: Validation timeout in minutes
+        description: Validation idle timeout in minutes (no output = killed)
         required: false
         type: string
         default: "15"
@@ -553,7 +553,7 @@ This phase starts only after the orchestrator judge returns `complete`.
 - The wrapper must call reusable [`/.github/workflows/validate.yml`](.github/workflows/validate.yml) with these inputs:
 - `tracking_issue` (tracking issue number)
 - `compose_file` (compose fallback path, default `docker-compose.yml`)
-- `validation_timeout` (minutes, default `15`)
+- `validation_timeout` (idle timeout in minutes — process is killed only after this long with no output, default `15`)
 - If the wrapper is missing or dispatch permissions are insufficient, the poller marks the tracking issue `ai:validation-failed`.
 
 ### Runtime Constraints

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -509,28 +509,71 @@ find validation -type f -name '*.sh' -exec chmod +x {} +
 
 
 # ---------------------------------------------------------------
-# Phase 2: Execute validation harness
+# Phase 2: Execute validation harness (idle-timeout based)
 # ---------------------------------------------------------------
+# The timeout is activity-based: the process is killed only if it
+# produces no output for VALIDATION_TIMEOUT minutes. This allows
+# large projects to run longer as long as they keep producing output.
+IDLE_TIMEOUT_SECS=$((VALIDATION_TIMEOUT * 60))
 VALIDATION_EXIT=0
+VALIDATION_IDLE_KILLED=0
+
 set +e
-timeout -k 30s "${VALIDATION_TIMEOUT}m" bash validation/validate.sh > "${VALIDATION_LOG_FILE}" 2>&1
+# Run validation in background, tee output to log file
+bash validation/validate.sh > "${VALIDATION_LOG_FILE}" 2>&1 &
+VALIDATION_PID=$!
+
+# Monitor the log file for activity; kill if idle too long
+LAST_SIZE=0
+IDLE_ELAPSED=0
+POLL_INTERVAL=5
+while kill -0 "${VALIDATION_PID}" 2>/dev/null; do
+  CURRENT_SIZE=0
+  if [ -f "${VALIDATION_LOG_FILE}" ]; then
+    CURRENT_SIZE=$(stat -c%s "${VALIDATION_LOG_FILE}" 2>/dev/null || echo 0)
+  fi
+
+  if [ "${CURRENT_SIZE}" -ne "${LAST_SIZE}" ]; then
+    LAST_SIZE="${CURRENT_SIZE}"
+    IDLE_ELAPSED=0
+  else
+    IDLE_ELAPSED=$((IDLE_ELAPSED + POLL_INTERVAL))
+  fi
+
+  if [ "${IDLE_ELAPSED}" -ge "${IDLE_TIMEOUT_SECS}" ]; then
+    echo "Validation idle for ${VALIDATION_TIMEOUT} minute(s) with no output — terminating." >> "${VALIDATION_LOG_FILE}"
+    kill "${VALIDATION_PID}" 2>/dev/null || true
+    # Grace period: SIGKILL after 30s if still running
+    sleep 30
+    if kill -0 "${VALIDATION_PID}" 2>/dev/null; then
+      kill -9 "${VALIDATION_PID}" 2>/dev/null || true
+    fi
+    VALIDATION_IDLE_KILLED=1
+    break
+  fi
+
+  sleep "${POLL_INTERVAL}"
+done
+
+wait "${VALIDATION_PID}" 2>/dev/null
 VALIDATION_EXIT=$?
 set -e
 
 tail -n 200 "${VALIDATION_LOG_FILE}" > "${VALIDATION_LOG_TAIL_FILE}" 2>/dev/null || true
 
-if [ "${VALIDATION_EXIT}" -eq 124 ] || [ "${VALIDATION_EXIT}" -eq 137 ]; then
-  timeout_test="validation-timeout"
-  timeout_error="Validation timed out after ${VALIDATION_TIMEOUT} minute(s)"
-  if [ "${VALIDATION_EXIT}" -eq 137 ]; then
+if [ "${VALIDATION_IDLE_KILLED}" -eq 1 ] || [ "${VALIDATION_EXIT}" -eq 124 ] || [ "${VALIDATION_EXIT}" -eq 137 ]; then
+  timeout_test="validation-idle-timeout"
+  timeout_error="Validation idle-timed out after ${VALIDATION_TIMEOUT} minute(s) with no output"
+  if [ "${VALIDATION_IDLE_KILLED}" -eq 0 ]; then
+    # Legacy exit codes (shouldn't normally happen now, but handle defensively)
     timeout_test="validation-timeout-signal"
-    timeout_error="Validation likely timed out and was terminated (exit code ${VALIDATION_EXIT}) after ${VALIDATION_TIMEOUT} minute(s)"
+    timeout_error="Validation terminated (exit code ${VALIDATION_EXIT}) after ${VALIDATION_TIMEOUT} minute(s)"
   fi
 
   jq -n \
     --arg timeout_test "${timeout_test}" \
     --arg timeout_error "${timeout_error}" \
-    --arg duration_seconds "$((VALIDATION_TIMEOUT * 60))" \
+    --arg duration_seconds "${IDLE_TIMEOUT_SECS}" \
     '{
       result: "fail",
       phase: "timeout",

--- a/workflow-templates/ai-validate.yml
+++ b/workflow-templates/ai-validate.yml
@@ -13,7 +13,7 @@ on:
         type: string
         default: "docker-compose.yml"
       validation_timeout:
-        description: Validation timeout in minutes
+        description: Validation idle timeout in minutes (killed after this long with no output)
         required: false
         type: string
         default: "15"


### PR DESCRIPTION
## Summary
This PR replaces the validation process's wall-clock timeout mechanism with an activity-based idle timeout. Instead of killing the validation process after a fixed duration, the process is now only terminated if it produces no output for the specified timeout period. This allows long-running projects to complete successfully as long as they continue producing output.

## Key Changes

- **Activity-based timeout logic**: Replaced `timeout` command with a custom monitoring loop that tracks log file size changes. The process is only killed if the log file hasn't grown for `VALIDATION_TIMEOUT` minutes.

- **Background process monitoring**: Validation script now runs in the background with a polling mechanism (5-second intervals) that checks for output activity rather than elapsed time.

- **Graceful termination**: Implements a two-stage kill process:
  - First sends SIGTERM and waits 30 seconds
  - Then sends SIGKILL if the process is still running

- **Updated exit code handling**: Changed from checking for exit code 124 (timeout) to checking a new `VALIDATION_IDLE_KILLED` flag to distinguish between idle timeouts and other terminations.

- **Documentation updates**: Updated all workflow files and README to clarify that the timeout is now "idle timeout" (no output) rather than wall-clock timeout, making the behavior explicit to users.

## Implementation Details

- The monitoring loop polls the log file size every 5 seconds and resets the idle counter whenever new output is detected
- Idle elapsed time is tracked separately and compared against `IDLE_TIMEOUT_SECS` (timeout in minutes × 60)
- The solution is portable and doesn't rely on GNU-specific tools beyond what was already in use
- Exit code handling remains backward-compatible while properly identifying idle timeout scenarios

https://claude.ai/code/session_01Sc44AmWN9LkKUaoStc3vAF