### PR TITLE
Exclude AI memory scripts from workflow git operations

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2346,11 +2346,11 @@ jobs:
           git config user.email "codex@users.noreply.github.com"
           git rm -r --cached node_modules 2>/dev/null || true
           if [ "${ALLOW_WORKFLOW_EDITS:-false}" = "true" ]; then
-            git add -u -- ':!node_modules'
-            git ls-files --others --exclude-standard -z -- ':!node_modules' ':!.serena' | xargs -0 -r git add --
+            git add -u -- ':!node_modules' ':!scripts/memory_helpers.sh' ':!scripts/ai_memory.py' ':!scripts/ai_memory_lib.py' ':!ai-memory'
+            git ls-files --others --exclude-standard -z -- ':!node_modules' ':!.serena' ':!scripts/memory_helpers.sh' ':!scripts/ai_memory.py' ':!scripts/ai_memory_lib.py' ':!ai-memory' | xargs -0 -r git add --
           else
-            git add -u -- ':!node_modules'
-            git ls-files --others --exclude-standard -z -- ':!node_modules' ':!.serena' ':!scripts' ':!prompts' ':!.github/ai' | xargs -0 -r git add --
+            git add -u -- ':!node_modules' ':!scripts/memory_helpers.sh' ':!scripts/ai_memory.py' ':!scripts/ai_memory_lib.py' ':!ai-memory'
+            git ls-files --others --exclude-standard -z -- ':!node_modules' ':!.serena' ':!scripts' ':!prompts' ':!.github/ai' ':!ai-memory' | xargs -0 -r git add --
           fi
 
           if git diff --cached --quiet; then
@@ -2782,11 +2782,11 @@ jobs:
             git config user.email "codex@users.noreply.github.com"
             git rm -r --cached node_modules 2>/dev/null || true
             if [ "${ALLOW_WORKFLOW_EDITS:-false}" = "true" ]; then
-              git add -u -- ':!node_modules'
-              git ls-files --others --exclude-standard -z -- ':!node_modules' ':!.serena' | xargs -0 -r git add --
+              git add -u -- ':!node_modules' ':!scripts/memory_helpers.sh' ':!scripts/ai_memory.py' ':!scripts/ai_memory_lib.py' ':!ai-memory'
+              git ls-files --others --exclude-standard -z -- ':!node_modules' ':!.serena' ':!scripts/memory_helpers.sh' ':!scripts/ai_memory.py' ':!scripts/ai_memory_lib.py' ':!ai-memory' | xargs -0 -r git add --
             else
-              git add -u -- ':!node_modules'
-              git ls-files --others --exclude-standard -z -- ':!node_modules' ':!.serena' ':!scripts' ':!prompts' ':!.github/ai' | xargs -0 -r git add --
+              git add -u -- ':!node_modules' ':!scripts/memory_helpers.sh' ':!scripts/ai_memory.py' ':!scripts/ai_memory_lib.py' ':!ai-memory'
+              git ls-files --others --exclude-standard -z -- ':!node_modules' ':!.serena' ':!scripts' ':!prompts' ':!.github/ai' ':!ai-memory' | xargs -0 -r git add --
             fi
             git commit -m "[ai-merge-resolve] resolve merge conflicts"
             git remote set-url origin https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}
@@ -3274,11 +3274,13 @@ jobs:
                     rm -f ./pre_assembled_static.txt
                     rm -f codex_system_instructions.md ai_pipeline.md unattended_llm_system_instructions.md agents.md
                     rm -f scripts/setup_serena.sh scripts/git_ref_health_check.sh scripts/serena_efficiency_report.py scripts/generate_symbol_diff_summary.py scripts/label_helpers.sh scripts/codex_model_catalog.json
+                    rm -f scripts/memory_helpers.sh scripts/ai_memory.py scripts/ai_memory_lib.py
+                    rm -rf ai-memory
                     rm -rf .serena
                     rm -rf prompts
                   fi
 
-                  git add -u -- ':!node_modules'
+                  git add -u -- ':!node_modules' ':!scripts/memory_helpers.sh' ':!scripts/ai_memory.py' ':!scripts/ai_memory_lib.py' ':!ai-memory'
                   if ! git diff --cached --quiet; then
                     git commit -m "[judge-fix] address review-blocked issues
 


### PR DESCRIPTION
## Summary
This PR updates the GitHub Actions workflow configuration to exclude AI memory-related scripts and directories from git staging operations during automated fixes and merge conflict resolution.

## Key Changes
- Added exclusions for AI memory scripts (`scripts/memory_helpers.sh`, `scripts/ai_memory.py`, `scripts/ai_memory_lib.py`) and the `ai-memory` directory in git staging commands across multiple workflow jobs
- Updated both the `ALLOW_WORKFLOW_EDITS=true` and `ALLOW_WORKFLOW_EDITS=false` code paths to consistently exclude these files
- Added explicit removal of AI memory files in the judge-fix cleanup section before committing changes
- Applied these exclusions consistently across three separate workflow job sections (review_autofix, merge resolution, and judge-fix jobs)

## Implementation Details
- The exclusions follow the existing pattern used for other generated/managed files (node_modules, .serena, prompts, .github/ai)
- Both `git add -u` (update tracked files) and `git ls-files` (add untracked files) commands were updated to respect these exclusions
- The `ai-memory` directory is excluded as a whole directory to prevent any memory-related artifacts from being committed

https://claude.ai/code/session_01TLDh4Esv37HHyqSYyAUacA