### PR TITLE
Remove stderr suppression from gh pr merge commands

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -498,9 +498,9 @@ for tidx in $(seq 0 $(( COUNT - 1 ))); do
       PR_MERGEABLE="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${RTM_PR}" --jq '.mergeable' 2>/dev/null || echo "")"
       if [ "${PR_STATE}" = "open" ] && [ "${PR_MERGEABLE}" = "true" ]; then
         echo "  Merging PR #${RTM_PR} (squash)..."
-        if gh pr merge "${RTM_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto 2>/dev/null; then
+        if gh pr merge "${RTM_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto; then
           echo "  PR #${RTM_PR} merge initiated."
-        elif gh pr merge "${RTM_PR}" --repo "${GITHUB_REPOSITORY}" --squash 2>/dev/null; then
+        elif gh pr merge "${RTM_PR}" --repo "${GITHUB_REPOSITORY}" --squash; then
           echo "  PR #${RTM_PR} merged directly."
         else
           echo "::warning::Could not merge PR #${RTM_PR} for issue #${rtm_issue}. May need manual merge or branch protection prevents it."
@@ -867,9 +867,9 @@ sys.exit(1)
           PR_STATE="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${RB_PR}" --jq '.state' 2>/dev/null || echo "")"
           PR_MERGEABLE="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${RB_PR}" --jq '.mergeable' 2>/dev/null || echo "")"
           if [ "${PR_STATE}" = "open" ] && [ "${PR_MERGEABLE}" = "true" ]; then
-            if gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto 2>/dev/null; then
+            if gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto; then
               echo "  PR #${RB_PR} merge initiated (auto)."
-            elif gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash 2>/dev/null; then
+            elif gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash; then
               echo "  PR #${RB_PR} merged directly."
             else
               echo "::warning::Could not merge PR #${RB_PR}."
@@ -914,8 +914,8 @@ sys.exit(1)
             PR_STATE="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${RB_PR}" --jq '.state' 2>/dev/null || echo "")"
             PR_MERGEABLE="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${RB_PR}" --jq '.mergeable' 2>/dev/null || echo "")"
             if [ "${PR_STATE}" = "open" ] && [ "${PR_MERGEABLE}" = "true" ]; then
-              gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto 2>/dev/null \
-                || gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash 2>/dev/null || true
+              gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto \
+                || gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash || true
             elif [ "${PR_STATE}" = "open" ] && [ "${PR_MERGEABLE}" = "false" ]; then
               echo "  PR #${RB_PR} is not mergeable (force-merge path). Attempting branch update..."
               if gh api "repos/${GITHUB_REPOSITORY}/pulls/${RB_PR}/update-branch" \
@@ -1079,8 +1079,8 @@ ${RB_FIX_DESC}
                     --remove-label 'ai:review-blocked' --add-label 'ai:ready-to-merge' 2>/dev/null || true
                   PR_STATE="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${RB_PR}" --jq '.state' 2>/dev/null || echo "")"
                   if [ "${PR_STATE}" = "open" ]; then
-                    gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto 2>/dev/null \
-                      || gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash 2>/dev/null || true
+                    gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto \
+                      || gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash || true
                   fi
                   tg_notify "✅ Orchestrator judge merged PR #${RB_PR} (no fix changes needed, issue #${rb_issue})"
                 fi


### PR DESCRIPTION
## Summary
This change removes `2>/dev/null` stderr redirection from all `gh pr merge` commands throughout the orchestration script. This allows error messages and diagnostic output from the GitHub CLI to be visible in logs, improving debuggability when merge operations fail.

## Key Changes
- Removed `2>/dev/null` from 8 instances of `gh pr merge` commands across the script
- Affected locations:
  - Lines 501 and 503: RTM (Ready-to-Merge) PR merge attempts
  - Lines 870 and 872: RB (Release Branch) PR merge attempts with auto-merge
  - Lines 917 and 918: RB PR merge attempts in fallback chain
  - Lines 1082 and 1083: RB PR merge attempts after label updates

## Implementation Details
The changes maintain the same logical flow and error handling patterns (using `||` operators and `|| true` fallbacks), but now allow stderr output from `gh pr merge` to be captured in CI logs. This enables better troubleshooting when:
- Merge operations fail due to branch protection rules
- GitHub API returns errors
- Authentication or permission issues occur
- Other unexpected conditions prevent merging

The removal is consistent across all merge command invocations in the script.

https://claude.ai/code/session_011mbSMG2fBqLgwirbCtAoFc