### PR TITLE
Add Docker Compose variable interpolation and validation script requirements

### DIFF
--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -57,6 +57,24 @@ Docker Compose healthcheck YAML rules (CRITICAL):
       test: ["CMD", mongosh, --eval, db.runCommand('ping').ok]
 - Always wrap every healthcheck test entry in double quotes inside the YAML list.
 
+Docker Compose variable interpolation rules (CRITICAL):
+- Docker Compose interpolates `$VAR` and `${VAR}` in string values at config-render time, BEFORE the container shell ever runs.
+- Any `$` that is meant for the in-container shell (POSIX shell variables, command substitution, parameter expansion) MUST be escaped as `$$` in the compose file. Compose collapses `$$` to a literal `$` after rendering, and the container shell then evaluates it normally.
+- This rule applies to EVERY Compose string field — including `healthcheck.test`, `command`, `entrypoint`, `environment` values, `labels`, etc. The healthcheck case is the most common foot-gun because the command often uses temp shell variables.
+- CORRECT (in-container shell variable, doubled `$`):
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - "RESP=$$(curl -sf http://localhost:8545 || true); [ -n \"$$RESP\" ] || exit 1"
+- WRONG (Compose eats `$RESP` and `$(...)` at render time, leaving the container shell with empty strings):
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - "RESP=$(curl -sf http://localhost:8545 || true); [ -n \"$RESP\" ] || exit 1"
+- Preferred alternative: avoid in-shell temp variables entirely in healthchecks. Use a single self-contained command, e.g. `curl -sf --max-time 2 http://localhost:8545 >/dev/null` or a one-shot `curl ... | jq -e '...'` pipeline. This eliminates the `$$` escaping requirement.
+- After generating the compose file, mentally render every string field and confirm that no unescaped `$` references a shell variable that should be evaluated in the container.
+- The same rule applies to any Compose `${VAR}` you want passed through literally (e.g. `$${VAR}`), but prefer rewriting to avoid this whenever possible.
+
 `validation/validate.sh` requirements:
 - Bash shell with `set -euo pipefail`
 - Include `#!/usr/bin/env bash` as the first line
@@ -70,6 +88,75 @@ Docker Compose healthcheck YAML rules (CRITICAL):
 - Emit a final machine-parseable JSON result object as the last line on stdout
 - The final JSON result must include: `result` (`pass` or `fail`), `phase`, `total_tests`, `passed_tests`, `failed_tests`, `failures` (array of objects with `test`, `error`, and `log_tail`), and `duration_seconds`
 - Keep each `log_tail` concise (for example, the last 30 lines)
+- Use `docker compose -f "$COMPOSE_FILE" config -q` (already in pre-flight) as the canonical compose-file lint. Do NOT use `python3 -c 'import yaml; ...'` to validate compose files — PyYAML is not installed on the GitHub Actions runner image and the import will raise `ModuleNotFoundError: No module named 'yaml'`.
+
+CRITICAL — final JSON must be emitted on EVERY exit path:
+- The upstream parser fails with `Unable to parse validation result JSON` whenever `validate.sh` exits without printing the final result object on stdout. This is treated as a harness error and blocks the validation pipeline.
+- Therefore `validate.sh` MUST emit the final JSON result object on EVERY exit path, including all early/abort paths, not just the "tests completed" path. The set of paths that historically miss this includes:
+  1. Pre-flight tool checks (`docker`, `docker compose`) missing
+  2. Compose file missing (`[ ! -f "$COMPOSE_FILE" ]`)
+  3. `docker compose -f "$COMPOSE_FILE" config` invalid
+  4. `docker compose -f "$COMPOSE_FILE" up -d --build` failure
+  5. Health-poll deadline exceeded ("service did not become healthy within timeout")
+  6. Canary script missing or not executable
+  7. Canary infrastructure gating fails (already covered today, but must remain covered)
+  8. Trap-driven teardown after an unexpected `set -e` abort
+  9. Normal end of run (pass or fail)
+- The recommended pattern is to centralize result emission in a single shell function, install it on `EXIT`, and replace every bare `exit N` in pre-flight/health code with a call that records a structured failure and exits via the function. This way no future edit can accidentally bypass JSON emission.
+- Recommended pattern:
+    PHASE="${PHASE:-validate}"
+    RESULT_EMITTED=0
+    emit_result() {
+      # Idempotent — safe to call from both fail paths and the EXIT trap.
+      if [ "$RESULT_EMITTED" = "1" ]; then return 0; fi
+      RESULT_EMITTED=1
+      local duration=$(( $(date +%s) - START_TS ))
+      local failures_json
+      failures_json="$(cat "$FAILURES_FILE" 2>/dev/null || printf '[]')"
+      RESULT="${RESULT:-fail}" PHASE="$PHASE" \
+        TOTAL_TESTS="$TOTAL_TESTS" PASSED_TESTS="$PASSED_TESTS" FAILED_TESTS="$FAILED_TESTS" \
+        DURATION="$duration" FAILURES_JSON="$failures_json" \
+        python3 -c '
+    import json, os
+    print(json.dumps({
+        "result": os.environ["RESULT"],
+        "phase": os.environ["PHASE"],
+        "total_tests": int(os.environ["TOTAL_TESTS"]),
+        "passed_tests": int(os.environ["PASSED_TESTS"]),
+        "failed_tests": int(os.environ["FAILED_TESTS"]),
+        "failures": json.loads(os.environ["FAILURES_JSON"]),
+        "duration_seconds": int(os.environ["DURATION"]),
+    }))
+    '
+    }
+    fail_fast() {
+      # $1 = test_name, $2 = error_msg, $3 = optional log file path
+      local test_name="$1" error_msg="$2" log_file="${3:-/dev/null}"
+      append_failure "$test_name" "$error_msg" "$log_file"
+      FAILED_TESTS=$((FAILED_TESTS + 1))
+      RESULT="fail"
+      emit_result
+      exit 1
+    }
+    # Belt-and-braces: also emit on any unexpected EXIT before normal path runs.
+    on_exit() {
+      local rc=$?
+      teardown
+      if [ "$RESULT_EMITTED" != "1" ]; then
+        RESULT="fail"
+        emit_result
+      fi
+      exit $rc
+    }
+    trap on_exit EXIT
+- With this pattern in place:
+  - Replace `echo "docker compose configuration is invalid" >&2; exit 1` with `fail_fast "preflight_compose_config" "docker compose configuration is invalid"`.
+  - Replace `echo "failed to build/start compose services" >&2; exit 1` with `fail_fast "preflight_compose_up" "failed to build/start compose services" "$COMPOSE_LOG"`.
+  - Replace `echo "service did not become healthy within timeout" >&2; exit 1` with `fail_fast "startup_health_timeout" "service did not become healthy within HEALTH_TIMEOUT seconds" "$COMPOSE_LOG"`.
+  - Replace `echo "canary test missing or not executable: $CANARY" >&2; exit 1` with `fail_fast "canary_missing" "canary test missing or not executable: $CANARY"`.
+  - Apply the same substitution to every other pre-flight check.
+- The normal end-of-run path must still call `emit_result` exactly once and then `exit 0` (pass) or `exit 1` (fail).
+- Verification: before finalizing the script, mentally walk every `exit` keyword in `validate.sh` and confirm `emit_result` (or `fail_fast`, which calls it) ran on the way out. The `EXIT` trap is the safety net, NOT a substitute for explicit emission.
 
 Canary requirement (mandatory):
 - The first test script in `validation/tests/` MUST be a canary infrastructure test (for example `validation/tests/00_canary.sh`).


### PR DESCRIPTION
## Summary
This PR enhances the validation prompt with critical guidance on Docker Compose variable interpolation and establishes comprehensive requirements for the `validate.sh` script to ensure proper JSON result emission across all exit paths.

## Key Changes

### Docker Compose Variable Interpolation Rules
- Added detailed documentation on how Docker Compose interpolates `$VAR` and `${VAR}` at config-render time before container execution
- Clarified that any `$` intended for in-container shell evaluation must be escaped as `$$` in the compose file
- Provided concrete examples of correct vs. incorrect healthcheck configurations
- Recommended best practice: avoid in-shell temporary variables in healthchecks entirely, using self-contained commands instead
- Added guidance on mentally rendering string fields to verify no unescaped `$` references are present

### Validation Script Requirements
- Specified use of `docker compose -f "$COMPOSE_FILE" config -q` as the canonical compose-file linter (avoiding PyYAML which is not available on GitHub Actions runners)
- Established critical requirement that final JSON result must be emitted on **every exit path**, not just the happy path
- Documented 9 specific exit scenarios that historically miss JSON emission:
  - Pre-flight tool checks
  - Missing compose file
  - Invalid compose configuration
  - Service startup failures
  - Health-poll timeouts
  - Missing/non-executable canary scripts
  - Canary infrastructure failures
  - Trap-driven teardown aborts
  - Normal completion

### Recommended Implementation Pattern
- Provided a complete reference implementation using:
  - Centralized `emit_result()` function for idempotent JSON emission
  - `fail_fast()` helper for structured failure recording
  - `on_exit()` trap handler as a safety net
  - Specific substitution guidance for converting existing `exit` calls to use the new pattern
- Included verification checklist to mentally walk through all `exit` keywords and confirm proper emission

## Notable Details
- The pattern ensures no future edits can accidentally bypass JSON emission
- The `EXIT` trap serves as a safety net but is not a substitute for explicit emission at each failure point
- All environment variables and JSON structure are clearly specified for consistency with upstream parsers

https://claude.ai/code/session_01NFLwMoKSYFrY4C2wrZ3Ngf