### PR TITLE
Add error handling for mktemp failures in gh_helpers.sh

### DIFF
--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -206,7 +206,10 @@ gh_retry_to_file()
 _safe_gh_jq()
 {
 	local _tmpf
-	_tmpf=$(mktemp "${TMPDIR:-/tmp}/_safe_gh_jq.XXXXXX")
+	if ! _tmpf=$(mktemp "${TMPDIR:-/tmp}/_safe_gh_jq.XXXXXX" 2>/dev/null); then
+		echo "::error::_safe_gh_jq: failed to create temp file (mktemp failed); aborting without running: $*" >&2
+		return 1
+	fi
 	if gh api "$@" > "${_tmpf}"; then
 		cat "${_tmpf}"
 		rm -f "${_tmpf}"
@@ -236,7 +239,10 @@ gh_api_json_to_file()
 	local max_attempts="${GH_RETRY_MAX_ATTEMPTS:-5}"
 	local attempt=1
 	local stderr_file
-	stderr_file=$(mktemp "${TMPDIR:-/tmp}/gh_api_json_stderr.XXXXXX")
+	if ! stderr_file=$(mktemp "${TMPDIR:-/tmp}/gh_api_json_stderr.XXXXXX" 2>/dev/null); then
+		echo "::error::gh_api_json_to_file: failed to create stderr temp file (mktemp failed); aborting without running: $*" >&2
+		return 1
+	fi
 
 	while [ "${attempt}" -le "${max_attempts}" ]; do
 		: > "${outfile}"

--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -97,7 +97,10 @@ gh_retry()
 	local max_attempts="${GH_RETRY_MAX_ATTEMPTS:-5}"
 	local attempt=1
 	local stderr_file
-	stderr_file=$(mktemp "${TMPDIR:-/tmp}/gh_retry_stderr.XXXXXX")
+	if ! stderr_file=$(mktemp "${TMPDIR:-/tmp}/gh_retry_stderr.XXXXXX" 2>/dev/null); then
+		echo "::error::gh_retry: failed to create stderr temp file (mktemp failed); aborting without running: $*" >&2
+		return 1
+	fi
 
 	while [ "${attempt}" -le "${max_attempts}" ]; do
 		if "$@" 2>"${stderr_file}"; then
@@ -146,7 +149,10 @@ gh_retry_to_file()
 	local max_attempts="${GH_RETRY_MAX_ATTEMPTS:-5}"
 	local attempt=1
 	local stderr_file
-	stderr_file=$(mktemp "${TMPDIR:-/tmp}/gh_retry_stderr.XXXXXX")
+	if ! stderr_file=$(mktemp "${TMPDIR:-/tmp}/gh_retry_stderr.XXXXXX" 2>/dev/null); then
+		echo "::error::gh_retry_to_file: failed to create stderr temp file (mktemp failed); aborting without running: $*" >&2
+		return 1
+	fi
 
 	while [ "${attempt}" -le "${max_attempts}" ]; do
 		if "$@" > "${outfile}" 2>"${stderr_file}"; then
@@ -292,8 +298,15 @@ curl_gh_api()
 	local max_attempts="${GH_RETRY_MAX_ATTEMPTS:-5}"
 	local attempt=1
 	local body_file header_file
-	body_file=$(mktemp "${TMPDIR:-/tmp}/curl_gh_body.XXXXXX")
-	header_file=$(mktemp "${TMPDIR:-/tmp}/curl_gh_hdr.XXXXXX")
+	if ! body_file=$(mktemp "${TMPDIR:-/tmp}/curl_gh_body.XXXXXX" 2>/dev/null); then
+		echo "::error::curl_gh_api: failed to create body temp file (mktemp failed); aborting without calling curl" >&2
+		return 1
+	fi
+	if ! header_file=$(mktemp "${TMPDIR:-/tmp}/curl_gh_hdr.XXXXXX" 2>/dev/null); then
+		echo "::error::curl_gh_api: failed to create header temp file (mktemp failed); aborting without calling curl" >&2
+		rm -f "${body_file}"
+		return 1
+	fi
 
 	while [ "${attempt}" -le "${max_attempts}" ]; do
 		: > "${body_file}"


### PR DESCRIPTION
## Summary
Add proper error handling for temporary file creation failures in shell helper functions. This prevents silent failures and provides clear error messages when `mktemp` operations fail.

## Key Changes
- **gh_retry()**: Added error checking for stderr temp file creation with early return on failure
- **gh_retry_to_file()**: Added error checking for stderr temp file creation with early return on failure
- **curl_gh_api()**: Added error checking for both body and header temp file creation, with cleanup of body file if header file creation fails

## Implementation Details
- All `mktemp` calls now redirect stderr to `/dev/null` and check the exit status
- Failures are reported via GitHub Actions error format (`::error::`) for better visibility in CI logs
- Error messages include the function name and context (which temp file failed)
- The `curl_gh_api()` function properly cleans up the body temp file if header file creation fails, preventing resource leaks
- Functions return exit code 1 on temp file creation failure, allowing callers to handle the error appropriately

https://claude.ai/code/session_017UMp72wpbcQoxgmq6CBzjm