### PR TITLE
fix: delete clarification comments when /answer is received

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -554,6 +554,7 @@ jobs:
           set -euo pipefail
           # Labels already set by "Set clarification phase label" step above.
           {
+            echo "<!-- ai:clarification-questions -->"
             echo "Clarification required"
             echo
             cat "${QUESTIONS_FILE}"

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -268,6 +268,27 @@ jobs:
           source scripts/tg_helpers.sh
           tg_cleanup_phase_msgs "${ISSUE_NUMBER}" "clarify"
 
+      - name: Delete clarification question comments
+        if: env.SKIP_PLAN != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          # Find clarification comments by HTML marker or legacy "Clarification required" prefix
+          CLARIFY_IDS="$(jq -r '
+            .[]
+            | select(
+                (.user.login // "" | test("\\[bot\\]$")) and
+                ((.body // "") | test("<!-- ai:clarification-questions -->|^Clarification required"))
+              )
+            | .id
+          ' "${ISSUE_COMMENTS_FILE}")"
+
+          for cid in ${CLARIFY_IDS}; do
+            echo "Deleting clarification comment ${cid}"
+            gh api -X DELETE "repos/${{ github.repository }}/issues/comments/${cid}" || true
+          done
+
       - name: Extract clarification answers and questions
         if: env.SKIP_PLAN != 'true'
         env:


### PR DESCRIPTION
Clarification question comments posted by the clarify workflow were
persisting on issues after users answered them. Now plan.yml deletes
these comments (identified by HTML marker or legacy prefix) before
proceeding with planning. Also adds a stable HTML marker to new
clarification comments for reliable identification.

https://claude.ai/code/session_01Ho7JDoUURswLRBGriZxakx