### PR TITLE
Refactor script fetching to support multiple scripts in workflow

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2374,25 +2374,29 @@ jobs:
           git reset --hard HEAD
           git clean -fd
 
-          # The script may have been removed during artifact cleanup in the
-          # commit step (caller repos delete fetched scripts before committing).
-          # Re-fetch it so the merge-conflict check can use it.
-          if [ ! -f scripts/git_ref_health_check.sh ]; then
-            wf_source="${{ github.repository_owner }}/coding-workflows"
-            if [ "${{ github.repository }}" = "${wf_source}" ]; then
-              script_ref="${{ github.sha }}"
-            else
-              script_ref="stable"
-            fi
-            mkdir -p scripts
-            if ! gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/${wf_source}/contents/scripts/git_ref_health_check.sh?ref=${script_ref}" > scripts/git_ref_health_check.sh 2>/dev/null; then
-              echo "::warning::git_ref_health_check.sh not found on ${script_ref}; falling back to main"
-              gh api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/scripts/git_ref_health_check.sh?ref=main" > scripts/git_ref_health_check.sh
-            fi
-            chmod +x scripts/git_ref_health_check.sh
+          # The scripts may have been removed during artifact cleanup in the
+          # commit step (caller repos delete fetched scripts before committing)
+          # or wiped by git clean -fd above.
+          # Re-fetch any missing scripts so later steps (merge-conflict check,
+          # Telegram notifications) can use them.
+          wf_source="${{ github.repository_owner }}/coding-workflows"
+          if [ "${{ github.repository }}" = "${wf_source}" ]; then
+            script_ref="${{ github.sha }}"
+          else
+            script_ref="stable"
           fi
+          for f in git_ref_health_check.sh tg_helpers.sh; do
+            if [ ! -f "scripts/${f}" ]; then
+              mkdir -p scripts
+              if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/scripts/${f}?ref=${script_ref}" > "scripts/${f}" 2>/dev/null; then
+                echo "::warning::${f} not found on ${script_ref}; falling back to main"
+                gh api -H 'Accept: application/vnd.github.raw+json' \
+                  "repos/${wf_source}/contents/scripts/${f}?ref=main" > "scripts/${f}"
+              fi
+              chmod +x "scripts/${f}"
+            fi
+          done
           bash scripts/git_ref_health_check.sh repair
           git fetch --no-tags --prune origin "refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}"
 


### PR DESCRIPTION
## Summary
Refactored the script fetching logic in the review autofix workflow to support fetching multiple scripts instead of just `git_ref_health_check.sh`. This change enables the workflow to reliably fetch all required scripts before they're needed by downstream steps.

## Key Changes
- **Generalized script fetching**: Converted the single-script conditional logic into a loop that fetches multiple scripts (`git_ref_health_check.sh` and `tg_helpers.sh`)
- **Improved robustness**: Moved script reference resolution outside the conditional block so it applies to all scripts being fetched
- **Enhanced documentation**: Updated comments to clarify that scripts may be removed during artifact cleanup or by `git clean -fd`, and that multiple steps depend on these scripts
- **Consistent error handling**: Applied the same fallback mechanism (trying `script_ref` first, then falling back to `main`) to all scripts in the loop

## Implementation Details
- The script reference (`script_ref`) is now determined once and reused for all scripts
- Each script is checked individually with `[ ! -f "scripts/${f}" ]` before fetching
- The GitHub API call and fallback logic remain unchanged, just parameterized with the script filename
- All fetched scripts are made executable with `chmod +x`

https://claude.ai/code/session_01EtDtNkRzoTp67XxZhNy6yU