### PR TITLE
Fix workflow condition to prevent posting on cancelled jobs

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2296,7 +2296,7 @@ jobs:
           fi
 
       - name: Post editor summary comment
-        if: always() && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && env.PR_CLOSED != 'true'
+        if: "!cancelled() && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && env.PR_CLOSED != 'true'"
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |


### PR DESCRIPTION
## Summary
Updated the conditional logic in the review autofix workflow to properly handle cancelled job states when deciding whether to post the editor summary comment.

## Key Changes
- Changed the job condition from `always()` to `!cancelled()` for the "Post editor summary comment" step
- This ensures the comment is not posted when the workflow is cancelled, while still allowing it to post on both success and failure states

## Implementation Details
The previous condition `always() && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && env.PR_CLOSED != 'true'` would execute the step regardless of cancellation status. By replacing `always()` with `!cancelled()`, the step will now skip execution if the workflow run is cancelled, preventing unnecessary comment posts while maintaining the existing behavior for completed (success/failure) runs.

https://claude.ai/code/session_01JtroeoSqX7SFVaffj9EcYB