### PR TITLE
Use jq to construct JSON for GitHub API comments

### DIFF
--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -521,8 +521,9 @@ jobs:
           EOF
           )"
 
-          gh api "repos/${{ github.repository }}/issues/${TRACKING_ISSUE_NUMBER}/comments" \
-            -f body="${STATE_COMMENT}" >/dev/null
+          jq -n --arg body "${STATE_COMMENT}" '{"body": $body}' \
+            | gh api "repos/${{ github.repository }}/issues/${TRACKING_ISSUE_NUMBER}/comments" \
+                --input - >/dev/null
           echo "Posted initial state to tracking issue #${TRACKING_ISSUE_NUMBER}"
 
       - name: Dispatch Wave 1
@@ -556,8 +557,9 @@ jobs:
 
           The orchestrator poller will monitor progress and dispatch subsequent waves when dependencies are met."
 
-          gh api "repos/${{ github.repository }}/issues/${TRACKING_ISSUE_NUMBER}/comments" \
-            -f body="${WAVE1_COMMENT}" >/dev/null
+          jq -n --arg body "${WAVE1_COMMENT}" '{"body": $body}' \
+            | gh api "repos/${{ github.repository }}/issues/${TRACKING_ISSUE_NUMBER}/comments" \
+                --input - >/dev/null
 
       - name: Write run summary
         if: always()

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -815,8 +815,9 @@ jobs:
           ${STATE_JSON}
           ORCHESTRATOR_STATE_V1 -->"
 
-          gh api "repos/${TEST_REPO}/issues/${TRACKING_NUMBER}/comments" \
-            -f body="${STATE_COMMENT}" >/dev/null
+          jq -n --arg body "${STATE_COMMENT}" '{"body": $body}' \
+            | gh api "repos/${TEST_REPO}/issues/${TRACKING_NUMBER}/comments" \
+                --input - >/dev/null
 
           echo "Posted orchestrator state to tracking issue #${TRACKING_NUMBER}"
 


### PR DESCRIPTION
## Summary
Updated GitHub API calls for posting comments to issues to use `jq` for JSON construction instead of relying on the `gh` CLI's `-f` flag for field assignment.

## Key Changes
- Modified comment posting in `orchestrate.yml` workflow:
  - Initial state comment posting now uses `jq` to construct the JSON body
  - Wave 1 dispatch comment posting now uses `jq` to construct the JSON body
- Modified comment posting in `test-and-mark-stable.yml` workflow:
  - Orchestrator state comment posting now uses `jq` to construct the JSON body

## Implementation Details
The changes replace the pattern:
```bash
gh api "repos/..." -f body="${COMMENT_TEXT}"
```

With:
```bash
jq -n --arg body "${COMMENT_TEXT}" '{"body": $body}' \
  | gh api "repos/..." --input -
```

This approach uses `jq` to safely construct the JSON payload and pipes it to `gh api` using the `--input -` flag. This provides better handling of special characters and complex content in comment bodies, and makes the JSON construction more explicit and maintainable.

https://claude.ai/code/session_015BK84rHjmz3UtwtTsVQngB