### PR TITLE
Replace cat piping with input redirection in codex exec calls

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1800,7 +1800,7 @@ for tidx in $(seq 0 $(( COUNT - 1 ))); do
       RB_JUDGE_SUCCESS=false
       for attempt in 1 2; do
         echo "  Review-blocked judge attempt ${attempt}/2..."
-        if cat "${RB_JUDGE_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --full-auto > "${RB_JUDGE_OUTPUT_FILE}" 2>/dev/null; then
+        if codex exec --model "${MODEL_EDITOR}" --full-auto < "${RB_JUDGE_PROMPT_FILE}" > "${RB_JUDGE_OUTPUT_FILE}" 2>/dev/null; then
           if grep -q '[^[:space:]]' "${RB_JUDGE_OUTPUT_FILE}"; then
             RB_JUDGE_SUCCESS=true
             break
@@ -2040,7 +2040,7 @@ sys.exit(1)
                 echo "fix_description describing what you changed."
               } > "${RB_FIX_PROMPT_FILE}"
 
-              if cat "${RB_FIX_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --full-auto > "${RB_FIX_OUTPUT_FILE}" 2>/dev/null; then
+              if codex exec --model "${MODEL_EDITOR}" --full-auto < "${RB_FIX_PROMPT_FILE}" > "${RB_FIX_OUTPUT_FILE}" 2>/dev/null; then
                 echo "  Fix codex completed."
               else
                 echo "::warning::Fix codex failed for PR #${RB_PR}."
@@ -2621,7 +2621,7 @@ ${PR_DIFF}
   max_attempts=2
   for attempt in $(seq 1 "${max_attempts}"); do
     echo "Judge attempt ${attempt}/${max_attempts}..."
-    if cat "${JUDGE_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --full-auto > "${JUDGE_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/judge_log.txt" >&2); then
+    if codex exec --model "${MODEL_EDITOR}" --full-auto < "${JUDGE_PROMPT_FILE}" > "${JUDGE_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/judge_log.txt" >&2); then
       if grep -q '[^[:space:]]' "${JUDGE_OUTPUT_FILE}"; then
         JUDGE_SUCCESS=true
         break


### PR DESCRIPTION
## Summary
Refactored three instances of piping file contents to `codex exec` commands to use input redirection (`<`) instead of `cat` piping. This is a stylistic improvement that follows shell best practices and eliminates unnecessary process spawning.

## Key Changes
- Replaced `cat "${RB_JUDGE_PROMPT_FILE}" | codex exec ...` with `codex exec ... < "${RB_JUDGE_PROMPT_FILE}"` (line 1803)
- Replaced `cat "${RB_FIX_PROMPT_FILE}" | codex exec ...` with `codex exec ... < "${RB_FIX_PROMPT_FILE}"` (line 2043)
- Replaced `cat "${JUDGE_PROMPT_FILE}" | codex exec ...` with `codex exec ... < "${JUDGE_PROMPT_FILE}"` (line 2624)

## Implementation Details
This change applies the principle of avoiding unnecessary `cat` commands (often referred to as "UUOC" - Useless Use of Cat). Input redirection is more efficient as it:
- Reduces process overhead by eliminating the `cat` subprocess
- Maintains identical functionality and behavior
- Improves code clarity by making the input source more explicit
- Follows POSIX shell best practices

https://claude.ai/code/session_01XrS8C2NVWfgFQwBoECt26g