### PR TITLE
Add workflow guards and manual dispatch triggers

### DIFF
--- a/workflow-templates/ai-implement.yml
+++ b/workflow-templates/ai-implement.yml
@@ -11,5 +11,8 @@ permissions:
   pull-requests: write
 jobs:
   implement:
+    if: >-
+      github.event.issue.pull_request == null &&
+      startsWith(github.event.comment.body, '/approved')
     uses: shubhodeep1/coding-workflows/.github/workflows/implement.yml@stable
     secrets: inherit

--- a/workflow-templates/ai-orchestrate-poll.yml
+++ b/workflow-templates/ai-orchestrate-poll.yml
@@ -5,6 +5,7 @@ name: AI Orchestrate Poller
 on:
   schedule:
     - cron: '*/5 * * * *'
+  workflow_dispatch: {}
 permissions:
   contents: write
   issues: write

--- a/workflow-templates/ai-plan.yml
+++ b/workflow-templates/ai-plan.yml
@@ -10,5 +10,8 @@ permissions:
   issues: write
 jobs:
   plan:
+    if: >-
+      github.event.issue.pull_request == null &&
+      startsWith(github.event.comment.body, '/answer')
     uses: shubhodeep1/coding-workflows/.github/workflows/plan.yml@stable
     secrets: inherit

--- a/workflow-templates/ai-review.yml
+++ b/workflow-templates/ai-review.yml
@@ -21,7 +21,36 @@ permissions:
   pull-requests: write
   issues: write
 jobs:
+  # Gate: skip synchronize events caused by autofix commits.  The autofix
+  # workflow already re-dispatches itself via workflow_dispatch, so the
+  # synchronize trigger is redundant and causes the completing run to
+  # appear "cancelled" due to the concurrency group.
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Check head commit message
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+        run: |
+          if [ "${{ github.event.action }}" = "synchronize" ]; then
+            msg=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}" --jq '.commit.message' 2>/dev/null | head -1 || true)
+            if [ -z "${msg}" ]; then
+              echo "::warning::Unable to read head commit message for autofix gate; continuing with review run."
+            fi
+            if printf '%s\n' "${msg}" | grep -q '^\[ai-autofix\]'; then
+              echo "Skipping: head commit is an autofix commit"
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+
   review:
+    needs: gate
+    if: needs.gate.outputs.should_run == 'true'
     uses: shubhodeep1/coding-workflows/.github/workflows/review_autofix.yml@stable
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}


### PR DESCRIPTION
## Summary
This PR adds safety guards and manual trigger capabilities to AI workflow templates to prevent redundant executions and improve workflow control.

## Key Changes

- **ai-review.yml**: Added a `gate` job that skips `synchronize` events triggered by autofix commits. This prevents duplicate review runs since the autofix workflow already re-dispatches itself via `workflow_dispatch`. The gate checks the head commit message for the `[ai-autofix]` prefix and conditionally gates the review job execution.

- **ai-implement.yml**: Added conditional check to ensure the implement job only runs on issue comments (not PR comments) that start with `/approved` command.

- **ai-plan.yml**: Added conditional check to ensure the plan job only runs on issue comments (not PR comments) that start with `/answer` command.

- **ai-orchestrate-poll.yml**: Added `workflow_dispatch: {}` trigger to allow manual execution of the scheduled poller workflow in addition to the cron schedule.

## Implementation Details

The gate job in ai-review.yml uses the GitHub API to fetch the head commit message and grep for the autofix marker. It gracefully handles API failures with a warning and continues with the review run if the message cannot be read. The conditional logic ensures that only non-autofix synchronize events proceed to the review job, reducing noise from redundant runs caused by the concurrency group.

The conditional guards in ai-implement.yml and ai-plan.yml prevent these workflows from triggering on pull request comments, ensuring they only respond to issue comments with the appropriate command prefix.

https://claude.ai/code/session_01TL9eidJssJfn35Bb7n7Ygu