### PR TITLE
Remove job timeout and safety check from orchestrate poll workflow

### DIFF
--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -28,7 +28,6 @@ env:
 jobs:
   poll:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     concurrency:
       # Only one poller per repo at a time
       group: ai-orchestrate-poll-${{ github.repository }}
@@ -264,11 +263,6 @@ jobs:
           # so the job ends just before the next billing minute boundary.
           TARGET=$(( ((MIN_TARGET + 5 + 59) / 60) * 60 - 5 ))
           SLEEP_SECS=$(( TARGET - ELAPSED ))
-          # Safety: skip if sleeping would push past 29m30s (near the
-          # 30-minute job timeout); fall back to the 30s minimum instead.
-          if [ $(( ELAPSED + SLEEP_SECS )) -gt 1770 ]; then
-            SLEEP_SECS=30
-          fi
           echo "Elapsed ${ELAPSED}s — sleeping ${SLEEP_SECS}s to align job end to ~${TARGET}s ($(( TARGET / 60 ))m$(( TARGET % 60 ))s)"
           sleep "${SLEEP_SECS}"
 


### PR DESCRIPTION
## Summary
Removed the 30-minute job timeout and the associated safety check that prevented the sleep duration from exceeding a threshold near the timeout boundary.

## Key Changes
- Removed `timeout-minutes: 30` from the poll job configuration
- Removed the safety check that limited sleep duration to prevent exceeding 29m30s (1770 seconds), allowing the job to sleep longer if needed to align with billing minute boundaries

## Implementation Details
The removal of the timeout allows the polling job to run without a hard time limit. Previously, the safety check would fall back to a 30-second minimum sleep if the calculated sleep duration would push the total elapsed time past 1770 seconds. With the timeout removed, this constraint is no longer necessary, and the job can now sleep for the full calculated duration to properly align job completion with billing minute boundaries.

https://claude.ai/code/session_01AQoj8ChvzzbEEfupg53zXH