### PR TITLE
fix: prevent docker build-context double-nesting and surface validation diagnosis in orchestrator

### DIFF
--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -28,6 +28,23 @@ Mandatory rules:
 - Ensure all generated `.sh` files are executable (for example, with `chmod +x`).
 - If no Dockerfile exists for the app, generate a minimal Dockerfile for validation and wire it into `validation/docker-compose.test.yml`.
 
+Docker build-context path rules (CRITICAL):
+- `docker compose` resolves `build.context` relative to the compose file's directory, NOT the working directory.
+- Since `validation/docker-compose.test.yml` lives inside `validation/`, a `context: .` resolves to the `validation/` directory.
+- To reference the repository root as the build context, use `context: ..` (one level up from the compose file).
+- The `dockerfile` path is resolved relative to the resolved `context` directory.
+- CORRECT examples when the Dockerfile is at `validation/Dockerfile.app`:
+    context: ..
+    dockerfile: validation/Dockerfile.app
+  Or when the Dockerfile is at `validation/Dockerfile.app` and you want context inside `validation/`:
+    context: .
+    dockerfile: Dockerfile.app
+- WRONG (double-nesting bug):
+    context: .
+    dockerfile: validation/Dockerfile.app
+  This resolves to `validation/validation/Dockerfile.app` which does not exist.
+- After generating the compose file, mentally verify that `<resolved_context>/<dockerfile>` points to a real file.
+
 `validation/validate.sh` requirements:
 - Bash shell with `set -euo pipefail`
 - Include `#!/usr/bin/env bash` as the first line

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -908,7 +908,25 @@ for tidx in $(seq 0 $(( COUNT - 1 ))); do
     fi
 
     if has_label "${TRACKING_LABELS}" "ai:validation-failed"; then
-      mark_validation_failed "Validation workflow reported failure (label ai:validation-failed)."
+      # Extract the detailed failure diagnosis from the most recent validation
+      # comment posted by validate_process.sh (matches headings like
+      # "Runtime validation failed", "Runtime validation harness error",
+      # "Runtime validation infeasible", or "Runtime validation found fixable issues").
+      VALIDATION_FAIL_BODY="$(echo "${COMMENTS}" | jq -r '
+        [.[] | select(.body | test("## [❌🧪⚠️]+ Runtime validation"))] | last | .body // ""
+      ')"
+      if [ -n "${VALIDATION_FAIL_BODY}" ] && [ "${VALIDATION_FAIL_BODY}" != "" ]; then
+        # Store the diagnosis in state and skip the duplicate comment —
+        # the detailed comment is already on the issue.
+        jq --arg reason "${VALIDATION_FAIL_BODY}" '.status = "failed" | .validation_failure_reason = $reason | .validation_active_fix_issues = []' \
+          "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
+        post_state_comment
+        set_tracking_phase_label "ai:validation-failed"
+        tg_notify "❌ Project #${TRACKING_NUM} validation failed (see tracking issue for diagnosis)."
+        tg_cleanup_msgs "${TRACKING_NUM}"
+      else
+        mark_validation_failed "Validation workflow reported failure (label ai:validation-failed)."
+      fi
       continue
     fi
 


### PR DESCRIPTION
Two fixes for the validation pipeline:

1. Add explicit Docker build-context path rules to the validate-generate
   prompt so Codex doesn't produce broken context/dockerfile combinations
   (e.g. context: . with dockerfile: validation/Dockerfile.app, which
   resolves to validation/validation/Dockerfile.app).

2. When the orchestrator detects ai:validation-failed, extract the detailed
   diagnosis from the existing tracking issue comment instead of posting a
   generic "Validation workflow reported failure" message. This preserves
   the AI analysis so downstream consumers can act on the root cause.

https://claude.ai/code/session_01Swd9Djt9eXDvsxSXLv6Ecw