### PR TITLE
Filter out skipped workflow runs in implementation tracking

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -389,7 +389,7 @@ jobs:
             if [ -n "$PR_NUMBER" ]; then
               echo "✓ Implementation PR #${PR_NUMBER} created"
               IMPL_RUN_ID=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=10&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq '[.workflow_runs[] | select(.name | test("Implement"; "i"))] | sort_by(.created_at) | last | .id // empty' 2>/dev/null || echo "")
+                --jq '[.workflow_runs[] | select(.name | test("Implement"; "i")) | select(.conclusion != "skipped")] | sort_by(.created_at) | last | .id // empty' 2>/dev/null || echo "")
               echo "run_id=${IMPL_RUN_ID}" >> "$GITHUB_OUTPUT"
               echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
               echo "status=success" >> "$GITHUB_OUTPUT"
@@ -400,13 +400,16 @@ jobs:
             LABELS=$(gh api "repos/${TEST_REPO}/issues/${ISSUE_NUMBER}" \
               --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
 
-            # Count all implement runs and how many are still in progress
+            # Count all implement runs and how many are still in progress.
+            # Exclude conclusion=="skipped" runs — those are triggered by
+            # non-/approved comments (clarify, /answer, plan) where the
+            # reusable workflow's job-level `if` evaluated to false.
             IMPL_RUN_TOTAL=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=10&created=>${{ steps.create-issue.outputs.created_after }}" \
-              --jq '[.workflow_runs[] | select(.name | test("Implement"; "i"))] | length' 2>/dev/null || echo "0")
+              --jq '[.workflow_runs[] | select(.name | test("Implement"; "i")) | select(.conclusion != "skipped")] | length' 2>/dev/null || echo "0")
             IMPL_RUN_IN_PROGRESS=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=10&created=>${{ steps.create-issue.outputs.created_after }}" \
-              --jq '[.workflow_runs[] | select(.name | test("Implement"; "i")) | select(.status != "completed")] | length' 2>/dev/null || echo "0")
+              --jq '[.workflow_runs[] | select(.name | test("Implement"; "i")) | select(.conclusion != "skipped") | select(.status != "completed")] | length' 2>/dev/null || echo "0")
             IMPL_RUN_STATUS=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=10&created=>${{ steps.create-issue.outputs.created_after }}" \
-              --jq '[.workflow_runs[] | select(.name | test("Implement"; "i"))] | sort_by(.created_at) | last | .status // "unknown"' 2>/dev/null || echo "unknown")
+              --jq '[.workflow_runs[] | select(.name | test("Implement"; "i")) | select(.conclusion != "skipped")] | sort_by(.created_at) | last | .status // "unknown"' 2>/dev/null || echo "unknown")
 
             CUR_STATE="labels=${LABELS};impl_run=${IMPL_RUN_STATUS};total=${IMPL_RUN_TOTAL};active=${IMPL_RUN_IN_PROGRESS}"
 


### PR DESCRIPTION
## Summary
Updated the workflow run filtering logic to exclude runs with `conclusion == "skipped"` when tracking implementation workflow executions. This prevents skipped runs (triggered by non-approved comments) from being counted or selected as the latest implementation run.

## Changes
- Added `select(.conclusion != "skipped")` filter to all four GitHub API queries that fetch implementation workflow runs
- Updated comment to clarify that skipped runs are excluded because they're triggered by non-approved comments (clarify, /answer, plan) where the reusable workflow's job-level `if` condition evaluated to false
- Applied filtering consistently across:
  - Latest run ID selection
  - Total run count
  - In-progress run count  
  - Latest run status retrieval

## Implementation Details
The changes ensure that workflow runs marked as "skipped" (which occur when certain comment types don't meet approval criteria) are filtered out from all tracking and counting operations. This provides more accurate metrics for implementation workflow progress and prevents skipped runs from being incorrectly identified as the current implementation attempt.

https://claude.ai/code/session_01PZkZvCNhZVs952kNet4czH