### PR TITLE
Add /judge_resume command for manual recovery from judge failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,21 @@ When a tracking issue reaches `ai:validation-failed`, you can manually reset it 
 
 This is useful after fixing the root cause manually (e.g. correcting a Docker config, adding a missing env var, or updating a dependency). There is no limit on how many times `/revalidate` can be used — the operator decides when to stop retrying.
 
+### Manual Reset: `/judge_resume`
+
+When a tracking issue reaches terminal `failed` status due to judge stall cycle exhaustion (`MAX_JUDGE_CYCLES`) or recovery attempt exhaustion (`MAX_RECOVERY_ATTEMPTS`), you can manually resume it by commenting `/judge_resume` on the tracking issue. The next poller cycle will:
+
+1. Reset judge stall cycles (`judge_stall_cycles` → 0).
+2. Reset recovery counter (`recovery_count` → 0).
+3. Transition the project status from `failed` to `in_progress`.
+4. Resume normal wave processing immediately.
+
+This does **not** reset the total `judge_cycle` counter (which is informational only — it tracks how many times the judge has been invoked overall). Only the stall and recovery counters that gate the failure limits are reset.
+
+Use this after manual intervention (e.g. fixing a problematic issue, merging a stuck PR, or adjusting `MAX_JUDGE_CYCLES`/`MAX_RECOVERY_ATTEMPTS` variables). There is no limit on how many times `/judge_resume` can be used.
+
+> **Note:** `/judge_resume` only applies to judge/recovery failures. For validation failures (`ai:validation-failed`), use `/revalidate` instead.
+
 ### Validation Controls
 
 | Variable | Default | Behavior |

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -2263,6 +2263,36 @@ for ((tidx=0; tidx<COUNT; tidx++)); do
     fi
   fi
 
+  # ---------------------------------------------------------------
+  # /judge_resume — manual reset from judge/recovery failure
+  # ---------------------------------------------------------------
+  # When a project is in terminal failed state (status="failed") but
+  # NOT from validation (no ai:validation-failed label), a /judge_resume
+  # comment posted AFTER the latest state comment resets judge stall
+  # cycles and recovery counters, allowing the poller to resume.
+  if [ "${PROJECT_STATUS}" = "failed" ] && ! has_label "${TRACKING_LABELS}" "ai:validation-failed"; then
+    JUDGE_RESUME_REQUESTED="$(echo "${COMMENTS}" | jq -r '
+      (to_entries | map(select(.value.body | contains("ORCHESTRATOR_STATE_V1"))) | last | .key // -1) as $last_state_idx |
+      [to_entries[] | select(.key > $last_state_idx and (.value.body | test("^\\s*/judge_resume(\\s|$)"; "m")))] | length > 0
+    ')"
+
+    if [ "${JUDGE_RESUME_REQUESTED}" = "true" ]; then
+      echo "  /judge_resume requested for project #${TRACKING_NUM}. Resetting judge and recovery counters."
+      PREV_JUDGE_STALL="$(jq -r '.judge_stall_cycles // .judge_cycle' "${STATE_FILE}")"
+      PREV_RECOVERY="$(jq -r '.recovery_count // 0' "${STATE_FILE}")"
+      jq \
+        '.status = "in_progress" |
+         .judge_stall_cycles = 0 |
+         .recovery_count = 0' \
+        "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
+      post_state_comment
+      post_tracking_comment "## ▶️ Project resumed via /judge_resume\n\nJudge stall cycles reset: ${PREV_JUDGE_STALL} → 0\nRecovery count reset: ${PREV_RECOVERY} → 0\nStatus: failed → in_progress\n\nThe poller will resume processing on the next cycle."
+      tg_notify "/judge_resume: project #${TRACKING_NUM} resumed from failed state. Judge stall cycles ${PREV_JUDGE_STALL}→0, recovery ${PREV_RECOVERY}→0." "WARNING"
+      # Fall through to normal processing below instead of continuing
+      PROJECT_STATUS="in_progress"
+    fi
+  fi
+
   if [ "${PROJECT_STATUS}" = "complete" ] || [ "${PROJECT_STATUS}" = "failed" ] || [ "${PROJECT_STATUS}" = "validation-failed" ]; then
     echo "Project already ${PROJECT_STATUS}, skipping."
     continue


### PR DESCRIPTION
## Summary
Adds a new `/judge_resume` manual intervention command that allows operators to recover projects stuck in terminal `failed` status due to judge stall cycle or recovery attempt exhaustion, without requiring validation resets.

## Key Changes
- **New `/judge_resume` handler** in `orchestrate_poll_process.sh`: Detects the `/judge_resume` comment posted after the latest state comment on a tracking issue and performs the following:
  - Resets `judge_stall_cycles` to 0
  - Resets `recovery_count` to 0
  - Transitions project status from `failed` back to `in_progress`
  - Posts state and tracking comments documenting the reset values
  - Sends Telegram notification with reset details
  - Allows normal wave processing to resume immediately

- **Documentation** in `README.md`: Added new "Manual Reset: `/judge_resume`" section explaining:
  - When to use `/judge_resume` (judge/recovery failures only, not validation failures)
  - What counters are reset and what are preserved
  - Distinction from `/revalidate` command
  - No usage limits

## Implementation Details
- The command detection uses jq to find the last state comment and checks for `/judge_resume` comments posted after it
- Only applies when `PROJECT_STATUS = "failed"` AND the project does NOT have the `ai:validation-failed` label
- Preserves the total `judge_cycle` counter (informational only) while resetting the stall/recovery gates
- Falls through to normal processing after reset, allowing the poller to resume work immediately

https://claude.ai/code/session_01R156pgMY7K3VnRynF9HdjD