### PR TITLE
Fix newline escaping in issue body text across workflows

### DIFF
--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -438,7 +438,7 @@ jobs:
             fi
 
             TITLE="$(jq -r ".issues[${idx}].title" "${DECOMPOSITION_FILE}")"
-            BODY="$(jq -r ".issues[${idx}].body" "${DECOMPOSITION_FILE}")"
+            BODY="$(jq -r ".issues[${idx}].body" "${DECOMPOSITION_FILE}" | sed 's/\\n/\n/g')"
             PRIORITY="$(jq -r ".issues[${idx}].priority" "${DECOMPOSITION_FILE}")"
 
             # Append orchestrator metadata to body

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2977,7 +2977,7 @@ jobs:
 
               # Create replacement issue
               NEW_ISSUE_TITLE="$(echo "${JUDGE_JSON}" | jq -r '.new_issue.title // empty')"
-              NEW_ISSUE_BODY="$(echo "${JUDGE_JSON}" | jq -r '.new_issue.body // empty')"
+              NEW_ISSUE_BODY="$(echo "${JUDGE_JSON}" | jq -r '.new_issue.body // empty' | sed 's/\\n/\n/g')"
               if [ -n "${NEW_ISSUE_TITLE}" ] && [ -n "${NEW_ISSUE_BODY}" ]; then
                 FULL_NEW_BODY="${NEW_ISSUE_BODY}
 

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1112,7 +1112,7 @@ ${RB_FIX_DESC}
 
           # Create replacement issue
           NEW_ISSUE_TITLE="$(echo "${RB_JUDGE_JSON}" | jq -r '.new_issue.title // empty')"
-          NEW_ISSUE_BODY="$(echo "${RB_JUDGE_JSON}" | jq -r '.new_issue.body // empty')"
+          NEW_ISSUE_BODY="$(echo "${RB_JUDGE_JSON}" | jq -r '.new_issue.body // empty' | sed 's/\\n/\n/g')"
           if [ -n "${NEW_ISSUE_TITLE}" ] && [ -n "${NEW_ISSUE_BODY}" ]; then
             FULL_NEW_BODY="${NEW_ISSUE_BODY}
 
@@ -1645,7 +1645,7 @@ Recovery was attempted but the judge still reports failure. Manual intervention 
         echo "Creating ${NEW_ISSUES_COUNT} fix-up issue(s)..."
         echo "${JUDGE_JSON}" | jq -c '.new_issues[]' | while read -r fix_issue; do
           FIX_TITLE="$(echo "${fix_issue}" | jq -r '.title')"
-          FIX_BODY="$(echo "${fix_issue}" | jq -r '.body')"
+          FIX_BODY="$(echo "${fix_issue}" | jq -r '.body' | sed 's/\\n/\n/g')"
           FIX_ID="$(echo "${fix_issue}" | jq -r '.id')"
 
           # --- Dedup guard: skip if this local ID already has a GitHub issue ---
@@ -1702,7 +1702,7 @@ Recovery was attempted but the judge still reports failure. Manual intervention 
         echo "Creating ${NEW_ISSUES_COUNT} new issue(s) from judge..."
         echo "${JUDGE_JSON}" | jq -c '.new_issues[]' | while read -r new_issue; do
           NEW_TITLE="$(echo "${new_issue}" | jq -r '.title')"
-          NEW_BODY="$(echo "${new_issue}" | jq -r '.body')"
+          NEW_BODY="$(echo "${new_issue}" | jq -r '.body' | sed 's/\\n/\n/g')"
           NEW_ID="$(echo "${new_issue}" | jq -r '.id')"
 
           # --- Dedup guard: skip if this local ID already has a GitHub issue ---
@@ -1773,7 +1773,7 @@ Recovery was attempted but the judge still reports failure. Manual intervention 
           fi
 
           DEF_TITLE="$(echo "${ISSUE_DEF}" | jq -r '.title')"
-          DEF_BODY="$(echo "${ISSUE_DEF}" | jq -r '.body')"
+          DEF_BODY="$(echo "${ISSUE_DEF}" | jq -r '.body' | sed 's/\\n/\n/g')"
           DEF_PRIORITY="$(echo "${ISSUE_DEF}" | jq -r '.priority')"
 
           FULL_BODY="${DEF_BODY}

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -781,7 +781,7 @@ case "${DIAG_STATUS}" in
     for idx in $(seq 0 $((FIX_COUNT - 1))); do
       FIX_ID="$(jq -r ".fix_issues[${idx}].id // \"validation-fix-$((idx + 1))\"" "${DIAGNOSE_RESULT_FILE}")"
       FIX_TITLE="$(jq -r ".fix_issues[${idx}].title // \"Validation fix-up $((idx + 1))\"" "${DIAGNOSE_RESULT_FILE}")"
-      FIX_BODY_BASE="$(jq -r ".fix_issues[${idx}].body // \"No body provided\"" "${DIAGNOSE_RESULT_FILE}")"
+      FIX_BODY_BASE="$(jq -r ".fix_issues[${idx}].body // \"No body provided\"" "${DIAGNOSE_RESULT_FILE}" | sed 's/\\n/\n/g')"
       FIX_PRIORITY="$(jq -r ".fix_issues[${idx}].priority // 5" "${DIAGNOSE_RESULT_FILE}")"
 
       FIX_BODY_FULL="${FIX_BODY_BASE}


### PR DESCRIPTION
## Summary
This PR fixes an issue where newline characters in issue body text were not being properly interpreted when creating GitHub issues. The JSON responses from various processes contained escaped newlines (`\n`) that needed to be converted to actual newlines for proper formatting in GitHub issues.

## Key Changes
- Added `sed 's/\\n/\n/g'` transformation to all issue body text extraction points across multiple scripts and workflows
- Applied fix in 4 files:
  - `scripts/orchestrate_poll_process.sh` (4 locations)
  - `.github/workflows/orchestrate.yml` (1 location)
  - `.github/workflows/review_autofix.yml` (1 location)
  - `scripts/validate_process.sh` (1 location)

## Implementation Details
The fix converts escaped newline sequences (`\\n` in JSON strings) to actual newline characters (`\n`) when extracting issue body content via `jq`. This ensures that multi-line issue descriptions are properly formatted when posted to GitHub, rather than appearing as literal `\n` text in the issue body.

The pattern is applied consistently to:
- Replacement issue bodies
- Fix-up issue bodies
- New issue bodies from judge responses
- Issue definitions from decomposition files
- Validation fix-up issue bodies

https://claude.ai/code/session_01PQviN6ZkoFC49LXuiFzNjV