### PR TITLE
Simplify PR diff output using here-string syntax

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1641,7 +1641,7 @@ for tidx in $(seq 0 $(( COUNT - 1 ))); do
         echo
         echo "=== PR #${RB_PR} DIFF ==="
         echo
-        echo "${PR_DIFF}" | { head -1000 || true; }
+        head -1000 <<< "${PR_DIFF}"
         echo
         echo "=== PR #${RB_PR} COMMENTS (editor summaries, reviewer findings) ==="
         echo


### PR DESCRIPTION
## Summary
Refactored the PR diff output command in the poll process orchestration script to use bash here-string syntax instead of piping through a subshell.

## Key Changes
- Replaced `echo "${PR_DIFF}" | { head -1000 || true; }` with `head -1000 <<< "${PR_DIFF}"`
- Eliminates unnecessary subshell and pipe operations
- Maintains identical functionality while improving code clarity and efficiency

## Implementation Details
The here-string (`<<<`) operator passes the variable content directly to `head` as standard input, which is more idiomatic bash and avoids the overhead of spawning a subshell. The error handling behavior remains the same since `head` naturally exits with status 0 when processing input successfully.

https://claude.ai/code/session_018vyf5xzhW1qWc73Ji5hjk9