### PR TITLE
Add conditional check to implement workflow trigger

### DIFF
--- a/.github/workflows/internal-implement.yml
+++ b/.github/workflows/internal-implement.yml
@@ -11,5 +11,8 @@ permissions:
 
 jobs:
   implement:
+    if: >-
+      github.event.issue.pull_request == null &&
+      startsWith(github.event.comment.body, '/approved')
     uses: ./.github/workflows/implement.yml
     secrets: inherit


### PR DESCRIPTION
## Summary
Added a conditional guard to the `implement` job in the internal workflow to ensure it only runs when triggered by a comment on an issue (not a pull request) that starts with `/approved`.

## Key Changes
- Added `if` condition to the `implement` job that checks:
  - `github.event.issue.pull_request == null` - ensures the event is from an issue, not a PR
  - `startsWith(github.event.comment.body, '/approved')` - ensures the comment begins with the `/approved` command

## Implementation Details
This prevents the workflow from being triggered unintentionally and ensures it only executes when explicitly approved via the `/approved` comment on an issue. This adds a safety mechanism to control when the implementation workflow runs.

https://claude.ai/code/session_01THujs9DmDQxdZ2M1r4fRL7