### PR TITLE
Remove unused default_val parameter from _validate_phase_threshold

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -149,7 +149,7 @@ fi
 # defaults in orchestrate_lib.py (60 min for lightweight phases, 120 min
 # for heavy phases).
 _validate_phase_threshold() {
-  local var_name="$1" default_val="$2"
+  local var_name="$1"
   local val="${!var_name:-}"
   if [ -n "${val}" ]; then
     if ! [[ "${val}" =~ ^[0-9]+$ ]] || [ "${val}" -lt 1 ]; then


### PR DESCRIPTION
## Summary
Removed an unused parameter from the `_validate_phase_threshold` function in the shell script to improve code clarity and reduce confusion.

## Key Changes
- Removed the `default_val="$2"` parameter from the `_validate_phase_threshold()` function declaration
- The parameter was never referenced or used within the function body

## Implementation Details
The `default_val` variable was declared but never utilized in the function logic. The function only uses the `var_name` parameter to validate the actual value stored in that variable. Removing this unused parameter makes the function signature clearer and prevents future maintainers from wondering about its purpose.

https://claude.ai/code/session_01QuirUNerKCLTkF9pXMCt2Y