### PR TITLE
Fix E2E smoke test race condition with spurious Plan workflow runs

### DIFF
--- a/.github/workflows/internal-plan.yml
+++ b/.github/workflows/internal-plan.yml
@@ -10,5 +10,8 @@ permissions:
 
 jobs:
   plan:
+    if: >-
+      github.event.issue.pull_request == null &&
+      startsWith(github.event.comment.body, '/answer')
     uses: ./.github/workflows/plan.yml
     secrets: inherit

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -323,6 +323,16 @@ jobs:
               if echo "$LABELS_RECHECK" | grep -qE 'ai:awaiting-approval|ai:implementing'; then
                 continue
               fi
+              # Check if other Plan runs are still queued or in-progress.
+              # The "completed" run may be a spurious trigger (e.g. non-/answer
+              # comment that caused the job to be skipped) while the real Plan
+              # run is still working.
+              OTHER_ACTIVE_PLAN_RUNS=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=10&created=>${{ steps.create-issue.outputs.created_after }}" \
+                --jq '[.workflow_runs[] | select(.name | test("Plan"; "i")) | select(.status == "in_progress" or .status == "queued")] | length' 2>/dev/null || echo "0")
+              if [ "$OTHER_ACTIVE_PLAN_RUNS" -gt 0 ]; then
+                echo "  ⏳ Found ${OTHER_ACTIVE_PLAN_RUNS} other active Plan run(s) — waiting for the real run to finish"
+                continue
+              fi
               echo "::error::Plan workflow completed but issue lacks expected labels (current: ${LABELS_RECHECK:-none})"
               echo "status=plan_failed" >> "$GITHUB_OUTPUT"
               exit 1


### PR DESCRIPTION
The clarify workflow posts two comments in quick succession (clear-to-proceed
+ auto /answer), each triggering a separate "Internal: AI Plan" run. The first
run (non-/answer comment) completes instantly with a skipped job, and the smoke
test mistakes it for the real plan run — failing because labels haven't changed.

Two fixes:
- internal-plan.yml: add job-level if-guard so the workflow only runs when
  the comment starts with /answer, preventing spurious runs entirely
- test-and-mark-stable.yml: before declaring plan_failed, check if other
  Plan runs are still queued/in-progress and keep polling if so

https://claude.ai/code/session_013tp8NSvkKxzEbyRngSkm6S