### PR TITLE
debug(review_autofix): diagnose reviewer codex-cli "os error 2" failures

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -357,7 +357,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ~/.codex
-          CATALOG_PATH="${SUPPORT_SCRIPTS_DIR}/codex_model_catalog.json"
+          CATALOG_PATH="${GITHUB_WORKSPACE}/${SUPPORT_SCRIPTS_DIR}/codex_model_catalog.json"
           {
             echo 'web_search = "disabled"'
             echo 'model_provider = "openrouter"'

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -357,7 +357,12 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ~/.codex
-          CATALOG_PATH="${GITHUB_WORKSPACE}/${SUPPORT_SCRIPTS_DIR}/codex_model_catalog.json"
+          # Compute absolute CATALOG_PATH correctly whether SUPPORT_SCRIPTS_DIR is absolute or relative
+          if [[ "${SUPPORT_SCRIPTS_DIR}" = /* ]]; then
+            CATALOG_PATH="${SUPPORT_SCRIPTS_DIR}/codex_model_catalog.json"
+          else
+            CATALOG_PATH="${GITHUB_WORKSPACE}/${SUPPORT_SCRIPTS_DIR}/codex_model_catalog.json"
+          fi
           {
             echo 'web_search = "disabled"'
             echo 'model_provider = "openrouter"'

--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -491,22 +491,18 @@ run_reviewer() {
     return 0
   fi
 
-  # DIAGNOSTIC (debug-reviewer-failures): the per-reviewer CODEX_HOME copy
-  # below is temporarily disabled to test whether the "No such file or
-  # directory (os error 2)" failures from codex-cli v0.114.0 originate from
-  # the copied CODEX_HOME (stale MCP command paths, missing helper under
-  # bin/, etc.). While disabled, all reviewers share the workflow-level
-  # CODEX_HOME=~/.codex that was prepared by the "Create Codex config" +
-  # "Setup Serena MCP server" steps. Re-enable by un-commenting.
+  # Each reviewer gets its own CODEX_HOME to prevent MCP server
+  # conflicts (Serena, language servers) when running in parallel.
+  # Avoid /tmp for CODEX_HOME because codex refuses helper binary setup there.
   local reviewer_codex_root reviewer_codex_home
   reviewer_codex_root="${RUNNER_TEMP:-${HOME}/.cache}/codex_home_reviewers"
   mkdir -p "${reviewer_codex_root}"
   reviewer_codex_home="$(mktemp -d "${reviewer_codex_root}/reviewer.${safe_name}.XXXXXX")"
-  # if [ -d "${CODEX_HOME:-}" ]; then
-  #   cp -r "${CODEX_HOME}/." "${reviewer_codex_home}/"
-  # fi
-  # mkdir -p "${reviewer_codex_home}/bin"
-  # export CODEX_HOME="${reviewer_codex_home}"
+  if [ -d "${CODEX_HOME:-}" ]; then
+    cp -r "${CODEX_HOME}/." "${reviewer_codex_home}/"
+  fi
+  mkdir -p "${reviewer_codex_home}/bin"
+  export CODEX_HOME="${reviewer_codex_home}"
 
   while [ "${attempt}" -le 3 ]; do
     # Early exit if PR was closed/merged (detected by watchdog or another reviewer)
@@ -583,11 +579,8 @@ run_reviewer() {
 
     # Run codex in a wrapper subshell so we can capture its PID
     # for the watchdog to kill on timeout.
-    # Diagnostic: RUST_BACKTRACE=1 + RUST_LOG=debug force codex-cli to emit
-    # full backtraces and the actual path behind "No such file or directory
-    # (os error 2)" so reviewer failures can be root-caused from workflow logs.
     (
-      exec env RUST_BACKTRACE=1 RUST_LOG=debug "${codex_bin}" exec --model "${model}" --full-auto "$(cat "${REVIEWER_PROMPT_FILE}")"
+      exec "${codex_bin}" exec --model "${model}" --full-auto "$(cat "${REVIEWER_PROMPT_FILE}")"
     ) > "${tmp_output}" 2> >(
       while IFS= read -r line || [ -n "$line" ]; do
         # Atomic heartbeat update: write to tmp then rename

--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -491,18 +491,22 @@ run_reviewer() {
     return 0
   fi
 
-  # Each reviewer gets its own CODEX_HOME to prevent MCP server
-  # conflicts (Serena, language servers) when running in parallel.
-  # Avoid /tmp for CODEX_HOME because codex refuses helper binary setup there.
+  # DIAGNOSTIC (debug-reviewer-failures): the per-reviewer CODEX_HOME copy
+  # below is temporarily disabled to test whether the "No such file or
+  # directory (os error 2)" failures from codex-cli v0.114.0 originate from
+  # the copied CODEX_HOME (stale MCP command paths, missing helper under
+  # bin/, etc.). While disabled, all reviewers share the workflow-level
+  # CODEX_HOME=~/.codex that was prepared by the "Create Codex config" +
+  # "Setup Serena MCP server" steps. Re-enable by un-commenting.
   local reviewer_codex_root reviewer_codex_home
   reviewer_codex_root="${RUNNER_TEMP:-${HOME}/.cache}/codex_home_reviewers"
   mkdir -p "${reviewer_codex_root}"
   reviewer_codex_home="$(mktemp -d "${reviewer_codex_root}/reviewer.${safe_name}.XXXXXX")"
-  if [ -d "${CODEX_HOME:-}" ]; then
-    cp -r "${CODEX_HOME}/." "${reviewer_codex_home}/"
-  fi
-  mkdir -p "${reviewer_codex_home}/bin"
-  export CODEX_HOME="${reviewer_codex_home}"
+  # if [ -d "${CODEX_HOME:-}" ]; then
+  #   cp -r "${CODEX_HOME}/." "${reviewer_codex_home}/"
+  # fi
+  # mkdir -p "${reviewer_codex_home}/bin"
+  # export CODEX_HOME="${reviewer_codex_home}"
 
   while [ "${attempt}" -le 3 ]; do
     # Early exit if PR was closed/merged (detected by watchdog or another reviewer)
@@ -579,8 +583,11 @@ run_reviewer() {
 
     # Run codex in a wrapper subshell so we can capture its PID
     # for the watchdog to kill on timeout.
+    # Diagnostic: RUST_BACKTRACE=1 + RUST_LOG=debug force codex-cli to emit
+    # full backtraces and the actual path behind "No such file or directory
+    # (os error 2)" so reviewer failures can be root-caused from workflow logs.
     (
-      exec "${codex_bin}" exec --model "${model}" --full-auto "$(cat "${REVIEWER_PROMPT_FILE}")"
+      exec env RUST_BACKTRACE=1 RUST_LOG=debug "${codex_bin}" exec --model "${model}" --full-auto "$(cat "${REVIEWER_PROMPT_FILE}")"
     ) > "${tmp_output}" 2> >(
       while IFS= read -r line || [ -n "$line" ]; do
         # Atomic heartbeat update: write to tmp then rename


### PR DESCRIPTION
All reviewers in review_autofix are exiting within ~150 ms with a
contextless "Error: No such file or directory (os error 2)" from
codex-cli v0.114.0. Preflight passes, cwd is the repo root, MCP
validation succeeds — the failure happens before codex reads its
prompt. This change applies three targeted diagnostics/fixes on the
reviewer boot path so the next run either succeeds or surfaces the
actual missing path:

1. review_autofix.yml: write model_catalog_json as an absolute path
   (${GITHUB_WORKSPACE}/scripts/codex_model_catalog.json) instead of
   the cwd-relative "scripts/codex_model_catalog.json". This mirrors
   orchestrate_poll_process.sh, which already uses $(pwd)/…, and
   removes the only cwd-sensitive file reference in the reviewer
   config.toml — a likely cause if codex v0.114.0 resolves catalog
   paths relative to CODEX_HOME.

2. review_run_reviewers.sh: wrap the codex invocation in
   `env RUST_BACKTRACE=1 RUST_LOG=debug` so the next failure emits
   the actual path behind the io::Error, letting us distinguish a
   missing catalog, a stale MCP command, or a missing helper binary.

3. review_run_reviewers.sh: temporarily disable the per-reviewer
   CODEX_HOME copy/export block. While disabled, all reviewers share
   the workflow-level CODEX_HOME=~/.codex prepared by "Create Codex
   config" + "Setup Serena MCP server". If reviewers start passing
   with only fix 1 in effect, the copied CODEX_HOME was the cause and
   the isolated copy needs to be rebuilt (not simply copied) before
   re-enabling. The reviewer_codex_home temp dir is still created so
   later rm -rf cleanup paths stay valid.

No consumer-facing contracts change. Fixes 2 and 3 are marked as
diagnostic in code comments and are meant to be reverted once the
root cause is identified.