### PR TITLE
fix: break validation loop by adding deterministic mongosh guidance and cycle-over-cycle feedback

### DIFF
--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -85,6 +85,18 @@ CRITICAL — safe final JSON emission:
 - Alternatively, write `FAILURES_JSON` to a temporary file and read it from Python.
 - If using a heredoc for Python, always quote it (`<<'PY'`) to suppress bash expansion, and pass all shell variables via env/argv.
 
+CRITICAL — deterministic MongoDB / mongosh assertions:
+- NEVER parse raw `mongosh` stdout text with `grep`, `awk`, or string matching for assertions. Shell output formatting varies across mongosh versions and environments (whitespace, BSON decorators, cursor metadata, banners).
+- ALWAYS use the `--quiet` flag with `mongosh` to suppress connection banners and prompts.
+- For existence/count checks, use `JSON.stringify` to produce machine-parseable output:
+    RESULT=$(mongosh --quiet --eval 'JSON.stringify({count: db.getSiblingDB("mydb").mycollection.countDocuments({event_id: "evt-001"})})' "$MONGO_URI")
+    COUNT=$(echo "$RESULT" | python3 -c 'import json,sys; print(json.load(sys.stdin)["count"])')
+- For value checks, project fields and wrap in `JSON.stringify`:
+    RESULT=$(mongosh --quiet --eval 'JSON.stringify(db.getSiblingDB("mydb").mycollection.findOne({event_id: "evt-001"}, {_id:0, status:1}))' "$MONGO_URI")
+- Parse the JSON output in Python (or `jq`) — never with shell string matching.
+- If `mongosh` is unavailable in the container, use `python3` with `pymongo` or a direct HTTP health-check as a fallback.
+- ALWAYS add a brief retry/sleep loop (e.g. 3 attempts, 1s apart) before the assertion to tolerate async write propagation. The HTTP 202 response only means the request was accepted, not that the write has landed.
+
 CRITICAL — grep-safe TAP counting under `set -e` / `pipefail`:
 - `grep` exits with code 1 when zero lines match. Under `set -e` or `pipefail`, this kills the script even when zero matches is the expected (all-pass) outcome.
 - When counting TAP `ok` / `not ok` lines, always use patterns that return exit code 0 on zero matches. Preferred approaches:

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -507,6 +507,30 @@ if command -v git >/dev/null 2>&1; then
   git status --porcelain --untracked-files=all -- . ':!validation/**' | sort > "${PRE_GENERATE_STATUS_FILE}" 2>/dev/null || true
 fi
 
+# ---------------------------------------------------------------
+# Cycle 2+: gather previous validation failure context so the LLM
+# avoids repeating the same harness mistakes.
+# ---------------------------------------------------------------
+PRIOR_FAILURE_CONTEXT_FILE="${RUNTIME_DIR}/prior_validation_failures.txt"
+: > "${PRIOR_FAILURE_CONTEXT_FILE}"
+
+if [ "${VALIDATION_CYCLE}" -gt 1 ] && is_tracking_run; then
+  echo "Cycle ${VALIDATION_CYCLE}: fetching prior validation failure context from tracking issue #${TRACKING_ISSUE_NUM}."
+  PRIOR_COMMENTS="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_ISSUE_NUM}/comments" \
+    --paginate --jq '[.[] | select(.body | test("Runtime validation"))] | .[-3:] | .[].body' 2>/dev/null || true)"
+  if [ -n "${PRIOR_COMMENTS}" ]; then
+    {
+      echo "IMPORTANT — PREVIOUS VALIDATION CYCLE FAILURES (cycle $((VALIDATION_CYCLE - 1))):"
+      echo "The following failures occurred in prior validation cycles. Your generated"
+      echo "harness MUST avoid these same patterns. If a prior failure was caused by"
+      echo "fragile shell output parsing (e.g. raw mongosh text matching), use the"
+      echo "deterministic assertion patterns described above instead."
+      echo
+      echo "${PRIOR_COMMENTS}"
+    } > "${PRIOR_FAILURE_CONTEXT_FILE}"
+  fi
+fi
+
 {
   cat "${STATIC_CONTEXT_FILE}"
   echo
@@ -516,6 +540,11 @@ fi
   echo
   cat prompts/mode-validate-generate.txt
   echo
+  if [ -s "${PRIOR_FAILURE_CONTEXT_FILE}" ]; then
+    echo "=== PRIOR VALIDATION FAILURES (DO NOT REPEAT) ==="
+    cat "${PRIOR_FAILURE_CONTEXT_FILE}"
+    echo
+  fi
   echo "=== PROJECT SPEC ==="
   cat "${PROJECT_SPEC_FILE}"
   echo
@@ -526,6 +555,7 @@ fi
   echo "TRACKING_ISSUE: ${TRACKING_ISSUE_RAW}"
   echo "VALIDATION_TIMEOUT_MINUTES: ${VALIDATION_TIMEOUT}"
   echo "PREFERRED_COMPOSE_FILE: ${VALIDATION_COMPOSE_FILE}"
+  echo "VALIDATION_CYCLE: ${VALIDATION_CYCLE}"
   echo "SYNTHETIC_TEST_USERNAME_ENV_VAR: VALIDATION_TEST_USERNAME"
   echo "SYNTHETIC_TEST_PASSWORD_ENV_VAR: VALIDATION_TEST_PASSWORD"
   echo "SYNTHETIC_TEST_API_KEY_ENV_VAR: VALIDATION_TEST_API_KEY"


### PR DESCRIPTION
The validation harness generator had no guidance about deterministic MongoDB
assertions, causing it to emit fragile `mongosh` output parsing (raw text
grep/awk). When the assertion failed due to formatting variance, the diagnosis
classified it as an app bug (needs_fixes) rather than a harness defect, creating
fix-up issues that couldn't resolve the real problem. Each cycle regenerated
the harness from scratch with no memory of prior failures, repeating the same
pattern until MAX_VALIDATE_CYCLES was exhausted.

Two changes:
1. prompts/mode-validate-generate.txt — Add a CRITICAL section mandating
   `--quiet` + `JSON.stringify` for all mongosh assertions, with retry loops
   for async write propagation (202 != persisted).
2. scripts/validate_process.sh — On cycle 2+, fetch the last 3 validation
   failure comments from the tracking issue and inject them into the generate
   prompt as a "DO NOT REPEAT" section, giving the LLM explicit context about
   what went wrong previously.

Closes #634

https://claude.ai/code/session_01WBRds6u14eoZ9mZ6YuSC9T