### PR TITLE
Add Docker Compose healthcheck YAML quoting rules to validation guide

### DIFF
--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -45,6 +45,18 @@ Docker build-context path rules (CRITICAL):
   This resolves to `validation/validation/Dockerfile.app` which does not exist.
 - After generating the compose file, mentally verify that `<resolved_context>/<dockerfile>` points to a real file.
 
+Docker Compose healthcheck YAML rules (CRITICAL):
+- Every entry in a `healthcheck.test` list MUST be an explicitly quoted string.
+- YAML auto-casts bare values like `true`, `false`, `yes`, `no`, `null`, and bare numbers into non-string types. Docker Compose schema validation rejects these with: `services.<name>.healthcheck.test.N must be a string`.
+- CORRECT:
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.runCommand('ping').ok"]
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"]
+- WRONG (YAML casts bare words to booleans/nulls):
+    healthcheck:
+      test: ["CMD", mongosh, --eval, db.runCommand('ping').ok]
+- Always wrap every healthcheck test entry in double quotes inside the YAML list.
+
 `validation/validate.sh` requirements:
 - Bash shell with `set -euo pipefail`
 - Include `#!/usr/bin/env bash` as the first line


### PR DESCRIPTION
## Summary
Added critical documentation about Docker Compose healthcheck YAML formatting requirements to prevent schema validation failures caused by YAML type auto-casting.

## Key Changes
- Added new "Docker Compose healthcheck YAML rules (CRITICAL)" section to the validation prompt guide
- Documented that all entries in `healthcheck.test` lists must be explicitly quoted strings
- Explained the YAML auto-casting behavior that causes validation errors (bare values like `true`, `false`, `yes`, `no`, `null`, and numbers are cast to non-string types)
- Provided correct examples showing properly quoted healthcheck test entries
- Provided incorrect examples demonstrating the common mistake of unquoted values
- Emphasized the requirement to wrap every healthcheck test entry in double quotes within YAML lists

## Implementation Details
This is a documentation-only change that clarifies a critical validation rule for Docker Compose files. The guidance helps prevent the error: `services.<name>.healthcheck.test.N must be a string` by ensuring developers understand the importance of explicit string quoting in healthcheck test arrays.

https://claude.ai/code/session_01ApPwaHxMR7Mcuw2eLaNKJq