### PR TITLE
orchestrate_poll: fetch ai_labels.py for consumer repos

### DIFF
--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -219,7 +219,7 @@ jobs:
             done; return 1
           }
           _fetched_scripts=()
-          for f in gh_helpers.sh setup_serena.sh git_ref_health_check.sh orchestrate_lib.py orchestrate_poll_process.sh render_prompt.sh tg_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py; do
+          for f in gh_helpers.sh setup_serena.sh git_ref_health_check.sh ai_labels.py orchestrate_lib.py orchestrate_poll_process.sh render_prompt.sh tg_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py; do
             if ! _gh_api_fetch "scripts/${f}" api -H 'Accept: application/vnd.github.raw+json' \
               "repos/${wf_source}/contents/scripts/${f}?ref=${script_ref}"; then
               echo "::warning::${f} not found on ${script_ref}; falling back to main"


### PR DESCRIPTION
scripts/orchestrate_poll_process.sh invokes
python3 scripts/ai_labels.py (resolve-phase, repair-labels), but the
"Fetch workflow support scripts" step in orchestrate_poll.yml did not
include ai_labels.py in its download list.  In consumer repos that do
not carry the file locally, every call to set_tracking_phase_label()
failed with "No such file or directory", and under set -e that aborted
the poller step (exit 1) on label transitions such as
ai:validation-recovery.

The dependency is already fetched the same way in validate.yml (whose
validate_process.sh has the same dependency), so this aligns the two
workflows.

Refs #811 (which surfaces the python stderr so this class of failure is
diagnosable in future runs).