### PR TITLE
Prevent workflow artifacts from being committed to caller repos

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -854,7 +854,7 @@ jobs:
           git config user.email "codex@users.noreply.github.com"
           git rm -r --cached node_modules 2>/dev/null || true
           git add -u -- ':!node_modules'
-          git ls-files --others --exclude-standard -z -- ':!node_modules' | xargs -0 -r git add --
+          git ls-files --others --exclude-standard -z -- ':!node_modules' ':!.serena' ':!scripts' ':!prompts' ':!.github/ai' | xargs -0 -r git add --
           git commit -m "AI implementation for issue #${ISSUE_NUMBER}"
           echo "did_commit=true" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2186,7 +2186,7 @@ jobs:
           git config user.email "codex@users.noreply.github.com"
           git rm -r --cached node_modules 2>/dev/null || true
           git add -u -- ':!node_modules'
-          git ls-files --others --exclude-standard -z -- ':!node_modules' ':!.serena' ':!scripts' ':!prompts' | xargs -0 -r git add --
+          git ls-files --others --exclude-standard -z -- ':!node_modules' ':!.serena' ':!scripts' ':!prompts' ':!.github/ai' | xargs -0 -r git add --
 
           if git diff --cached --quiet; then
             echo "No repository changes to commit."
@@ -2533,6 +2533,7 @@ jobs:
             rm -f codex_system_instructions.md ai_pipeline.md unattended_llm_system_instructions.md agents.md
             rm -f scripts/setup_serena.sh scripts/git_ref_health_check.sh scripts/serena_efficiency_report.py scripts/generate_symbol_diff_summary.py scripts/label_helpers.sh scripts/tg_helpers.sh scripts/codex_model_catalog.json
             rm -rf .serena prompts
+            rm -f .github/ai/orchestrate_schema.v1.json
           fi
 
           if [ -n "$(git status --porcelain)" ]; then
@@ -2540,7 +2541,7 @@ jobs:
             git config user.email "codex@users.noreply.github.com"
             git rm -r --cached node_modules 2>/dev/null || true
             git add -u -- ':!node_modules'
-            git ls-files --others --exclude-standard -z -- ':!node_modules' | xargs -0 -r git add --
+            git ls-files --others --exclude-standard -z -- ':!node_modules' ':!.serena' ':!scripts' ':!prompts' ':!.github/ai' | xargs -0 -r git add --
             git commit -m "[ai-merge-resolve] resolve merge conflicts"
             git remote set-url origin https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}
             # NOTE: push deferred to final "Push all pending commits" step.

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1261,15 +1261,16 @@ __CONFLICT_RESOLVER_PROMPT__
 		rm -f codex_system_instructions.md ai_pipeline.md unattended_llm_system_instructions.md agents.md
 		rm -f scripts/setup_serena.sh scripts/git_ref_health_check.sh scripts/serena_efficiency_report.py \
 			scripts/generate_symbol_diff_summary.py scripts/label_helpers.sh scripts/tg_helpers.sh \
-			scripts/codex_model_catalog.json
+			scripts/codex_model_catalog.json scripts/orchestrate_poll_process.sh scripts/orchestrate_lib.py
 		rm -rf .serena prompts
+		rm -f .github/ai/orchestrate_schema.v1.json
 	fi
 
 	# --- Commit and push resolved files ---
 	if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
 		git rm -r --cached node_modules 2>/dev/null || true
-		git add -u -- ':!node_modules' 2>/dev/null || true
-		git ls-files --others --exclude-standard -z -- ':!node_modules' | xargs -0 -r git add -- 2>/dev/null || true
+		git add -u -- ':!node_modules' ':!scripts' ':!prompts' ':!.github/ai' ':!.serena' 2>/dev/null || true
+		git ls-files --others --exclude-standard -z -- ':!node_modules' ':!.serena' ':!scripts' ':!prompts' ':!.github/ai' | xargs -0 -r git add -- 2>/dev/null || true
 		if git commit -m "[ai-merge-resolve] resolve merge conflicts (orchestrator)" 2>/dev/null; then
 			if git push origin "HEAD:${head_ref}" 2>/dev/null; then
 				echo "  ${log_prefix} Conflicts resolved, committed, and pushed."
@@ -2172,11 +2173,24 @@ sys.exit(1)
                 echo "::warning::Fix codex failed for PR #${RB_PR}."
               fi
 
+              # Remove workflow-generated/fetched artifacts so they are never
+              # committed to caller repos.
+              if [[ "${GITHUB_REPOSITORY}" != *"/coding-workflows" ]]; then
+                rm -f ./pre_assembled_static.txt
+                rm -f codex_system_instructions.md ai_pipeline.md unattended_llm_system_instructions.md agents.md
+                rm -f scripts/setup_serena.sh scripts/git_ref_health_check.sh scripts/serena_efficiency_report.py \
+                  scripts/generate_symbol_diff_summary.py scripts/label_helpers.sh scripts/tg_helpers.sh \
+                  scripts/codex_model_catalog.json scripts/orchestrate_poll_process.sh scripts/orchestrate_lib.py
+                rm -rf .serena prompts
+                rm -f .github/ai/orchestrate_schema.v1.json
+              fi
+
               # Check if there are changes to commit
               if [ -n "$(git status --porcelain)" ]; then
                 git config user.name "codex-bot"
                 git config user.email "codex@users.noreply.github.com"
-                git add -A
+                git add -u -- ':!node_modules' ':!scripts' ':!prompts' ':!.github/ai' ':!.serena'
+                git ls-files --others --exclude-standard -z -- ':!node_modules' ':!.serena' ':!scripts' ':!prompts' ':!.github/ai' | xargs -0 -r git add --
                 git commit -m "[orchestrator-fix] address review-blocked issues for #${rb_issue}
 
 Orchestrator judge applied fixes to unblock the review pipeline.


### PR DESCRIPTION
## Summary
This change prevents workflow-generated and fetched artifacts from being accidentally committed to caller repositories. The orchestrator and related workflows now explicitly exclude these temporary files and directories when staging changes for commit.

## Key Changes
- **Artifact cleanup**: Added removal of workflow-generated files including:
  - `scripts/orchestrate_poll_process.sh` and `scripts/orchestrate_lib.py`
  - `.github/ai/orchestrate_schema.v1.json`
  - Various generated documentation and configuration files

- **Git staging exclusions**: Updated `git add` commands across multiple workflows to exclude:
  - `scripts/` directory
  - `prompts/` directory
  - `.github/ai/` directory
  - `.serena/` directory
  
  This prevents these workflow-managed directories from being committed to non-coding-workflows repositories.

- **Conditional cleanup**: Added repository check in `orchestrate_poll_process.sh` to only perform artifact cleanup when not running in the `coding-workflows` repository itself.

## Files Modified
- `scripts/orchestrate_poll_process.sh`: Updated cleanup logic and git staging patterns
- `.github/workflows/review_autofix.yml`: Updated git staging to exclude workflow directories
- `.github/workflows/implement.yml`: Updated git staging to exclude workflow directories

## Implementation Details
The changes ensure that temporary artifacts generated during the orchestration process (schemas, scripts, prompts) are never committed back to caller repositories, maintaining repository cleanliness and preventing unintended file propagation.

https://claude.ai/code/session_01FBASdFxDtCqLaykPMj8GTv