### PR TITLE
Add workflow output for commit status in review autofix

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2284,6 +2284,7 @@ jobs:
             # fires.  Pushing here causes a concurrency self-cancel race
             # that kills all subsequent steps.
             echo "DID_COMMIT=true" >> "$GITHUB_ENV"
+            echo "did_commit=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Post editor summary comment


### PR DESCRIPTION
## Summary
This change adds a workflow output variable to expose the commit status from the review autofix workflow, enabling downstream jobs or workflows to access this information.

## Key Changes
- Added `echo "did_commit=true" >> "$GITHUB_OUTPUT"` to set a workflow output variable when a commit is made during the autofix process
- This complements the existing `GITHUB_ENV` variable assignment that was already in place

## Implementation Details
The change outputs the commit status as `did_commit=true` whenever the autofix workflow successfully creates a commit. This allows other jobs in the workflow or dependent workflows to conditionally execute steps based on whether changes were actually committed, providing better workflow orchestration and visibility into the autofix process results.

https://claude.ai/code/session_01BEGrKM4U7VGahu4y74L7JN