### PR TITLE
Fix merge commit ancestry by preserving merge index state

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2080,11 +2080,14 @@ jobs:
             git config user.email "codex@users.noreply.github.com"
             git rm -r --cached node_modules 2>/dev/null || true
             if [ "${IS_WORKFLOW_SOURCE_REPO:-false}" = "true" ]; then
-              # On the workflow source repo, commit ONLY files Codex actually
-              # wrote during conflict resolution.  Auto-merged hunks are
-              # dropped — they will replay when the PR is really merged into
-              # BASE.  This avoids committing files the editor never touched
-              # just because git merge happened to auto-stage them.
+              # On the workflow source repo, identify the files Codex actually
+              # wrote during conflict resolution so we can surface them in
+              # the job log and (below) stage them on top of the live merge
+              # index.  Auto-merged files the editor did NOT touch stay in
+              # the index as git merged them — we deliberately do NOT strip
+              # them, because stripping them broke merge ancestry (see the
+              # comment block below the pre-snapshot diff for the full
+              # rationale).
               RESOLVER_TOUCHED_FILE="${RUNTIME_DIR}/codex_touched_resolver.txt"
               : > "${RESOLVER_TOUCHED_FILE}"
               if [ -f "${PRE_RESOLVER_STATE_FILE:-/nonexistent}" ]; then
@@ -2129,13 +2132,40 @@ jobs:
               touched_count="$(wc -l < "${RESOLVER_TOUCHED_FILE}" | tr -d '[:space:]')"
               echo "Resolver-touched files (${touched_count}):"
               sed 's/^/ - /' "${RESOLVER_TOUCHED_FILE}" || true
-              # Drop the merge state so the commit we're about to make is a
-              # regular commit containing ONLY the resolver's edits, not a
-              # merge commit that carries every auto-merged hunk.  The real
-              # merge-into-BASE will replay those hunks naturally later.
-              git read-tree HEAD
+              # Stage the editor's conflict resolutions on top of the
+              # existing merge index.  Crucially, we KEEP .git/MERGE_HEAD
+              # in place AND we do NOT reset the index to HEAD.  Both
+              # are required for correctness:
+              #
+              # 1. Keeping MERGE_HEAD makes `git commit` below produce a
+              #    real merge commit with two parents (HEAD and base).
+              #    Without the second parent, git's merge-base walker
+              #    rewinds to the original merge base on every subsequent
+              #    `git merge base` attempt and re-raises the identical
+              #    conflict — observed on PR #908, where the previous
+              #    single-parent resolve commit left the PR in
+              #    mergeable_state=dirty with the same conflict line.
+              #
+              # 2. NOT resetting the index preserves git merge's
+              #    auto-merged content for files the editor did not
+              #    touch.  An earlier attempt at this fix did `git
+              #    read-tree HEAD` to keep the commit's first-parent
+              #    diff minimal, but that silently reverted base-side
+              #    changes to auto-merged files: when the PR was
+              #    eventually merged into BASE, git saw PR HEAD's old
+              #    content as "theirs" against base's unchanged content
+              #    and applied the revert.  Keeping the merged index
+              #    lets base's changes flow through the merge commit
+              #    unchanged, so the eventual merge-to-BASE is a clean
+              #    fast-forward-equivalent.
+              #
+              # The previous per-file `git add`/`git rm` loop below still
+              # runs on top of the merge index: for conflicted paths
+              # whose conflict markers the editor removed, `git add`
+              # replaces the unmerged index entries with the editor's
+              # resolved content.  Auto-merged paths the editor did not
+              # touch stay in the index as git merged them.
               git rm -r --cached --ignore-unmatch -- node_modules 2>/dev/null || true
-              rm -f .git/MERGE_HEAD .git/MERGE_MSG .git/MERGE_MODE .git/AUTO_MERGE 2>/dev/null || true
               while IFS= read -r touched_path; do
                 [ -z "${touched_path}" ] && continue
                 case "${touched_path}" in


### PR DESCRIPTION
## Summary
This change fixes a critical issue where conflict resolution commits were losing merge ancestry information, causing subsequent merge attempts to re-raise identical conflicts. The fix preserves git's merge state and index instead of resetting to HEAD.

## Key Changes
- **Removed `git read-tree HEAD`**: Previously reset the index to HEAD, which stripped auto-merged content and broke merge ancestry by creating single-parent commits instead of proper merge commits
- **Preserved `.git/MERGE_HEAD`**: Kept the merge state marker so `git commit` produces a real merge commit with two parents, maintaining correct merge-base ancestry for future merge operations
- **Kept auto-merged content in index**: Files that the editor didn't touch remain in the index as git merged them, preserving base-side changes through the merge commit
- **Updated comments**: Replaced outdated rationale with detailed explanation of why both MERGE_HEAD preservation and index preservation are critical for correctness

## Implementation Details
The fix ensures that:
1. The commit produced is a proper merge commit with two parents (HEAD and base), preventing git's merge-base walker from rewinding to the original merge base on subsequent merge attempts
2. Auto-merged files the editor didn't modify retain their merged content, so when the PR is eventually merged into BASE, base's changes flow through cleanly as a fast-forward-equivalent
3. The per-file `git add`/`git rm` loop still runs on top of the merge index, replacing unmerged entries for conflicted paths the editor resolved while leaving untouched auto-merged paths intact

This resolves issues like PR #908 where single-parent resolve commits left PRs in a dirty mergeable state with recurring conflicts.

https://claude.ai/code/session_01CCCYp7SqJeywtTVbX9QxVf