### PR TITLE
Clarify regression fingerprint requirements in review script

### DIFF
--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -266,24 +266,21 @@ Only modify previously changed lines if:
 • the code would fail at runtime
 • the code clearly violates correctness
 
-When you modify any previously changed hunk, include both fields in Changes made:
-• Regression fingerprint: <stable file/symbol/failure key>
-• Runtime failure path: <specific execution path and failure outcome>
+When you modify any previously changed hunk, populate the top-level
+"Regression fingerprint:" and "Runtime failure path:" sections below
+with concrete values (not the "- n/a" default).
 
 FINAL RESPONSE FORMAT
 Plain text only.
 Output exactly these sections in this order:
 Changes made:
-IMPORTANT: If ANY bullet under "Changes made:" touches a line that was
-also modified in the LAST RUN DIFF, you MUST include these two fields
-in that bullet (the commit will be rejected otherwise):
-  • Regression fingerprint: <file:symbol or failure key>
-  • Runtime failure path: <execution path that fails>
 Already satisfied (suggested but already present):
 Ignored suggestions (with short reason):
 Reviewer files processed:
 Review file issue audit:
 PR comment audit:
+Regression fingerprint:
+Runtime failure path:
 Under Reviewer files processed: include one bullet per manifest file with:
 - exact file path
 - checksum
@@ -299,6 +296,16 @@ Under PR comment audit: include one bullet per bot PR review/review_comment entr
 - path and line (if available)
 - disposition: applied / already satisfied / ignored
 - short reason for the disposition
+Under Regression fingerprint: and Runtime failure path:
+- ALWAYS emit both sections, even when no previously changed hunk was
+  touched. Each section must contain at least one bullet. The commit
+  will be rejected if either header is missing.
+- If ANY bullet under "Changes made:" touches a line that was also
+  modified in the LAST RUN DIFF, list concrete values (file:symbol or
+  failure key for the fingerprint; the specific execution path that
+  fails for the runtime path).
+- If no previously changed hunk was modified, write exactly:
+  - n/a (no prior-hunk overlap)
 Each section must contain bullet points.
 If a section has no items, write:
 - none


### PR DESCRIPTION
This change restructures the instructions in `scripts/review_apply_fixes.sh` to clarify when and how to populate regression tracking fields in the review response format.

## Summary
The pull request improves the documentation and requirements for the "Regression fingerprint" and "Runtime failure path" sections that must be included in review responses. The changes make it explicit that these sections are always required, even when no previously changed code was modified.

## Key changes made

- **Moved regression fields to top-level sections**: Converted "Regression fingerprint" and "Runtime failure path" from inline bullet requirements to dedicated top-level sections in the response format, making them more prominent and harder to miss.

- **Clarified mandatory nature**: Added explicit language stating that both sections "ALWAYS" must be emitted, and the commit will be rejected if either header is missing.

- **Defined fallback value**: Specified the exact placeholder text (`- n/a (no prior-hunk overlap)`) to use when no previously changed hunks were modified, eliminating ambiguity about what constitutes a valid empty section.

- **Improved conditional logic**: Reorganized the instructions to clearly separate the two scenarios:
  - When a previously changed hunk was touched: populate with concrete values
  - When no prior-hunk overlap occurred: use the standardized "n/a" marker

- **Enhanced readability**: Restructured the format specification to list all required sections upfront, then provide detailed guidance for each section separately.

## Notable implementation details

The changes maintain backward compatibility with the existing review process while making the requirements more explicit and enforceable. The new structure prevents accidental omission of regression tracking information by elevating these fields to the same level as other mandatory sections like "Changes made" and "Already satisfied."

https://claude.ai/code/session_01H6YKmg5uNRtV86jtphLodq