### PR TITLE
Add MAX_VALIDATION_RECOVERY_ATTEMPTS config to test setup

### DIFF
--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -373,6 +373,7 @@ print(json.dumps(parsed))
 				"SERENA_DISABLED": "true",
 				"SERENA_IGNORED_DIRS": "",
 				"MAX_REVIEW_BLOCKED_RETRIES": "2",
+				"MAX_VALIDATION_RECOVERY_ATTEMPTS": "0",
 				"ENABLE_VALIDATION": enable_validation,
 				"MAX_VALIDATE_CYCLES": max_validate_cycles,
 				"GH_MOCK_STORE": str(store_file),


### PR DESCRIPTION
## Summary
Added the `MAX_VALIDATION_RECOVERY_ATTEMPTS` environment variable configuration to the test orchestration setup with a default value of "0".

## Changes
- Added `MAX_VALIDATION_RECOVERY_ATTEMPTS: "0"` to the environment configuration in the `parse_api()` test function
- This configuration is set alongside other validation-related settings like `ENABLE_VALIDATION` and `MAX_VALIDATE_CYCLES`

## Details
This change ensures that the validation recovery attempts configuration is explicitly set during test execution, allowing tests to run with a known and controlled validation recovery behavior. Setting it to "0" disables validation recovery attempts in the test environment.

https://claude.ai/code/session_019htEfYkzBGxSvHF8f1DVa8