### PR TITLE
Reduce API rate limit sleep duration from 60s to 30s

### DIFF
--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -241,8 +241,8 @@ jobs:
           && steps.find_tracking.outputs.has_work == 'true'
           && inputs.caller_workflow != ''
         run: |
-          echo "Sleeping 60s to avoid GitHub API rate limits…"
-          sleep 60
+          echo "Sleeping 30s to avoid GitHub API rate limits…"
+          sleep 30
 
       - name: Retrigger poller for continuous polling
         if: >-


### PR DESCRIPTION
## Summary
Reduced the sleep duration in the orchestrate_poll workflow to avoid GitHub API rate limits from 60 seconds to 30 seconds.

## Changes
- Updated the sleep duration in the rate limit avoidance step from 60 seconds to 30 seconds
- Updated the corresponding echo message to reflect the new duration

## Details
This change optimizes the polling workflow by reducing unnecessary wait time while still maintaining a buffer to avoid hitting GitHub API rate limits. The 30-second delay should be sufficient to prevent rate limiting while allowing the workflow to execute more frequently.

https://claude.ai/code/session_01W1ipuSGUZXkbf5fjUrQpoA