### PR TITLE
Reduce orchestrate poller interval from 10 to 5 minutes

### DIFF
--- a/.github/workflows/internal-orchestrate-poll.yml
+++ b/.github/workflows/internal-orchestrate-poll.yml
@@ -2,7 +2,7 @@ name: "Internal: AI Orchestrate Poller"
 
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '*/5 * * * *'
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -31,7 +31,7 @@ jobs:
       group: ai-orchestrate-${{ github.repository }}-${{ github.run_id }}
       cancel-in-progress: false
     env:
-      ORCHESTRATE_POLL_INTERVAL: ${{ vars.ORCHESTRATE_POLL_INTERVAL || '10' }}
+      ORCHESTRATE_POLL_INTERVAL: ${{ vars.ORCHESTRATE_POLL_INTERVAL || '5' }}
 
     steps:
       - name: Log trigger context

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `SERENA_LANGUAGES` | No | `""` (empty) | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, validate | Languages for Serena symbol analysis |
 | `SERENA_DISABLED` | No | `false` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, validate | Disable the Serena MCP server |
 | `WORKFLOW_ORCHESTRATE_MODEL` | No | (falls back to `WORKFLOW_EDITOR_MODEL`) | orchestrate, orchestrate_poll | Model override for orchestrator decomposer and judge |
-| `ORCHESTRATE_POLL_INTERVAL` | No | `10` | orchestrate | Reserved poll interval setting (current poll cadence is controlled by the poller wrapper cron schedule) |
+| `ORCHESTRATE_POLL_INTERVAL` | No | `5` | orchestrate | Reserved poll interval setting (current poll cadence is controlled by the poller wrapper cron schedule) |
 | `EDITOR_IDLE_TIMEOUT` | No | `1200` | review_autofix, implement | Editor watchdog idle timeout in seconds. The editor is killed if it produces no output for this long and has no active network connections. |
 | `EDITOR_MAX_WALL` | No | `3300` | review_autofix, implement | Maximum wall-clock seconds per editor attempt. Budget-aware: auto-capped to remaining job time minus a 2-min buffer. |
 | `EDITOR_MIN_ATTEMPT_SECS` | No | `300` | review_autofix | Minimum remaining job budget (seconds) required to start an editor attempt. Prevents futile retries near the job deadline. |
@@ -306,7 +306,7 @@ jobs:
 name: AI Orchestrate Poller
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '*/5 * * * *'
 permissions:
   contents: write
   issues: write
@@ -411,7 +411,7 @@ See [`workflow-templates/`](workflow-templates/) in this repository for ready-to
 | `memory_maintenance.yml` | `schedule` (monthly) | Memory compaction/archival |
 | `orchestrate.yml` | `workflow_dispatch` | Project decomposition + multi-issue orchestration |
 | `orchestrate_clarify_respond.yml` | `issue_comment.created` | Auto-answers clarification questions on orchestrator issues |
-| `orchestrate_poll.yml` | `schedule` (every ~10 min) | Orchestrator progress poller + judge + auto-recovery |
+| `orchestrate_poll.yml` | `schedule` (every ~5 min) | Orchestrator progress poller + judge + auto-recovery |
 
 ## Required Secrets
 
@@ -460,7 +460,7 @@ See [`workflow-templates/`](workflow-templates/) in this repository for ready-to
 | `WORKFLOW_ORCHESTRATE_MODEL` | (falls back to `WORKFLOW_EDITOR_MODEL`) | Model override for orchestrator/judge |
 | `THINKING_LEVEL_ORCHESTRATE` | `xhigh` | Reasoning effort for project decomposition |
 | `THINKING_LEVEL_JUDGE` | `xhigh` | Reasoning effort for judge evaluation |
-| `ORCHESTRATE_POLL_INTERVAL` | `10` | Reserved poll interval setting (current poll cadence is controlled by the poller wrapper cron schedule) |
+| `ORCHESTRATE_POLL_INTERVAL` | `5` | Reserved poll interval setting (current poll cadence is controlled by the poller wrapper cron schedule) |
 | `EDITOR_IDLE_TIMEOUT` | `1200` | Editor watchdog idle timeout (seconds); killed if no output and no active network connections |
 | `EDITOR_MAX_WALL` | `3300` | Max wall-clock seconds per editor attempt; auto-capped to remaining job budget |
 | `EDITOR_MIN_ATTEMPT_SECS` | `300` | Minimum job budget (seconds) required to start an editor attempt |
@@ -495,7 +495,7 @@ workflow_dispatch (project description)
 
 - [`ai-orchestrate.yml`](workflow-templates/ai-orchestrate.yml) — triggers decomposition via `workflow_dispatch`
 - [`ai-orchestrate-clarify-respond.yml`](workflow-templates/ai-orchestrate-clarify-respond.yml) — auto-answers clarification questions on orchestrator issues
-- [`ai-orchestrate-poll.yml`](workflow-templates/ai-orchestrate-poll.yml) — scheduled poller (every 10 min)
+- [`ai-orchestrate-poll.yml`](workflow-templates/ai-orchestrate-poll.yml) — scheduled poller (every 5 min)
 
 Or create them manually — see the inline examples in the [Quickstart](#quickstart) section above.
 
@@ -509,7 +509,7 @@ Or create them manually — see the inline examples in the [Quickstart](#quickst
 2. **Wave dispatch:** Wave 1 issues (no dependencies) are created immediately and enter the existing clarify → plan → implement → review pipeline automatically. If clarification questions are raised, the `orchestrate_clarify_respond` workflow answers them automatically using an LLM, so the pipeline runs fully unattended.
 3. **Auto-merge:** The poller automatically merges PRs via squash merge when they reach `ai:ready-to-merge`. If a PR has merge conflicts (e.g. `main` advanced since the PR was created), the poller automatically updates the PR branch via the GitHub API before retrying the merge. This requires either (a) no branch protection rules, or (b) branch protection with "Require status checks" that have already passed. See [Enabling auto-merge](#enabling-auto-merge) below.
 4. **In-progress conflict resolution:** When the base branch advances and creates merge conflicts on in-progress PRs (still going through the review/autofix cycle), the poller detects the conflict (`mergeable == false`) and re-triggers the review workflow by pushing an empty commit. The review workflow's built-in Codex conflict resolver then handles the actual merge conflict resolution automatically.
-5. **Polling:** Every 10 minutes, the poller checks if the current wave's issues have reached `ai:merged`. When all are merged, it runs the judge.
+5. **Polling:** Every 5 minutes, the poller checks if the current wave's issues have reached `ai:merged`. When all are merged, it runs the judge.
 6. **Judge:** Full repo checkout + tool access (Serena, shell, file reads) with `xhigh` thinking. Compares merged code against the project spec. Decides: complete, in_progress (next wave or fix-ups), or failed.
 7. **Next wave:** When the judge approves, the poller creates the next wave's issues (deferred creation — they don't exist until their dependencies are met). This triggers `clarify.yml` via `issues.opened`.
 8. **Review-blocked resolution:** When a PR exhausts its autofix iterations (`ai:review-blocked`), the poller invokes a dedicated review-blocked judge (xhigh thinking, full PR context). The judge makes autonomous architectural and security trade-off decisions — it does not defer to humans. It can: (a) merge the PR as-is if remaining issues are cosmetic or low-risk, (b) push an `[orchestrator-fix]` commit with targeted fixes (resets the autofix counter, re-triggers review), or (c) close the PR and create a replacement issue with refined guidance. After `MAX_REVIEW_BLOCKED_RETRIES` (default 2), the judge must choose merge or close+reissue — no further fix attempts.

--- a/workflow-templates/ai-orchestrate-poll.yml
+++ b/workflow-templates/ai-orchestrate-poll.yml
@@ -1,7 +1,7 @@
 name: AI Orchestrate Poller
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '*/5 * * * *'
 permissions:
   contents: write
   issues: write


### PR DESCRIPTION
## Summary
This PR reduces the polling interval for the AI orchestrate poller from 10 minutes to 5 minutes, enabling faster detection and response to orchestration progress updates.

## Changes
- Updated cron schedule in `internal-orchestrate-poll.yml` from `*/10 * * * *` to `*/5 * * * *`
- Updated cron schedule in `ai-orchestrate-poll.yml` workflow template from `*/10 * * * *` to `*/5 * * * *`
- Updated default `ORCHESTRATE_POLL_INTERVAL` environment variable from `10` to `5` in `orchestrate.yml`
- Updated documentation in `README.md` to reflect the new 5-minute polling cadence across all references (configuration table, workflow descriptions, and orchestration flow explanation)

## Implementation Details
The polling interval is now consistently set to 5 minutes across:
- The internal orchestrate poller workflow
- The workflow template for user deployments
- The default environment variable fallback
- All documentation references

This change accelerates the orchestrator's ability to detect when waves complete, merge PRs, run judges, and trigger subsequent waves, improving overall project decomposition throughput.

https://claude.ai/code/session_01JrpDU6KVbTwYktYPyhNHfR