### PR TITLE
Use current commit ref in workflows when running in coding-workflows

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -69,6 +69,14 @@ jobs:
           # NOTE: github.workflow_ref resolves to the *caller* workflow, not
           # this reusable workflow, so we cannot derive the source repo from it.
           wf_source="${{ github.repository_owner }}/coding-workflows"
+          # When running within coding-workflows itself, use the current
+          # commit to avoid version skew with the stable tag (stable is
+          # only updated after e2e tests pass — causes bootstrap failures).
+          if [ "${{ github.repository }}" = "${wf_source}" ]; then
+            script_ref="${{ github.sha }}"
+          else
+            script_ref="stable"
+          fi
           # ALWAYS fetch canonical scripts from coding-workflows, even if the
           # caller repo ships its own scripts/ directory. Stale caller-repo
           # scripts (e.g. writing to mcp.json instead of config.toml) cause
@@ -76,8 +84,8 @@ jobs:
           mkdir -p scripts
           for f in setup_serena.sh git_ref_health_check.sh tg_helpers.sh; do
             if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}" 2>/dev/null; then
-              echo "::warning::${f} not found on stable; falling back to main"
+              "repos/${wf_source}/contents/scripts/${f}?ref=${script_ref}" > "scripts/${f}" 2>/dev/null; then
+              echo "::warning::${f} not found on ${script_ref}; falling back to main"
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/scripts/${f}?ref=main" > "scripts/${f}"
             fi
@@ -89,8 +97,8 @@ jobs:
           for f in codex_system_instructions.md ai_pipeline.md; do
             if [ ! -f "${f}" ]; then
               if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}" 2>/dev/null; then
-                echo "::warning::${f} not found on stable; falling back to main"
+                "repos/${wf_source}/contents/${f}?ref=${script_ref}" > "${f}" 2>/dev/null; then
+                echo "::warning::${f} not found on ${script_ref}; falling back to main"
                 gh api -H 'Accept: application/vnd.github.raw+json' \
                   "repos/${wf_source}/contents/${f}?ref=main" > "${f}"
               fi

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -123,9 +123,14 @@ jobs:
           set -euo pipefail
           # tg_helpers.sh not yet fetched at this step; inline-fetch it
           wf_source="${{ github.repository_owner }}/coding-workflows"
+          if [ "${{ github.repository }}" = "${wf_source}" ]; then
+            script_ref="${{ github.sha }}"
+          else
+            script_ref="stable"
+          fi
           mkdir -p scripts
           gh api -H 'Accept: application/vnd.github.raw+json' \
-            "repos/${wf_source}/contents/scripts/tg_helpers.sh?ref=stable" > "scripts/tg_helpers.sh" 2>/dev/null || true
+            "repos/${wf_source}/contents/scripts/tg_helpers.sh?ref=${script_ref}" > "scripts/tg_helpers.sh" 2>/dev/null || true
           if [ -f scripts/tg_helpers.sh ]; then
             source scripts/tg_helpers.sh
           fi
@@ -156,6 +161,14 @@ jobs:
           # NOTE: github.workflow_ref resolves to the *caller* workflow, not
           # this reusable workflow, so we cannot derive the source repo from it.
           wf_source="${{ github.repository_owner }}/coding-workflows"
+          # When running within coding-workflows itself, use the current
+          # commit to avoid version skew with the stable tag (stable is
+          # only updated after e2e tests pass — causes bootstrap failures).
+          if [ "${{ github.repository }}" = "${wf_source}" ]; then
+            script_ref="${{ github.sha }}"
+          else
+            script_ref="stable"
+          fi
 
           # Track files fetched by the workflow so cleanup only removes what
           # we created — never files that already belong to the caller repo.
@@ -175,8 +188,8 @@ jobs:
           mkdir -p scripts
           for f in setup_serena.sh git_ref_health_check.sh serena_efficiency_report.py tg_helpers.sh; do
             if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}" 2>/dev/null; then
-              echo "::warning::${f} not found on stable; falling back to main"
+              "repos/${wf_source}/contents/scripts/${f}?ref=${script_ref}" > "scripts/${f}" 2>/dev/null; then
+              echo "::warning::${f} not found on ${script_ref}; falling back to main"
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/scripts/${f}?ref=main" > "scripts/${f}"
             fi
@@ -191,8 +204,8 @@ jobs:
           for f in codex_system_instructions.md ai_pipeline.md; do
             if [ ! -f "${f}" ]; then
               if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}" 2>/dev/null; then
-                echo "::warning::${f} not found on stable; falling back to main"
+                "repos/${wf_source}/contents/${f}?ref=${script_ref}" > "${f}" 2>/dev/null; then
+                echo "::warning::${f} not found on ${script_ref}; falling back to main"
                 gh api -H 'Accept: application/vnd.github.raw+json' \
                   "repos/${wf_source}/contents/${f}?ref=main" > "${f}"
               fi
@@ -207,7 +220,7 @@ jobs:
           # (if any) during prompt assembly — the caller's copy is never
           # overwritten or deleted.
           gh api -H 'Accept: application/vnd.github.raw+json' \
-            "repos/${wf_source}/contents/agents.md?ref=stable" > "${RUNTIME_DIR}/agents_canonical.md" 2>/dev/null || true
+            "repos/${wf_source}/contents/agents.md?ref=${script_ref}" > "${RUNTIME_DIR}/agents_canonical.md" 2>/dev/null || true
 
       - name: Fetch issue metadata
         if: env.SKIP_IMPLEMENT != 'true'
@@ -749,10 +762,15 @@ jobs:
           # Re-fetch git_ref_health_check.sh — the commit step deletes fetched
           # artifacts to keep them out of caller repos.
           wf_source="${{ github.repository_owner }}/coding-workflows"
+          if [ "${{ github.repository }}" = "${wf_source}" ]; then
+            script_ref="${{ github.sha }}"
+          else
+            script_ref="stable"
+          fi
           mkdir -p scripts
           if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-            "repos/${wf_source}/contents/scripts/git_ref_health_check.sh?ref=stable" > scripts/git_ref_health_check.sh 2>/dev/null; then
-            echo "::warning::git_ref_health_check.sh not found on stable; falling back to main"
+            "repos/${wf_source}/contents/scripts/git_ref_health_check.sh?ref=${script_ref}" > scripts/git_ref_health_check.sh 2>/dev/null; then
+            echo "::warning::git_ref_health_check.sh not found on ${script_ref}; falling back to main"
             gh api -H 'Accept: application/vnd.github.raw+json' \
               "repos/${wf_source}/contents/scripts/git_ref_health_check.sh?ref=main" > scripts/git_ref_health_check.sh
           fi

--- a/.github/workflows/issue_pr_status.yml
+++ b/.github/workflows/issue_pr_status.yml
@@ -135,9 +135,14 @@ jobs:
 
           # Fetch tg_helpers.sh
           wf_source="shubhodeep1/coding-workflows"
+          if [ "${{ github.repository }}" = "${wf_source}" ]; then
+            script_ref="${{ github.sha }}"
+          else
+            script_ref="stable"
+          fi
           mkdir -p scripts
           gh api -H 'Accept: application/vnd.github.raw+json' \
-            "repos/${wf_source}/contents/scripts/tg_helpers.sh?ref=stable" > "scripts/tg_helpers.sh" 2>/dev/null || {
+            "repos/${wf_source}/contents/scripts/tg_helpers.sh?ref=${script_ref}" > "scripts/tg_helpers.sh" 2>/dev/null || {
             echo "::warning::Could not fetch tg_helpers.sh; skipping TG cleanup."
             exit 0
           }

--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -123,11 +123,19 @@ jobs:
         run: |
           set -euo pipefail
           wf_source="${{ github.repository_owner }}/coding-workflows"
+          # When running within coding-workflows itself, use the current
+          # commit to avoid version skew with the stable tag (stable is
+          # only updated after e2e tests pass — causes bootstrap failures).
+          if [ "${{ github.repository }}" = "${wf_source}" ]; then
+            script_ref="${{ github.sha }}"
+          else
+            script_ref="stable"
+          fi
           mkdir -p scripts
           for f in setup_serena.sh git_ref_health_check.sh orchestrate_lib.py tg_helpers.sh; do
             if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}" 2>/dev/null; then
-              echo "::warning::${f} not found on stable; falling back to main"
+              "repos/${wf_source}/contents/scripts/${f}?ref=${script_ref}" > "scripts/${f}" 2>/dev/null; then
+              echo "::warning::${f} not found on ${script_ref}; falling back to main"
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/scripts/${f}?ref=main" > "scripts/${f}"
             fi
@@ -136,33 +144,33 @@ jobs:
           # Fetch prompt template
           mkdir -p prompts
           if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-            "repos/${wf_source}/contents/prompts/mode-orchestrate.txt?ref=stable" > "prompts/mode-orchestrate.txt" 2>/dev/null; then
-            echo "::warning::mode-orchestrate.txt not found on stable; falling back to main"
+            "repos/${wf_source}/contents/prompts/mode-orchestrate.txt?ref=${script_ref}" > "prompts/mode-orchestrate.txt" 2>/dev/null; then
+            echo "::warning::mode-orchestrate.txt not found on ${script_ref}; falling back to main"
             gh api -H 'Accept: application/vnd.github.raw+json' \
               "repos/${wf_source}/contents/prompts/mode-orchestrate.txt?ref=main" > "prompts/mode-orchestrate.txt"
           fi
           # Fetch schema for reference in prompt
           mkdir -p .github/ai
           if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-            "repos/${wf_source}/contents/.github/ai/orchestrate_schema.v1.json?ref=stable" > ".github/ai/orchestrate_schema.v1.json" 2>/dev/null; then
-            echo "::warning::orchestrate_schema.v1.json not found on stable; falling back to main"
+            "repos/${wf_source}/contents/.github/ai/orchestrate_schema.v1.json?ref=${script_ref}" > ".github/ai/orchestrate_schema.v1.json" 2>/dev/null; then
+            echo "::warning::orchestrate_schema.v1.json not found on ${script_ref}; falling back to main"
             gh api -H 'Accept: application/vnd.github.raw+json' \
               "repos/${wf_source}/contents/.github/ai/orchestrate_schema.v1.json?ref=main" > ".github/ai/orchestrate_schema.v1.json"
           fi
           # Fetch canonical instruction files
-          # Model catalog: try stable first, fall back to local copy from checkout.
+          # Model catalog: try script_ref first, fall back to local copy from checkout.
           if gh api -H 'Accept: application/vnd.github.raw+json' \
-            "repos/${wf_source}/contents/scripts/codex_model_catalog.json?ref=stable" > "scripts/codex_model_catalog.json.tmp" 2>/dev/null; then
+            "repos/${wf_source}/contents/scripts/codex_model_catalog.json?ref=${script_ref}" > "scripts/codex_model_catalog.json.tmp" 2>/dev/null; then
             mv "scripts/codex_model_catalog.json.tmp" "scripts/codex_model_catalog.json"
           else
             rm -f "scripts/codex_model_catalog.json.tmp"
-            echo "Model catalog not on stable tag yet; using local copy."
+            echo "Model catalog not on ${script_ref} yet; using local copy."
           fi
           for f in codex_system_instructions.md ai_pipeline.md; do
             if [ ! -f "${f}" ]; then
               if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}" 2>/dev/null; then
-                echo "::warning::${f} not found on stable; falling back to main"
+                "repos/${wf_source}/contents/${f}?ref=${script_ref}" > "${f}" 2>/dev/null; then
+                echo "::warning::${f} not found on ${script_ref}; falling back to main"
                 gh api -H 'Accept: application/vnd.github.raw+json' \
                   "repos/${wf_source}/contents/${f}?ref=main" > "${f}"
               fi

--- a/.github/workflows/orchestrate_clarify_respond.yml
+++ b/.github/workflows/orchestrate_clarify_respond.yml
@@ -90,31 +90,39 @@ jobs:
         run: |
           set -euo pipefail
           wf_source="shubhodeep1/coding-workflows"
+          # When running within coding-workflows itself, use the current
+          # commit to avoid version skew with the stable tag (stable is
+          # only updated after e2e tests pass — causes bootstrap failures).
+          if [ "${{ github.repository }}" = "${wf_source}" ]; then
+            script_ref="${{ github.sha }}"
+          else
+            script_ref="stable"
+          fi
           mkdir -p scripts
           for f in setup_serena.sh tg_helpers.sh; do
             if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}" 2>/dev/null; then
-              echo "::warning::${f} not found on stable; falling back to main"
+              "repos/${wf_source}/contents/scripts/${f}?ref=${script_ref}" > "scripts/${f}" 2>/dev/null; then
+              echo "::warning::${f} not found on ${script_ref}; falling back to main"
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/scripts/${f}?ref=main" > "scripts/${f}"
             fi
             chmod +x "scripts/${f}"
           done
-          # Model catalog: try stable first, fall back to local copy from checkout.
+          # Model catalog: try script_ref first, fall back to local copy from checkout.
           if gh api -H 'Accept: application/vnd.github.raw+json' \
-            "repos/${wf_source}/contents/scripts/codex_model_catalog.json?ref=stable" > "scripts/codex_model_catalog.json.tmp" 2>/dev/null; then
+            "repos/${wf_source}/contents/scripts/codex_model_catalog.json?ref=${script_ref}" > "scripts/codex_model_catalog.json.tmp" 2>/dev/null; then
             mv "scripts/codex_model_catalog.json.tmp" "scripts/codex_model_catalog.json"
           else
             rm -f "scripts/codex_model_catalog.json.tmp"
-            echo "Model catalog not on stable tag yet; using local copy."
+            echo "Model catalog not on ${script_ref} yet; using local copy."
           fi
           # Fetch the clarify-respond prompt
           PROMPT_SOURCE="prompts/mode-clarify-respond.txt"
           mkdir -p prompts
           if [ ! -f "${PROMPT_SOURCE}" ]; then
             if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/${PROMPT_SOURCE}?ref=stable" > "${PROMPT_SOURCE}" 2>/dev/null; then
-              echo "::warning::${PROMPT_SOURCE} not found on stable; falling back to main"
+              "repos/${wf_source}/contents/${PROMPT_SOURCE}?ref=${script_ref}" > "${PROMPT_SOURCE}" 2>/dev/null; then
+              echo "::warning::${PROMPT_SOURCE} not found on ${script_ref}; falling back to main"
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/${PROMPT_SOURCE}?ref=main" > "${PROMPT_SOURCE}"
             fi

--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -105,11 +105,19 @@ jobs:
         run: |
           set -euo pipefail
           wf_source="${{ github.repository_owner }}/coding-workflows"
+          # When running within coding-workflows itself, use the current
+          # commit to avoid version skew with the stable tag (stable is
+          # only updated after e2e tests pass — causes bootstrap failures).
+          if [ "${{ github.repository }}" = "${wf_source}" ]; then
+            script_ref="${{ github.sha }}"
+          else
+            script_ref="stable"
+          fi
           mkdir -p scripts prompts .github/ai
           for f in setup_serena.sh git_ref_health_check.sh orchestrate_lib.py orchestrate_poll_process.sh tg_helpers.sh; do
             if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}" 2>/dev/null; then
-              echo "::warning::${f} not found on stable; falling back to main"
+              "repos/${wf_source}/contents/scripts/${f}?ref=${script_ref}" > "scripts/${f}" 2>/dev/null; then
+              echo "::warning::${f} not found on ${script_ref}; falling back to main"
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/scripts/${f}?ref=main" > "scripts/${f}"
             fi
@@ -117,31 +125,31 @@ jobs:
           done
           for pf in mode-judge.txt mode-judge-review-blocked.txt; do
             if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/prompts/${pf}?ref=stable" > "prompts/${pf}" 2>/dev/null; then
-              echo "::warning::${pf} not found on stable; falling back to main"
+              "repos/${wf_source}/contents/prompts/${pf}?ref=${script_ref}" > "prompts/${pf}" 2>/dev/null; then
+              echo "::warning::${pf} not found on ${script_ref}; falling back to main"
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/prompts/${pf}?ref=main" > "prompts/${pf}"
             fi
           done
           if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-            "repos/${wf_source}/contents/.github/ai/orchestrate_schema.v1.json?ref=stable" > ".github/ai/orchestrate_schema.v1.json" 2>/dev/null; then
-            echo "::warning::orchestrate_schema.v1.json not found on stable; falling back to main"
+            "repos/${wf_source}/contents/.github/ai/orchestrate_schema.v1.json?ref=${script_ref}" > ".github/ai/orchestrate_schema.v1.json" 2>/dev/null; then
+            echo "::warning::orchestrate_schema.v1.json not found on ${script_ref}; falling back to main"
             gh api -H 'Accept: application/vnd.github.raw+json' \
               "repos/${wf_source}/contents/.github/ai/orchestrate_schema.v1.json?ref=main" > ".github/ai/orchestrate_schema.v1.json"
           fi
-          # Model catalog: try stable first, fall back to local copy from checkout.
+          # Model catalog: try script_ref first, fall back to local copy from checkout.
           if gh api -H 'Accept: application/vnd.github.raw+json' \
-            "repos/${wf_source}/contents/scripts/codex_model_catalog.json?ref=stable" > "scripts/codex_model_catalog.json.tmp" 2>/dev/null; then
+            "repos/${wf_source}/contents/scripts/codex_model_catalog.json?ref=${script_ref}" > "scripts/codex_model_catalog.json.tmp" 2>/dev/null; then
             mv "scripts/codex_model_catalog.json.tmp" "scripts/codex_model_catalog.json"
           else
             rm -f "scripts/codex_model_catalog.json.tmp"
-            echo "Model catalog not on stable tag yet; using local copy."
+            echo "Model catalog not on ${script_ref} yet; using local copy."
           fi
           for f in codex_system_instructions.md ai_pipeline.md; do
             if [ ! -f "${f}" ]; then
               if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}" 2>/dev/null; then
-                echo "::warning::${f} not found on stable; falling back to main"
+                "repos/${wf_source}/contents/${f}?ref=${script_ref}" > "${f}" 2>/dev/null; then
+                echo "::warning::${f} not found on ${script_ref}; falling back to main"
                 gh api -H 'Accept: application/vnd.github.raw+json' \
                   "repos/${wf_source}/contents/${f}?ref=main" > "${f}"
               fi

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -93,6 +93,14 @@ jobs:
           # NOTE: github.workflow_ref resolves to the *caller* workflow, not
           # this reusable workflow, so we cannot derive the source repo from it.
           wf_source="${{ github.repository_owner }}/coding-workflows"
+          # When running within coding-workflows itself, use the current
+          # commit to avoid version skew with the stable tag (stable is
+          # only updated after e2e tests pass — causes bootstrap failures).
+          if [ "${{ github.repository }}" = "${wf_source}" ]; then
+            script_ref="${{ github.sha }}"
+          else
+            script_ref="stable"
+          fi
           # ALWAYS fetch canonical scripts from coding-workflows, even if the
           # caller repo ships its own scripts/ directory. Stale caller-repo
           # scripts cause silent MCP failures.
@@ -101,8 +109,8 @@ jobs:
           # git_ref_health_check.sh is only needed by implement/edit workflows.
           for f in setup_serena.sh tg_helpers.sh; do
             if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}" 2>/dev/null; then
-              echo "::warning::${f} not found on stable; falling back to main"
+              "repos/${wf_source}/contents/scripts/${f}?ref=${script_ref}" > "scripts/${f}" 2>/dev/null; then
+              echo "::warning::${f} not found on ${script_ref}; falling back to main"
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/scripts/${f}?ref=main" > "scripts/${f}"
             fi
@@ -114,8 +122,8 @@ jobs:
           for f in codex_system_instructions.md ai_pipeline.md; do
             if [ ! -f "${f}" ]; then
               if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}" 2>/dev/null; then
-                echo "::warning::${f} not found on stable; falling back to main"
+                "repos/${wf_source}/contents/${f}?ref=${script_ref}" > "${f}" 2>/dev/null; then
+                echo "::warning::${f} not found on ${script_ref}; falling back to main"
                 gh api -H 'Accept: application/vnd.github.raw+json' \
                   "repos/${wf_source}/contents/${f}?ref=main" > "${f}"
               fi

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -71,29 +71,37 @@ jobs:
           # NOTE: github.workflow_ref resolves to the *caller* workflow, not
           # this reusable workflow, so we cannot derive the source repo from it.
           wf_source="${{ github.repository_owner }}/coding-workflows"
+          # When running within coding-workflows itself, use the current
+          # commit to avoid version skew with the stable tag (stable is
+          # only updated after e2e tests pass — causes bootstrap failures).
+          if [ "${{ github.repository }}" = "${wf_source}" ]; then
+            script_ref="${{ github.sha }}"
+          else
+            script_ref="stable"
+          fi
           # ALWAYS fetch canonical scripts from coding-workflows, even if the
           # caller repo ships its own scripts/ directory. Stale caller-repo
           # scripts cause silent MCP failures.
           mkdir -p scripts
           for f in setup_serena.sh git_ref_health_check.sh generate_symbol_diff_summary.py serena_efficiency_report.py tg_helpers.sh; do
             if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/${f}?ref=stable" > "scripts/${f}" 2>/dev/null; then
-              echo "::warning::${f} not found on stable; falling back to main"
+              "repos/${wf_source}/contents/scripts/${f}?ref=${script_ref}" > "scripts/${f}" 2>/dev/null; then
+              echo "::warning::${f} not found on ${script_ref}; falling back to main"
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/scripts/${f}?ref=main" > "scripts/${f}"
             fi
             chmod +x "scripts/${f}"
           done
-          # Model catalog: try stable first, fall back to local copy from checkout.
+          # Model catalog: try script_ref first, fall back to local copy from checkout.
           # Write to a temp file first so the redirect doesn't clobber the
           # local copy when the gh api call fails (the file doesn't exist on
           # the stable tag yet).
           if gh api -H 'Accept: application/vnd.github.raw+json' \
-            "repos/${wf_source}/contents/scripts/codex_model_catalog.json?ref=stable" > "scripts/codex_model_catalog.json.tmp" 2>/dev/null; then
+            "repos/${wf_source}/contents/scripts/codex_model_catalog.json?ref=${script_ref}" > "scripts/codex_model_catalog.json.tmp" 2>/dev/null; then
             mv "scripts/codex_model_catalog.json.tmp" "scripts/codex_model_catalog.json"
           else
             rm -f "scripts/codex_model_catalog.json.tmp"
-            echo "Model catalog not on stable tag yet; using local copy."
+            echo "Model catalog not on ${script_ref} yet; using local copy."
           fi
           # Always use the canonical instruction files from coding-workflows
           # (must be outside the if-block so they're fetched even when the
@@ -101,8 +109,8 @@ jobs:
           for f in unattended_llm_system_instructions.md codex_system_instructions.md; do
             if [ ! -f "${f}" ]; then
               if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}" 2>/dev/null; then
-                echo "::warning::${f} not found on stable; falling back to main"
+                "repos/${wf_source}/contents/${f}?ref=${script_ref}" > "${f}" 2>/dev/null; then
+                echo "::warning::${f} not found on ${script_ref}; falling back to main"
                 gh api -H 'Accept: application/vnd.github.raw+json' \
                   "repos/${wf_source}/contents/${f}?ref=main" > "${f}"
               fi
@@ -112,7 +120,7 @@ jobs:
           mkdir -p prompts
           if [ ! -f prompts/mode-judge-review-blocked.txt ]; then
             gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/prompts/mode-judge-review-blocked.txt?ref=stable" \
+              "repos/${wf_source}/contents/prompts/mode-judge-review-blocked.txt?ref=${script_ref}" \
               > prompts/mode-judge-review-blocked.txt 2>/dev/null || true
           fi
 
@@ -2371,10 +2379,15 @@ jobs:
           # Re-fetch it so the merge-conflict check can use it.
           if [ ! -f scripts/git_ref_health_check.sh ]; then
             wf_source="${{ github.repository_owner }}/coding-workflows"
+            if [ "${{ github.repository }}" = "${wf_source}" ]; then
+              script_ref="${{ github.sha }}"
+            else
+              script_ref="stable"
+            fi
             mkdir -p scripts
             if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/git_ref_health_check.sh?ref=stable" > scripts/git_ref_health_check.sh 2>/dev/null; then
-              echo "::warning::git_ref_health_check.sh not found on stable; falling back to main"
+              "repos/${wf_source}/contents/scripts/git_ref_health_check.sh?ref=${script_ref}" > scripts/git_ref_health_check.sh 2>/dev/null; then
+              echo "::warning::git_ref_health_check.sh not found on ${script_ref}; falling back to main"
               gh api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/scripts/git_ref_health_check.sh?ref=main" > scripts/git_ref_health_check.sh
             fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -85,55 +85,63 @@ jobs:
         run: |
           set -euo pipefail
           wf_source="shubhodeep1/coding-workflows"
+          # When running within coding-workflows itself, use the current
+          # commit to avoid version skew with the stable tag (stable is
+          # only updated after e2e tests pass — causes bootstrap failures).
+          if [ "${{ github.repository }}" = "${wf_source}" ]; then
+            script_ref="${{ github.sha }}"
+          else
+            script_ref="stable"
+          fi
           mkdir -p scripts prompts .github/ai
 
-          fetch_from_stable_or_local() {
+          fetch_from_ref_or_local() {
             local repo_path="$1"
             local target_path="$2"
             local tmp_path="${target_path}.tmp"
             if gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/${repo_path}?ref=stable" > "${tmp_path}" 2>/dev/null; then
+              "repos/${wf_source}/contents/${repo_path}?ref=${script_ref}" > "${tmp_path}" 2>/dev/null; then
               mv "${tmp_path}" "${target_path}"
               return 0
             fi
 
             rm -f "${tmp_path}"
             if [ -f "${target_path}" ]; then
-              echo "Using local fallback for ${target_path} (not found on stable: ${repo_path})"
+              echo "Using local fallback for ${target_path} (not found on ${script_ref}: ${repo_path})"
               return 0
             fi
 
-            echo "Missing required file: ${repo_path} (stable) and local fallback ${target_path}" >&2
+            echo "Missing required file: ${repo_path} (${script_ref}) and local fallback ${target_path}" >&2
             exit 1
           }
 
           for f in setup_serena.sh ai_labels.py validate_process.sh tg_helpers.sh; do
-            fetch_from_stable_or_local "scripts/${f}" "scripts/${f}"
+            fetch_from_ref_or_local "scripts/${f}" "scripts/${f}"
             chmod +x "scripts/${f}"
           done
 
           if gh api -H 'Accept: application/vnd.github.raw+json' \
-            "repos/${wf_source}/contents/scripts/codex_model_catalog.json?ref=stable" > "scripts/codex_model_catalog.json.tmp" 2>/dev/null; then
+            "repos/${wf_source}/contents/scripts/codex_model_catalog.json?ref=${script_ref}" > "scripts/codex_model_catalog.json.tmp" 2>/dev/null; then
             mv "scripts/codex_model_catalog.json.tmp" "scripts/codex_model_catalog.json"
           else
             rm -f "scripts/codex_model_catalog.json.tmp"
-            echo "Model catalog not on stable tag yet; using local copy."
+            echo "Model catalog not on ${script_ref} yet; using local copy."
           fi
 
           for pf in mode-validate-generate.txt mode-validate-diagnose.txt; do
-            fetch_from_stable_or_local "prompts/${pf}" "prompts/${pf}"
+            fetch_from_ref_or_local "prompts/${pf}" "prompts/${pf}"
           done
 
           for f in codex_system_instructions.md ai_pipeline.md; do
             if [ ! -f "${f}" ]; then
               gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/${f}?ref=stable" > "${f}"
+                "repos/${wf_source}/contents/${f}?ref=${script_ref}" > "${f}"
             fi
           done
 
           if [ ! -f .github/ai/label_contract.v1.json ]; then
             gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/.github/ai/label_contract.v1.json?ref=stable" > .github/ai/label_contract.v1.json 2>/dev/null || true
+              "repos/${wf_source}/contents/.github/ai/label_contract.v1.json?ref=${script_ref}" > .github/ai/label_contract.v1.json 2>/dev/null || true
           fi
 
       - name: Run validation process


### PR DESCRIPTION
## Summary
This change fixes bootstrap failures in the coding-workflows repository by using the current commit SHA instead of the `stable` tag when fetching workflow scripts and resources from within the coding-workflows repository itself.

## Problem
When the coding-workflows repository runs its own workflows (e.g., during CI/CD), it was fetching scripts and resources from the `stable` tag. However, the `stable` tag is only updated after e2e tests pass, creating a version skew issue where the workflow tries to use scripts from an older stable version while running the current code. This causes bootstrap failures.

## Solution
Added logic to all workflow files to detect when they're running within the coding-workflows repository itself and use the current commit SHA (`github.sha`) as the reference instead of the hardcoded `stable` tag:

```bash
if [ "${{ github.repository }}" = "${wf_source}" ]; then
  script_ref="${{ github.sha }}"
else
  script_ref="stable"
fi
```

Then use `${script_ref}` instead of hardcoded `stable` in all GitHub API calls that fetch workflow resources.

## Files Modified
- `.github/workflows/implement.yml` - 3 locations
- `.github/workflows/review_autofix.yml` - 3 locations  
- `.github/workflows/orchestrate.yml` - 1 location
- `.github/workflows/orchestrate_poll.yml` - 1 location
- `.github/workflows/validate.yml` - 1 location
- `.github/workflows/orchestrate_clarify_respond.yml` - 1 location
- `.github/workflows/clarify.yml` - 1 location
- `.github/workflows/plan.yml` - 1 location
- `.github/workflows/issue_pr_status.yml` - 1 location

## Key Changes
- Added `script_ref` variable initialization in all workflow fetch sections
- Replaced all hardcoded `ref=stable` with `ref=${script_ref}` in GitHub API calls
- Updated warning messages to reference `${script_ref}` instead of hardcoded `stable`
- Renamed helper function in validate.yml from `fetch_from_stable_or_local` to `fetch_from_ref_or_local` for clarity
- Updated comments to reflect the new behavior

## Implementation Details
- The check compares `github.repository` against the workflow source repository path
- When running in coding-workflows itself, uses the current commit; otherwise defaults to `stable`
- Maintains backward compatibility for external repositories using these workflows
- All fallback logic (trying main branch if ref not found) remains unchanged

https://claude.ai/code/session_01Qr3hTiitRfUL5M65smF8Uz