### PR TITLE
Increase default timeouts in test and mark stable workflow

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -38,7 +38,7 @@ name: Test & Mark Stable Release
           longer than this value.
         required: false
         type: number
-        default: 15
+        default: 30
       review_timeout:
         description: >
           Max minutes of *inactivity* before the review & autofix phase
@@ -122,8 +122,8 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GH_PAT }}
       TEST_REPO: ${{ inputs.test_repo || github.repository }}
-      PHASE_TIMEOUT: ${{ inputs.phase_timeout || 15 }}
-      REVIEW_TIMEOUT: ${{ inputs.review_timeout || inputs.phase_timeout || 20 }}
+      PHASE_TIMEOUT: ${{ inputs.phase_timeout || 30 }}
+      REVIEW_TIMEOUT: ${{ inputs.review_timeout || inputs.phase_timeout || 30 }}
       POLL_INTERVAL: 10
 
     steps:


### PR DESCRIPTION
## Summary
This PR increases the default timeout values in the "Test & Mark Stable Release" GitHub Actions workflow to provide more time for test execution and review phases.

## Changes
- Increased `phase_timeout` default from 15 minutes to 30 minutes
- Increased `review_timeout` default from 20 minutes to 30 minutes
- Updated both the input parameter default and the environment variable fallback values

## Details
These timeout increases apply to:
- **Phase timeout**: The maximum duration allowed for the main test phase
- **Review timeout**: The maximum duration of inactivity before the review and autofix phase times out

The changes ensure that longer-running tests and review processes have sufficient time to complete without premature timeout failures.

https://claude.ai/code/session_01RXgL4aeBafxjcdKf2ppepd