### PR TITLE
Add orphan sweep to recover review-blocked issues from previous waves

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1031,7 +1031,7 @@ for tidx in $(seq 0 $(( COUNT - 1 ))); do
   fi
 
   if [ -n "${ORPHAN_RB_JSON}" ] && [ "${ORPHAN_RB_JSON}" != "[]" ]; then
-    ORPHAN_COUNT="$(echo "${ORPHAN_RB_JSON}" | jq 'length')"
+    ORPHAN_COUNT="$(printf '%s' "${ORPHAN_RB_JSON}" | jq -r 'if type=="array" then length else 0 end' 2>/dev/null || echo 0)"
     if ! [[ "${ORPHAN_COUNT}" =~ ^[0-9]+$ ]]; then
       echo "::warning::Orphan sweep received invalid issue array length '${ORPHAN_COUNT}'; skipping orphan injection for this pass." >&2
       ORPHAN_COUNT=0
@@ -1072,10 +1072,13 @@ for tidx in $(seq 0 $(( COUNT - 1 ))); do
         echo "  [orphan-sweep] Injecting orphan review-blocked issue #${orphan_num} into wave ${CURRENT_WAVE}."
 
         # Inject into the state file's current wave
-        jq "(.waves[${WAVE_IDX}].issues) += [{\"id\": \"orphan-rb-${orphan_num}\", \"github_issue\": ${orphan_num}, \"status\": \"in_progress\"}]" \
-          "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
-
-        ISSUE_NUMS="${ISSUE_NUMS} ${orphan_num}"
+        if jq "(.waves[${WAVE_IDX}].issues) += [{\"id\": \"orphan-rb-${orphan_num}\", \"github_issue\": ${orphan_num}, \"status\": \"in_progress\"}]" \
+          "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"; then
+          ISSUE_NUMS="${ISSUE_NUMS} ${orphan_num}"
+        else
+          echo "::warning::Orphan sweep failed to update state file for issue #${orphan_num}; skipping orphan injection for this pass." >&2
+          rm -f "${STATE_FILE}.tmp"
+        fi
       done
     fi
   fi


### PR DESCRIPTION
## Summary
This change adds an "orphan sweep" mechanism to the poll orchestration script that identifies and recovers review-blocked issues that belong to the current project but are not tracked in the active wave. This prevents orchestrator-managed issues from becoming permanently stuck with the `ai:review-blocked` label.

## Problem
The in-workflow judge skips orchestrator-managed issues (returning exit 0) with the expectation that the poller will handle them. However, the poller only processes issues listed in the state file's current wave. Issues that were previously blocked but not re-added to the current wave become orphaned and remain stuck with the `ai:review-blocked` label indefinitely.

## Key Changes
- Added orphan sweep logic that runs during each poll cycle to query for all open issues with the `ai:review-blocked` label
- Filters orphans to only include issues that:
  - Are not already tracked in the current wave
  - Reference the correct tracking issue in their body
  - Are marked as orchestrator-managed
- Automatically injects discovered orphans into the current wave with `in_progress` status
- Logs each injected orphan for visibility and debugging

## Implementation Details
- Uses `gh issue list` with label filtering to find review-blocked issues (limited to 50 results)
- Validates orphan ownership through body text matching (tracking issue reference and orchestrator management marker)
- Updates the state file's wave configuration using `jq` to add orphan entries
- Gracefully handles empty results and API failures with fallback to empty array

https://claude.ai/code/session_01PFzXxMnAmBDyqHcfweBRhE