### PR TITLE
Allow template edits in canonical coding-workflows repository

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1083,16 +1083,28 @@ jobs:
           git config user.name "codex-bot"
           git config user.email "codex@users.noreply.github.com"
           git rm -r --cached node_modules 2>/dev/null || true
-          if [ "${ALLOW_WORKFLOW_EDITS:-false}" = "true" ]; then
-            git add -u -- ':!node_modules' ':!scripts' ':!.github/prompts' ':!.github/scripts'
-            git ls-files --others --exclude-standard -z -- ':!node_modules' ':!.serena' ':!scripts' ':!prompts' ':!.github/ai' ':!.github/prompts' ':!.github/scripts' | xargs -0 -r git add --
-          else
-            git add -u -- ':!node_modules' ':!scripts' ':!.github/prompts' ':!.github/scripts'
-            git ls-files --others --exclude-standard -z -- ':!node_modules' ':!.serena' ':!scripts' ':!prompts' ':!.github/ai' ':!.github/prompts' ':!.github/scripts' | xargs -0 -r git add --
+          # Template-owned paths (scripts/, prompts/, .github/prompts/,
+          # .github/scripts/) are fetched from coding-workflows at runtime in
+          # consumer repos, and must NOT be committed there — any edit to them
+          # in a consumer wrapper would either be a no-op (overwritten next run)
+          # or leak a stale copy back into the caller's tree.  In the canonical
+          # `*/coding-workflows` repository these paths ARE the source of truth
+          # and must be editable, so the excludes are dropped.
+          is_self_repo="false"
+          if [[ "${{ github.repository }}" == *"/coding-workflows" ]]; then
+            is_self_repo="true"
           fi
+          add_u_excludes=(':!node_modules')
+          add_o_excludes=(':!node_modules' ':!.serena' ':!.github/ai')
+          if [ "${is_self_repo}" = "false" ]; then
+            add_u_excludes+=(':!scripts' ':!.github/prompts' ':!.github/scripts')
+            add_o_excludes+=(':!scripts' ':!prompts' ':!.github/prompts' ':!.github/scripts')
+          fi
+          git add -u -- "${add_u_excludes[@]}"
+          git ls-files --others --exclude-standard -z -- "${add_o_excludes[@]}" | xargs -0 -r git add --
           echo "Staged files before commit:"
           git diff --cached --name-only | sed 's/^/ - /' || true
-          if git diff --cached --name-only | grep -E '^\.github/(prompts|scripts)/'; then
+          if [ "${is_self_repo}" = "false" ] && git diff --cached --name-only | grep -E '^\.github/(prompts|scripts)/'; then
             echo "Error: .github/prompts or .github/scripts is staged"
             exit 1
           fi
@@ -1102,7 +1114,11 @@ jobs:
           # `git commit` fail — the "Handle no-op implementation" step below will
           # re-label the issue and post an explanatory comment.
           if [ -z "$(git diff --cached --name-only)" ]; then
-            echo "All Codex changes were filtered out (scripts/, .github/prompts/, .github/scripts/, or fetched-manifest cleanup); nothing to commit."
+            if [ "${is_self_repo}" = "false" ]; then
+              echo "All Codex changes were filtered out (scripts/, .github/prompts/, .github/scripts/, or fetched-manifest cleanup); nothing to commit."
+            else
+              echo "No staged changes after fetched-manifest cleanup; nothing to commit."
+            fi
             echo "did_commit=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -896,7 +896,7 @@ jobs:
           fi
 
       - name: Guard plans targeting template-owned paths
-        if: env.SKIP_PLAN != 'true' && steps.parse_plan.outputs.needs_clarification != 'true'
+        if: env.SKIP_PLAN != 'true' && steps.parse_plan.outputs.needs_clarification != 'true' && !endsWith(github.repository, '/coding-workflows')
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
@@ -909,14 +909,26 @@ jobs:
           # issue is routed back to humans with a clear reason rather than
           # producing a silent no-op PR downstream.
           #
-          # We match backtick-wrapped path tokens only — the convention Codex
-          # uses in its "Files likely to change" section and inline file
-          # references. This avoids false positives on prose mentions.
+          # This guard is skipped entirely when the workflow is running inside
+          # the canonical `*/coding-workflows` repository, because in that repo
+          # those paths *are* the source of truth and must be editable.
+          #
+          # We only scan the plan's "Files likely to change" section (and any
+          # equivalent "Files to change" heading), not prose, so that a plan
+          # which merely *mentions* `scripts/render_prompt.sh` in a verification
+          # step does not get rejected as if it were editing it.
+          FILES_SECTION_FILE="${RUNTIME_DIR}/files_section.txt"
+          perl -ne '
+            BEGIN { $in = 0 }
+            if (/^\s{0,3}#{1,6}\s*Files\b[^\n]*\bchange\b/i) { $in = 1; next; }
+            if ($in && /^\s{0,3}#{1,6}\s+\S/) { $in = 0; }
+            print if $in;
+          ' "${CODEX_OUTPUT_FILE}" > "${FILES_SECTION_FILE}"
           EXCLUDED_RE='`(scripts/|\.github/prompts/|\.github/scripts/)'
-          if grep -nE "${EXCLUDED_RE}" "${CODEX_OUTPUT_FILE}" >/dev/null; then
-            echo "::error::Plan references template-owned paths (scripts/, .github/prompts/, .github/scripts/) which are excluded from Codex commits in implement.yml. Changes to those paths belong in the coding-workflows repository."
-            echo "Offending lines:"
-            grep -nE "${EXCLUDED_RE}" "${CODEX_OUTPUT_FILE}" || true
+          if [ -s "${FILES_SECTION_FILE}" ] && grep -nE "${EXCLUDED_RE}" "${FILES_SECTION_FILE}" >/dev/null; then
+            echo "::error::Plan's 'Files likely to change' section lists template-owned paths (scripts/, .github/prompts/, .github/scripts/) which are excluded from Codex commits in implement.yml. Changes to those paths belong in the coding-workflows repository."
+            echo "Offending lines (from Files section):"
+            grep -nE "${EXCLUDED_RE}" "${FILES_SECTION_FILE}" || true
             source scripts/gh_helpers.sh 2>/dev/null || true
             type gh_retry >/dev/null 2>&1 || gh_retry() { "$@"; }
             # Clean up the progress comment so the failure comment (posted by


### PR DESCRIPTION
## Summary
This PR modifies the CI/CD workflows to distinguish between the canonical `coding-workflows` repository and consumer repositories that use it as a template. Template-owned paths (scripts/, prompts/, .github/prompts/, .github/scripts/) are now editable in the canonical repo but remain excluded from consumer repos, where they are fetched at runtime.

## Key Changes

**implement.yml:**
- Added detection logic to identify if the workflow is running in the canonical `*/coding-workflows` repository
- Made path exclusions conditional: template-owned paths are only excluded in consumer repos, not in the canonical repo
- Updated the "no-op" message to reflect different scenarios (consumer vs. canonical repo)
- Refactored git add commands to use bash arrays for cleaner exclude list management

**plan.yml:**
- Added a guard condition to skip the template-owned paths validation when running in the canonical `*/coding-workflows` repository
- Improved the path detection logic to only scan the "Files likely to change" section of the plan (using perl to extract the relevant section), avoiding false positives from prose mentions
- Updated error messages to clarify that only the "Files likely to change" section is checked
- This prevents legitimate edits to template paths in the canonical repo from being rejected

## Implementation Details
- Repository detection uses `github.repository` to check if it ends with `/coding-workflows`
- The plan validation now uses a perl script to extract only the "Files to change" section headers and their content, preventing false positives when template paths are merely mentioned in verification steps
- Bash arrays are used for exclude lists to improve maintainability and reduce duplication

https://claude.ai/code/session_01Tu8ANydxfHizMa7xD7mojp