### PR TITLE
feat: add self-retrigger to orchestrate poller for near-instant polling

### DIFF
--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -3,6 +3,16 @@ name: AI Orchestrate Poller (Reusable)
 
 "on":
   workflow_call:
+    inputs:
+      caller_workflow:
+        description: >
+          Filename of the caller wrapper workflow to retrigger for continuous
+          polling.  The poller dispatches this workflow at the end of each run
+          so the next cycle starts immediately instead of waiting for the cron
+          schedule.  Set to empty string to disable self-retrigger.
+        required: false
+        type: string
+        default: ai-orchestrate-poll.yml
     secrets:
       GH_PAT:
         required: true
@@ -223,3 +233,20 @@ jobs:
               echo "| Tracking issues processed | 0 |"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Retrigger poller for continuous polling
+        if: >-
+          !cancelled()
+          && steps.find_tracking.outputs.has_work == 'true'
+          && inputs.caller_workflow != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          CALLER="${{ inputs.caller_workflow }}"
+          echo "Retriggering ${CALLER} for continuous polling…"
+          if gh workflow run "${CALLER}" --repo "${{ github.repository }}"; then
+            echo "Successfully dispatched ${CALLER}"
+          else
+            echo "::warning::Failed to retrigger ${CALLER}; cron schedule will resume the chain"
+          fi

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `SERENA_DISABLED` | No | `false` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, validate | Disable the Serena MCP server |
 | `WORKFLOW_ORCHESTRATE_MODEL` | No | (falls back to `WORKFLOW_EDITOR_MODEL`) | orchestrate, orchestrate_poll | Model override for orchestrator decomposer and judge |
 | `ORCHESTRATE_POLL_INTERVAL` | No | `5` | orchestrate | Reserved poll interval setting (current poll cadence is controlled by the poller wrapper cron schedule) |
+| `ORCHESTRATE_POLL_CALLER_WORKFLOW` | No | `ai-orchestrate-poll.yml` | orchestrate_poll | Filename of the caller wrapper workflow to retrigger for continuous polling. The poller dispatches this workflow via `workflow_dispatch` at the end of each run when active tracking issues exist, so the next cycle starts immediately instead of waiting for the cron schedule. Set to empty string to disable self-retrigger. |
 | `EDITOR_IDLE_TIMEOUT` | No | `1200` | review_autofix, implement | Editor watchdog idle timeout in seconds. The editor is killed if it produces no output for this long and has no active network connections. |
 | `EDITOR_MAX_WALL` | No | `3300` | review_autofix, implement | Maximum wall-clock seconds per editor attempt. Budget-aware: auto-capped to remaining job time minus a 2-min buffer. |
 | `EDITOR_MIN_ATTEMPT_SECS` | No | `300` | review_autofix | Minimum remaining job budget (seconds) required to start an editor attempt. Prevents futile retries near the job deadline. |
@@ -449,7 +450,7 @@ See [`workflow-templates/`](workflow-templates/) in this repository for ready-to
 | `memory_maintenance.yml` | `schedule` (monthly) | Memory compaction/archival |
 | `orchestrate.yml` | `workflow_dispatch` | Project decomposition + multi-issue orchestration |
 | `orchestrate_clarify_respond.yml` | `issue_comment.created` | Auto-answers clarification questions on orchestrator issues |
-| `orchestrate_poll.yml` | `schedule` (every ~5 min) | Orchestrator progress poller + judge + auto-recovery |
+| `orchestrate_poll.yml` | `schedule` (every ~5 min) + self-retrigger | Orchestrator progress poller + judge + auto-recovery. Self-retriggers via `workflow_dispatch` when active tracking issues exist for near-immediate next cycles; cron acts as fallback. |
 | `update_workflows.yml` | `schedule` (daily), `repository_dispatch`, `workflow_dispatch` | Auto-updates workflow wrappers from upstream templates |
 
 ## Required Secrets
@@ -500,6 +501,7 @@ See [`workflow-templates/`](workflow-templates/) in this repository for ready-to
 | `THINKING_LEVEL_ORCHESTRATE` | `xhigh` | Reasoning effort for project decomposition |
 | `THINKING_LEVEL_JUDGE` | `xhigh` | Reasoning effort for judge evaluation |
 | `ORCHESTRATE_POLL_INTERVAL` | `5` | Reserved poll interval setting (current poll cadence is controlled by the poller wrapper cron schedule) |
+| `ORCHESTRATE_POLL_CALLER_WORKFLOW` | `ai-orchestrate-poll.yml` | Caller workflow filename for self-retrigger; empty string disables |
 | `EDITOR_IDLE_TIMEOUT` | `1200` | Editor watchdog idle timeout (seconds); killed if no output and no active network connections |
 | `EDITOR_MAX_WALL` | `3300` | Max wall-clock seconds per editor attempt; auto-capped to remaining job budget |
 | `EDITOR_MIN_ATTEMPT_SECS` | `300` | Minimum job budget (seconds) required to start an editor attempt |


### PR DESCRIPTION
GitHub Actions cron schedules are best-effort and routinely delayed
10-30+ minutes.  The poller now dispatches itself via workflow_dispatch
at the end of each run when active tracking issues exist, so the next
cycle starts in seconds instead of waiting for the next cron tick.

The existing */5 cron schedule is preserved as a fallback safety net
in case the retrigger chain breaks.  A new `caller_workflow` input
(default: ai-orchestrate-poll.yml) allows consumers to override the
wrapper filename or disable self-retrigger by passing an empty string.

https://claude.ai/code/session_013qDVWEdeN3hzTjBw7pgnvh