### PR TITLE
Keep tracking issues open after validation completion

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -399,8 +399,7 @@ mark_validation_complete() {
     "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
   post_state_comment
   set_tracking_phase_label "ai:validated"
-  gh_retry gh issue close "${TRACKING_NUM}" --repo "${GITHUB_REPOSITORY}" \
-    --comment "Project completed successfully after runtime validation passed (cycle ${validation_cycle})." || true
+  post_tracking_comment "Project completed successfully after runtime validation passed (cycle ${validation_cycle}). Issue kept open for manual review."
   tg_cleanup_msgs "${TRACKING_NUM}"
   MSG="✅ Project #${TRACKING_NUM} completed after validation pass (cycle ${validation_cycle})."
   MSG+=$'\n'"Tracking: $(_gh_url "issues/${TRACKING_NUM}")"
@@ -2577,8 +2576,8 @@ PRs to revert: ${REVERT_COUNT}"
         jq '.status = "complete" | .judge_cycle += 1' "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
         post_state_comment
 
-        gh issue close "${TRACKING_NUM}" --repo "${GITHUB_REPOSITORY}" \
-          --comment "Project completed successfully after $((JUDGE_CYCLE + 1)) judge cycle(s)." || true
+        set_tracking_phase_label "ai:validated"
+        post_tracking_comment "Project completed successfully after $((JUDGE_CYCLE + 1)) judge cycle(s). Issue kept open for manual review."
 
         tg_cleanup_msgs "${TRACKING_NUM}"
         MSG="✅ Project #${TRACKING_NUM} completed! All waves merged and judge approved."

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -456,7 +456,7 @@ def test_complete_verdict_redispatches_validation_when_previous_dispatch_cycle_e
 
 
 
-def test_complete_verdict_closes_when_validation_disabled():
+def test_complete_verdict_keeps_open_when_validation_disabled():
 	state = _base_state(status="in_progress")
 	result = _run_poller(
 		state=state,
@@ -465,7 +465,7 @@ def test_complete_verdict_closes_when_validation_disabled():
 		issue_labels={10: ["ai:merged"]},
 	)
 	assert result["latest_state"]["status"] == "complete"
-	assert result["tracking_closed"] is True
+	assert result["tracking_closed"] is False
 	assert result["validation_dispatches"] == []
 
 
@@ -557,7 +557,7 @@ def test_invalid_max_validate_cycles_defaults_to_three():
 	assert result["latest_state"]["status"] == "failed"
 	assert "MAX_VALIDATE_CYCLES=3" in result["latest_state"].get("validation_failure_reason", "")
 
-def test_validated_label_marks_complete_and_closes():
+def test_validated_label_marks_complete_and_keeps_open():
 	state = _base_state(status="validating")
 	state["validation_cycle"] = 2
 	result = _run_poller(
@@ -568,7 +568,7 @@ def test_validated_label_marks_complete_and_closes():
 	)
 	assert result["latest_state"]["status"] == "complete"
 	assert result["latest_state"]["validation_completed_cycle"] == 2
-	assert result["tracking_closed"] is True
+	assert result["tracking_closed"] is False
 	assert "ai:validated" in result["tracking_labels"]
 
 


### PR DESCRIPTION
## Summary
Changed the orchestration process to keep tracking issues open after validation and judge cycles complete, instead of automatically closing them. This allows for manual review before final closure.

## Key Changes
- **Test updates**: Updated test names and assertions to reflect new behavior
  - `test_complete_verdict_closes_when_validation_disabled` → `test_complete_verdict_keeps_open_when_validation_disabled`
  - `test_validated_label_marks_complete_and_closes` → `test_validated_label_marks_complete_and_keeps_open`
  - Changed assertions from `tracking_closed is True` to `tracking_closed is False`

- **Validation completion flow**: Modified `mark_validation_complete()` to post a comment instead of closing the issue
  - Removed: `gh issue close` command after validation passes
  - Added: `post_tracking_comment` with message indicating issue is kept open for manual review
  - Maintained: `ai:validated` label setting

- **Judge cycle completion flow**: Modified judge cycle completion to keep issue open
  - Removed: `gh issue close` command after judge approval
  - Added: `set_tracking_phase_label "ai:validated"` and `post_tracking_comment` with appropriate message
  - Ensures consistent behavior with validation completion

## Implementation Details
Both completion paths now use `post_tracking_comment` to communicate the completion status while keeping the issue open, enabling manual review and verification before final closure.

https://claude.ai/code/session_017NRAd8F7h2u6GkED2ePWGP