### PR TITLE
fix: prevent active poller runs from being cancelled by newer triggers

### DIFF
--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -29,9 +29,11 @@ jobs:
   poll:
     runs-on: ubuntu-latest
     concurrency:
-      # Only one poller per repo at a time
+      # Only one poller per repo at a time; newer runs queue instead of
+      # killing the active run (which may be mid-way through conflict
+      # resolution or judge evaluation).
       group: ai-orchestrate-poll-${{ github.repository }}
-      cancel-in-progress: true
+      cancel-in-progress: false
 
     steps:
       - name: Create runtime workspace


### PR DESCRIPTION
cancel-in-progress: true was killing in-progress poller runs (including
long-running Codex conflict resolution) whenever a new poll was triggered.
Switch to false so newer runs queue instead, preserving active work.

https://claude.ai/code/session_01HyU49dyW99JdJz5YtJqLTE