### PR TITLE
Add scheduled runs to workflow log analysis

### DIFF
--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -13,6 +13,10 @@ on:
         required: false
         default: ""
         type: string
+  schedule:
+    # Approximates an every-48h cadence: runs on even days of the month at 06:00 UTC.
+    # Note: day-of-month `*/2` drifts at month boundaries (occasional 1-day or 3-day gap).
+    - cron: "0 6 */2 * *"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -109,7 +113,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          LOOKBACK_DAYS="${{ github.event.inputs.lookback_days || '7' }}"
+          LOOKBACK_DAYS="${{ github.event.inputs.lookback_days || (github.event_name == 'schedule' && '2' || '7') }}"
           mapfile -t REPOS < /tmp/workflow-analysis-repos.txt
 
           COLLECT_ARGS=(

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -14,7 +14,7 @@ on:
         default: ""
         type: string
   schedule:
-    # Approximates an every-48h cadence: runs on even days of the month at 06:00 UTC.
+    # Approximates an every-48h cadence: runs every other day (1, 3, 5, ...) at 06:00 UTC.
     # Note: day-of-month `*/2` drifts at month boundaries (occasional 1-day or 3-day gap).
     - cron: "0 6 */2 * *"
 

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -15,7 +15,7 @@ on:
         type: string
   schedule:
     # Approximates an every-48h cadence: runs every other day (1, 3, 5, ...) at 06:00 UTC.
-    # Note: day-of-month `*/2` drifts at month boundaries (occasional 1-day or 3-day gap).
+    # Note: day-of-month `*/2` drifts at month boundaries (occasional 1-day or 2-day gap).
     - cron: "0 6 */2 * *"
 
 env:

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ Run **Actions -> Workflow Log Analysis -> Run workflow**, or let the built-in sc
 Triggers:
 
 - `workflow_dispatch` (manual).
-- `schedule`: `cron: "0 6 */2 * *"` — runs on even days of the month at 06:00 UTC, approximating an every-48h cadence. Day-of-month `*/2` drifts at month boundaries (occasional 1-day or 3-day gap).
+- `schedule`: `cron: "0 6 */2 * *"` — runs every other day (1, 3, 5, ...) at 06:00 UTC, approximating an every-48h cadence. Day-of-month `*/2` drifts at month boundaries (occasional 1-day or 3-day gap).
 
 `workflow_dispatch` inputs:
 

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ Run **Actions -> Workflow Log Analysis -> Run workflow**, or let the built-in sc
 Triggers:
 
 - `workflow_dispatch` (manual).
-- `schedule`: `cron: "0 6 */2 * *"` — runs every other day (1, 3, 5, ...) at 06:00 UTC, approximating an every-48h cadence. Day-of-month `*/2` drifts at month boundaries (occasional 1-day or 3-day gap).
+- `schedule`: `cron: "0 6 */2 * *"` — runs every other day (1, 3, 5, ...) at 06:00 UTC, approximating an every-48h cadence. Day-of-month `*/2` drifts at month boundaries (occasional 1-day or 2-day gap).
 
 `workflow_dispatch` inputs:
 

--- a/README.md
+++ b/README.md
@@ -506,16 +506,21 @@ This repository includes [`.github/workflows/workflow-log-analysis.yml`](.github
 
 ### How to run
 
-Run **Actions -> Workflow Log Analysis -> Run workflow**.
+Run **Actions -> Workflow Log Analysis -> Run workflow**, or let the built-in schedule fire automatically.
+
+Triggers:
+
+- `workflow_dispatch` (manual).
+- `schedule`: `cron: "0 6 */2 * *"` — runs on even days of the month at 06:00 UTC, approximating an every-48h cadence. Day-of-month `*/2` drifts at month boundaries (occasional 1-day or 3-day gap).
 
 `workflow_dispatch` inputs:
 
 | Input | Default | Description |
 |---|---|---|
-| `lookback_days` | `"7"` | Days of workflow runs to collect. Passed to `scripts/collect_workflow_logs.py --lookback-days`. |
+| `lookback_days` | `"7"` | Days of workflow runs to collect. Passed to `scripts/collect_workflow_logs.py --lookback-days`. On scheduled runs this falls back to `"2"` to match the 48h cadence; manual dispatch keeps the `"7"` default unless overridden. |
 | `repos_override` | `""` | Optional comma-separated `owner/repo` list. Each item is validated with `^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`; invalid values fail the run. |
 
-Repository selection behavior:
+Repository selection behavior (applies to both manual and scheduled runs):
 
 1. If `repos_override` is set, only those repositories are used.
 2. Otherwise, the workflow reads `.github/ai/consumer_repos.json` (if present) and also includes `${GITHUB_REPOSITORY}`.


### PR DESCRIPTION
## Summary
This PR adds automatic scheduled execution to the Workflow Log Analysis workflow, allowing it to run on a regular cadence without manual intervention.

## Key Changes
- **Added scheduled trigger**: Configured `schedule` trigger with a cron expression (`0 6 */2 * *`) to run automatically on even days of the month at 06:00 UTC, approximating a 48-hour cadence
- **Dynamic lookback period**: Modified the `lookback_days` input logic to use a 2-day lookback for scheduled runs (matching the 48h cadence) while maintaining the 7-day default for manual dispatch
- **Updated documentation**: Enhanced README with clear explanation of both trigger types, cron schedule details (including month boundary drift behavior), and clarification that the lookback period adapts based on trigger type

## Implementation Details
- The lookback days now uses a conditional expression: `github.event.inputs.lookback_days || (github.event_name == 'schedule' && '2' || '7')` to automatically select 2 days for scheduled runs and 7 days for manual runs
- Documentation notes the known limitation that `*/2` day-of-month scheduling drifts at month boundaries, occasionally creating 1-day or 3-day gaps
- Repository selection behavior remains unchanged and applies to both manual and scheduled runs

https://claude.ai/code/session_01S5RUmzRdP2oHaAaVRddU8a