### PR TITLE
Update setup-runtime action to use external workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Setup shared runtime
         id: runtime
-        uses: ./.github/actions/setup-runtime
+        uses: shubhodeep1/coding-workflows/.github/actions/setup-runtime@stable
         with:
           runtime_prefix: codex-validate
           required_env_csv: OPENROUTER_API_KEY


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow to reference the `setup-runtime` action from an external shared workflows repository instead of using a local action.

## Key Changes
- Changed `setup-runtime` action source from local path (`./.github/actions/setup-runtime`) to external repository (`shubhodeep1/coding-workflows/.github/actions/setup-runtime@stable`)
- This enables reuse of the action across multiple repositories without duplicating the action code

## Implementation Details
- The action is now pinned to the `stable` branch of the external repository, ensuring consistent behavior across workflow runs
- All action inputs (`runtime_prefix` and `required_env_csv`) remain unchanged and compatible with the external action

https://claude.ai/code/session_01SzpLsFmDZqdNtKnrqxXFZt