### PR TITLE
Add /revalidate command to manually reset validation-failed state

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,17 @@ This phase starts only after the orchestrator judge returns `complete`.
 - Terminal failure: validation dispatch failure, harness error, infeasible diagnosis, unknown diagnosis payload, closed fix-up issues, or cycle limit exceeded.
 - Terminal failure label: `ai:validation-failed`.
 
+### Manual Reset: `/revalidate`
+
+When a tracking issue reaches `ai:validation-failed`, you can manually reset it by commenting `/revalidate` on the tracking issue. The next poller cycle will:
+
+1. Reset all validation counters (`validation_cycle` → 1, `validation_recovery_count` → 0).
+2. Clear the failure reason and any tracked fix-up issues.
+3. Transition the label from `ai:validation-failed` to `ai:validating`.
+4. Dispatch a fresh validation run (cycle 1).
+
+This is useful after fixing the root cause manually (e.g. correcting a Docker config, adding a missing env var, or updating a dependency). There is no limit on how many times `/revalidate` can be used — the operator decides when to stop retrying.
+
 ### Validation Controls
 
 | Variable | Default | Behavior |

--- a/docs/validation-phase-spec.md
+++ b/docs/validation-phase-spec.md
@@ -95,6 +95,13 @@ validate.yml runs:
               ├─ Cycles remaining → create more fix-ups → loop
               └─ MAX_VALIDATE_CYCLES exhausted
                   → ai:validation-failed → Telegram → manual review ❌
+
+Manual reset (comment /revalidate on tracking issue):
+  ai:validation-failed
+    │ operator comments /revalidate
+    ▼
+  Reset counters (cycle=1, recovery=0)
+    → ai:validating → dispatch validate.yml (fresh cycle 1)
 ```
 
 ### Self-healing via issue creation (not direct commits)

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1473,6 +1473,40 @@ for tidx in $(seq 0 $(( COUNT - 1 ))); do
     continue
   fi
 
+  # ---------------------------------------------------------------
+  # /revalidate — manual reset from validation-failed
+  # ---------------------------------------------------------------
+  # When a project is in terminal validation-failed state (status="failed"
+  # with ai:validation-failed label), a /revalidate comment posted AFTER
+  # the latest state comment resets counters and re-dispatches validation.
+  if [ "${PROJECT_STATUS}" = "failed" ] && has_label "${TRACKING_LABELS}" "ai:validation-failed"; then
+    REVALIDATE_REQUESTED="$(echo "${COMMENTS}" | jq -r '
+      (to_entries | map(select(.value.body | contains("ORCHESTRATOR_STATE_V1"))) | last | .key // -1) as $last_state_idx |
+      [to_entries[] | select(.key > $last_state_idx and (.value.body | test("^\\s*/revalidate(\\s|$)"; "m")))] | length > 0
+    ')"
+
+    if [ "${REVALIDATE_REQUESTED}" = "true" ]; then
+      echo "  /revalidate requested for project #${TRACKING_NUM}. Resetting validation state."
+      jq \
+        '.status = "validating" |
+         .validation_cycle = 1 |
+         .validation_recovery_count = 0 |
+         .validation_active_fix_issues = [] |
+         .validation_last_dispatch_cycle = 0 |
+         .validation_completed_cycle = null |
+         del(.validation_failure_reason)' \
+        "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
+      post_state_comment
+      set_tracking_phase_label "ai:validating"
+      post_tracking_comment "## 🔁 Validation reset via /revalidate\n\nAll validation counters cleared. Re-dispatching validation (cycle 1)."
+      tg_notify "🔁 /revalidate: project #${TRACKING_NUM} reset from validation-failed. Dispatching validation cycle 1."
+      if ! dispatch_validation_if_needed 1; then
+        mark_validation_failed "Unable to dispatch ${VALIDATE_WORKFLOW_NAME:-ai-validate.yml} after /revalidate reset."
+      fi
+      continue
+    fi
+  fi
+
   if [ "${PROJECT_STATUS}" = "complete" ] || [ "${PROJECT_STATUS}" = "failed" ] || [ "${PROJECT_STATUS}" = "validation-failed" ]; then
     echo "Project already ${PROJECT_STATUS}, skipping."
     continue

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -841,6 +841,90 @@ def test_in_progress_judge_recreates_closed_fixup_id_stays_on_current_wave():
 
 
 # ---------------------------------------------------------------------------
+# Tests: /revalidate reset from validation-failed
+# ---------------------------------------------------------------------------
+
+
+def test_revalidate_resets_validation_failed_and_dispatches():
+	"""A /revalidate comment posted after the state comment should reset a
+	validation-failed project back to validating and dispatch validation."""
+	state = _base_state(status="failed")
+	state["validation_cycle"] = 3
+	state["validation_recovery_count"] = 2
+	state["validation_failure_reason"] = "Exceeded MAX_VALIDATE_CYCLES"
+	state["validation_active_fix_issues"] = [501]
+	state["validation_last_dispatch_cycle"] = 3
+	result = _run_poller(
+		state=state,
+		enable_validation="true",
+		max_validate_cycles="3",
+		tracking_labels=["ai:validation-failed"],
+		tracking_comments=["/revalidate"],
+	)
+	ls = result["latest_state"]
+	assert ls["status"] == "validating", f"Expected status=validating, got {ls['status']}"
+	assert ls["validation_cycle"] == 1, f"Expected validation_cycle=1, got {ls['validation_cycle']}"
+	assert ls["validation_recovery_count"] == 0, f"Expected validation_recovery_count=0, got {ls['validation_recovery_count']}"
+	assert ls["validation_active_fix_issues"] == [], f"Expected empty fix issues, got {ls['validation_active_fix_issues']}"
+	assert ls["validation_last_dispatch_cycle"] == 1
+	assert "validation_failure_reason" not in ls, f"Expected validation_failure_reason to be removed, got {ls.get('validation_failure_reason')}"
+	assert "ai:validating" in result["tracking_labels"]
+	assert "ai:validation-failed" not in result["tracking_labels"]
+	assert len(result["validation_dispatches"]) == 1
+
+
+def test_revalidate_ignored_when_no_comment():
+	"""Without a /revalidate comment, a validation-failed project stays skipped."""
+	state = _base_state(status="failed")
+	state["validation_failure_reason"] = "Some failure"
+	result = _run_poller(
+		state=state,
+		enable_validation="true",
+		max_validate_cycles="3",
+		tracking_labels=["ai:validation-failed"],
+	)
+	ls = result["latest_state"]
+	assert ls["status"] == "failed", f"Expected status=failed, got {ls['status']}"
+	assert "ai:validation-failed" in result["tracking_labels"]
+	assert result["validation_dispatches"] == []
+
+
+def test_revalidate_with_extra_text_after_command():
+	"""A /revalidate comment with additional text (reason) should still trigger."""
+	state = _base_state(status="failed")
+	state["validation_failure_reason"] = "Exceeded cycles"
+	state["validation_recovery_count"] = 1
+	result = _run_poller(
+		state=state,
+		enable_validation="true",
+		max_validate_cycles="3",
+		tracking_labels=["ai:validation-failed"],
+		tracking_comments=["/revalidate fixed the Docker config manually"],
+	)
+	ls = result["latest_state"]
+	assert ls["status"] == "validating", f"Expected status=validating, got {ls['status']}"
+	assert ls["validation_cycle"] == 1
+	assert ls["validation_recovery_count"] == 0
+	assert len(result["validation_dispatches"]) == 1
+
+
+def test_revalidate_not_triggered_for_non_validation_failure():
+	"""A project in failed state without ai:validation-failed label should not
+	be affected by /revalidate (e.g. judge-level failure)."""
+	state = _base_state(status="failed")
+	result = _run_poller(
+		state=state,
+		enable_validation="true",
+		max_validate_cycles="3",
+		tracking_labels=["ai:closed"],
+		tracking_comments=["/revalidate"],
+	)
+	ls = result["latest_state"]
+	assert ls["status"] == "failed", f"Expected status=failed, got {ls['status']}"
+	assert result["validation_dispatches"] == []
+
+
+# ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds support for a `/revalidate` command that allows manual reset of projects stuck in `ai:validation-failed` state. When a user comments `/revalidate` on a tracking issue, the orchestrator will reset all validation counters and re-dispatch validation from cycle 1.

## Key Changes

- **orchestrate_poll_process.sh**: Implemented `/revalidate` command handler that:
  - Detects `/revalidate` comments posted after the latest state comment
  - Resets validation counters (`validation_cycle` → 1, `validation_recovery_count` → 0)
  - Clears failure reason and tracked fix-up issues
  - Transitions label from `ai:validation-failed` to `ai:validating`
  - Dispatches a fresh validation run with notifications

- **test_orchestrate_poll_process.py**: Added comprehensive test coverage:
  - `test_revalidate_resets_validation_failed_and_dispatches`: Verifies full reset flow
  - `test_revalidate_ignored_when_no_comment`: Confirms no-op without comment
  - `test_revalidate_with_extra_text_after_command`: Validates command with trailing text
  - `test_revalidate_not_triggered_for_non_validation_failure`: Ensures label-specific behavior

- **README.md & docs/validation-phase-spec.md**: Added documentation explaining:
  - When and how to use `/revalidate`
  - What state changes occur
  - Use cases (e.g., after manual fixes to Docker config or dependencies)
  - Unlimited retry capability

## Implementation Details

- The `/revalidate` command is only recognized when:
  - Project status is `"failed"` AND
  - `ai:validation-failed` label is present AND
  - Comment is posted after the latest orchestrator state comment
- Command syntax is flexible: `/revalidate` alone or with trailing text (e.g., `/revalidate fixed the Docker config`)
- Resets `validation_last_dispatch_cycle` to 0 to ensure immediate re-dispatch
- Posts state comment, updates tracking label, and sends Telegram notification

https://claude.ai/code/session_017TXFckvnCcgmtnuXuvgXpj