### PR TITLE
Improve implement workflow monitoring with detailed run tracking

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -400,10 +400,15 @@ jobs:
             LABELS=$(gh api "repos/${TEST_REPO}/issues/${ISSUE_NUMBER}" \
               --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
 
-            IMPL_RUN_STATUS=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=5&created=>${{ steps.create-issue.outputs.created_after }}" \
+            # Count all implement runs and how many are still in progress
+            IMPL_RUN_TOTAL=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=10&created=>${{ steps.create-issue.outputs.created_after }}" \
+              --jq '[.workflow_runs[] | select(.name | test("Implement"; "i"))] | length' 2>/dev/null || echo "0")
+            IMPL_RUN_IN_PROGRESS=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=10&created=>${{ steps.create-issue.outputs.created_after }}" \
+              --jq '[.workflow_runs[] | select(.name | test("Implement"; "i")) | select(.status != "completed")] | length' 2>/dev/null || echo "0")
+            IMPL_RUN_STATUS=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=10&created=>${{ steps.create-issue.outputs.created_after }}" \
               --jq '[.workflow_runs[] | select(.name | test("Implement"; "i"))] | sort_by(.created_at) | last | .status // "unknown"' 2>/dev/null || echo "unknown")
 
-            CUR_STATE="labels=${LABELS};impl_run=${IMPL_RUN_STATUS}"
+            CUR_STATE="labels=${LABELS};impl_run=${IMPL_RUN_STATUS};total=${IMPL_RUN_TOTAL};active=${IMPL_RUN_IN_PROGRESS}"
 
             # Reset inactivity timer on any state change
             if [ "$CUR_STATE" != "$PREV_STATE" ]; then
@@ -415,16 +420,16 @@ jobs:
               PREV_STATE="$CUR_STATE"
             fi
 
-            # Detect implement workflow failure
-            if [ "$IMPL_RUN_STATUS" = "completed" ]; then
-              # Implement finished but no PR appeared — give one more cycle
+            # Detect implement workflow failure — only if ALL runs have completed
+            if [ "$IMPL_RUN_TOTAL" -gt 0 ] && [ "$IMPL_RUN_IN_PROGRESS" -eq 0 ]; then
+              # All implement runs finished but no PR appeared — give one more cycle
               sleep "$POLL_INTERVAL"
               PR_RECHECK=$(gh api "repos/${TEST_REPO}/pulls?state=open&head=${TEST_REPO%%/*}:ai/issue-${ISSUE_NUMBER}&per_page=1" \
                 --jq '.[0].number // empty' 2>/dev/null || echo "")
               if [ -n "$PR_RECHECK" ]; then
                 continue
               fi
-              echo "::error::Implement workflow completed but no PR was created"
+              echo "::error::All ${IMPL_RUN_TOTAL} implement workflow run(s) completed but no PR was created"
               echo "status=implement_failed" >> "$GITHUB_OUTPUT"
               exit 1
             fi
@@ -437,7 +442,7 @@ jobs:
             fi
 
             REMAINING=$(( (INACTIVITY_LIMIT - IDLE + 59) / 60 ))
-            echo "  ... idle ${IDLE}s (timeout in ~${REMAINING}m) — impl_run: ${IMPL_RUN_STATUS}, labels: ${LABELS:-none}"
+            echo "  ... idle ${IDLE}s (timeout in ~${REMAINING}m) — impl_runs: ${IMPL_RUN_TOTAL} total, ${IMPL_RUN_IN_PROGRESS} active, latest: ${IMPL_RUN_STATUS}, labels: ${LABELS:-none}"
             sleep "$POLL_INTERVAL"
           done
 


### PR DESCRIPTION
## Summary
Enhanced the workflow monitoring logic in the test-and-mark-stable job to track multiple implement workflow runs and their completion status more accurately. This prevents premature failure detection when multiple runs are in progress.

## Key Changes
- **Added granular run tracking**: Now counts total implement runs and tracks how many are still in progress, rather than just checking the latest run's status
- **Improved failure detection**: Only reports implement workflow failure when ALL runs have completed, not just when the latest one finishes
- **Enhanced logging**: Updated status messages to show total runs, active runs, and the latest run status for better visibility into workflow progress
- **Increased API page size**: Changed `per_page` parameter from 5 to 10 to capture more workflow runs in the query

## Implementation Details
- Introduced two new variables: `IMPL_RUN_TOTAL` (count of all implement runs) and `IMPL_RUN_IN_PROGRESS` (count of non-completed runs)
- Changed failure condition from `IMPL_RUN_STATUS = "completed"` to `IMPL_RUN_TOTAL > 0 && IMPL_RUN_IN_PROGRESS = 0` to ensure all runs are done before declaring failure
- Updated the state tracking string to include total and active run counts for better inactivity detection
- Improved error message to indicate how many runs completed without creating a PR

https://claude.ai/code/session_01R22TbU96axe5EhFgfizPoo