### PR TITLE
Improve pre-flight validation visibility and clarify YAML indentation rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,10 @@ Logging must be structured, searchable, with context keys.
 
 ## 9. Code Style
 
-- **Tabs** for indentation
+- **Tabs** for indentation — EXCEPT in formats where the language forbids tabs or mandates a different indentation token:
+	- **YAML** (`.yml`, `.yaml`) MUST use **2-space** indentation. YAML spec disallows tab characters as indentation; `docker compose config` and every YAML parser will reject tab-indented YAML.
+	- Makefile recipe bodies must use a literal TAB (this is a Make requirement, not a style choice).
+	- If a sub-directory pins a different convention via `.editorconfig`, honour that file for files it covers.
 - Opening braces on a **new line**
 
 ---

--- a/agents.md
+++ b/agents.md
@@ -177,7 +177,10 @@ Logging must be structured, searchable, with context keys.
 
 ## 9. Code Style
 
-- **Tabs** for indentation
+- **Tabs** for indentation — EXCEPT in formats where the language forbids tabs or mandates a different indentation token:
+	- **YAML** (`.yml`, `.yaml`) MUST use **2-space** indentation. YAML spec disallows tab characters as indentation; `docker compose config` and every YAML parser will reject tab-indented YAML.
+	- Makefile recipe bodies must use a literal TAB (this is a Make requirement, not a style choice).
+	- If a sub-directory pins a different convention via `.editorconfig`, honour that file for files it covers.
 - Opening braces on a **new line**
 
 ---

--- a/codex_system_instructions.md
+++ b/codex_system_instructions.md
@@ -187,7 +187,10 @@ Logging must be structured, searchable, with context keys.
 
 ## 9. Code Style
 
-- **Tabs** for indentation
+- **Tabs** for indentation — EXCEPT in formats where the language forbids tabs or mandates a different indentation token:
+	- **YAML** (`.yml`, `.yaml`) MUST use **2-space** indentation. YAML spec disallows tab characters as indentation; `docker compose config` and every YAML parser will reject tab-indented YAML.
+	- Makefile recipe bodies must use a literal TAB (this is a Make requirement, not a style choice).
+	- If a sub-directory pins a different convention via `.editorconfig`, honour that file for files it covers.
 - Opening braces on a **new line**
 
 ---

--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -45,6 +45,10 @@ Docker build-context path rules (CRITICAL):
   This resolves to `validation/validation/Dockerfile.app` which does not exist.
 - After generating the compose file, mentally verify that `<resolved_context>/<dockerfile>` points to a real file.
 
+YAML indentation rule (CRITICAL):
+- `validation/docker-compose.test.yml` and any other generated `.yml`/`.yaml` file MUST use **2-space indentation**. YAML spec disallows TAB characters as indentation; `docker compose config` and every YAML parser will reject tab-indented YAML with an error like `found character that cannot start any token`. This is the ONE exception to the repo-wide "tabs for indentation" style rule.
+- Shell scripts (`.sh`), Dockerfiles, and Python may continue to use tabs per the repo convention. Only YAML files are spaces-only.
+
 Docker Compose healthcheck YAML rules (CRITICAL):
 - Every entry in a `healthcheck.test` list MUST be an explicitly quoted string.
 - YAML auto-casts bare values like `true`, `false`, `yes`, `no`, `null`, and bare numbers into non-string types. Docker Compose schema validation rejects these with: `services.<name>.healthcheck.test.N must be a string`.

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -428,12 +428,12 @@ run_preflight_checks()
 	# Emit the tail of the pre-flight log to stderr so that the failing command's
 	# output is visible directly in the GitHub Actions job log, without requiring
 	# the validation_preflight.log artifact to be downloaded. Structured with
-	# clear delimiter markers for grep-ability per CLAUDE.md §8.
+	# clear delimiter markers so the excerpt is easy to scan and grep in CI logs.
 	_emit_preflight_tail()
 	{
 		local reason="$1"
 		{
-			echo "##[error]Pre-flight failed: ${reason}"
+			echo "::error::Pre-flight failed: ${reason}"
 			echo "----- validation_preflight.log (tail -n 40) -----"
 			tail -n 40 "${PRE_FLIGHT_LOG_FILE}" 2>/dev/null || true
 			echo "-------------------------------------------------"

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -425,15 +425,32 @@ run_preflight_checks()
 	PRE_FLIGHT_STATUS="running"
 	: > "${PRE_FLIGHT_LOG_FILE}"
 
+	# Emit the tail of the pre-flight log to stderr so that the failing command's
+	# output is visible directly in the GitHub Actions job log, without requiring
+	# the validation_preflight.log artifact to be downloaded. Structured with
+	# clear delimiter markers for grep-ability per CLAUDE.md §8.
+	_emit_preflight_tail()
+	{
+		local reason="$1"
+		{
+			echo "##[error]Pre-flight failed: ${reason}"
+			echo "----- validation_preflight.log (tail -n 40) -----"
+			tail -n 40 "${PRE_FLIGHT_LOG_FILE}" 2>/dev/null || true
+			echo "-------------------------------------------------"
+		} >&2
+	}
+
 	if [ ! -f validation/docker-compose.test.yml ]; then
 		echo "Missing validation/docker-compose.test.yml" >> "${PRE_FLIGHT_LOG_FILE}"
 		PRE_FLIGHT_STATUS="fail"
+		_emit_preflight_tail "validation/docker-compose.test.yml missing"
 		return 1
 	fi
 
 	if ! docker compose -f validation/docker-compose.test.yml config --quiet >> "${PRE_FLIGHT_LOG_FILE}" 2>&1; then
 		echo "Compose syntax/validation check failed." >> "${PRE_FLIGHT_LOG_FILE}"
 		PRE_FLIGHT_STATUS="fail"
+		_emit_preflight_tail "docker compose config failed (YAML/schema invalid). Common cause: YAML must use space indentation, not tabs."
 		return 1
 	fi
 
@@ -442,6 +459,7 @@ run_preflight_checks()
 	if [ "${shell_count}" -eq 0 ]; then
 		echo "No shell scripts found under validation/." >> "${PRE_FLIGHT_LOG_FILE}"
 		PRE_FLIGHT_STATUS="fail"
+		_emit_preflight_tail "no shell scripts found under validation/"
 		return 1
 	fi
 
@@ -449,6 +467,7 @@ run_preflight_checks()
 		if ! bash -n "${shell_file}" >> "${PRE_FLIGHT_LOG_FILE}" 2>&1; then
 			echo "Shell syntax check failed: ${shell_file}" >> "${PRE_FLIGHT_LOG_FILE}"
 			PRE_FLIGHT_STATUS="fail"
+			_emit_preflight_tail "bash -n failed for ${shell_file}"
 			return 1
 		fi
 	done < <(find validation -type f -name '*.sh' -not -path 'validation/logs/*' | sort)
@@ -514,6 +533,7 @@ print("Build context and dockerfile path checks passed.")
 PY
 	then
 		PRE_FLIGHT_STATUS="fail"
+		_emit_preflight_tail "build context / dockerfile path resolution failed"
 		return 1
 	fi
 


### PR DESCRIPTION
## Summary
This PR enhances the pre-flight validation process to surface errors directly in GitHub Actions logs and clarifies the YAML indentation requirement across documentation.

## Key Changes

### Pre-flight Validation Improvements (`scripts/validate_process.sh`)
- **Added `_emit_preflight_tail()` helper function** that outputs the tail of the pre-flight log to stderr with clear delimiter markers, making validation failures visible in GitHub Actions job logs without requiring artifact downloads
- **Integrated error emission** at all pre-flight check failure points:
  - Missing `validation/docker-compose.test.yml`
  - Docker Compose config validation failures
  - Missing shell scripts
  - Shell syntax check failures
  - Build context/Dockerfile path resolution failures
- Each failure now includes a contextual reason message to aid debugging

### Documentation Updates
Updated code style guidelines in `CLAUDE.md`, `agents.md`, and `codex_system_instructions.md` to explicitly document the YAML indentation exception:
- **Tabs** remain the default indentation style
- **YAML files (`.yml`, `.yaml`) MUST use 2-space indentation** — the YAML spec disallows tab characters; `docker compose config` and all YAML parsers reject tab-indented YAML
- Makefile recipe bodies continue to require literal TAB characters (Make requirement)
- Sub-directory `.editorconfig` files take precedence when present

### Prompt Enhancement (`prompts/mode-validate-generate.txt`)
- Added explicit YAML indentation rule as a CRITICAL requirement
- Clarified that only YAML files are spaces-only; shell scripts, Dockerfiles, and Python continue using tabs per repo convention
- Included example error message users may encounter with tab-indented YAML

## Implementation Details
- Error messages follow GitHub Actions annotation format (`##[error]`) for better integration
- Log tail output (40 lines) provides sufficient context for most validation failures
- Structured with grep-able delimiters per existing documentation standards
- All changes are backward-compatible; no functional behavior changes to validation logic itself

https://claude.ai/code/session_01J1uQBj9y9ir8XTdZFgSvgC