### PR TITLE
Resolve merge conflicts directly with Codex in orchestrator

### DIFF
--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -227,6 +227,8 @@ jobs:
           MAX_STALL_RECOVERIES_PER_ISSUE: ${{ vars.MAX_STALL_RECOVERIES_PER_ISSUE || '5' }}
           MAX_RECOVERY_ATTEMPTS: ${{ vars.MAX_RECOVERY_ATTEMPTS || '3' }}
           MAX_VALIDATION_RECOVERY_ATTEMPTS: ${{ vars.MAX_VALIDATION_RECOVERY_ATTEMPTS || '2' }}
+          MODEL_CONFLICT_RESOLVER: ${{ vars.WORKFLOW_EDITOR_MODEL || 'openai/gpt-5.3-codex' }}
+          CONFLICT_RESOLVER_REASONING_EFFORT: ${{ vars.THINKING_LEVEL_CONFLICT_RESOLVER || 'xhigh' }}
           PYTHONDONTWRITEBYTECODE: "1"
         run: bash scripts/orchestrate_poll_process.sh
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `THINKING_LEVEL_JUDGE` | `xhigh` | orchestrate_poll | Reasoning effort for judge evaluation |
 | `THINKING_LEVEL_CLARIFY_RESPOND` | `medium` | orchestrate_clarify_respond | Reasoning effort for auto-answering clarification questions |
 | `THINKING_LEVEL_VALIDATE` | `xhigh` | validate | Reasoning effort for runtime validation harness generation and diagnosis |
+| `THINKING_LEVEL_CONFLICT_RESOLVER` | `xhigh` | orchestrate_poll | Reasoning effort for the orchestrator's Codex-based merge conflict resolver |
 
 **Tool call budgets** — soft limits on the number of MCP + shell tool calls per phase. The LLM treats these as guidelines; it may exceed them for large refactors that span many files.
 
@@ -331,10 +332,14 @@ jobs:
 > **Standalone PR conflict sweep** — After processing orchestrator-managed
 > tracking issues, the poller scans all open PRs on `ai/issue-*` branches for
 > merge conflicts. When a conflict is detected it attempts a GitHub API branch
-> update; if that fails (real conflicts), it pushes an empty commit to force a
-> `synchronize` event so the review workflow's Codex conflict resolver can run.
-> This ensures standalone (non-orchestrator) AI PRs are not permanently blocked
-> by merge conflicts.
+> update; if that fails (real conflicts), the poller runs a dedicated Codex
+> conflict resolution instance (using `WORKFLOW_EDITOR_MODEL` at
+> `THINKING_LEVEL_CONFLICT_RESOLVER` reasoning effort) to resolve the
+> conflicts directly, commits the result, and pushes. This produces a clean
+> merge ref so the subsequent autofix run triggers normally. If Codex
+> resolution fails, it falls back to pushing an empty commit to force a
+> `synchronize` event. This ensures standalone (non-orchestrator) AI PRs are
+> not permanently blocked by merge conflicts.
 
 **`.github/workflows/ai-validate.yml`** — Runs runtime validation (generate harness -> execute -> structured artifacts)
 ```yaml
@@ -565,7 +570,7 @@ Or create them manually — see the inline examples in the [Quickstart](#quickst
 1. **Decomposition:** The LLM reads your repo, breaks the project into scoped issues with a dependency graph, and creates a tracking issue (labeled `ai:orchestrator-tracking`).
 2. **Wave dispatch:** Wave 1 issues (no dependencies) are created immediately and enter the existing clarify → plan → implement → review pipeline automatically. If clarification questions are raised, the `orchestrate_clarify_respond` workflow answers them automatically using an LLM, so the pipeline runs fully unattended.
 3. **Auto-merge:** The poller automatically merges PRs via squash merge when they reach `ai:ready-to-merge`. If a PR has merge conflicts (e.g. `main` advanced since the PR was created), the poller automatically updates the PR branch via the GitHub API before retrying the merge. This requires either (a) no branch protection rules, or (b) branch protection with "Require status checks" that have already passed. See [Enabling auto-merge](#enabling-auto-merge) below.
-4. **In-progress conflict resolution:** When the base branch advances and creates merge conflicts on in-progress PRs (still going through the review/autofix cycle), the poller detects the conflict (`mergeable == false`) and re-triggers the review workflow by pushing an empty commit. The review workflow's built-in Codex conflict resolver then handles the actual merge conflict resolution automatically.
+4. **In-progress conflict resolution:** When the base branch advances and creates merge conflicts on in-progress PRs (still going through the review/autofix cycle), the poller detects the conflict (`mergeable == false`) and runs a dedicated Codex conflict resolution instance directly (using `WORKFLOW_EDITOR_MODEL` at `THINKING_LEVEL_CONFLICT_RESOLVER` reasoning effort). The resolved files are committed and pushed, producing a clean merge ref so the subsequent autofix run triggers normally. If Codex resolution fails, it falls back to pushing an empty commit. The review workflow also retains its own built-in Codex conflict resolver as a second line of defense.
 5. **Polling:** Every 5 minutes, the poller checks if the current wave's issues have reached `ai:merged`. When all are merged, it runs the judge.
 6. **Judge:** Full repo checkout + tool access (Serena, shell, file reads) with `xhigh` thinking. Compares merged code against the project spec. Decides: complete, in_progress (next wave or fix-ups), or failed.
 7. **Next wave:** When the judge approves, the poller creates the next wave's issues (deferred creation — they don't exist until their dependencies are met). This triggers `clarify.yml` via `issues.opened`.

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1007,6 +1007,250 @@ The judge will evaluate this gap when the wave completes and decide whether to r
 }
 
 # ---------------------------------------------------------------
+# Helper: Resolve merge conflicts on a PR branch using Codex
+# ---------------------------------------------------------------
+# Runs a dedicated Codex instance (same model as the editor, xhigh
+# reasoning) to resolve merge conflict markers, commits the result,
+# pushes, and dispatches the review workflow.
+#
+# Previously the orchestrator pushed an empty commit to force a
+# synchronize event, expecting the review_autofix workflow's conflict
+# resolver to handle it.  But when the PR has real conflicts the merge
+# ref (refs/pull/N/merge) is unbuildable, causing GitHub to silently
+# skip the reusable workflow — stalling the pipeline.  By resolving
+# conflicts directly here, the push produces a clean merge ref so the
+# subsequent autofix run triggers normally.
+#
+# Usage: _resolve_merge_conflicts_with_codex <pr_number> <head_ref> <base_branch> [issue_number]
+# Returns 0 on success (conflicts resolved + pushed), 1 on failure.
+# Leaves the repo on a detached HEAD regardless of outcome.
+_resolve_merge_conflicts_with_codex()
+{
+	local pr_number="$1"
+	local head_ref="$2"
+	local base_branch="$3"
+	local issue_number="${4:-}"
+
+	local log_prefix="[conflict-resolver]"
+	if [ -n "${issue_number}" ]; then
+		log_prefix="[conflict-resolver] PR #${pr_number} (issue #${issue_number})"
+	else
+		log_prefix="[conflict-resolver] PR #${pr_number}"
+	fi
+
+	echo "  ${log_prefix} Starting Codex-based merge conflict resolution..."
+
+	# --- Fetch and checkout the PR branch ---
+	if ! git fetch origin "${head_ref}:refs/remotes/origin/${head_ref}" 2>/dev/null; then
+		echo "::warning::${log_prefix} Could not fetch head ref ${head_ref}; skipping."
+		return 1
+	fi
+	if ! git fetch origin "${base_branch}:refs/remotes/origin/${base_branch}" 2>/dev/null; then
+		echo "::warning::${log_prefix} Could not fetch base branch ${base_branch}; skipping."
+		return 1
+	fi
+	if ! git checkout "origin/${head_ref}" 2>/dev/null; then
+		echo "::warning::${log_prefix} Could not checkout ${head_ref}; skipping."
+		return 1
+	fi
+
+	git config user.name "codex-bot"
+	git config user.email "codex@users.noreply.github.com"
+
+	# --- Start merge to introduce conflict markers ---
+	git merge --no-commit --no-ff "origin/${base_branch}" 2>/dev/null || true
+
+	if [ -z "$(git ls-files --unmerged 2>/dev/null)" ]; then
+		# Clean merge — no actual conflicts.  Commit and push.
+		if git commit -m "[orchestrator-merge] update branch with ${base_branch}" 2>/dev/null; then
+			if git push origin "HEAD:${head_ref}" 2>/dev/null; then
+				echo "  ${log_prefix} Clean merge committed and pushed."
+				git checkout --detach HEAD 2>/dev/null || true
+				return 0
+			fi
+		fi
+		# Merge was already up-to-date or push failed
+		if [ -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
+			git merge --abort 2>/dev/null || true
+		fi
+		git checkout --detach HEAD 2>/dev/null || true
+		echo "::warning::${log_prefix} Clean merge push failed."
+		return 1
+	fi
+
+	echo "  ${log_prefix} Conflict markers present. Running Codex to resolve..."
+
+	# --- Setup Codex config for the conflict resolver model ---
+	mkdir -p ~/.codex
+	local catalog_path
+	catalog_path="$(pwd)/scripts/codex_model_catalog.json"
+	{
+		echo 'web_search = "live"'
+		echo 'model_provider = "openrouter"'
+		echo "model = \"${MODEL_CONFLICT_RESOLVER:-${MODEL_EDITOR}}\""
+		echo "model_reasoning_effort = \"${CONFLICT_RESOLVER_REASONING_EFFORT:-xhigh}\""
+		if [ -f "${catalog_path}" ]; then
+			echo "model_catalog_json = \"${catalog_path}\""
+		fi
+		echo
+		echo '[model_providers.openrouter]'
+		echo 'name = "OpenRouter"'
+		echo 'base_url = "https://openrouter.ai/api/v1"'
+		echo 'env_key = "OPENROUTER_API_KEY"'
+		echo 'wire_api = "responses"'
+		echo 'stream_idle_timeout_ms = 600000'
+		echo 'stream_max_retries = 5'
+		echo 'request_max_retries = 3'
+		echo
+		echo '[sandbox_workspace_write]'
+		echo 'network_access = true'
+	} > ~/.codex/config.toml
+
+	# --- Build conflict resolver prompt ---
+	local prompt_file
+	prompt_file="$(mktemp)"
+	cat > "${prompt_file}" <<'__CONFLICT_RESOLVER_PROMPT__'
+Repository task: Resolve merge conflicts.
+
+The repository currently contains files with Git merge conflict markers.
+
+Conflict markers appear in this format:
+<<<<<<< HEAD
+code
+=======
+other code
+>>>>>>> branch
+
+Your task:
+Resolve merge conflicts safely.
+
+Rules:
+- Only resolve conflicts.
+- Do not introduce new functionality.
+- Do not refactor unrelated code.
+- Do not modify files that do not contain conflict markers.
+- Prefer preserving behavior from both sides when possible.
+- If both sides are incompatible, choose the version consistent with surrounding code.
+- Remove all conflict markers.
+- Ensure the final code compiles logically.
+- You may read repository files as needed.
+- You may modify repository files directly.
+- Do not generate patches.
+- Do not generate scripts.
+- Do not modify GitHub workflow files except when resolving merge conflicts.
+- Do not access the network.
+
+Final output must be plain text.
+
+Output sections:
+Conflicts resolved:
+- list files where conflicts were resolved
+
+Notes:
+- brief explanation if any resolution required choosing one side
+__CONFLICT_RESOLVER_PROMPT__
+
+	# --- Run Codex to resolve conflicts ---
+	local resolver_success=false
+	local attempt=1
+	local tmp_output
+	while [ "${attempt}" -le 3 ]; do
+		tmp_output="$(mktemp)"
+		if codex exec \
+			--model "${MODEL_CONFLICT_RESOLVER:-${MODEL_EDITOR}}" \
+			--full-auto \
+			"$(cat "${prompt_file}")" > "${tmp_output}" 2>/dev/null; then
+			if [ -s "${tmp_output}" ]; then
+				echo "  ${log_prefix} Codex resolver succeeded on attempt ${attempt}."
+				resolver_success=true
+				rm -f "${tmp_output}"
+				break
+			fi
+		fi
+		rm -f "${tmp_output}"
+		if [ "${attempt}" -eq 3 ]; then
+			echo "::warning::${log_prefix} Codex conflict resolver failed after 3 attempts."
+		fi
+		attempt=$((attempt + 1))
+		sleep 2
+	done
+	rm -f "${prompt_file}"
+
+	if [ "${resolver_success}" != "true" ]; then
+		# Abort merge and fall back to empty-commit re-trigger
+		git merge --abort 2>/dev/null || true
+		git reset --hard HEAD 2>/dev/null || true
+		echo "  ${log_prefix} Falling back to empty-commit re-trigger."
+		git commit --allow-empty \
+			-m "[orchestrator] re-trigger review for conflict resolution (PR #${pr_number})" \
+			2>/dev/null || true
+		if git push origin "HEAD:${head_ref}" 2>/dev/null; then
+			echo "  ${log_prefix} Pushed empty commit as fallback re-trigger."
+		else
+			echo "::warning::${log_prefix} Could not push fallback empty commit."
+		fi
+		git checkout --detach HEAD 2>/dev/null || true
+		return 1
+	fi
+
+	# --- Clean up workflow artifacts so they are not committed to caller repos ---
+	if [[ "${GITHUB_REPOSITORY}" != *"/coding-workflows" ]]; then
+		rm -f ./pre_assembled_static.txt
+		rm -f codex_system_instructions.md ai_pipeline.md unattended_llm_system_instructions.md agents.md
+		rm -f scripts/setup_serena.sh scripts/git_ref_health_check.sh scripts/serena_efficiency_report.py \
+			scripts/generate_symbol_diff_summary.py scripts/label_helpers.sh scripts/tg_helpers.sh \
+			scripts/codex_model_catalog.json
+		rm -rf .serena prompts
+	fi
+
+	# --- Commit and push resolved files ---
+	if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+		git rm -r --cached node_modules 2>/dev/null || true
+		git add -u -- ':!node_modules' 2>/dev/null || true
+		git ls-files --others --exclude-standard -z -- ':!node_modules' | xargs -0 -r git add -- 2>/dev/null || true
+		if git commit -m "[ai-merge-resolve] resolve merge conflicts (orchestrator)" 2>/dev/null; then
+			if git push origin "HEAD:${head_ref}" 2>/dev/null; then
+				echo "  ${log_prefix} Conflicts resolved, committed, and pushed."
+
+				# Dispatch review workflow via workflow_dispatch as a reliable
+				# re-trigger — the synchronize event from the push also fires,
+				# but workflow_dispatch resolves from the target ref (always
+				# exists) rather than the merge ref (may lag).
+				local dispatched=false
+				for wf_candidate in ai-review.yml internal-review.yml review_autofix.yml; do
+					if gh workflow run "${wf_candidate}" \
+						--repo "${GITHUB_REPOSITORY}" \
+						--ref "${head_ref}" \
+						-f pr_number="${pr_number}" 2>/dev/null; then
+						echo "  ${log_prefix} Dispatched ${wf_candidate} for next review cycle."
+						dispatched=true
+						break
+					fi
+				done
+				if [ "${dispatched}" = "false" ]; then
+					echo "  ${log_prefix} workflow_dispatch fallback failed; synchronize event will trigger review."
+				fi
+
+				git checkout --detach HEAD 2>/dev/null || true
+				return 0
+			else
+				echo "::warning::${log_prefix} Push failed after conflict resolution."
+			fi
+		else
+			echo "::warning::${log_prefix} Commit failed after conflict resolution."
+		fi
+	else
+		echo "  ${log_prefix} No changes after conflict resolution (conflicts may still exist)."
+	fi
+
+	# Cleanup on failure
+	git merge --abort 2>/dev/null || true
+	git reset --hard HEAD 2>/dev/null || true
+	git checkout --detach HEAD 2>/dev/null || true
+	return 1
+}
+
+# ---------------------------------------------------------------
 # Normalize truthy env vars (case-insensitive 1/true/yes/on)
 # ---------------------------------------------------------------
 _is_truthy() {
@@ -1392,51 +1636,16 @@ for tidx in $(seq 0 $(( COUNT - 1 ))); do
           2>/dev/null; then
           echo "  PR #${RTM_PR} branch updated via API. The synchronize event will re-trigger review (including conflict resolution)."
         else
-          echo "  API branch update failed for PR #${RTM_PR}. Attempting local merge + conflict resolution..."
+          echo "  API branch update failed for PR #${RTM_PR}. Running Codex conflict resolution..."
 
-          # Fetch the PR head branch and base branch
           RTM_HEAD_REF="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${RTM_PR}" --jq '.head.ref' 2>/dev/null || echo "")"
           if [ -n "${RTM_HEAD_REF}" ] && [ "${RTM_HEAD_REF}" != "null" ]; then
             DEFAULT_BRANCH="$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.default_branch' 2>/dev/null || echo "main")"
-            if ! git fetch origin "${RTM_HEAD_REF}:refs/remotes/origin/${RTM_HEAD_REF}" 2>/dev/null || \
-               ! git fetch origin "${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}" 2>/dev/null || \
-               ! git checkout "origin/${RTM_HEAD_REF}" 2>/dev/null; then
-              echo "::warning::Could not fetch or checkout refs for PR #${RTM_PR}; skipping local conflict handling."
-              git checkout --detach HEAD 2>/dev/null || true
-              continue
-            fi
-            git config user.name "codex-bot"
-            git config user.email "codex@users.noreply.github.com"
-
-            if git merge --no-commit --no-ff "origin/${DEFAULT_BRANCH}" 2>/dev/null; then
-              # Clean merge — no conflicts
-              git commit -m "[orchestrator-merge] update branch with ${DEFAULT_BRANCH}" 2>/dev/null || true
-              git push origin "HEAD:${RTM_HEAD_REF}" 2>/dev/null || true
-              echo "  PR #${RTM_PR} branch updated via local merge (no conflicts)."
-            elif [ -n "$(git ls-files --unmerged 2>/dev/null)" ]; then
-              git merge --abort 2>/dev/null || true
-              echo "  PR #${RTM_PR} has real merge conflicts — cannot auto-resolve from poller."
-              echo "  The review workflow's Codex conflict resolver handles this on synchronize events."
-              tg_notify "⚠️ PR #${RTM_PR} (issue #${rtm_issue}) has real merge conflicts. Attempting to re-trigger review workflow."$'\n'"PR: $(_gh_url "pull/${RTM_PR}")"$'\n'"Issue: $(_gh_url "issues/${rtm_issue}")"
-
-              # Force a synchronize event by creating an empty commit on the PR branch
-              if git checkout "origin/${RTM_HEAD_REF}" 2>/dev/null; then
-                git config user.name "codex-bot"
-                git config user.email "codex@users.noreply.github.com"
-                git commit --allow-empty -m "[orchestrator] re-trigger review for conflict resolution" 2>/dev/null || true
-                git push origin "HEAD:${RTM_HEAD_REF}" 2>/dev/null || {
-                  echo "::warning::Could not push empty commit to re-trigger review for PR #${RTM_PR}."
-                }
-              else
-                echo "::warning::Could not check out ${RTM_HEAD_REF} to re-trigger review for PR #${RTM_PR}."
-              fi
+            if _resolve_merge_conflicts_with_codex "${RTM_PR}" "${RTM_HEAD_REF}" "${DEFAULT_BRANCH}" "${rtm_issue}"; then
+              tg_notify "✅ PR #${RTM_PR} (issue #${rtm_issue}) merge conflicts resolved by orchestrator Codex."$'\n'"PR: $(_gh_url "pull/${RTM_PR}")"$'\n'"Issue: $(_gh_url "issues/${rtm_issue}")"
             else
-              git merge --abort 2>/dev/null || true
-              echo "::warning::Unexpected merge state for PR #${RTM_PR}."
+              tg_notify "⚠️ PR #${RTM_PR} (issue #${rtm_issue}) merge conflict resolution failed. Review workflow re-triggered as fallback."$'\n'"PR: $(_gh_url "pull/${RTM_PR}")"$'\n'"Issue: $(_gh_url "issues/${rtm_issue}")"
             fi
-
-            # Return to detached HEAD / original state
-            git checkout --detach HEAD 2>/dev/null || true
           else
             echo "::warning::Could not determine head ref for PR #${RTM_PR}."
           fi
@@ -1459,9 +1668,11 @@ for tidx in $(seq 0 $(( COUNT - 1 ))); do
   # branch moves, so the review workflow is never re-triggered.
   #
   # This block detects in-progress issues whose linked PRs have become
-  # unmergeable and pushes an empty commit to force a synchronize
-  # event, which re-triggers the review workflow (including its merge
-  # conflict resolver).
+  # unmergeable and runs a dedicated Codex conflict resolution instance
+  # to resolve conflicts directly, then pushes.  The resolved push
+  # produces a clean merge ref so the subsequent autofix run triggers
+  # normally.  If Codex resolution fails, falls back to an empty-commit
+  # push.
   # ---------------------------------------------------------------
   echo "${WAVE_STATUS}" | jq -r '.issues[] | select(.status == "in_progress") | .github_issue' | while read -r ip_issue; do
     [ -n "${ip_issue}" ] && [ "${ip_issue}" != "null" ] || continue
@@ -1476,7 +1687,7 @@ for tidx in $(seq 0 $(( COUNT - 1 ))); do
     if [ "${IP_PR_STATE}" != "open" ] || [ "${IP_MERGEABLE}" != "false" ]; then
       continue
     fi
-    echo "  In-progress issue #${ip_issue} has PR #${IP_PR} with merge conflicts. Attempting to re-trigger review..."
+    echo "  In-progress issue #${ip_issue} has PR #${IP_PR} with merge conflicts. Running Codex conflict resolution..."
 
     # Try the GitHub API update-branch first (creates a merge commit
     # if the merge is clean; fails when there are real conflicts).
@@ -1488,26 +1699,15 @@ for tidx in $(seq 0 $(( COUNT - 1 ))); do
       continue
     fi
 
-    # API update failed — real conflicts exist.  Push an empty commit
-    # on the PR branch to force a synchronize event so the review
-    # workflow's Codex conflict resolver can handle it.
+    # API update failed — real conflicts exist.  Resolve with Codex.
     IP_HEAD_REF="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${IP_PR}" --jq '.head.ref' 2>/dev/null || echo "")"
     if [ -n "${IP_HEAD_REF}" ] && [ "${IP_HEAD_REF}" != "null" ]; then
-      if ! git fetch origin "${IP_HEAD_REF}:refs/remotes/origin/${IP_HEAD_REF}" 2>/dev/null || ! git checkout "origin/${IP_HEAD_REF}" 2>/dev/null; then
-        echo "::warning::Could not fetch or checkout head ref ${IP_HEAD_REF} for PR #${IP_PR}; skipping review re-trigger."
-        git checkout --detach HEAD 2>/dev/null || true
-        continue
-      fi
-      git config user.name "codex-bot"
-      git config user.email "codex@users.noreply.github.com"
-      git commit --allow-empty -m "[orchestrator] re-trigger review for conflict resolution" 2>/dev/null || true
-      if git push origin "HEAD:${IP_HEAD_REF}" 2>/dev/null; then
-        echo "  Pushed empty commit to PR #${IP_PR} to re-trigger review workflow."
-        tg_notify "⚠️ PR #${IP_PR} (issue #${ip_issue}) has merge conflicts. Re-triggered review for auto-resolution."$'\n'"PR: $(_gh_url "pull/${IP_PR}")"$'\n'"Issue: $(_gh_url "issues/${ip_issue}")"
+      DEFAULT_BRANCH="$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.default_branch' 2>/dev/null || echo "main")"
+      if _resolve_merge_conflicts_with_codex "${IP_PR}" "${IP_HEAD_REF}" "${DEFAULT_BRANCH}" "${ip_issue}"; then
+        tg_notify "✅ PR #${IP_PR} (issue #${ip_issue}) merge conflicts resolved by orchestrator Codex."$'\n'"PR: $(_gh_url "pull/${IP_PR}")"$'\n'"Issue: $(_gh_url "issues/${ip_issue}")"
       else
-        echo "::warning::Could not push empty commit to re-trigger review for PR #${IP_PR}."
+        tg_notify "⚠️ PR #${IP_PR} (issue #${ip_issue}) merge conflict resolution failed. Review workflow re-triggered as fallback."$'\n'"PR: $(_gh_url "pull/${IP_PR}")"$'\n'"Issue: $(_gh_url "issues/${ip_issue}")"
       fi
-      git checkout --detach HEAD 2>/dev/null || true
     else
       echo "::warning::Could not determine head ref for in-progress PR #${IP_PR}."
     fi
@@ -1777,22 +1977,16 @@ sys.exit(1)
               2>/dev/null; then
               echo "  PR #${RB_PR} branch updated. Synchronize event will re-trigger review + conflict resolution."
             else
-              echo "  API branch update failed for review-blocked PR #${RB_PR}. Pushing empty commit to re-trigger review workflow..."
+              echo "  API branch update failed for review-blocked PR #${RB_PR}. Running Codex conflict resolution..."
               RB_HEAD_REF="$(echo "${PR_META}" | jq -r '.head_ref')"
               if [ -n "${RB_HEAD_REF}" ] && [ "${RB_HEAD_REF}" != "null" ]; then
-                if ! git fetch origin "${RB_HEAD_REF}:refs/remotes/origin/${RB_HEAD_REF}" 2>/dev/null || ! git checkout "origin/${RB_HEAD_REF}" 2>/dev/null; then
-                  echo "::warning::Could not fetch or checkout head ref ${RB_HEAD_REF} for PR #${RB_PR}; skipping review re-trigger."
-                  git checkout --detach HEAD 2>/dev/null || true
-                  continue
+                RB_BASE_REF="$(echo "${PR_META}" | jq -r '.base_ref')"
+                : "${RB_BASE_REF:=${DEFAULT_BRANCH:-main}}"
+                if _resolve_merge_conflicts_with_codex "${RB_PR}" "${RB_HEAD_REF}" "${RB_BASE_REF}" "${rb_issue}"; then
+                  tg_notify "✅ Review-blocked PR #${RB_PR} (issue #${rb_issue}) merge conflicts resolved by orchestrator Codex."$'\n'"PR: $(_gh_url "pull/${RB_PR}")"$'\n'"Issue: $(_gh_url "issues/${rb_issue}")"
+                else
+                  tg_notify "⚠️ Review-blocked PR #${RB_PR} (issue #${rb_issue}) merge conflict resolution failed."$'\n'"PR: $(_gh_url "pull/${RB_PR}")"$'\n'"Issue: $(_gh_url "issues/${rb_issue}")"
                 fi
-                git config user.name "codex-bot"
-                git config user.email "codex@users.noreply.github.com"
-                git commit --allow-empty -m "[orchestrator] re-trigger review for conflict resolution (issue #${rb_issue})" 2>/dev/null || true
-                git push origin "HEAD:${RB_HEAD_REF}" 2>/dev/null || {
-                  echo "::warning::Could not push to re-trigger review for PR #${RB_PR}."
-                  tg_notify "⚠️ Review-blocked PR #${RB_PR} (issue #${rb_issue}) has merge conflicts that could not be auto-resolved."$'\n'"PR: $(_gh_url "pull/${RB_PR}")"$'\n'"Issue: $(_gh_url "issues/${rb_issue}")"
-                }
-                git checkout --detach HEAD 2>/dev/null || true
               else
                 echo "::warning::Could not determine head ref for review-blocked PR #${RB_PR}."
               fi
@@ -1830,22 +2024,16 @@ sys.exit(1)
                 2>/dev/null; then
                 echo "  PR #${RB_PR} branch updated. Will retry force-merge on next poll cycle."
               else
-                echo "  API branch update failed for force-merge PR #${RB_PR}. Re-triggering review for conflict resolution..."
+                echo "  API branch update failed for force-merge PR #${RB_PR}. Running Codex conflict resolution..."
                 RB_HEAD_REF="$(echo "${PR_META}" | jq -r '.head_ref')"
                 if [ -n "${RB_HEAD_REF}" ] && [ "${RB_HEAD_REF}" != "null" ]; then
-                  if ! git fetch origin "${RB_HEAD_REF}:refs/remotes/origin/${RB_HEAD_REF}" 2>/dev/null || ! git checkout "origin/${RB_HEAD_REF}" 2>/dev/null; then
-                    echo "::warning::Could not fetch or checkout head ref ${RB_HEAD_REF} for force-merge PR #${RB_PR}; skipping review re-trigger."
-                    git checkout --detach HEAD 2>/dev/null || true
-                    continue
+                  RB_BASE_REF="$(echo "${PR_META}" | jq -r '.base_ref')"
+                  : "${RB_BASE_REF:=${DEFAULT_BRANCH:-main}}"
+                  if _resolve_merge_conflicts_with_codex "${RB_PR}" "${RB_HEAD_REF}" "${RB_BASE_REF}" "${rb_issue}"; then
+                    echo "  PR #${RB_PR} conflicts resolved. Will retry force-merge on next poll cycle."
+                  else
+                    tg_notify "⚠️ Force-merge PR #${RB_PR} (issue #${rb_issue}) merge conflict resolution failed."$'\n'"PR: $(_gh_url "pull/${RB_PR}")"$'\n'"Issue: $(_gh_url "issues/${rb_issue}")"
                   fi
-                  git config user.name "codex-bot"
-                  git config user.email "codex@users.noreply.github.com"
-                  git commit --allow-empty -m "[orchestrator] re-trigger review for conflict resolution (issue #${rb_issue})" 2>/dev/null || true
-                  git push origin "HEAD:${RB_HEAD_REF}" 2>/dev/null || {
-                    echo "::warning::Could not push to re-trigger review for force-merge PR #${RB_PR}."
-                    tg_notify "⚠️ Force-merge PR #${RB_PR} (issue #${rb_issue}) has unresolvable merge conflicts."$'\n'"PR: $(_gh_url "pull/${RB_PR}")"$'\n'"Issue: $(_gh_url "issues/${rb_issue}")"
-                  }
-                  git checkout --detach HEAD 2>/dev/null || true
                 else
                   echo "::warning::Could not determine head ref for force-merge PR #${RB_PR}."
                 fi
@@ -2931,8 +3119,9 @@ done
 # branch moves forward.
 #
 # This section scans all open PRs on AI-generated branches
-# (ai/issue-*) that are not mergeable and re-triggers the review
-# workflow so its conflict resolver can act.
+# (ai/issue-*) that are not mergeable and resolves conflicts
+# directly using a dedicated Codex instance, then pushes so the
+# review workflow can trigger on a clean merge ref.
 # ---------------------------------------------------------------
 echo ""
 echo "========================================"
@@ -2952,6 +3141,7 @@ STANDALONE_COUNT="$(echo "${STANDALONE_PRS}" | jq 'length')"
 echo "Found ${STANDALONE_COUNT} open PR(s) to scan."
 
 CONFLICT_SWEEP_FIXED=0
+DEFAULT_BRANCH="$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.default_branch' 2>/dev/null || echo "main")"
 
 for (( sidx=0; sidx<STANDALONE_COUNT; sidx++ )); do
 	S_PR="$(echo "${STANDALONE_PRS}" | jq -r ".[${sidx}].number")"
@@ -2976,7 +3166,7 @@ for (( sidx=0; sidx<STANDALONE_COUNT; sidx++ )); do
 		continue
 	fi
 
-	echo "  PR #${S_PR} (${S_HEAD}) is in conflicted mergeable state. Attempting to re-trigger review..."
+	echo "  PR #${S_PR} (${S_HEAD}) is in conflicted mergeable state. Running Codex conflict resolution..."
 
 	# Stage 1: Try the GitHub API update-branch endpoint (clean merge)
 	S_HEAD_SHA="$(echo "${S_PR_JSON}" | jq -r '.head.sha // ""')"
@@ -2987,33 +3177,13 @@ for (( sidx=0; sidx<STANDALONE_COUNT; sidx++ )); do
 		continue
 	fi
 
-	# Stage 2: Push empty commit to force a synchronize event so the
-	# review workflow's Codex conflict resolver can run.
-	if ! git fetch origin "${S_HEAD}:refs/remotes/origin/${S_HEAD}" 2>/dev/null; then
-		echo "::warning::Could not fetch standalone PR #${S_PR} head ${S_HEAD}; skipping re-trigger."
-		continue
-	fi
-	if ! git checkout --detach "refs/remotes/origin/${S_HEAD}" 2>/dev/null; then
-		echo "::warning::Could not check out standalone PR #${S_PR} head ${S_HEAD}; skipping re-trigger."
-		continue
-	fi
-	git config user.name "codex-bot"
-	git config user.email "codex@users.noreply.github.com"
-	if ! git commit --allow-empty \
-		-m "[orchestrator] re-trigger review for conflict resolution (standalone PR #${S_PR})" \
-		2>/dev/null; then
-		echo "::warning::Could not create empty commit for standalone PR #${S_PR}; skipping push."
-		git checkout --detach HEAD 2>/dev/null || true
-		continue
-	fi
-	if git push origin "HEAD:${S_HEAD}" 2>/dev/null; then
-		echo "  Pushed empty commit to PR #${S_PR} to re-trigger review workflow."
+	# Stage 2: Resolve conflicts with Codex and push.
+	if _resolve_merge_conflicts_with_codex "${S_PR}" "${S_HEAD}" "${DEFAULT_BRANCH}"; then
 		CONFLICT_SWEEP_FIXED=$(( CONFLICT_SWEEP_FIXED + 1 ))
-		tg_send_msg "⚠️ Standalone PR #${S_PR} has merge conflicts. Re-triggered review for auto-resolution."$'\n'"PR: $(_gh_url "pull/${S_PR}")" >/dev/null 2>&1 || true
+		tg_send_msg "✅ Standalone PR #${S_PR} merge conflicts resolved by orchestrator Codex."$'\n'"PR: $(_gh_url "pull/${S_PR}")" >/dev/null 2>&1 || true
 	else
-		echo "::warning::Could not push empty commit to re-trigger review for standalone PR #${S_PR}."
+		tg_send_msg "⚠️ Standalone PR #${S_PR} merge conflict resolution failed. Review workflow re-triggered as fallback."$'\n'"PR: $(_gh_url "pull/${S_PR}")" >/dev/null 2>&1 || true
 	fi
-	git checkout --detach HEAD 2>/dev/null || true
 done
 
 echo "Standalone conflict sweep complete. Fixed: ${CONFLICT_SWEEP_FIXED}."


### PR DESCRIPTION
## Summary

Refactors the orchestrator's merge conflict handling to resolve conflicts directly using a dedicated Codex instance, rather than relying on empty commits to trigger the review workflow's conflict resolver. This ensures a clean merge ref is produced before pushing, allowing the subsequent autofix workflow to trigger normally.

## Key Changes

- **New helper function `_resolve_merge_conflicts_with_codex()`**: Encapsulates the complete conflict resolution workflow:
  - Fetches and checks out the PR branch and base branch
  - Attempts a merge to introduce conflict markers
  - If conflicts exist, runs a dedicated Codex instance with xhigh reasoning effort to resolve them
  - Cleans up workflow artifacts to avoid polluting caller repositories
  - Commits and pushes resolved conflicts
  - Dispatches the review workflow via `workflow_dispatch` for reliable re-triggering
  - Falls back to empty-commit push if Codex resolution fails

- **Replaced inline conflict handling** in three locations with calls to the new helper:
  - Ready-to-merge (RTM) PR conflict handling
  - In-progress issue PR conflict handling
  - Review-blocked and force-merge PR conflict handling
  - Standalone PR conflict sweep

- **Updated documentation** in README.md and script comments to reflect the new direct-resolution approach

- **Added environment variable** `THINKING_LEVEL_CONFLICT_RESOLVER` (defaults to `xhigh`) to control reasoning effort for the conflict resolver

- **Improved Telegram notifications** to distinguish between successful conflict resolution and fallback re-triggers

## Implementation Details

The new helper function:
- Configures Codex with the same model as the editor (`MODEL_CONFLICT_RESOLVER` or `MODEL_EDITOR`) at xhigh reasoning effort
- Uses a focused prompt that instructs Codex to resolve only merge conflicts without refactoring or introducing new functionality
- Retries up to 3 times with 2-second delays between attempts
- Removes workflow artifacts (`.serena`, `prompts`, setup scripts, etc.) before committing to avoid polluting consumer repositories
- Handles both clean merges (no conflicts) and conflicted merges
- Leaves the repository in a detached HEAD state regardless of outcome
- Returns 0 on success, 1 on failure

This approach eliminates the race condition where GitHub's merge ref becomes unbuildable during real conflicts, causing the review workflow to silently skip, and instead produces a clean, mergeable state before triggering the next review cycle.

https://claude.ai/code/session_01Si571L2B3zHv1wUzsTeA8t