### PR TITLE
Remove workflow file checkout logic from conflict resolver

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2507,11 +2507,6 @@ jobs:
             sleep 2
           done
 
-          if [ -n "$(git status --porcelain .github/workflows)" ]; then
-            echo "Discarding workflow-file edits from conflict resolver."
-            git checkout -- .github/workflows || true
-          fi
-
           # Remove workflow-generated/fetched artifacts so they are never
           # committed to caller repos.  Skip when running on coding-workflows
           # itself — these files are actual source code there, not artifacts.


### PR DESCRIPTION
## Summary
Removed the conditional logic that discards workflow file edits from the conflict resolver in the review autofix workflow.

## Changes
- Removed the git status check and subsequent `git checkout -- .github/workflows` command that was intended to discard any modifications to workflow files made during conflict resolution

## Details
This simplifies the workflow by eliminating a defensive checkout step that was specifically targeting `.github/workflows` directory changes. The removal suggests either that this safeguard is no longer necessary or that workflow file modifications should be preserved rather than discarded during the conflict resolution process.

https://claude.ai/code/session_01Hd55ad8k5ZYHPCLkvRY1sV