### PR TITLE
Skip internal review for autofix commits

### DIFF
--- a/.github/workflows/internal-review.yml
+++ b/.github/workflows/internal-review.yml
@@ -10,7 +10,33 @@ permissions:
   issues: write
 
 jobs:
+  # Gate: skip synchronize events from autofix commits.  The autofix
+  # workflow already re-dispatches itself via workflow_dispatch, so the
+  # synchronize trigger is redundant and causes the completing run to
+  # appear "cancelled" due to the concurrency group.
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Check head commit message
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event.action }}" = "synchronize" ]; then
+            msg=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}" --jq '.commit.message' 2>/dev/null | head -1 || true)
+            if printf '%s\n' "${msg}" | grep -q '^\[ai-autofix\]'; then
+              echo "Skipping: head commit is an autofix commit"
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+
   review:
+    needs: gate
+    if: needs.gate.outputs.should_run == 'true'
     uses: ./.github/workflows/review_autofix.yml
     with:
       allow_workflow_edits: ${{ vars.ALLOW_WORKFLOW_EDITS == 'true' }}


### PR DESCRIPTION
## Summary
Add a gate job to the internal-review workflow that skips the review step for pull requests where the head commit is an autofix commit. This prevents redundant workflow runs and avoids the "cancelled" status that appears due to the concurrency group when the autofix workflow re-dispatches itself.

## Changes
- **New `gate` job**: Checks if the triggering event is a `synchronize` action and inspects the head commit message for the `[ai-autofix]` prefix
  - Outputs `should_run=false` if the commit is an autofix commit, `should_run=true` otherwise
  - Uses GitHub API to fetch the commit message safely
- **Updated `review` job**: Now depends on the `gate` job and only runs when `should_run == 'true'`

## Implementation Details
- The gate job only performs the check for `synchronize` events (pull request updates), allowing the workflow to run normally on initial `opened` events
- The autofix workflow already re-dispatches itself via `workflow_dispatch`, making the `synchronize` trigger redundant
- This prevents the completing run from appearing "cancelled" due to the concurrency group configuration

https://claude.ai/code/session_01KvJf1C4KsJDqWTS3NEDGqw