### PR TITLE
Refactor workflow run ID capture with retry logic and pagination

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -227,8 +227,8 @@ jobs:
             local result=""
             local _attempt
             for _attempt in 1 2 3 4 5; do
-              result=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=100&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq "[.workflow_runs[] | select(.name | test(\"${name_re}\"; \"i\")) | select(.conclusion != \"skipped\")] | sort_by(.created_at) | last | .id // empty" 2>/dev/null || echo "")
+              result=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?per_page=100&created=>${{ steps.create-issue.outputs.created_after }}" \
+                --jq "[.workflow_runs[] | select(.name | test(\"${name_re}\"; \"i\")) | select(.conclusion != \"skipped\")] | sort_by(.created_at) | last | .id // empty" || echo "")
               if [ -n "$result" ] && [ "$result" != "null" ]; then
                 printf '%s' "$result"
                 return 0
@@ -335,8 +335,8 @@ jobs:
             local result=""
             local _attempt
             for _attempt in 1 2 3 4 5; do
-              result=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=100&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq "[.workflow_runs[] | select(.name | test(\"${name_re}\"; \"i\")) | select(.conclusion != \"skipped\")] | sort_by(.created_at) | last | .id // empty" 2>/dev/null || echo "")
+              result=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?per_page=100&created=>${{ steps.create-issue.outputs.created_after }}" \
+                --jq "[.workflow_runs[] | select(.name | test(\"${name_re}\"; \"i\")) | select(.conclusion != \"skipped\")] | sort_by(.created_at) | last | .id // empty" || echo "")
               if [ -n "$result" ] && [ "$result" != "null" ]; then
                 printf '%s' "$result"
                 return 0
@@ -485,8 +485,8 @@ jobs:
             local result=""
             local _attempt
             for _attempt in 1 2 3 4 5; do
-              result=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=100&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq "[.workflow_runs[] | select(.name | test(\"${name_re}\"; \"i\")) | select(.conclusion != \"skipped\")] | sort_by(.created_at) | last | .id // empty" 2>/dev/null || echo "")
+              result=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?per_page=100&created=>${{ steps.create-issue.outputs.created_after }}" \
+                --jq "[.workflow_runs[] | select(.name | test(\"${name_re}\"; \"i\")) | select(.conclusion != \"skipped\")] | sort_by(.created_at) | last | .id // empty" || echo "")
               if [ -n "$result" ] && [ "$result" != "null" ]; then
                 printf '%s' "$result"
                 return 0

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -217,6 +217,28 @@ jobs:
             echo ""; return 1
           }
 
+          # Robust workflow run-ID capture — retries on empty results to ride out
+          # the brief race window where the matching run isn't yet indexed by the
+          # API, and widens pagination to per_page=100 in case of high concurrent
+          # workflow run volume on the target repo. Returns the run id on stdout
+          # (empty string if all attempts fail).
+          capture_run_id() {
+            local name_re="$1"
+            local result=""
+            local _attempt
+            for _attempt in 1 2 3 4 5; do
+              result=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=100&created=>${{ steps.create-issue.outputs.created_after }}" \
+                --jq "[.workflow_runs[] | select(.name | test(\"${name_re}\"; \"i\")) | select(.conclusion != \"skipped\")] | sort_by(.created_at) | last | .id // empty" 2>/dev/null || echo "")
+              if [ -n "$result" ] && [ "$result" != "null" ]; then
+                printf '%s' "$result"
+                return 0
+              fi
+              sleep 2
+            done
+            printf ''
+            return 0
+          }
+
           while true; do
             NOW=$(date +%s)
             IDLE=$((NOW - LAST_ACTIVITY))
@@ -247,8 +269,7 @@ jobs:
             # Clarify succeeded if we see planning or awaiting-approval
             if echo "$LABELS" | grep -qE 'ai:planning|ai:awaiting-approval'; then
               echo "✓ Clarify phase completed — issue moved to planning"
-              CLARIFY_RUN_ID=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=50&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq '[.workflow_runs[] | select(.name | test("Clarif"; "i")) | select(.conclusion != "skipped")] | sort_by(.created_at) | last | .id // empty' 2>/dev/null || echo "")
+              CLARIFY_RUN_ID=$(capture_run_id "Clarif")
               echo "run_id=${CLARIFY_RUN_ID}" >> "$GITHUB_OUTPUT"
               echo "status=success" >> "$GITHUB_OUTPUT"
               exit 0
@@ -304,6 +325,28 @@ jobs:
             echo ""; return 1
           }
 
+          # Robust workflow run-ID capture — retries on empty results to ride out
+          # the brief race window where the matching run isn't yet indexed by the
+          # API, and widens pagination to per_page=100 in case of high concurrent
+          # workflow run volume on the target repo. Returns the run id on stdout
+          # (empty string if all attempts fail).
+          capture_run_id() {
+            local name_re="$1"
+            local result=""
+            local _attempt
+            for _attempt in 1 2 3 4 5; do
+              result=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=100&created=>${{ steps.create-issue.outputs.created_after }}" \
+                --jq "[.workflow_runs[] | select(.name | test(\"${name_re}\"; \"i\")) | select(.conclusion != \"skipped\")] | sort_by(.created_at) | last | .id // empty" 2>/dev/null || echo "")
+              if [ -n "$result" ] && [ "$result" != "null" ]; then
+                printf '%s' "$result"
+                return 0
+              fi
+              sleep 2
+            done
+            printf ''
+            return 0
+          }
+
           while true; do
             NOW=$(date +%s)
             IDLE=$((NOW - LAST_ACTIVITY))
@@ -339,8 +382,7 @@ jobs:
 
             if echo "$LABELS" | grep -q 'ai:awaiting-approval'; then
               echo "✓ Plan phase completed — awaiting approval"
-              PLAN_RUN_ID=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=50&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq '[.workflow_runs[] | select(.name | test("Plan"; "i")) | select(.conclusion != "skipped")] | sort_by(.created_at) | last | .id // empty' 2>/dev/null || echo "")
+              PLAN_RUN_ID=$(capture_run_id "Plan")
               echo "run_id=${PLAN_RUN_ID}" >> "$GITHUB_OUTPUT"
               echo "status=success" >> "$GITHUB_OUTPUT"
               exit 0
@@ -349,8 +391,7 @@ jobs:
             # Check for auto-approved (if AUTO_IMPLEMENT_ON_CLEAR_PLAN is on)
             if echo "$LABELS" | grep -q 'ai:implementing'; then
               echo "✓ Plan phase completed with auto-approval — already implementing"
-              PLAN_RUN_ID=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=50&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq '[.workflow_runs[] | select(.name | test("Plan"; "i")) | select(.conclusion != "skipped")] | sort_by(.created_at) | last | .id // empty' 2>/dev/null || echo "")
+              PLAN_RUN_ID=$(capture_run_id "Plan")
               echo "run_id=${PLAN_RUN_ID}" >> "$GITHUB_OUTPUT"
               echo "status=auto_approved" >> "$GITHUB_OUTPUT"
               exit 0
@@ -434,6 +475,28 @@ jobs:
             echo ""; return 1
           }
 
+          # Robust workflow run-ID capture — retries on empty results to ride out
+          # the brief race window where the matching run isn't yet indexed by the
+          # API, and widens pagination to per_page=100 in case of high concurrent
+          # workflow run volume on the target repo. Returns the run id on stdout
+          # (empty string if all attempts fail).
+          capture_run_id() {
+            local name_re="$1"
+            local result=""
+            local _attempt
+            for _attempt in 1 2 3 4 5; do
+              result=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=100&created=>${{ steps.create-issue.outputs.created_after }}" \
+                --jq "[.workflow_runs[] | select(.name | test(\"${name_re}\"; \"i\")) | select(.conclusion != \"skipped\")] | sort_by(.created_at) | last | .id // empty" 2>/dev/null || echo "")
+              if [ -n "$result" ] && [ "$result" != "null" ]; then
+                printf '%s' "$result"
+                return 0
+              fi
+              sleep 2
+            done
+            printf ''
+            return 0
+          }
+
           while true; do
             NOW=$(date +%s)
             IDLE=$((NOW - LAST_ACTIVITY))
@@ -451,8 +514,7 @@ jobs:
 
             if [ -n "$PR_NUMBER" ]; then
               echo "✓ Implementation PR #${PR_NUMBER} created"
-              IMPL_RUN_ID=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=50&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq '[.workflow_runs[] | select(.name | test("Implement"; "i")) | select(.conclusion != "skipped")] | sort_by(.created_at) | last | .id // empty' 2>/dev/null || echo "")
+              IMPL_RUN_ID=$(capture_run_id "Implement")
               echo "run_id=${IMPL_RUN_ID}" >> "$GITHUB_OUTPUT"
               echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
               echo "status=success" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -214,6 +214,7 @@ jobs:
               sleep "$RATE_LIMIT_BACKOFF"
               echo ""; return 1
             fi
+            cat /tmp/gh_api_err >&2 2>/dev/null || true
             echo ""; return 1
           }
 
@@ -322,6 +323,7 @@ jobs:
               sleep "$RATE_LIMIT_BACKOFF"
               echo ""; return 1
             fi
+            cat /tmp/gh_api_err >&2 2>/dev/null || true
             echo ""; return 1
           }
 
@@ -472,6 +474,7 @@ jobs:
               sleep "$RATE_LIMIT_BACKOFF"
               echo ""; return 1
             fi
+            cat /tmp/gh_api_err >&2 2>/dev/null || true
             echo ""; return 1
           }
 


### PR DESCRIPTION
## Summary
This PR refactors the workflow run ID capture logic across three jobs in the test-and-mark-stable workflow by extracting repeated code into a reusable `capture_run_id()` function with improved reliability.

## Key Changes
- **Introduced `capture_run_id()` helper function** in three workflow jobs (clarify, plan, and implement phases) that:
  - Retries up to 5 times with 2-second delays to handle API indexing race conditions
  - Increases pagination to `per_page=100` to handle high concurrent workflow volume
  - Returns the workflow run ID on stdout or empty string if all attempts fail
  
- **Replaced inline API calls** with the new helper function in 4 locations:
  - Clarify phase: `CLARIFY_RUN_ID` capture
  - Plan phase: `PLAN_RUN_ID` capture (2 occurrences)
  - Implement phase: `IMPL_RUN_ID` capture

## Implementation Details
- The function uses a retry loop to mitigate the brief race window where a newly created workflow run isn't yet indexed by the GitHub API
- Pagination increased from `per_page=50` to `per_page=100` to better handle repositories with high concurrent workflow activity
- Maintains the same filtering logic (case-insensitive name matching, excluding skipped runs, sorting by creation time)
- Returns exit code 0 in all cases (success or failure) to allow graceful handling of missing run IDs
- Reduces code duplication and improves maintainability across the workflow

https://claude.ai/code/session_016sh4WQ5AQfrraeEEDFudPH