### PR TITLE
Increase timeout for lint and validate-scripts jobs to 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/mark-stable.yml
+++ b/.github/workflows/mark-stable.yml
@@ -76,7 +76,7 @@ jobs:
   validate-scripts:
     needs: [resolve-version]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1371,7 +1371,7 @@ jobs:
   validate-scripts:
     needs: [resolve-version]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
This PR increases the timeout duration for lint and script validation jobs across multiple CI/CD workflows from 10 minutes to 30 minutes.

## Changes
- **ci.yml**: Increased `lint` job timeout from 10 to 30 minutes
- **mark-stable.yml**: Increased `validate-scripts` job timeout from 10 to 30 minutes
- **test-and-mark-stable.yml**: Increased `validate-scripts` job timeout from 10 to 30 minutes

## Rationale
The timeout increase allows these jobs more time to complete, reducing the likelihood of timeout failures on slower runners or when processing larger codebases. This provides better reliability for the CI/CD pipeline without significantly impacting overall workflow duration.

https://claude.ai/code/session_01Nh84ZEVvZYAH6sXyLBy64k