### PR TITLE
Fix graceful shutdown assertions for npm-wrapped services

### DIFF
--- a/prompts/mode-validate-fix-harness.txt
+++ b/prompts/mode-validate-fix-harness.txt
@@ -71,8 +71,9 @@ CRITICAL — graceful shutdown container resolution:
 - A harness-initiated `docker compose stop` sends SIGTERM to PID 1. The test MUST treat ALL of the following as a graceful shutdown (pass):
     1. Exit code 0 (clean return from a SIGTERM handler).
     2. Exit code 143 = 128 + SIGTERM (signal-exit convention).
-    3. Exit code 1 when PID 1 is an `npm` / `yarn` / `pnpm` wrapper AND `validation/logs/compose.log` contains a wrapper SIGTERM marker (for example `npm ERR! signal SIGTERM` or `Command failed with signal "SIGTERM"`) for the wrapped command. npm translates signal termination of its child into exit 1 rather than propagating 143; this is a wrapper artifact, not an application crash.
+    3. Exit code 1 when PID 1 is an `npm` / `yarn` / `pnpm` wrapper AND `validation/logs/compose.log` (captured via `docker compose ... logs`) contains a wrapper SIGTERM marker (for example `npm ERR! signal SIGTERM` or `Command failed with signal "SIGTERM"`) for the wrapped command. npm translates signal termination of its child into exit 1 rather than propagating 143; this is a wrapper artifact, not an application crash.
 - If a graceful shutdown test fails with `app exited with code 1 (expected 0)` AND the compose log shows a wrapper SIGTERM marker for the wrapped command (e.g. `sh -c hardhat node ...`), the bug is in the assertion, not the app. Fix by broadening the accept-list above rather than by changing the app or the container entrypoint.
+- If `validation/logs/compose.log` is missing at assertion time, fix the harness to write `docker compose ... logs` output to that path before running the wrapper-SIGTERM grep.
 - If a graceful shutdown test fails with "app container id unavailable after stop", this is almost certainly caused by using `docker compose ps -q <service>` (without `--status exited` or `--all`) after stop. Fix by switching to the `--status exited` or `--all` variant.
 
 Output contract:

--- a/prompts/mode-validate-fix-harness.txt
+++ b/prompts/mode-validate-fix-harness.txt
@@ -68,7 +68,11 @@ CRITICAL — graceful shutdown container resolution:
 - `docker compose ps -q <service>` only returns RUNNING containers and will return empty after stop.
 - To resolve a stopped container's ID, use: `docker compose ps -q --status exited <service>` or `docker compose ps -aq --filter "status=exited" <service>`.
 - To check the exit code, use: `docker inspect --format='{{.State.ExitCode}}' <container_id>`.
-- The test should assert the container exited with code 0 (clean shutdown), not just that it stopped.
+- A harness-initiated `docker compose stop` sends SIGTERM to PID 1. The test MUST treat ALL of the following as a graceful shutdown (pass):
+    1. Exit code 0 (clean return from a SIGTERM handler).
+    2. Exit code 143 = 128 + SIGTERM (signal-exit convention).
+    3. Exit code 1 when PID 1 is an `npm` / `yarn` / `pnpm` wrapper AND `validation/logs/compose.log` contains `npm error signal SIGTERM` (or the yarn/pnpm equivalent) for the wrapped command. npm translates signal termination of its child into exit 1 rather than propagating 143; this is a wrapper artifact, not an application crash.
+- If a graceful shutdown test fails with `app exited with code 1 (expected 0)` AND the compose log shows `npm error signal SIGTERM` for the wrapped command (e.g. `sh -c hardhat node ...`), the bug is in the assertion, not the app. Fix by broadening the accept-list above rather than by changing the app or the container entrypoint.
 - If a graceful shutdown test fails with "app container id unavailable after stop", this is almost certainly caused by using `docker compose ps -q <service>` (without `--status exited` or `--all`) after stop. Fix by switching to the `--status exited` or `--all` variant.
 
 Output contract:

--- a/prompts/mode-validate-fix-harness.txt
+++ b/prompts/mode-validate-fix-harness.txt
@@ -71,8 +71,8 @@ CRITICAL — graceful shutdown container resolution:
 - A harness-initiated `docker compose stop` sends SIGTERM to PID 1. The test MUST treat ALL of the following as a graceful shutdown (pass):
     1. Exit code 0 (clean return from a SIGTERM handler).
     2. Exit code 143 = 128 + SIGTERM (signal-exit convention).
-    3. Exit code 1 when PID 1 is an `npm` / `yarn` / `pnpm` wrapper AND `validation/logs/compose.log` contains `npm error signal SIGTERM` (or the yarn/pnpm equivalent) for the wrapped command. npm translates signal termination of its child into exit 1 rather than propagating 143; this is a wrapper artifact, not an application crash.
-- If a graceful shutdown test fails with `app exited with code 1 (expected 0)` AND the compose log shows `npm error signal SIGTERM` for the wrapped command (e.g. `sh -c hardhat node ...`), the bug is in the assertion, not the app. Fix by broadening the accept-list above rather than by changing the app or the container entrypoint.
+    3. Exit code 1 when PID 1 is an `npm` / `yarn` / `pnpm` wrapper AND `validation/logs/compose.log` contains a wrapper SIGTERM marker (for example `npm ERR! signal SIGTERM` or `Command failed with signal "SIGTERM"`) for the wrapped command. npm translates signal termination of its child into exit 1 rather than propagating 143; this is a wrapper artifact, not an application crash.
+- If a graceful shutdown test fails with `app exited with code 1 (expected 0)` AND the compose log shows a wrapper SIGTERM marker for the wrapped command (e.g. `sh -c hardhat node ...`), the bug is in the assertion, not the app. Fix by broadening the accept-list above rather than by changing the app or the container entrypoint.
 - If a graceful shutdown test fails with "app container id unavailable after stop", this is almost certainly caused by using `docker compose ps -q <service>` (without `--status exited` or `--all`) after stop. Fix by switching to the `--status exited` or `--all` variant.
 
 Output contract:

--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -224,7 +224,7 @@ CRITICAL — graceful shutdown container resolution:
     EXIT_CODE=$(docker inspect --format='{{.State.ExitCode}}' "$CID" 2>/dev/null || echo unknown)
     NPM_SIGTERM=0
     if [ "$EXIT_CODE" = "1" ] && [ -f "$COMPOSE_LOG" ] \
-       && grep -qiE '(npm( ERR!)?.*signal.*SIGTERM|Command failed with signal "SIGTERM")' "$COMPOSE_LOG"; then
+       && grep -qiE '((npm|yarn|pnpm).*signal.*SIGTERM|Command failed with signal.*SIGTERM)' "$COMPOSE_LOG"; then
       NPM_SIGTERM=1
     fi
     if [ "$EXIT_CODE" = "0" ] || [ "$EXIT_CODE" = "143" ] || [ "$NPM_SIGTERM" = "1" ]; then

--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -64,7 +64,7 @@ Docker Compose healthcheck YAML rules (CRITICAL):
 - Build/start via Docker Compose using the generated test file (`-f validation/docker-compose.test.yml`)
 - Health polling with explicit timeout
 - Execute generated scripts in `validation/tests/`
-- Capture logs under `validation/logs/`
+- Capture logs under `validation/logs/`, including a deterministic Compose log at `validation/logs/compose.log` (used by graceful-shutdown SIGTERM detection)
 - Always teardown via trap on EXIT using `docker compose -f validation/docker-compose.test.yml down -v --remove-orphans`
 - Exit 0 on pass and non-zero on failure
 - Emit a final machine-parseable JSON result object as the last line on stdout
@@ -222,6 +222,7 @@ CRITICAL — graceful shutdown container resolution:
       exit 1
     fi
     EXIT_CODE=$(docker inspect --format='{{.State.ExitCode}}' "$CID" 2>/dev/null || echo unknown)
+    docker compose -f "$COMPOSE_FILE" logs --no-color app > "$COMPOSE_LOG" 2>&1 || true
     NPM_SIGTERM=0
     if [ "$EXIT_CODE" = "1" ] && [ -f "$COMPOSE_LOG" ] \
        && grep -qiE '((npm|yarn|pnpm).*signal.*SIGTERM|Command failed with signal.*SIGTERM)' "$COMPOSE_LOG"; then

--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -207,7 +207,7 @@ CRITICAL — graceful shutdown container resolution:
 - A harness-initiated `docker compose stop` sends SIGTERM to PID 1. Any of the following outcomes is a graceful shutdown and MUST be treated as pass:
     1. Exit code 0 — PID 1 handled SIGTERM and returned cleanly.
     2. Exit code 143 (= 128 + SIGTERM) — PID 1 was terminated by SIGTERM without a custom handler; this is the documented signal-exit convention.
-    3. Exit code 1 when PID 1 is an `npm` / `yarn` / `pnpm` wrapper AND the compose log contains `npm error signal SIGTERM` (or the yarn/pnpm equivalent) for the wrapped command. npm translates signal-termination of its child into exit code 1 instead of propagating 143; this is a wrapper artifact, NOT an application crash.
+    3. Exit code 1 when PID 1 is an `npm` / `yarn` / `pnpm` wrapper AND the compose log contains a wrapper SIGTERM marker (for example `npm ERR! signal SIGTERM` or `Command failed with signal "SIGTERM"`) for the wrapped command. npm translates signal-termination of its child into exit code 1 instead of propagating 143; this is a wrapper artifact, NOT an application crash.
 - NEVER hardcode a strict `EXIT_CODE == 0` check when the service is launched via an `npm` / `yarn` / `pnpm` script — you will get false failures on every clean `docker stop` because of (3) above.
 - Recommended pattern:
     COMPOSE_FILE="validation/docker-compose.test.yml"
@@ -224,7 +224,7 @@ CRITICAL — graceful shutdown container resolution:
     EXIT_CODE=$(docker inspect --format='{{.State.ExitCode}}' "$CID" 2>/dev/null || echo unknown)
     NPM_SIGTERM=0
     if [ "$EXIT_CODE" = "1" ] && [ -f "$COMPOSE_LOG" ] \
-       && grep -qE '(npm|yarn|pnpm) error signal SIGTERM' "$COMPOSE_LOG"; then
+       && grep -qiE '(npm( ERR!)?.*signal.*SIGTERM|Command failed with signal "SIGTERM")' "$COMPOSE_LOG"; then
       NPM_SIGTERM=1
     fi
     if [ "$EXIT_CODE" = "0" ] || [ "$EXIT_CODE" = "143" ] || [ "$NPM_SIGTERM" = "1" ]; then

--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -215,7 +215,7 @@ CRITICAL — graceful shutdown container resolution:
     docker compose -f "$COMPOSE_FILE" stop -t 5 app
     CID=$(docker compose -f "$COMPOSE_FILE" ps -q --status exited app | head -n1 || true)
     if [ -z "$CID" ]; then
-      CID=$(docker ps -aq --filter "status=exited" --filter "name=app" | head -n1 || true)
+      CID=$(docker ps -aq --filter "status=exited" --filter "label=com.docker.compose.service=app" | head -n1 || true)
     fi
     if [ -z "$CID" ]; then
       echo "not ok - app container id unavailable after stop"

--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -204,23 +204,35 @@ CRITICAL — graceful shutdown container resolution:
 - `docker compose ps -q <service>` only returns RUNNING containers and will return empty after stop.
 - To resolve a stopped container's ID, use: `docker compose ps -q --status exited <service>` or `docker compose ps -aq --filter "status=exited" <service>`.
 - To check the exit code, use: `docker inspect --format='{{.State.ExitCode}}' <container_id>`.
-- The test should assert the container exited with code 0 (clean shutdown), not just that it stopped.
+- A harness-initiated `docker compose stop` sends SIGTERM to PID 1. Any of the following outcomes is a graceful shutdown and MUST be treated as pass:
+    1. Exit code 0 — PID 1 handled SIGTERM and returned cleanly.
+    2. Exit code 143 (= 128 + SIGTERM) — PID 1 was terminated by SIGTERM without a custom handler; this is the documented signal-exit convention.
+    3. Exit code 1 when PID 1 is an `npm` / `yarn` / `pnpm` wrapper AND the compose log contains `npm error signal SIGTERM` (or the yarn/pnpm equivalent) for the wrapped command. npm translates signal-termination of its child into exit code 1 instead of propagating 143; this is a wrapper artifact, NOT an application crash.
+- NEVER hardcode a strict `EXIT_CODE == 0` check when the service is launched via an `npm` / `yarn` / `pnpm` script — you will get false failures on every clean `docker stop` because of (3) above.
 - Recommended pattern:
-    docker compose -f validation/docker-compose.test.yml stop -t 5 app
-    CID=$(docker compose -f validation/docker-compose.test.yml ps -q --status exited app)
+    COMPOSE_FILE="validation/docker-compose.test.yml"
+    COMPOSE_LOG="validation/logs/compose.log"
+    docker compose -f "$COMPOSE_FILE" stop -t 5 app
+    CID=$(docker compose -f "$COMPOSE_FILE" ps -q --status exited app | head -n1 || true)
     if [ -z "$CID" ]; then
-      CID=$(docker ps -aq --filter "status=exited" --filter "name=app")
+      CID=$(docker ps -aq --filter "status=exited" --filter "name=app" | head -n1 || true)
     fi
     if [ -z "$CID" ]; then
       echo "not ok - app container id unavailable after stop"
       exit 1
     fi
-    EXIT_CODE=$(docker inspect --format='{{.State.ExitCode}}' "$CID")
-    if [ "$EXIT_CODE" != "0" ]; then
-      echo "not ok - app exited with code $EXIT_CODE (expected 0)"
+    EXIT_CODE=$(docker inspect --format='{{.State.ExitCode}}' "$CID" 2>/dev/null || echo unknown)
+    NPM_SIGTERM=0
+    if [ "$EXIT_CODE" = "1" ] && [ -f "$COMPOSE_LOG" ] \
+       && grep -qE '(npm|yarn|pnpm) error signal SIGTERM' "$COMPOSE_LOG"; then
+      NPM_SIGTERM=1
+    fi
+    if [ "$EXIT_CODE" = "0" ] || [ "$EXIT_CODE" = "143" ] || [ "$NPM_SIGTERM" = "1" ]; then
+      echo "ok - app shut down gracefully (exit=$EXIT_CODE npm_sigterm=$NPM_SIGTERM)"
+    else
+      echo "not ok - app exited with code $EXIT_CODE (expected 0, 143, or npm-wrapped SIGTERM)"
       exit 1
     fi
-    echo "ok - app shut down gracefully with exit code 0"
 
 CRITICAL — robust synthetic env-var assertions in env_var_validation tests:
 - Docker Compose services declare synthetic test credentials with an override-or-default expression:


### PR DESCRIPTION
## Summary
Updated graceful shutdown validation guidance to correctly handle exit codes from npm/yarn/pnpm-wrapped services. Previously, tests were hardcoded to expect exit code 0, causing false failures when package managers translate SIGTERM signal termination into exit code 1.

## Key Changes
- **Expanded exit code acceptance criteria** for graceful shutdown:
  - Exit code 0 (clean SIGTERM handler return)
  - Exit code 143 (128 + SIGTERM signal-exit convention)
  - Exit code 1 when wrapped by npm/yarn/pnpm AND compose log contains the corresponding signal error message
  
- **Updated test pattern** in both validation mode prompts:
  - Added compose log file tracking for signal detection
  - Implemented robust container ID resolution with fallbacks and `head -n1` to handle edge cases
  - Added NPM_SIGTERM detection logic that checks both exit code and log contents
  - Changed assertion from strict `EXIT_CODE == 0` to multi-condition pass criteria
  - Improved error handling with `2>/dev/null` fallback for docker inspect

- **Added diagnostic guidance** for developers:
  - Clarified that npm wrapper exit code 1 on SIGTERM is expected behavior, not an app crash
  - Provided explicit instructions for fixing false-positive test failures
  - Emphasized that the bug is in the assertion, not the application, when this pattern occurs

## Implementation Details
The updated pattern uses shell variable assignments and conditional logic to detect npm signal termination without requiring changes to application code or container entrypoints. The compose log check provides definitive proof that the service was cleanly terminated by the harness rather than crashing.

https://claude.ai/code/session_01QFMR3KKTY9y7bQT8LdyMao