### PR TITLE
Add rate-limit cooldown before retriggering poller workflow

### DIFF
--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -235,6 +235,15 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Rate-limit cooldown before retrigger
+        if: >-
+          !cancelled()
+          && steps.find_tracking.outputs.has_work == 'true'
+          && inputs.caller_workflow != ''
+        run: |
+          echo "Sleeping 60s to avoid GitHub API rate limits…"
+          sleep 60
+
       - name: Retrigger poller for continuous polling
         if: >-
           !cancelled()


### PR DESCRIPTION
## Summary
Added a 60-second cooldown delay before retriggering the poller workflow to prevent hitting GitHub API rate limits during continuous polling operations.

## Key Changes
- Inserted a new workflow step that sleeps for 60 seconds before the "Retrigger poller for continuous polling" step
- The cooldown only executes when:
  - The workflow hasn't been cancelled
  - Work was found in the tracking step (`has_work == 'true'`)
  - The workflow was triggered by a caller workflow (not empty)

## Implementation Details
- Uses a simple `sleep 60` command with an informative echo message
- Positioned strategically between the summary output step and the retrigger step to ensure the delay happens at the right point in the workflow execution
- Conditional logic ensures the cooldown only applies to continuous polling scenarios, avoiding unnecessary delays in other execution paths

https://claude.ai/code/session_01A1g4srKg7iSzh1gvrdivDU