### PR TITLE
fix(cancel_on_pr_close): filter runs API by branch+event to avoid jq E2BIG

### DIFF
--- a/.github/workflows/cancel_on_pr_close.yml
+++ b/.github/workflows/cancel_on_pr_close.yml
@@ -59,12 +59,20 @@ jobs:
           RUNS_JQ='{workflow_runs:
             [.[].workflow_runs // []]
             | flatten}'
+          # Filter at the API level by branch+event so the response is
+          # bounded to this PR's branch only. This avoids fetching every
+          # queued/in-progress run in the repo, which previously produced
+          # JSON blobs large enough to exceed ARG_MAX when passed via
+          # `jq --argjson` (E2BIG -> exit 126). The client-side selects
+          # below are kept as a defensive double-check.
           queued_runs_json="$(
             _gh_retry gh api \
               --method GET \
               "repos/${REPOSITORY}/actions/runs" \
               --paginate \
               -f status=queued \
+              -f event=pull_request \
+              -f "branch=${PR_HEAD_REF}" \
               -f per_page=100 \
             | jq -s "${RUNS_JQ}"
           )"
@@ -74,6 +82,8 @@ jobs:
               "repos/${REPOSITORY}/actions/runs" \
               --paginate \
               -f status=in_progress \
+              -f event=pull_request \
+              -f "branch=${PR_HEAD_REF}" \
               -f per_page=100 \
             | jq -s "${RUNS_JQ}"
           )"


### PR DESCRIPTION
The cancel-active-runs job was failing with:

    /usr/bin/jq: Argument list too long
    ##[error]Process completed with exit code 126.

Root cause: the script paginated `repos/{repo}/actions/runs` for every
queued/in-progress run in the repo and passed the resulting JSON blobs to
`jq -n --argjson queued ... --argjson in_progress ...`. On a busy repo the
combined argv exceeded the kernel ARG_MAX (~128 KB), so execve() failed
with E2BIG and bash returned exit code 126.

Filter at the API level with `event=pull_request` and `branch=${PR_HEAD_REF}`
so each response is bounded to this PR's branch only. This shrinks the JSON
payloads to a handful of runs and eliminates the E2BIG path while preserving
the existing client-side `select` filters as a defensive double-check.

https://claude.ai/code/session_01Ho2j3gvkrzNbYebR8AWeUh