### PR TITLE
Remove standalone stall recovery feature from orchestrate poll

### DIFF
--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -53,7 +53,6 @@ jobs:
         id: find_tracking
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
-          ENABLE_STANDALONE_STALL_RECOVERY: ${{ vars.ENABLE_STANDALONE_STALL_RECOVERY || 'true' }}
         run: |
           set -euo pipefail
           # gh_helpers.sh is not yet available (checkout + fetch happen later),
@@ -90,18 +89,6 @@ jobs:
             return 1
           }
 
-          _is_truthy() {
-            case "$(echo "$1" | tr '[:upper:]' '[:lower:]')" in
-              1|true|yes|on) return 0 ;;
-              *) return 1 ;;
-            esac
-          }
-
-          STANDALONE_ENABLED=false
-          if _is_truthy "${ENABLE_STANDALONE_STALL_RECOVERY:-true}"; then
-            STANDALONE_ENABLED=true
-          fi
-
           # Find all open issues with the orchestrator tracking label
           TRACKING_ISSUES="$(_gh_retry gh issue list \
             --repo "${{ github.repository }}" \
@@ -116,14 +103,7 @@ jobs:
           echo "${TRACKING_ISSUES}" > "${RUNTIME_DIR}/tracking_issues.json"
 
           if [ "${COUNT}" -eq 0 ]; then
-            if [ "${STANDALONE_ENABLED}" = "true" ]; then
-              echo "No active orchestrator projects. Continuing for standalone stall recovery."
-              echo "has_tracking=false" >> "$GITHUB_OUTPUT"
-              echo "has_work=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-
-            echo "No active orchestrator projects and standalone stall recovery is disabled. Exiting."
+            echo "No active orchestrator projects. Exiting gracefully — cron will start the next cycle."
             echo "has_tracking=false" >> "$GITHUB_OUTPUT"
             echo "has_work=false" >> "$GITHUB_OUTPUT"
             exit 0


### PR DESCRIPTION
## Summary
This PR removes the standalone stall recovery feature from the orchestrate poll workflow. The feature allowed the workflow to continue processing standalone stall recovery when no active orchestrator projects were found, controlled by an `ENABLE_STANDALONE_STALL_RECOVERY` environment variable.

## Key Changes
- Removed the `ENABLE_STANDALONE_STALL_RECOVERY` environment variable from the workflow
- Removed the `_is_truthy()` helper function used to parse the feature flag
- Removed the conditional logic that checked if standalone stall recovery was enabled
- Simplified the "no active projects" exit path to always set `has_work=false` and exit gracefully, regardless of configuration
- Updated the exit message to clarify that the workflow will exit and the next cron cycle will start

## Implementation Details
Previously, when no active orchestrator projects were found, the workflow would check the `ENABLE_STANDALONE_STALL_RECOVERY` flag. If enabled (default: true), it would set `has_work=true` to continue processing. Now, the workflow always exits with `has_work=false` when no active projects are found, simplifying the control flow and removing the feature flag dependency.

https://claude.ai/code/session_01HGUXTg9StXcbrohgVezZb3