### PR TITLE
Remove autofix commit gate from review workflows

### DIFF
--- a/.github/workflows/internal-review.yml
+++ b/.github/workflows/internal-review.yml
@@ -21,36 +21,7 @@ permissions:
   issues: write
 
 jobs:
-  # Gate: skip synchronize events caused by autofix commits.  The autofix
-  # workflow already re-dispatches itself via workflow_dispatch, so the
-  # synchronize trigger is redundant and causes the completing run to
-  # appear "cancelled" due to the concurrency group.
-  gate:
-    runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.check.outputs.should_run }}
-    steps:
-      - name: Check head commit message
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
-        run: |
-          if [ "${{ github.event.action }}" = "synchronize" ]; then
-            msg=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}" --jq '.commit.message' 2>/dev/null | head -1 || true)
-            if [ -z "${msg}" ]; then
-              echo "::warning::Unable to read head commit message for autofix gate; continuing with review run."
-            fi
-            if printf '%s\n' "${msg}" | grep -q '^\[ai-autofix\]'; then
-              echo "Skipping: head commit is an autofix commit"
-              echo "should_run=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          fi
-          echo "should_run=true" >> "$GITHUB_OUTPUT"
-
   review:
-    needs: gate
-    if: needs.gate.outputs.should_run == 'true'
     uses: ./.github/workflows/review_autofix.yml
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3265,6 +3265,9 @@ jobs:
         # which always exists.  The concurrency group ensures only one run
         # proceeds if both the synchronize event and this dispatch fire.
         #
+        # If the dispatch fails, the synchronize event from the push still
+        # serves as a fallback so the autofix cycle is never silently broken.
+        #
         # Dispatch order:
         #   1. review_autofix.yml (this file) — works when it exists in the
         #      current repo (coding-workflows itself, or consumer repos that
@@ -3324,7 +3327,7 @@ jobs:
           fi
 
           if [ "${dispatched}" = "false" ]; then
-            echo "::warning::Could not dispatch review workflow via workflow_dispatch. The synchronize event may still trigger it. To enable the fallback, add a workflow_dispatch trigger with a pr_number input and an optional allow_workflow_edits boolean input to your caller workflow. Ensure GH_PAT can dispatch workflows (classic PAT: repo+workflow; fine-grained PAT: Actions read/write)."
+            echo "::warning::Could not dispatch review workflow via workflow_dispatch; the synchronize event from the push will trigger the next review run instead. To enable dispatch (avoids merge-ref resolution issues), add a workflow_dispatch trigger with a pr_number input and an optional allow_workflow_edits boolean input to your caller workflow. Ensure GH_PAT can dispatch workflows (classic PAT: repo+workflow; fine-grained PAT: Actions read/write)."
           fi
 
       - name: Telegram success

--- a/workflow-templates/ai-review.yml
+++ b/workflow-templates/ai-review.yml
@@ -21,36 +21,7 @@ permissions:
   pull-requests: write
   issues: write
 jobs:
-  # Gate: skip synchronize events caused by autofix commits.  The autofix
-  # workflow already re-dispatches itself via workflow_dispatch, so the
-  # synchronize trigger is redundant and causes the completing run to
-  # appear "cancelled" due to the concurrency group.
-  gate:
-    runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.check.outputs.should_run }}
-    steps:
-      - name: Check head commit message
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
-        run: |
-          if [ "${{ github.event.action }}" = "synchronize" ]; then
-            msg=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}" --jq '.commit.message' 2>/dev/null | head -1 || true)
-            if [ -z "${msg}" ]; then
-              echo "::warning::Unable to read head commit message for autofix gate; continuing with review run."
-            fi
-            if printf '%s\n' "${msg}" | grep -q '^\[ai-autofix\]'; then
-              echo "Skipping: head commit is an autofix commit"
-              echo "should_run=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          fi
-          echo "should_run=true" >> "$GITHUB_OUTPUT"
-
   review:
-    needs: gate
-    if: needs.gate.outputs.should_run == 'true'
     uses: shubhodeep1/coding-workflows/.github/workflows/review_autofix.yml@stable
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}


### PR DESCRIPTION
## Summary
Removes the `gate` job that was skipping review workflow runs for autofix commits in both the internal and template review workflows. The gate logic is no longer needed since the synchronize event now serves as a reliable fallback mechanism.

## Key Changes
- **Removed gate job** from `.github/workflows/internal-review.yml` and `workflow-templates/ai-review.yml`
  - Eliminated the commit message check that detected `[ai-autofix]` prefixed commits
  - Removed the conditional dependency (`needs: gate` and `if: needs.gate.outputs.should_run == 'true'`) from the review job
  
- **Updated fallback documentation** in `.github/workflows/review_autofix.yml`
  - Clarified that the synchronize event from the push serves as a fallback when workflow_dispatch fails
  - Improved warning message to explain that the synchronize event will trigger the next review run instead of silently failing
  - Added comment explaining the fallback behavior and its importance for the autofix cycle

## Implementation Details
The gate job was originally implemented to prevent duplicate runs when autofix commits triggered both a synchronize event and a workflow_dispatch. However, the concurrency group already handles this deduplication, making the gate redundant. By removing it and relying on the synchronize event as a fallback, the workflow becomes simpler while maintaining reliability—if dispatch fails, the push event ensures the review cycle continues.

https://claude.ai/code/session_01Vw7PzHmnfZ5qgPBHJabVoB