### PR TITLE
Add semantic keyword extraction to memory retrieval scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,9 @@ See [`workflow-templates/`](workflow-templates/) in this repository for ready-to
 | `AI_MEMORY_ROOT` | `ai-memory` | Memory root path used by workflows |
 | `AI_MEMORY_RETRIEVAL_PROFILES` | `ai-memory/config/retrieval_profiles.v1.json` | Retrieval role config |
 | `AI_MEMORY_ENABLED` | `true` | Enable/disable memory operations |
+| `AI_MEMORY_KEYWORD_MODEL` | `openai/gpt-5-mini` | Model for semantic keyword extraction during retrieval |
+| `AI_MEMORY_KEYWORD_BASE_URL` | `https://openrouter.ai/api/v1` | API base URL for keyword model |
+| `AI_MEMORY_TOKEN_BUDGET_<ROLE>` | _(from profile)_ | Per-role token budget override (e.g. `AI_MEMORY_TOKEN_BUDGET_IMPLEMENTATION=3200`) |
 | `THINKING_LEVEL_CLARIFY` | `medium` | Reasoning effort for clarification (`xhigh`, `high`, `medium`, `low`) |
 | `THINKING_LEVEL_PLAN` | `xhigh` | Reasoning effort for planning |
 | `THINKING_LEVEL_IMPLEMENT` | `xhigh` | Reasoning effort for implementation |

--- a/ai-memory/README.md
+++ b/ai-memory/README.md
@@ -38,7 +38,7 @@ Fail policy:
 - Retrieval/candidate failures are fail-open at workflow level (logged in run ledger).
 - Promotion/finalization failures are fail-closed.
 
-## Deterministic retrieval
+## Retrieval
 
 `retrieve` scores records by:
 
@@ -46,8 +46,15 @@ Fail policy:
 - confidence
 - issue/PR scope boosts
 - active-status boost
+- keyword overlap (issue title/body matched against record summary/details)
 
-Selection is deterministic and bounded by fixed per-role token budgets and `max_records`.
+When `OPENROUTER_API_KEY` is available, retrieval uses an LLM (`AI_MEMORY_KEYWORD_MODEL`,
+default `openai/gpt-5-mini`) to extract semantic keywords from the issue before scoring.
+If the LLM call fails or returns an unparseable response after 3 retries, it falls back
+to plain tokenisation-based keyword extraction.
+
+Selection is bounded by per-role token budgets (overridable via
+`AI_MEMORY_TOKEN_BUDGET_<ROLE>` env vars, e.g. `AI_MEMORY_TOKEN_BUDGET_IMPLEMENTATION`).
 
 ## Retention and compaction
 
@@ -76,3 +83,6 @@ Processed command CLI:
 - `AI_MEMORY_ROOT` (default `ai-memory`)
 - `AI_MEMORY_RETRIEVAL_PROFILES` (default `ai-memory/config/retrieval_profiles.v1.json`)
 - `AI_MEMORY_PUSH_RETRIES` (default `5`)
+- `AI_MEMORY_KEYWORD_MODEL` (default `openai/gpt-5-mini`) — model for semantic keyword extraction
+- `AI_MEMORY_KEYWORD_BASE_URL` (default `https://openrouter.ai/api/v1`) — API base URL for keyword model
+- `AI_MEMORY_TOKEN_BUDGET_<ROLE>` — per-role token budget override (e.g. `AI_MEMORY_TOKEN_BUDGET_IMPLEMENTATION=3200`)

--- a/ai-memory/config/retrieval_profiles.v1.json
+++ b/ai-memory/config/retrieval_profiles.v1.json
@@ -4,13 +4,13 @@
   "roles": {
     "clarify": {
       "token_budget": 900,
-      "max_records": 8,
       "confidence_weight": 11,
       "same_issue_boost": 24,
       "scope_issue_boost": 9,
       "same_pr_boost": 4,
       "scope_pr_boost": 2,
       "active_status_boost": 2,
+      "keyword_match_boost": 10,
       "category_weights": {
         "constraints": 16,
         "incidents": 14,
@@ -22,13 +22,13 @@
     },
     "planning": {
       "token_budget": 1200,
-      "max_records": 10,
       "confidence_weight": 10,
       "same_issue_boost": 22,
       "scope_issue_boost": 9,
       "same_pr_boost": 5,
       "scope_pr_boost": 3,
       "active_status_boost": 3,
+      "keyword_match_boost": 12,
       "category_weights": {
         "constraints": 15,
         "decisions": 15,
@@ -40,13 +40,13 @@
     },
     "implementation": {
       "token_budget": 1600,
-      "max_records": 12,
       "confidence_weight": 9,
       "same_issue_boost": 20,
       "scope_issue_boost": 8,
       "same_pr_boost": 12,
       "scope_pr_boost": 8,
       "active_status_boost": 4,
+      "keyword_match_boost": 12,
       "category_weights": {
         "constraints": 17,
         "decisions": 16,
@@ -58,13 +58,13 @@
     },
     "reviewer": {
       "token_budget": 1400,
-      "max_records": 11,
       "confidence_weight": 9,
       "same_issue_boost": 16,
       "scope_issue_boost": 8,
       "same_pr_boost": 14,
       "scope_pr_boost": 10,
       "active_status_boost": 3,
+      "keyword_match_boost": 11,
       "category_weights": {
         "incidents": 17,
         "constraints": 16,
@@ -76,13 +76,13 @@
     },
     "autofix": {
       "token_budget": 1400,
-      "max_records": 11,
       "confidence_weight": 8,
       "same_issue_boost": 15,
       "scope_issue_boost": 8,
       "same_pr_boost": 15,
       "scope_pr_boost": 11,
       "active_status_boost": 4,
+      "keyword_match_boost": 11,
       "category_weights": {
         "incidents": 16,
         "patterns": 15,

--- a/scripts/ai_memory.py
+++ b/scripts/ai_memory.py
@@ -130,12 +130,23 @@ def cmd_retrieve(args: argparse.Namespace) -> int:
         if not profiles_path.exists():
             raise MemoryValidationError(f"Retrieval profiles not found: {profiles_path}")
 
+        issue_body = None
+        if getattr(args, "issue_body_file", None):
+            body_path = Path(args.issue_body_file)
+            if body_path.exists():
+                issue_body = body_path.read_text(encoding="utf-8")
+
+        api_key = os.getenv("OPENROUTER_API_KEY")
+
         result = retrieve_memory_context(
             memory_root,
             profiles_path,
             role=_require_nonempty(args.role, "role"),
             issue_number=_safe_int(args.issue_number),
             pr_number=_safe_int(args.pr_number),
+            issue_title=getattr(args, "issue_title", None),
+            issue_body=issue_body,
+            api_key=api_key,
         )
 
         if args.output_file:
@@ -597,6 +608,8 @@ def build_parser() -> argparse.ArgumentParser:
     retrieve.add_argument("--pr-number", default=None)
     retrieve.add_argument("--output-file", default=None)
     retrieve.add_argument("--retrieval-profiles", default=None)
+    retrieve.add_argument("--issue-title", default=None)
+    retrieve.add_argument("--issue-body-file", default=None)
     retrieve.set_defaults(func=cmd_retrieve)
 
     event = subparsers.add_parser("record-run-event", help="Append run ledger event")

--- a/scripts/ai_memory_lib.py
+++ b/scripts/ai_memory_lib.py
@@ -11,17 +11,22 @@ import contextlib
 import fcntl
 import hashlib
 import json
+import logging
 import math
 import os
 import re
 import shutil
 import subprocess
 import tempfile
+import urllib.request
+import urllib.error
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
+
+_log = logging.getLogger(__name__)
 
 MEMORY_RECORD_SCHEMA_VERSION = "memory_record.v1"
 RUN_LEDGER_SCHEMA_VERSION = "run_ledger_entry.v1"
@@ -792,6 +797,155 @@ def promote_candidates(
     }
 
 
+_KEYWORD_STOP_WORDS = frozenset({
+    "a", "an", "the", "and", "or", "but", "in", "on", "at", "to", "for",
+    "of", "with", "by", "from", "is", "it", "as", "be", "was", "are",
+    "been", "being", "have", "has", "had", "do", "does", "did", "will",
+    "would", "could", "should", "may", "might", "shall", "can", "need",
+    "this", "that", "these", "those", "i", "we", "you", "he", "she",
+    "they", "me", "us", "him", "her", "them", "my", "our", "your",
+    "his", "its", "their", "what", "which", "who", "whom", "how",
+    "when", "where", "why", "if", "then", "else", "so", "not", "no",
+    "all", "each", "every", "any", "some", "such", "than", "too",
+    "very", "just", "also", "into", "over", "after", "before", "between",
+    "under", "about", "up", "out", "off", "more", "most", "other",
+    "new", "old", "one", "two", "only", "own", "same", "like",
+    "here", "there", "now", "still", "well", "get", "got", "make",
+    "made", "take", "use", "used", "using", "add", "added", "see",
+    "set", "let", "try", "want", "please", "think", "know",
+})
+
+_KEYWORD_EXTRACT_PROMPT = """\
+Extract 10-15 semantic keywords or short concept phrases from the following \
+GitHub issue. Return ONLY a JSON array of lowercase strings, nothing else. \
+Focus on domain concepts, technical terms, component names, and action verbs \
+that capture what the issue is about.
+
+Example output: ["payment processing", "retry logic", "redis caching", "rate limit", "webhook"]
+
+Title: {title}
+
+Body:
+{body}"""
+
+_KEYWORD_MODEL_DEFAULT = "openai/gpt-5-mini"
+_KEYWORD_MAX_RETRIES = 3
+
+
+def _extract_keywords_plain(title: str, body: str) -> set[str]:
+    """Extract keywords from issue title and body using simple tokenisation."""
+    text = f"{title} {body}".lower()
+    tokens = re.findall(r"[a-z][a-z0-9_]+", text)
+    return {t for t in tokens if t not in _KEYWORD_STOP_WORDS and len(t) > 2}
+
+
+def _parse_keyword_response(raw: str) -> list[str] | None:
+    """Parse LLM response expecting a JSON array of strings. Returns None on failure."""
+    raw = raw.strip()
+    # Handle markdown code fences
+    if raw.startswith("```"):
+        lines = raw.split("\n")
+        lines = [l for l in lines if not l.strip().startswith("```")]
+        raw = "\n".join(lines).strip()
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(parsed, list):
+        return None
+    result = []
+    for item in parsed:
+        if isinstance(item, str) and item.strip():
+            result.append(item.strip().lower())
+    return result if result else None
+
+
+def _extract_keywords_llm(
+    title: str,
+    body: str,
+    *,
+    api_key: str,
+    model: str | None = None,
+    base_url: str | None = None,
+) -> list[str] | None:
+    """Call an LLM to extract semantic keywords. Returns None on failure."""
+    resolved_model = model or os.getenv("AI_MEMORY_KEYWORD_MODEL", _KEYWORD_MODEL_DEFAULT)
+    resolved_base_url = (base_url or os.getenv("AI_MEMORY_KEYWORD_BASE_URL", "https://openrouter.ai/api/v1")).rstrip("/")
+
+    # Truncate body to avoid excessive prompt size
+    truncated_body = body[:4000] if body else ""
+    prompt = _KEYWORD_EXTRACT_PROMPT.format(title=title, body=truncated_body)
+
+    payload = json.dumps({
+        "model": resolved_model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0.0,
+        "max_tokens": 300,
+    }).encode("utf-8")
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+
+    for attempt in range(1, _KEYWORD_MAX_RETRIES + 1):
+        try:
+            req = urllib.request.Request(
+                f"{resolved_base_url}/chat/completions",
+                data=payload,
+                headers=headers,
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                resp_data = json.loads(resp.read().decode("utf-8"))
+            content = resp_data.get("choices", [{}])[0].get("message", {}).get("content", "")
+            keywords = _parse_keyword_response(content)
+            if keywords is not None:
+                _log.debug("LLM keyword extraction succeeded on attempt %d: %s", attempt, keywords)
+                return keywords
+            _log.warning(
+                "LLM keyword extraction returned unparseable response on attempt %d/%d: %s",
+                attempt, _KEYWORD_MAX_RETRIES, content[:200],
+            )
+        except (urllib.error.URLError, urllib.error.HTTPError, OSError, json.JSONDecodeError, KeyError, IndexError) as exc:
+            _log.warning(
+                "LLM keyword extraction failed on attempt %d/%d: %s",
+                attempt, _KEYWORD_MAX_RETRIES, exc,
+            )
+    return None
+
+
+def _extract_keywords(
+    title: str | None,
+    body: str | None,
+    *,
+    api_key: str | None = None,
+) -> set[str]:
+    """Extract keywords using LLM when available, falling back to plain tokenisation."""
+    safe_title = title or ""
+    safe_body = body or ""
+    if not safe_title and not safe_body:
+        return set()
+
+    if api_key:
+        llm_keywords = _extract_keywords_llm(safe_title, safe_body, api_key=api_key)
+        if llm_keywords is not None:
+            # Combine LLM concepts with plain tokens for broader coverage
+            plain = _extract_keywords_plain(safe_title, safe_body)
+            return plain | {kw.lower() for kw in llm_keywords}
+
+    return _extract_keywords_plain(safe_title, safe_body)
+
+
+def _keyword_overlap_ratio(keywords: set[str], text: str) -> float:
+    """Calculate the fraction of keywords that appear in the given text."""
+    if not keywords or not text:
+        return 0.0
+    text_lower = text.lower()
+    matched = sum(1 for kw in keywords if kw in text_lower)
+    return matched / len(keywords)
+
+
 def _estimate_tokens(text: str) -> int:
     if not text:
         return 0
@@ -810,7 +964,13 @@ def _load_retrieval_profiles(profiles_path: Path) -> dict[str, Any]:
     return payload
 
 
-def _record_score(record: dict[str, Any], profile: dict[str, Any], issue_number: int | None, pr_number: int | None) -> tuple[float, str, str]:
+def _record_score(
+    record: dict[str, Any],
+    profile: dict[str, Any],
+    issue_number: int | None,
+    pr_number: int | None,
+    keywords: set[str] | None = None,
+) -> tuple[float, str, str]:
     category_weights = profile.get("category_weights") or {}
     score = float(category_weights.get(record.get("category"), 0.0))
     score += float(record.get("confidence", 0.0)) * float(profile.get("confidence_weight", 10.0))
@@ -831,9 +991,27 @@ def _record_score(record: dict[str, Any], profile: dict[str, Any], issue_number:
     if record.get("status") == "active":
         score += float(profile.get("active_status_boost", 4.0))
 
+    if keywords:
+        summary = record.get("summary") or ""
+        details = record.get("details") or ""
+        overlap = _keyword_overlap_ratio(keywords, f"{summary} {details}")
+        score += overlap * float(profile.get("keyword_match_boost", 10.0))
+
     created_at = str((record.get("timestamps") or {}).get("created_at") or "")
     record_id = str(record.get("record_id") or "")
     return score, created_at, record_id
+
+
+def _resolve_token_budget(profile: dict[str, Any], role: str) -> int:
+    """Resolve token budget: env var override > profile value > default."""
+    env_key = f"AI_MEMORY_TOKEN_BUDGET_{role.upper()}"
+    env_val = os.getenv(env_key)
+    if env_val is not None:
+        try:
+            return int(env_val)
+        except (ValueError, TypeError):
+            pass
+    return int(profile.get("token_budget", 900))
 
 
 def retrieve_memory_context(
@@ -843,6 +1021,9 @@ def retrieve_memory_context(
     role: str,
     issue_number: int | None,
     pr_number: int | None,
+    issue_title: str | None = None,
+    issue_body: str | None = None,
+    api_key: str | None = None,
 ) -> RetrievalResult:
     ensure_memory_layout(memory_root)
     profiles = _load_retrieval_profiles(profiles_path)
@@ -853,8 +1034,10 @@ def retrieve_memory_context(
         raise MemoryValidationError(f"Unknown retrieval role: {role}")
 
     profile = roles[resolved_role]
-    token_budget = int(profile.get("token_budget", 900))
-    max_records = int(profile.get("max_records", 12))
+    token_budget = _resolve_token_budget(profile, resolved_role)
+
+    # Extract keywords for content-aware scoring
+    keywords = _extract_keywords(issue_title, issue_body, api_key=api_key)
 
     records: list[dict[str, Any]] = []
     for record in _load_canonical_records(memory_root):
@@ -873,7 +1056,9 @@ def retrieve_memory_context(
             validate_memory_record(record, memory_root)
         except MemoryValidationError:
             continue
-        score, created_at, record_id = _record_score(record, profile, issue_number, pr_number)
+        score, created_at, record_id = _record_score(
+            record, profile, issue_number, pr_number, keywords=keywords or None,
+        )
         if not record_id or record_id in seen_record_ids:
             continue
         seen_record_ids.add(record_id)
@@ -884,8 +1069,6 @@ def retrieve_memory_context(
     selected: list[dict[str, Any]] = []
     used_tokens = 0
     for _score, _created_at, _record_id, record in scored:
-        if len(selected) >= max_records:
-            break
         line = (
             f"[{record['category']}|{record['status']}|conf={record['confidence']:.2f}|"
             f"id={record['record_id']}] {record['summary']}"


### PR DESCRIPTION
## Summary
Enhance the memory retrieval system with LLM-powered semantic keyword extraction from GitHub issues, enabling content-aware scoring that improves relevance of retrieved memory records.

## Key Changes

- **Semantic keyword extraction**: Added `_extract_keywords()` function that uses an LLM (via OpenRouter API) to extract 10-15 semantic keywords from issue title and body, with fallback to plain tokenization when LLM is unavailable or fails
  - Supports configurable model (`AI_MEMORY_KEYWORD_MODEL`, default `openai/gpt-5-mini`)
  - Configurable API base URL (`AI_MEMORY_KEYWORD_BASE_URL`, default `https://openrouter.ai/api/v1`)
  - Automatic retry logic (3 attempts) with graceful degradation to plain tokenization

- **Keyword-aware scoring**: Modified `_record_score()` to incorporate keyword overlap between extracted keywords and record summary/details via new `keyword_match_boost` profile parameter (added to all roles with values 10-12)

- **Token budget flexibility**: Replaced fixed `max_records` limits with dynamic token-budget-only selection, and added environment variable overrides (`AI_MEMORY_TOKEN_BUDGET_<ROLE>`) for per-role token budgets

- **CLI enhancements**: Extended `retrieve` command with `--issue-title` and `--issue-body-file` arguments to pass issue context for keyword extraction

- **Logging**: Added structured logging via `logging` module for debugging keyword extraction attempts and failures

## Implementation Details

- Plain tokenization uses regex-based extraction with a comprehensive stop-word list (100+ common English words)
- LLM responses are parsed as JSON arrays with markdown code fence handling
- Keyword overlap calculated as fraction of extracted keywords appearing in record text
- Combined approach: when LLM succeeds, results are merged with plain tokens for broader coverage
- All changes are backward compatible; keyword extraction is optional and gracefully degrades

https://claude.ai/code/session_0141A4TkNpVmTr6wcjCqTjNd