### PR TITLE
Handle cancelled workflow runs in review-blocked status updates

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3153,7 +3153,7 @@ jobs:
           tg_send_tracked "${PR_NUMBER}" "${MSG}"
 
       - name: Mark linked issues review-blocked (workflow failure)
-        if: failure() && env.PR_CLOSED != 'true'
+        if: (failure() || cancelled()) && env.PR_CLOSED != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           REPOSITORY: ${{ github.repository }}
@@ -3187,7 +3187,7 @@ jobs:
           done <<< "${ISSUE_NUMBERS}"
 
       - name: Post review-blocked comment on PR (workflow failure)
-        if: failure() && env.PR_CLOSED != 'true'
+        if: (failure() || cancelled()) && env.PR_CLOSED != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |


### PR DESCRIPTION
## Summary
Updated the review autofix workflow to properly handle cancelled workflow runs in addition to failed runs when marking linked issues as review-blocked and posting status comments on pull requests.

## Key Changes
- Modified two conditional checks in the `review_autofix.yml` workflow to include `cancelled()` status alongside `failure()`
  - "Mark linked issues review-blocked (workflow failure)" step
  - "Post review-blocked comment on PR (workflow failure)" step

## Details
Previously, these workflow steps only triggered when the workflow explicitly failed. By adding the `cancelled()` condition, the workflow will now also execute these cleanup steps when a workflow run is cancelled by a user or external process. This ensures that linked issues are properly marked as review-blocked and PR comments are posted even in cancellation scenarios, maintaining consistent status tracking across all non-successful workflow outcomes.

https://claude.ai/code/session_01FRxKiCiApexGACeZgE7pB4