### PR TITLE
Fix backtick escaping in stall recovery issue template

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1137,6 +1137,7 @@ STALL_EOF
         local new_body
         local new_url
         local new_url_clean
+        local bt='`'
         local new_num
 		orig_title="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/issues/${issue_num}" --jq '.title' || echo "")"
 		orig_body="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/issues/${issue_num}" --jq '.body // ""' || echo "")"
@@ -1146,11 +1147,11 @@ ${orig_body}
 
 ---
 
-**⚠️ Re-issued from #${issue_num}** — previous issue stalled in \\`${phase}\\` for ${elapsed_minutes} minutes despite $((recovery_count + 1)) recovery attempt(s).
+**⚠️ Re-issued from #${issue_num}** — previous issue stalled in ${bt}${phase}${bt} for ${elapsed_minutes} minutes despite $((recovery_count + 1)) recovery attempt(s).
 
 **Guidance for AI agents:**
 - This issue was re-created by standalone stall recovery.
-- Previous attempt stalled at phase: \\`${phase}\\`.
+- Previous attempt stalled at phase: ${bt}${phase}${bt}.
 - Proceed through clarify → plan → implement → review.
 REISSUE_EOF
 )"


### PR DESCRIPTION
## Summary
Fixed incorrect escaping of backticks in the stall recovery issue template by replacing double-escaped backticks with a variable-based approach.

## Changes
- Introduced a local variable `bt='`'` to store a single backtick character
- Replaced `\\`${phase}\\`` with `${bt}${phase}${bt}` in two locations within the reissue template
- This ensures backticks are properly rendered in the generated GitHub issue without over-escaping

## Details
The previous implementation used double-escaped backticks (`\\``) which would not render correctly in the final GitHub issue markdown. By storing a backtick in a variable and concatenating it around the phase variable, the backticks are now properly included in the issue body when it's created.

This affects the stall recovery mechanism that automatically re-issues tasks when they stall, ensuring the generated issue has correct markdown formatting for code blocks.

https://claude.ai/code/session_01BUd3U4qLKdiPHgn3oGjBa5