### PR TITLE
Make Codex version configurable via GitHub Actions variable

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -66,7 +66,7 @@ jobs:
         if: env.SKIP_IMPLEMENT != 'true'
         run: |
           set -euo pipefail
-          CODEX_VERSION="v0.114.0"
+          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
           npm install -g @openai/codex@"${CODEX_VERSION}" --no-audit --no-fund
 
       - name: Install uv for Serena

--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -73,7 +73,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          npm install -g "@openai/codex@v0.114.0" --no-audit --no-fund
+          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
+          npm install -g "@openai/codex@${CODEX_VERSION}" --no-audit --no-fund
 
           missing_tools=()
           for tool in jq curl gh; do

--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -147,7 +147,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          npm install -g "@openai/codex@v0.114.0" --no-audit --no-fund
+          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
+          npm install -g "@openai/codex@${CODEX_VERSION}" --no-audit --no-fund
 
           missing_tools=()
           for tool in jq curl gh; do

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Install dependencies
         run: |
           set -euo pipefail
-          CODEX_VERSION="v0.114.0"
+          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
           npm install -g @openai/codex@"${CODEX_VERSION}" --no-audit --no-fund
           sudo apt-get update
           sudo apt-get install -y jq curl python3


### PR DESCRIPTION
## Summary
This PR makes the Codex package version configurable through a GitHub Actions repository variable, while maintaining backward compatibility with a sensible default.

## Key Changes
- Updated all four workflow files (`orchestrate.yml`, `orchestrate_poll.yml`, `implement.yml`, and `review_autofix.yml`) to use a configurable `CODEX_VERSION` variable
- The version now defaults to `v0.114.0` if the `vars.CODEX_VERSION` repository variable is not set
- Standardized the version configuration approach across all workflows using the pattern: `${{ vars.CODEX_VERSION || 'v0.114.0' }}`

## Implementation Details
- The change allows operators to override the Codex version globally by setting the `CODEX_VERSION` repository variable in GitHub Actions settings
- If the variable is not defined, workflows fall back to the current version (`v0.114.0`), ensuring no breaking changes
- This approach provides flexibility for testing new versions or pinning to specific releases without modifying workflow files

https://claude.ai/code/session_019uDZawRRtT1e1JyzAtJBdb