### PR TITLE
Improve error reporting in set_tracking_phase_label function

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -454,10 +454,16 @@ set_tracking_phase_label() {
   fi
 
   local phase_changes
-  if ! phase_changes="$(python3 scripts/ai_labels.py resolve-phase --contract-file "${contract_file}" --phase "${phase_label}" 2>/dev/null)"; then
-    echo "::warning::set_tracking_phase_label: resolve-phase failed for '${phase_label}' using ${contract_file}." >&2
+  local _resolve_err_file
+  _resolve_err_file="$(mktemp)"
+  if ! phase_changes="$(python3 scripts/ai_labels.py resolve-phase --contract-file "${contract_file}" --phase "${phase_label}" 2>"${_resolve_err_file}")"; then
+    local _resolve_err
+    _resolve_err="$(tr '\n' ' ' < "${_resolve_err_file}" 2>/dev/null || true)"
+    rm -f "${_resolve_err_file}"
+    echo "::warning::set_tracking_phase_label: resolve-phase failed for '${phase_label}' using ${contract_file}: ${_resolve_err:-<no stderr captured>}" >&2
     return 1
   fi
+  rm -f "${_resolve_err_file}"
 
   # Fetch current labels on the issue so we only attempt to remove labels
   # that are actually present.  Trying to remove a label that does not


### PR DESCRIPTION
## Summary
Enhanced error handling and diagnostics in the `set_tracking_phase_label` function to capture and display stderr output when the `resolve-phase` command fails.

## Key Changes
- Capture stderr from the `resolve-phase` Python script to a temporary file instead of discarding it
- Extract and display the captured error message in the warning output for better debugging
- Clean up temporary error file after use (both on success and failure paths)
- Improve the warning message to include the actual error details, making it easier to diagnose issues

## Implementation Details
- Uses `mktemp` to create a temporary file for stderr redirection
- Converts newlines to spaces in the error output for single-line display
- Includes fallback text `<no stderr captured>` if error file cannot be read
- Ensures proper cleanup of temporary files in all code paths

https://claude.ai/code/session_01GofKctHMnm7u3Z3fMT6BXV