### PR TITLE
Add Step 3.5 Flash model to catalog

### DIFF
--- a/scripts/codex_model_catalog.json
+++ b/scripts/codex_model_catalog.json
@@ -181,6 +181,36 @@
       "input_modalities": ["text", "image"]
     },
     {
+      "slug": "stepfun/step-3.5-flash",
+      "display_name": "Step 3.5 Flash",
+      "description": "StepFun Step 3.5 Flash - 262K context, text-only, MoE reasoning model (196B/11B active)",
+      "supported_reasoning_levels": [
+        {"effort": "medium", "description": "Balanced reasoning"},
+        {"effort": "high", "description": "Thorough reasoning"},
+        {"effort": "xhigh", "description": "Maximum reasoning depth"}
+      ],
+      "shell_type": "shell_command",
+      "visibility": "list",
+      "supported_in_api": true,
+      "priority": 10,
+      "upgrade": null,
+      "base_instructions": "You are a senior software engineer acting as an AI code reviewer and editor. You have access to shell commands for reading files and exploring the repository. Use them to understand the codebase before making changes. Be precise, minimal, and correct.",
+      "model_messages": null,
+      "supports_reasoning_summaries": false,
+      "default_reasoning_summary": "auto",
+      "support_verbosity": false,
+      "default_verbosity": null,
+      "apply_patch_tool_type": "freeform",
+      "truncation_policy": {"mode": "bytes", "limit": 262000},
+      "supports_parallel_tool_calls": true,
+      "supports_image_detail_original": false,
+      "context_window": 262144,
+      "auto_compact_token_limit": null,
+      "effective_context_window_percent": 90,
+      "experimental_supported_tools": [],
+      "input_modalities": ["text"]
+    },
+    {
       "slug": "openai/gpt-5-mini",
       "display_name": "GPT-5 Mini",
       "description": "OpenAI GPT-5 Mini - 400K context, multimodal",


### PR DESCRIPTION
## Summary
Added StepFun's Step 3.5 Flash model to the model catalog with full configuration for code review and editing tasks.

## Key Changes
- Added new model entry for `stepfun/step-3.5-flash` (Step 3.5 Flash)
- Configured as a text-only MoE reasoning model with 262K context window
- Set up three reasoning effort levels: medium, high, and xhigh
- Configured model parameters:
  - Shell command support for file exploration and repository navigation
  - Freeform patch application tool type
  - Parallel tool calls enabled
  - 90% effective context window utilization
  - Base instructions for senior software engineer code review role
  - Priority level: 10

## Notable Details
- Model supports three distinct reasoning levels for flexible task complexity handling
- Text-only input modality (no image support)
- 262K context window with byte-based truncation policy
- Designed specifically for code review and editing workflows with shell command access

https://claude.ai/code/session_01251jq2mgzyCZUQFNwhggLy