### PR TITLE
Optimize poller billing by aligning job end to 55th-second marks

### DIFF
--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -45,6 +45,7 @@ jobs:
             echo "STATE_FILE=${RUNTIME_DIR}/state.json"
             echo "JUDGE_PROMPT_FILE=${RUNTIME_DIR}/judge_prompt.txt"
             echo "JUDGE_OUTPUT_FILE=${RUNTIME_DIR}/judge_output.txt"
+            echo "JOB_START_EPOCH=$(date +%s)"
           } >> "$GITHUB_ENV"
 
       - name: Find active tracking issues
@@ -248,14 +249,28 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Rate-limit cooldown before retrigger
+      - name: Billing-optimized cooldown before retrigger
         if: >-
           !cancelled()
           && steps.find_tracking.outputs.has_work == 'true'
           && inputs.caller_workflow != ''
         run: |
-          echo "Sleeping 30s to avoid GitHub API rate limits…"
-          sleep 30
+          set -euo pipefail
+          NOW="$(date +%s)"
+          ELAPSED=$(( NOW - JOB_START_EPOCH ))
+          # Minimum 30s cooldown to avoid GitHub API rate limits
+          MIN_TARGET=$(( ELAPSED + 30 ))
+          # Round up to the next 55th-second mark (55s, 1m55s, 2m55s, …)
+          # so the job ends just before the next billing minute boundary.
+          TARGET=$(( ((MIN_TARGET + 5 + 59) / 60) * 60 - 5 ))
+          SLEEP_SECS=$(( TARGET - ELAPSED ))
+          # Safety: skip if sleeping would push past 29m30s (near the
+          # 30-minute job timeout); fall back to the 30s minimum instead.
+          if [ $(( ELAPSED + SLEEP_SECS )) -gt 1770 ]; then
+            SLEEP_SECS=30
+          fi
+          echo "Elapsed ${ELAPSED}s — sleeping ${SLEEP_SECS}s to align job end to ~${TARGET}s ($(( TARGET / 60 ))m$(( TARGET % 60 ))s)"
+          sleep "${SLEEP_SECS}"
 
       - name: Retrigger poller for continuous polling
         if: >-


### PR DESCRIPTION
## Summary

- Replaces the fixed 30s rate-limit cooldown in the orchestrate poller with a billing-optimized sleep that targets the nearest 55th-second mark (55s, 1m55s, 2m55s, …)
- Records `JOB_START_EPOCH` at job start to compute elapsed time accurately
- Preserves the minimum 30s cooldown for GitHub API rate-limit safety, with a guard to avoid exceeding the 30-minute job timeout

GitHub Actions bills per minute (rounded up), so ending a job at :55 maximizes use of each billed minute and avoids the fixed 30s sleep pushing the job just past a minute boundary — which would cost an extra billed minute.

## Test plan

- [x] Existing test suite passes (34/34)
- [ ] Verify in a live poller run that the log line shows correct elapsed/sleep/target values
- [ ] Confirm the job ends near a :55 mark by checking the Actions job duration

https://claude.ai/code/session_016abxdoGZcg7syVcTiHr8Gt