### PR TITLE
Auto-tune LLM reasoning effort for E2E smoke tests

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -140,6 +140,14 @@ jobs:
             echo "ISSUE_TITLE=${ISSUE_TITLE}"
           } >> "$GITHUB_ENV"
 
+      - name: Detect smoke test and tune LLM settings
+        run: |
+          set -euo pipefail
+          if echo "${ISSUE_TITLE}" | grep -qi '\[E2E Smoke Test\]'; then
+            echo "🔬 Smoke test detected — switching to low reasoning effort"
+            echo "MODEL_REASONING_EFFORT=low" >> "$GITHUB_ENV"
+          fi
+
       - name: Fetch issue comments
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -260,6 +260,16 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_ENV"
 
+      - name: Detect smoke test and tune LLM settings
+        if: env.SKIP_IMPLEMENT != 'true'
+        run: |
+          set -euo pipefail
+          ISSUE_TITLE="$(jq -r '.title // ""' "${ISSUE_META_FILE}")"
+          if echo "${ISSUE_TITLE}" | grep -qi '\[E2E Smoke Test\]'; then
+            echo "🔬 Smoke test detected — switching to low reasoning effort"
+            echo "MODEL_REASONING_EFFORT=low" >> "$GITHUB_ENV"
+          fi
+
       - name: Fetch issue comments
         if: env.SKIP_IMPLEMENT != 'true'
         env:

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -167,6 +167,16 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_ENV"
 
+      - name: Detect smoke test and tune LLM settings
+        if: env.SKIP_PLAN != 'true'
+        run: |
+          set -euo pipefail
+          ISSUE_TITLE="$(jq -r '.title // ""' "${ISSUE_META_FILE}")"
+          if echo "${ISSUE_TITLE}" | grep -qi '\[E2E Smoke Test\]'; then
+            echo "🔬 Smoke test detected — switching to low reasoning effort"
+            echo "MODEL_REASONING_EFFORT=low" >> "$GITHUB_ENV"
+          fi
+
       - name: Fetch issue comments
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `EDITOR_MAX_WALL` | No | `3300` | review_autofix, implement | Maximum wall-clock seconds per editor attempt. Budget-aware: auto-capped to remaining job time minus a 2-min buffer. |
 | `EDITOR_MIN_ATTEMPT_SECS` | No | `300` | review_autofix | Minimum remaining job budget (seconds) required to start an editor attempt. Prevents futile retries near the job deadline. |
 
-**Thinking levels** — control the model's reasoning effort per phase. Valid values: `xhigh`, `high`, `medium`, `low`. Defaults are tuned per phase: `medium` for clarify (gap analysis doesn't need deep reasoning), `xhigh` for plan (architectural decisions benefit from maximum reasoning), `high` for implement (follows an existing plan), and `xhigh` for review (last line of defense for catching bugs).
+**Thinking levels** — control the model's reasoning effort per phase. Valid values: `xhigh`, `high`, `medium`, `low`. Defaults are tuned per phase: `medium` for clarify (gap analysis doesn't need deep reasoning), `xhigh` for plan (architectural decisions benefit from maximum reasoning), `high` for implement (follows an existing plan), and `xhigh` for review (last line of defense for catching bugs). **E2E smoke test override:** when an issue title contains `[E2E Smoke Test]`, all phases (clarify, plan, implement, review/edit) automatically switch to `low` reasoning effort to reduce cost and latency during release validation.
 
 | Variable | Default | Used By | Description |
 |---|---|---|---|


### PR DESCRIPTION
## Summary
Add automatic detection and tuning of LLM reasoning effort for E2E smoke test runs. When an issue title contains `[E2E Smoke Test]`, all workflow phases automatically switch to `low` reasoning effort to reduce cost and latency during release validation.

## Key Changes
- **clarify.yml**: Added smoke test detection step that sets `MODEL_REASONING_EFFORT=low` when `[E2E Smoke Test]` is found in the issue title
- **plan.yml**: Added identical smoke test detection step with conditional skip logic
- **implement.yml**: Added identical smoke test detection step with conditional skip logic
- **README.md**: Documented the E2E smoke test override behavior in the thinking levels section

## Implementation Details
- Detection uses case-insensitive grep matching (`grep -qi`) on the issue title extracted from `ISSUE_META_FILE`
- Each workflow phase includes the detection step at an appropriate point after issue metadata is loaded
- The `clarify.yml` step runs unconditionally, while `plan.yml` and `implement.yml` steps respect their respective skip conditions (`SKIP_PLAN` and `SKIP_IMPLEMENT`)
- When triggered, the step outputs a clear indicator message (🔬 emoji) to the workflow logs
- The `MODEL_REASONING_EFFORT=low` setting automatically applies to all downstream LLM calls in that phase

https://claude.ai/code/session_01PMdr22JKuNzFkJroHkwXjc