### PR TITLE
Fix head command failure in PR diff output

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -733,7 +733,7 @@ for tidx in $(seq 0 $(( COUNT - 1 ))); do
         echo
         echo "=== PR #${RB_PR} DIFF ==="
         echo
-        echo "${PR_DIFF}" | head -1000
+        echo "${PR_DIFF}" | { head -1000 || true; }
         echo
         echo "=== PR #${RB_PR} COMMENTS (editor summaries, reviewer findings) ==="
         echo


### PR DESCRIPTION
## Summary
Fixed a potential script failure when displaying PR diff output by making the `head` command non-fatal.

## Key Changes
- Wrapped the `head -1000` command in a subshell with `|| true` to prevent the script from exiting if `head` fails
- This handles edge cases where the PR diff might be empty or contain fewer than 1000 lines, which could cause `head` to return a non-zero exit code in certain shell configurations

## Implementation Details
The change ensures that the orchestration script continues executing even if the `head` command encounters an error while truncating the PR diff output. This improves script robustness when processing pull requests with varying diff sizes.

https://claude.ai/code/session_01GuAvrRhAV3wXqLuzzrLFVr