### PR TITLE
Short-circuit reviewer fan-out when PR closes mid-run

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1219,6 +1219,16 @@ jobs:
           SERENA_REPORT_FILE="${RUNTIME_DIR}/serena_efficiency_report.md"
           echo "SERENA_REPORT_FILE=${SERENA_REPORT_FILE}" >> "$GITHUB_ENV"
 
+          # When the PR closed/merged mid-run the reviewers aborted before
+          # doing meaningful semantic work, so the Serena adoption counters
+          # are unrepresentative. Keep the report (it's still useful for
+          # post-mortem) but drop the warn threshold to 0 so we don't emit
+          # a misleading ::warning:: on a closed-PR short-circuit.
+          if [ "${PR_CLOSED:-}" = "true" ]; then
+            echo "PR_CLOSED=true — zeroing SERENA_WARN_THRESHOLD to suppress unrepresentative adoption warning."
+            SERENA_WARN_THRESHOLD=0
+          fi
+
           # Collect editor stderr files for scanning
           extra_files=()
           for f in "${PREVIOUS_REVIEWS_DIR}"/editor_attempt_*.err; do

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `TOKEN_WARN_THRESHOLD_ORCHESTRATE` | `200000` | orchestrate | Token usage warning threshold for orchestration |
 | `TOKEN_WARN_THRESHOLD_CLARIFY_RESPOND` | `80000` | orchestrate_clarify_respond | Token usage warning threshold for auto-answering clarification questions |
 
-**Serena adoption warning thresholds** — when Serena efficiency falls below the threshold (and at least 5 total code operations are detected), workflows emit a non-blocking `::warning::` alert.
+**Serena adoption warning thresholds** — when Serena efficiency falls below the threshold (and at least 5 total code operations are detected), workflows emit a non-blocking `::warning::` alert. `review_autofix` automatically forces the threshold to `0` when the PR closed/merged mid-run, because in that case reviewers are short-circuited before doing meaningful semantic work and the adoption counters are not representative.
 
 | Variable | Default | Used By | Description |
 |---|---|---|---|

--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -17,6 +17,25 @@ if [ -z "${SUPPORT_PROMPTS_DIR:-}" ] || [ ! -s "${SERENA_BLOCK_PATH}" ]; then
   exit 1
 fi
 
+# Pre-flight PR state check — short-circuit if the PR is already closed/merged
+# before paying for the parallel reviewer fan-out. This catches the common case
+# where the PR was closed between workflow dispatch and reviewer invocation
+# (e.g. while codex CLI/tool setup was still running earlier in the job).
+# Safe to skip on local/manual invocation where PR_NUMBER or REPOSITORY are
+# unset — downstream watchdog polling remains the fallback.
+if [ -n "${PR_NUMBER:-}" ] && [ -n "${REPOSITORY:-}" ] && command -v gh >/dev/null 2>&1; then
+  preflight_state="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.state' 2>/dev/null | grep -xE 'open|closed|merged' || echo "open")"
+  if [ "${preflight_state}" != "open" ]; then
+    echo "Pre-flight: PR #${PR_NUMBER} is ${preflight_state} — skipping reviewer fan-out."
+    mkdir -p "${PREVIOUS_REVIEWS_DIR}"
+    touch "/tmp/pr_closed_sentinel_${PR_NUMBER}"
+    if [ -n "${GITHUB_ENV:-}" ] && [ -w "${GITHUB_ENV}" ]; then
+      echo "PR_CLOSED=true" >> "$GITHUB_ENV"
+    fi
+    exit 0
+  fi
+fi
+
 mkdir -p "${PREVIOUS_REVIEWS_DIR}"
 
 PROMPT_ARTIFACT_PATH_HINT="$(printf '%s\n' \
@@ -527,17 +546,38 @@ run_reviewer() {
     local codex_pid_file
     codex_pid_file="$(mktemp /tmp/codex_pid_reviewer.XXXXXX)"
 
+    # Reason file — watchdog writes here before exit so the outer loop
+    # can distinguish idle timeout vs max wall vs PR-closed kill from a
+    # generic codex failure. Cleaned up alongside the heartbeat file.
+    local wd_reason_file
+    wd_reason_file="$(mktemp /tmp/reviewer_wd_reason.XXXXXX)"
+
     # Background watchdog for this reviewer attempt
     (
       wd_iter=$(( RANDOM % 9 ))  # jitter: stagger PR state checks across reviewers
       while true; do
         sleep 10
+
+        # Fast path: if another reviewer (or the pre-flight check) already
+        # detected PR closure, short-circuit immediately instead of waiting
+        # up to ~90s for our own gh api poll cycle.
+        if [ -n "${PR_NUMBER:-}" ] && [ -f "/tmp/pr_closed_sentinel_${PR_NUMBER}" ]; then
+          echo "Reviewer ${model} aborted — PR close sentinel observed." | tee -a "${log_file}" >&2
+          printf 'pr_closed_sentinel' > "${wd_reason_file}"
+          local cpid
+          cpid="$(cat "${codex_pid_file}" 2>/dev/null || true)"
+          if [ -n "${cpid}" ]; then kill -TERM "${cpid}" 2>/dev/null; sleep 5; kill -KILL "${cpid}" 2>/dev/null; fi
+          rm -f "${hb_file}"
+          exit 144
+        fi
+
         now="$(date +%s)"
         last="$(cat "${hb_file}" 2>/dev/null || echo "$now")"
         # Guard against empty/corrupt reads: if last is not numeric, treat as now
         if ! [[ "${last}" =~ ^[0-9]+$ ]]; then last="${now}"; fi
         if [ $(( now - last )) -ge "${reviewer_idle_timeout}" ]; then
           echo "Reviewer ${model} killed — no output for $(( now - last ))s (idle limit: ${reviewer_idle_timeout}s)." | tee -a "${log_file}" >&2
+          printf 'idle_timeout' > "${wd_reason_file}"
           # Actually kill the codex process
           local cpid
           cpid="$(cat "${codex_pid_file}" 2>/dev/null || true)"
@@ -547,6 +587,7 @@ run_reviewer() {
         fi
         if [ $(( now - start_time )) -ge "${reviewer_max_wall}" ]; then
           echo "Reviewer ${model} killed — max wall time ${reviewer_max_wall}s exceeded." | tee -a "${log_file}" >&2
+          printf 'max_wall' > "${wd_reason_file}"
           local cpid
           cpid="$(cat "${codex_pid_file}" 2>/dev/null || true)"
           if [ -n "${cpid}" ]; then kill -TERM "${cpid}" 2>/dev/null; sleep 5; kill -KILL "${cpid}" 2>/dev/null; fi
@@ -564,6 +605,7 @@ run_reviewer() {
           pr_state="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.state' 2>/dev/null | grep -xE 'open|closed|merged' || echo "open")"
           if [ "${pr_state}" != "open" ]; then
             echo "Reviewer ${model} aborted — PR #${PR_NUMBER} is ${pr_state}." | tee -a "${log_file}" >&2
+            printf 'pr_closed_api' > "${wd_reason_file}"
             touch "/tmp/pr_closed_sentinel_${PR_NUMBER}"
             echo "PR_CLOSED=true" >> "$GITHUB_ENV"
             local cpid
@@ -599,6 +641,26 @@ run_reviewer() {
     kill "${wd_pid}" 2>/dev/null; wait "${wd_pid}" 2>/dev/null || true
     rm -f "${hb_file}" "${hb_file}.tmp" "${codex_pid_file}"
 
+    # Pick up the watchdog termination reason (if any) before we delete it.
+    # Values: idle_timeout | max_wall | pr_closed_sentinel | pr_closed_api
+    local wd_reason=""
+    if [ -s "${wd_reason_file}" ]; then
+      wd_reason="$(cat "${wd_reason_file}" 2>/dev/null || true)"
+    fi
+    rm -f "${wd_reason_file}"
+
+    # Watchdog-induced PR-closed kill: do not retry, do not treat as failure.
+    case "${wd_reason}" in
+      pr_closed_sentinel|pr_closed_api)
+        cat "${tmp_stderr}" >> "${log_file}"
+        echo "Reviewer ${model} stopped — PR #${PR_NUMBER:-unknown} was closed/merged (reason: ${wd_reason})." | tee -a "${log_file}"
+        echo "pr_closed" > "${status_file}"
+        rm -f "${tmp_output}" "${tmp_stderr}"
+        rm -rf "${reviewer_codex_home}" 2>/dev/null || true
+        return 0
+        ;;
+    esac
+
     if [ "${cmd_rc}" -eq 0 ]; then
       cat "${tmp_stderr}" >> "${log_file}"
       if [ -s "${tmp_output}" ]; then
@@ -612,7 +674,17 @@ run_reviewer() {
       echo "Reviewer ${model} produced empty output on attempt ${attempt}." | tee -a "${log_file}"
     else
       cat "${tmp_stderr}" >> "${log_file}"
-      echo "Reviewer ${model} execution failed on attempt ${attempt} (exit=${cmd_rc})." | tee -a "${log_file}"
+      case "${wd_reason}" in
+        idle_timeout)
+          echo "Reviewer ${model} killed by watchdog on attempt ${attempt} (idle timeout ${reviewer_idle_timeout}s, exit=${cmd_rc})." | tee -a "${log_file}"
+          ;;
+        max_wall)
+          echo "Reviewer ${model} killed by watchdog on attempt ${attempt} (max wall ${reviewer_max_wall}s, exit=${cmd_rc})." | tee -a "${log_file}"
+          ;;
+        *)
+          echo "Reviewer ${model} execution failed on attempt ${attempt} (exit=${cmd_rc})." | tee -a "${log_file}"
+          ;;
+      esac
     fi
 
     if [ -s "${tmp_stderr}" ]; then


### PR DESCRIPTION
## Summary
Add pre-flight and watchdog-based detection to gracefully handle PRs that close or merge while the review workflow is in progress. This prevents unnecessary reviewer invocations and provides clearer diagnostics when early termination occurs.

## Key Changes

- **Pre-flight PR state check**: Before spawning reviewer processes, query the GitHub API to detect if the PR is already closed/merged. If so, exit early with a sentinel file and environment variable to signal downstream processes.

- **Watchdog PR-closed detection**: Each reviewer's watchdog loop now checks for a shared sentinel file (`/tmp/pr_closed_sentinel_${PR_NUMBER}`) written by either the pre-flight check or another reviewer's watchdog. This provides a fast path to abort without waiting for the next API poll cycle (~90s).

- **Watchdog termination reason tracking**: Introduce a reason file that the watchdog writes before killing the codex process, distinguishing between:
  - `pr_closed_sentinel`: Fast-path detection via shared sentinel
  - `pr_closed_api`: Detection via direct GitHub API call
  - `idle_timeout`: No output for the configured idle limit
  - `max_wall`: Max wall-clock time exceeded

- **Improved error messaging**: When a reviewer is killed by the watchdog, the log message now includes the specific reason (idle timeout, max wall time, or PR closure) rather than a generic "execution failed" message.

- **PR-closed early return**: When a reviewer detects PR closure via watchdog, it returns success (exit 0) with status `pr_closed` instead of treating it as a failure, preventing unnecessary retry attempts.

- **Serena adoption threshold adjustment**: When `PR_CLOSED=true`, the workflow automatically sets `SERENA_WARN_THRESHOLD=0` to suppress misleading adoption warnings, since reviewers short-circuited before doing meaningful semantic work.

- **Documentation update**: README clarified that `review_autofix` automatically suppresses Serena adoption warnings when the PR closes mid-run.

## Implementation Details

- The pre-flight check is safe to skip on local/manual invocation where `PR_NUMBER` or `REPOSITORY` are unset; downstream watchdog polling remains the fallback.
- Watchdog jitter (staggered PR state checks) is preserved to avoid thundering herd on the GitHub API.
- Sentinel file and environment variable are used to coordinate across multiple concurrent reviewer processes.
- Cleanup of temporary files (reason file, heartbeat file, codex PID file) is properly sequenced to avoid race conditions.

https://claude.ai/code/session_01EVaTZmM6QHkgPTBqcEBJek