### PR TITLE
Add head ref information to mock PR API response

### DIFF
--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -493,7 +493,11 @@ if args[0] == 'api':
 		elif jq == '.head.sha':
 			print(pr.get('headSha', f'mocksha{pr_num}'))
 		else:
-			print(json.dumps({'state': pr.get('state', 'open'), 'mergeable': pr.get('mergeable', True)}))
+			print(json.dumps({
+				'state': pr.get('state', 'open'),
+				'mergeable': pr.get('mergeable', True),
+				'head': {'sha': pr.get('headSha', f'mocksha{pr_num}'), 'ref': pr.get('headRefName', '')},
+			}))
 		sys.exit(0)
 
 	if re.search(r'/merges$', path) and (method == 'POST' or fields):


### PR DESCRIPTION
## Summary
Updated the mock GitHub API response in the test orchestration module to include additional head reference information in pull request queries.

## Key Changes
- Extended the default JSON response for PR queries to include a `head` object containing:
  - `sha`: The head commit SHA (defaults to `mocksha{pr_num}`)
  - `ref`: The head reference name (defaults to empty string)
- Reformatted the response object for improved readability with multi-line formatting

## Implementation Details
The change enhances the mock API's fidelity by providing the `head.sha` and `head.ref` fields in the general PR query response, rather than only through the dedicated `.head.sha` jq filter. This allows tests that parse the full PR response object to access head reference information without requiring separate API calls.

https://claude.ai/code/session_01Eq1UREJwPAFE4BexWLcVcb