### PR TITLE
Add validation guards for AI merge conflict resolver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           python3 -m py_compile scripts/ai_labels.py
           python3 -m py_compile scripts/collect_workflow_logs.py
           python3 -m py_compile scripts/analyze_workflow_logs.py
+          python3 -m py_compile scripts/check_workflow_script_refs.py
 
       - name: Orchestrate lib unit tests
         run: |
@@ -171,20 +172,11 @@ jobs:
           ruff check --select E,F --ignore E501 scripts/*.py
 
       - name: Script-workflow cross-reference
+        # Canonical check used by both CI and the inline post-resolver
+        # guard in review_autofix.yml.  Catches three reference patterns:
+        # explicit `scripts/<name>.<ext>`, `${SUPPORT_SCRIPTS_DIR}/<name>`,
+        # and bare names enumerated in bootstrap fetch loops.  See
+        # scripts/check_workflow_script_refs.py for details.
         run: |
           set -euo pipefail
-          echo "Verifying all scripts referenced by workflows exist..."
-          MISSING=0
-          for ref in $(grep -rhoE 'scripts/[a-zA-Z0-9_.-]+\.(sh|py|json)' .github/workflows/ | sort -u); do
-            if [ ! -f "$ref" ]; then
-              echo "FAIL: $ref referenced in workflows but does not exist"
-              MISSING=$((MISSING + 1))
-            else
-              echo "OK: $ref"
-            fi
-          done
-          if [ "$MISSING" -gt 0 ]; then
-            echo "::error::${MISSING} script(s) referenced by workflows are missing"
-            exit 1
-          fi
-          echo "All referenced scripts exist."
+          PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_workflow_script_refs.py

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2215,19 +2215,28 @@ jobs:
               # On failure: skip the merge-resolve commit and exit 1 so
               # the run goes to ai:review-blocked instead of pushing a
               # broken commit that breaks every subsequent autofix run.
-              if [ -f "${CONFLICTED_PATHS_FILE:-/nonexistent}" ] && \
-                 [ -x "${SUPPORT_SCRIPTS_DIR}/check_resolver_diff.sh" ]; then
-                if ! "${SUPPORT_SCRIPTS_DIR}/check_resolver_diff.sh" \
-                    --conflicted-set "${CONFLICTED_PATHS_FILE}" \
-                    --touched-set    "${RESOLVER_TOUCHED_FILE}" \
-                    --repo-root      "${PWD}"; then
-                  echo "::error::Conflict resolver output failed validation; skipping [ai-merge-resolve] commit."
-                  echo "CONFLICT_RESOLVED=false" >> "$GITHUB_ENV"
-                  rm -f "${RESOLVER_TOUCHED_FILE}"
-                  exit 1
-                fi
-              else
-                echo "::warning::check_resolver_diff.sh or conflicted-paths snapshot missing; skipping resolver guard."
+              if [ ! -f "${CONFLICTED_PATHS_FILE:-/nonexistent}" ]; then
+                echo "::error::Conflicted-paths snapshot missing; refusing to create [ai-merge-resolve] commit without resolver validation."
+                echo "CONFLICT_RESOLVED=false" >> "$GITHUB_ENV"
+                rm -f "${RESOLVER_TOUCHED_FILE}"
+                exit 1
+              fi
+
+              if [ ! -x "${SUPPORT_SCRIPTS_DIR}/check_resolver_diff.sh" ]; then
+                echo "::error::check_resolver_diff.sh is missing or not executable; refusing to create [ai-merge-resolve] commit without resolver validation."
+                echo "CONFLICT_RESOLVED=false" >> "$GITHUB_ENV"
+                rm -f "${RESOLVER_TOUCHED_FILE}"
+                exit 1
+              fi
+
+              if ! "${SUPPORT_SCRIPTS_DIR}/check_resolver_diff.sh" \
+                  --conflicted-set "${CONFLICTED_PATHS_FILE}" \
+                  --touched-set    "${RESOLVER_TOUCHED_FILE}" \
+                  --repo-root      "${PWD}"; then
+                echo "::error::Conflict resolver output failed validation; skipping [ai-merge-resolve] commit."
+                echo "CONFLICT_RESOLVED=false" >> "$GITHUB_ENV"
+                rm -f "${RESOLVER_TOUCHED_FILE}"
+                exit 1
               fi
 
               # Stage the editor's conflict resolutions on top of the

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -199,12 +199,24 @@ jobs:
               else return 1; fi
             done; return 1
           }
-          for f in gh_helpers.sh setup_serena.sh git_ref_health_check.sh generate_symbol_diff_summary.py serena_efficiency_report.py render_prompt.sh tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py review_run_reviewers.sh review_apply_fixes.sh review_rb_judge.sh; do
+          for f in gh_helpers.sh setup_serena.sh git_ref_health_check.sh generate_symbol_diff_summary.py serena_efficiency_report.py render_prompt.sh tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py review_run_reviewers.sh review_apply_fixes.sh review_rb_judge.sh check_workflow_script_refs.py check_resolver_diff.sh; do
+            # Defensive: when neither fetch succeeds we MUST NOT abort the
+            # bootstrap with `set -e`.  A single missing helper script used
+            # to crash the whole job (PR #912 hallucination), which then
+            # cascaded into "unbound variable" failures across every later
+            # step.  Downgrade both fetch failures to warnings; downstream
+            # steps that actually need the missing file will fail with a
+            # specific error pointing at that file, not a stack of unbound
+            # variables.
             if ! _gh_api_fetch "${SUPPORT_SCRIPTS_DIR}/${f}" api -H 'Accept: application/vnd.github.raw+json' \
               "repos/${wf_source}/contents/scripts/${f}?ref=${script_ref}"; then
               echo "::warning::${f} not found on ${script_ref}; falling back to main"
-              _gh_api_fetch "${SUPPORT_SCRIPTS_DIR}/${f}" api -H 'Accept: application/vnd.github.raw+json' \
-                "repos/${wf_source}/contents/scripts/${f}?ref=main"
+              if ! _gh_api_fetch "${SUPPORT_SCRIPTS_DIR}/${f}" api -H 'Accept: application/vnd.github.raw+json' \
+                "repos/${wf_source}/contents/scripts/${f}?ref=main"; then
+                echo "::warning::${f} not found on main either; downstream steps that need it will fail with a specific error."
+                rm -f "${SUPPORT_SCRIPTS_DIR}/${f}"
+                continue
+              fi
             fi
             chmod +x "${SUPPORT_SCRIPTS_DIR}/${f}"
           done
@@ -1758,14 +1770,22 @@ jobs:
               else return 1; fi
             done; return 1
           }
-          for f in gh_helpers.sh git_ref_health_check.sh tg_helpers.sh label_helpers.sh review_run_reviewers.sh review_apply_fixes.sh review_rb_judge.sh; do
+          for f in gh_helpers.sh git_ref_health_check.sh tg_helpers.sh label_helpers.sh review_run_reviewers.sh review_apply_fixes.sh review_rb_judge.sh check_workflow_script_refs.py check_resolver_diff.sh; do
             if [ ! -f "${SUPPORT_SCRIPTS_DIR}/${f}" ]; then
               mkdir -p "${SUPPORT_SCRIPTS_DIR}"
+              # Defensive: see the longer comment on the matching loop in
+              # the "Fetch support scripts" step above.  Both fallback
+              # branches are guarded so a missing file degrades to a
+              # warning rather than aborting the whole job.
               if ! _gh_api_fetch "${SUPPORT_SCRIPTS_DIR}/${f}" api -H 'Accept: application/vnd.github.raw+json' \
                 "repos/${wf_source}/contents/scripts/${f}?ref=${script_ref}"; then
                 echo "::warning::${f} not found on ${script_ref}; falling back to main"
-                _gh_api_fetch "${SUPPORT_SCRIPTS_DIR}/${f}" api -H 'Accept: application/vnd.github.raw+json' \
-                  "repos/${wf_source}/contents/scripts/${f}?ref=main"
+                if ! _gh_api_fetch "${SUPPORT_SCRIPTS_DIR}/${f}" api -H 'Accept: application/vnd.github.raw+json' \
+                  "repos/${wf_source}/contents/scripts/${f}?ref=main"; then
+                  echo "::warning::${f} not found on main either; downstream steps that need it will fail with a specific error."
+                  rm -f "${SUPPORT_SCRIPTS_DIR}/${f}"
+                  continue
+                fi
               fi
               chmod +x "${SUPPORT_SCRIPTS_DIR}/${f}"
             fi
@@ -2004,11 +2024,41 @@ jobs:
           - Do not modify GitHub workflow files except when resolving merge conflicts.
           - Do not access the network.
 
+          HARD CONSTRAINT — out-of-conflict edits are rejected:
+          Your edits will be diff-checked against the set of files that
+          actually had merge conflicts.  Any file you modify that did NOT
+          contain conflict markers will cause the run to abort with no
+          commit.  Do not "improve" surrounding code.  Do not rewrite
+          unrelated sections.  Do not add new helper scripts, env vars,
+          or workflow steps.  If you find yourself wanting to edit a
+          file that has no conflict markers, STOP and leave it alone.
+
+          HARD CONSTRAINT — no inventing files or commands:
+          Before you finalize, perform this self-check on every edit:
+          1. List every file path you reference in your edits (including
+             any path mentioned in a shell command, sourced script,
+             bootstrap fetch list, or workflow step you would add).
+          2. For each path, verify the file already exists in the
+             repository tree by reading it.
+          3. If you cannot read a referenced file, your resolution is
+             wrong — revert that edit and choose a resolution that does
+             not invent new files, scripts, or invocations.
+          The most common failure mode for this step is hallucinating a
+          plausible-looking helper script (e.g. build_repo_overview.sh,
+          protected_paths.txt) and wiring it into the bootstrap loop.
+          The downstream existence check will catch this and abort the
+          merge-resolve commit, wasting the entire review run.  Do not
+          do it.
+
           Final output must be plain text.
 
           Output sections:
           Conflicts resolved:
           - list files where conflicts were resolved
+
+          Self-check:
+          - confirm every edited file contained conflict markers
+          - confirm every file path referenced by your edits exists in the repository
 
           Notes:
           - brief explanation if any resolution required choosing one side
@@ -2041,6 +2091,23 @@ jobs:
                 printf 'U\t%s\n' "${snap_path}" >> "${PRE_RESOLVER_STATE_FILE}"
             done < <(git ls-files --others --exclude-standard)
             echo "Pre-resolver snapshot captured: $(wc -l < "${PRE_RESOLVER_STATE_FILE}") entries"
+
+            # Capture the set of paths that actually have merge conflicts
+            # right now, before the resolver runs.  This is the canonical
+            # whitelist for "files the resolver is allowed to edit"; the
+            # post-resolver guard (check_resolver_diff.sh) rejects any
+            # touched file that is not in this set.
+            CONFLICTED_PATHS_FILE="${RUNTIME_DIR}/conflicted_paths.txt"
+            : > "${CONFLICTED_PATHS_FILE}"
+            git ls-files --unmerged | awk '{print $4}' | sort -u >> "${CONFLICTED_PATHS_FILE}"
+            # Belt-and-suspenders: also include any tracked file that
+            # currently contains a literal git conflict marker.  This
+            # catches paths git auto-merged but left with residual markers
+            # (rare but possible with --no-ff).
+            git grep -lE '^(<<<<<<< |>>>>>>> )' -- ':!*.md' 2>/dev/null \
+              >> "${CONFLICTED_PATHS_FILE}" || true
+            sort -u -o "${CONFLICTED_PATHS_FILE}" "${CONFLICTED_PATHS_FILE}"
+            echo "Conflicted paths captured: $(wc -l < "${CONFLICTED_PATHS_FILE}") entries"
           fi
 
           attempt=1
@@ -2132,6 +2199,37 @@ jobs:
               touched_count="$(wc -l < "${RESOLVER_TOUCHED_FILE}" | tr -d '[:space:]')"
               echo "Resolver-touched files (${touched_count}):"
               sed 's/^/ - /' "${RESOLVER_TOUCHED_FILE}" || true
+
+              # Hard guardrail against hallucinated merge resolutions.
+              # check_resolver_diff.sh enforces three invariants:
+              #   1. touched ⊆ conflicted  — the resolver may only edit
+              #      files that actually had merge markers.  This is what
+              #      catches the PR #912 failure mode where the resolver
+              #      added 300 lines + references to nonexistent helper
+              #      scripts under the guise of "merge resolution".
+              #   2. bash -n / py_compile / json.load on every touched
+              #      file — catches truncated heredocs and similar.
+              #   3. Workflow → script reference integrity for any
+              #      modified .github/workflows/*.yml — would have caught
+              #      build_repo_overview.sh / protected_paths.txt.
+              # On failure: skip the merge-resolve commit and exit 1 so
+              # the run goes to ai:review-blocked instead of pushing a
+              # broken commit that breaks every subsequent autofix run.
+              if [ -f "${CONFLICTED_PATHS_FILE:-/nonexistent}" ] && \
+                 [ -x "${SUPPORT_SCRIPTS_DIR}/check_resolver_diff.sh" ]; then
+                if ! "${SUPPORT_SCRIPTS_DIR}/check_resolver_diff.sh" \
+                    --conflicted-set "${CONFLICTED_PATHS_FILE}" \
+                    --touched-set    "${RESOLVER_TOUCHED_FILE}" \
+                    --repo-root      "${PWD}"; then
+                  echo "::error::Conflict resolver output failed validation; skipping [ai-merge-resolve] commit."
+                  echo "CONFLICT_RESOLVED=false" >> "$GITHUB_ENV"
+                  rm -f "${RESOLVER_TOUCHED_FILE}"
+                  exit 1
+                fi
+              else
+                echo "::warning::check_resolver_diff.sh or conflicted-paths snapshot missing; skipping resolver guard."
+              fi
+
               # Stage the editor's conflict resolutions on top of the
               # existing merge index.  Crucially, we KEEP .git/MERGE_HEAD
               # in place AND we do NOT reset the index to HEAD.  Both

--- a/scripts/check_resolver_diff.sh
+++ b/scripts/check_resolver_diff.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Validate the output of the AI conflict-resolver step before committing.
+#
+# Enforces three invariants on the resolver's edits:
+#
+#   1. Touched-set ⊆ conflicted-set.  The resolver may only modify files
+#      that contained merge conflicts (paths from `git ls-files --unmerged`
+#      taken before the resolver ran).  Any edit outside that set is
+#      treated as a hallucination — the resolver inventing new code under
+#      the guise of "merge resolution" — and the run aborts.
+#
+#   2. Per-file syntax sanity.  For every modified .sh, run `bash -n`.
+#      For every modified .py, run `python3 -m py_compile`.  Catches
+#      truncated heredocs, missing fi/done, etc., before they reach a
+#      consumer repo.
+#
+#   3. Workflow → script reference integrity.  For every modified
+#      .github/workflows/*.yml file, invoke check_workflow_script_refs.py
+#      to verify all script paths it references exist in scripts/.  This
+#      is what would have caught the build_repo_overview.sh /
+#      protected_paths.txt hallucination on PR #912.
+#
+# Exit code 0 on success.  Exit code 1 with a diagnostic on the first
+# failure — the caller (review_autofix.yml) treats this as a hard error
+# and skips the [ai-merge-resolve] commit.
+#
+# Usage:
+#   check_resolver_diff.sh \
+#     --conflicted-set <path> \
+#     --touched-set    <path> \
+#     [--repo-root     <path>]
+#
+# All paths are interpreted as relative to --repo-root (default: $PWD).
+# Paths starting with "/" are treated as absolute.
+
+set -euo pipefail
+
+CONFLICTED_SET=""
+TOUCHED_SET=""
+REPO_ROOT="${PWD}"
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--conflicted-set)
+			CONFLICTED_SET="$2"; shift 2 ;;
+		--touched-set)
+			TOUCHED_SET="$2"; shift 2 ;;
+		--repo-root)
+			REPO_ROOT="$2"; shift 2 ;;
+		-h|--help)
+			sed -n '2,30p' "$0"; exit 0 ;;
+		*)
+			echo "::error::check_resolver_diff.sh: unknown argument: $1" >&2
+			exit 2 ;;
+	esac
+done
+
+if [ -z "${CONFLICTED_SET}" ] || [ -z "${TOUCHED_SET}" ]; then
+	echo "::error::check_resolver_diff.sh: --conflicted-set and --touched-set are required" >&2
+	exit 2
+fi
+
+if [ ! -f "${CONFLICTED_SET}" ]; then
+	echo "::error::check_resolver_diff.sh: conflicted-set file not found: ${CONFLICTED_SET}" >&2
+	exit 2
+fi
+if [ ! -f "${TOUCHED_SET}" ]; then
+	echo "::error::check_resolver_diff.sh: touched-set file not found: ${TOUCHED_SET}" >&2
+	exit 2
+fi
+
+cd "${REPO_ROOT}"
+
+# Sort+dedupe both sets in place so comm sees consistent ordering.
+sort -u -o "${CONFLICTED_SET}" "${CONFLICTED_SET}"
+sort -u -o "${TOUCHED_SET}"    "${TOUCHED_SET}"
+
+touched_count="$(wc -l < "${TOUCHED_SET}" | tr -d '[:space:]')"
+conflicted_count="$(wc -l < "${CONFLICTED_SET}" | tr -d '[:space:]')"
+echo "check_resolver_diff: touched=${touched_count} conflicted=${conflicted_count}"
+
+# ---------------------------------------------------------------------------
+# (1) Touched ⊆ Conflicted
+# ---------------------------------------------------------------------------
+# `comm -23 a b` prints lines in a not in b.  A non-empty result means the
+# resolver edited paths that did NOT contain merge conflicts.
+out_of_conflict="$(comm -23 "${TOUCHED_SET}" "${CONFLICTED_SET}" || true)"
+if [ -n "${out_of_conflict}" ]; then
+	echo "::error::Conflict resolver edited files outside the conflicted set:" >&2
+	printf '  - %s\n' ${out_of_conflict} >&2
+	echo "::error::This usually indicates a hallucinated merge resolution. Aborting." >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# (2) Per-file syntax sanity
+# ---------------------------------------------------------------------------
+# Read touched paths into an array (preserves whitespace) and run language-
+# appropriate syntax checks.  Skip files the resolver deleted.
+syntax_failed=0
+while IFS= read -r touched; do
+	[ -z "${touched}" ] && continue
+	[ -e "${touched}" ] || continue
+	case "${touched}" in
+		*.sh)
+			if ! bash -n -- "${touched}" 2>&1; then
+				echo "::error::bash -n failed for ${touched}" >&2
+				syntax_failed=$((syntax_failed + 1))
+			fi
+			;;
+		*.py)
+			if ! PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile "${touched}" 2>&1; then
+				echo "::error::py_compile failed for ${touched}" >&2
+				syntax_failed=$((syntax_failed + 1))
+			fi
+			;;
+		*.json)
+			if ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "${touched}" 2>&1; then
+				echo "::error::JSON parse failed for ${touched}" >&2
+				syntax_failed=$((syntax_failed + 1))
+			fi
+			;;
+	esac
+done < "${TOUCHED_SET}"
+
+if [ "${syntax_failed}" -gt 0 ]; then
+	echo "::error::${syntax_failed} touched file(s) failed syntax check. Aborting." >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# (3) Workflow → script reference integrity
+# ---------------------------------------------------------------------------
+# For every modified .github/workflows/*.yml, verify the script paths it
+# references all exist.  Uses the canonical checker so CI and the inline
+# guard share identical logic.
+workflow_files=()
+while IFS= read -r touched; do
+	[ -z "${touched}" ] && continue
+	[ -e "${touched}" ] || continue
+	case "${touched}" in
+		.github/workflows/*.yml|.github/workflows/*.yaml)
+			workflow_files+=("${touched}") ;;
+	esac
+done < "${TOUCHED_SET}"
+
+if [ "${#workflow_files[@]}" -gt 0 ]; then
+	checker="${REPO_ROOT}/scripts/check_workflow_script_refs.py"
+	if [ ! -f "${checker}" ]; then
+		echo "::error::check_workflow_script_refs.py not found at ${checker}" >&2
+		exit 1
+	fi
+	if ! PYTHONDONTWRITEBYTECODE=1 python3 "${checker}" \
+			--repo-root "${REPO_ROOT}" \
+			--files "${workflow_files[@]}"; then
+		echo "::error::Modified workflow file references nonexistent script(s). Aborting." >&2
+		exit 1
+	fi
+fi
+
+echo "check_resolver_diff: OK"

--- a/scripts/check_resolver_diff.sh
+++ b/scripts/check_resolver_diff.sh
@@ -87,7 +87,9 @@ echo "check_resolver_diff: touched=${touched_count} conflicted=${conflicted_coun
 out_of_conflict="$(comm -23 "${TOUCHED_SET}" "${CONFLICTED_SET}" || true)"
 if [ -n "${out_of_conflict}" ]; then
 	echo "::error::Conflict resolver edited files outside the conflicted set:" >&2
-	printf '  - %s\n' ${out_of_conflict} >&2
+	while IFS= read -r path; do
+		printf '  - %s\n' "${path}" >&2
+	done <<< "${out_of_conflict}"
 	echo "::error::This usually indicates a hallucinated merge resolution. Aborting." >&2
 	exit 1
 fi

--- a/scripts/check_resolver_diff.sh
+++ b/scripts/check_resolver_diff.sh
@@ -60,6 +60,23 @@ if [ -z "${CONFLICTED_SET}" ] || [ -z "${TOUCHED_SET}" ]; then
 	exit 2
 fi
 
+if ! REPO_ROOT="$(cd "${REPO_ROOT}" 2>/dev/null && pwd)"; then
+	echo "::error::check_resolver_diff.sh: repo-root directory not found: ${REPO_ROOT}" >&2
+	exit 2
+fi
+
+resolve_path() {
+	local path="$1"
+	if [[ "${path}" == /* ]]; then
+		printf '%s\n' "${path}"
+	else
+		printf '%s\n' "${REPO_ROOT}/${path}"
+	fi
+}
+
+CONFLICTED_SET="$(resolve_path "${CONFLICTED_SET}")"
+TOUCHED_SET="$(resolve_path "${TOUCHED_SET}")"
+
 if [ ! -f "${CONFLICTED_SET}" ]; then
 	echo "::error::check_resolver_diff.sh: conflicted-set file not found: ${CONFLICTED_SET}" >&2
 	exit 2
@@ -97,7 +114,7 @@ fi
 # ---------------------------------------------------------------------------
 # (2) Per-file syntax sanity
 # ---------------------------------------------------------------------------
-# Read touched paths into an array (preserves whitespace) and run language-
+# Read touched paths line-by-line (preserves whitespace) and run language-
 # appropriate syntax checks.  Skip files the resolver deleted.
 syntax_failed=0
 while IFS= read -r touched; do

--- a/scripts/check_workflow_script_refs.py
+++ b/scripts/check_workflow_script_refs.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Verify every script referenced by a workflow file exists in scripts/.
+
+Catches three categories of references:
+
+  1. Explicit ``scripts/<name>.<ext>`` substrings (sh, py, json, txt, md).
+  2. ``${SUPPORT_SCRIPTS_DIR}/<name>.<ext>`` substrings.
+  3. Bare names enumerated inside a ``for f in … ; do … done`` block whose
+     body actually fetches/uses ``scripts/${f}``.  This is the bootstrap
+     fetch loop pattern used by review_autofix.yml — historically a source
+     of hallucinated references because the names are bare strings rather
+     than paths.
+
+Exit code 0 if every reference resolves to a file under scripts/.
+Exit code 1 with one line per missing reference otherwise.
+
+Designed to be cheap (pure stdlib, no YAML parser) so it can run both
+in CI and inline in the autofix workflow before pushing AI-resolved
+merge commits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+from typing import Iterable
+
+EXPLICIT_REF = re.compile(r"scripts/([a-zA-Z0-9_.\-]+\.(?:sh|py|json|txt|md))")
+SCRIPTS_VAR_REF = re.compile(
+	r"\$\{SUPPORT_SCRIPTS_DIR\}/([a-zA-Z0-9_.\-]+\.(?:sh|py|json|txt|md))"
+)
+BARE_NAME = re.compile(r"^[a-zA-Z0-9_.\-]+\.(?:sh|py|json|txt|md)$")
+FOR_LOOP = re.compile(
+	r"for\s+f\s+in\s+([^;]+?);\s*do(.*?)done",
+	re.DOTALL,
+)
+
+
+def extract_refs(text: str) -> set[str]:
+	refs: set[str] = set()
+	refs.update(EXPLICIT_REF.findall(text))
+	refs.update(SCRIPTS_VAR_REF.findall(text))
+	for items_blob, body in FOR_LOOP.findall(text):
+		# Only treat the loop as a script-fetch loop when its body actually
+		# uses scripts/${f} (either as a fetch path or a local path under
+		# SUPPORT_SCRIPTS_DIR).  This avoids matching unrelated for-loops
+		# such as the instruction-file fetch loop further down.
+		if "scripts/${f}" not in body and "${SUPPORT_SCRIPTS_DIR}/${f}" not in body:
+			continue
+		for item in items_blob.split():
+			item = item.strip()
+			if BARE_NAME.match(item):
+				refs.add(item)
+	return refs
+
+
+def check_workflows(repo_root: pathlib.Path) -> list[str]:
+	workflow_dir = repo_root / ".github" / "workflows"
+	scripts_dir = repo_root / "scripts"
+	errors: list[str] = []
+	if not workflow_dir.is_dir():
+		errors.append(f"workflow directory does not exist: {workflow_dir}")
+		return errors
+	if not scripts_dir.is_dir():
+		errors.append(f"scripts directory does not exist: {scripts_dir}")
+		return errors
+	for yml in sorted(workflow_dir.glob("*.yml")):
+		try:
+			text = yml.read_text()
+		except OSError as exc:
+			errors.append(f"{yml.name}: cannot read ({exc})")
+			continue
+		refs = extract_refs(text)
+		for ref in sorted(refs):
+			target = scripts_dir / ref
+			if not target.is_file():
+				errors.append(
+					f"{yml.name}: references scripts/{ref} which does not exist"
+				)
+	return errors
+
+
+def check_paths(paths: Iterable[pathlib.Path], scripts_dir: pathlib.Path) -> list[str]:
+	"""Run the existence check against an explicit list of workflow files.
+
+	Used by the inline post-resolver guard, which only needs to scan the
+	files the merge-resolver actually touched.
+	"""
+	errors: list[str] = []
+	for p in paths:
+		try:
+			text = p.read_text()
+		except OSError as exc:
+			errors.append(f"{p}: cannot read ({exc})")
+			continue
+		for ref in sorted(extract_refs(text)):
+			target = scripts_dir / ref
+			if not target.is_file():
+				errors.append(
+					f"{p.name}: references scripts/{ref} which does not exist"
+				)
+	return errors
+
+
+def main() -> int:
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument(
+		"--repo-root",
+		type=pathlib.Path,
+		default=pathlib.Path(__file__).resolve().parent.parent,
+		help="repository root (defaults to parent of scripts/)",
+	)
+	parser.add_argument(
+		"--files",
+		nargs="*",
+		type=pathlib.Path,
+		help="explicit list of workflow files to check (defaults to all)",
+	)
+	args = parser.parse_args()
+
+	repo_root = args.repo_root.resolve()
+	if args.files:
+		scripts_dir = repo_root / "scripts"
+		errors = check_paths([f.resolve() for f in args.files], scripts_dir)
+	else:
+		errors = check_workflows(repo_root)
+
+	if errors:
+		for line in errors:
+			print(f"FAIL: {line}", file=sys.stderr)
+		print(
+			f"\n{len(errors)} workflow script reference(s) do not exist",
+			file=sys.stderr,
+		)
+		return 1
+	print("All workflow script references resolve to existing files.")
+	return 0
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/scripts/check_workflow_script_refs.py
+++ b/scripts/check_workflow_script_refs.py
@@ -126,7 +126,11 @@ def main() -> int:
 	repo_root = args.repo_root.resolve()
 	if args.files:
 		scripts_dir = repo_root / "scripts"
-		errors = check_paths([f.resolve() for f in args.files], scripts_dir)
+		workflow_paths = [
+			f.resolve() if f.is_absolute() else (repo_root / f).resolve()
+			for f in args.files
+		]
+		errors = check_paths(workflow_paths, scripts_dir)
 	else:
 		errors = check_workflows(repo_root)
 

--- a/scripts/check_workflow_script_refs.py
+++ b/scripts/check_workflow_script_refs.py
@@ -66,10 +66,13 @@ def check_workflows(repo_root: pathlib.Path) -> list[str]:
 	if not scripts_dir.is_dir():
 		errors.append(f"scripts directory does not exist: {scripts_dir}")
 		return errors
-	for yml in sorted(workflow_dir.glob("*.yml")):
+	workflow_files = sorted(
+		set(workflow_dir.glob("*.yml")) | set(workflow_dir.glob("*.yaml"))
+	)
+	for yml in workflow_files:
 		try:
-			text = yml.read_text()
-		except OSError as exc:
+			text = yml.read_text(encoding="utf-8")
+		except (OSError, UnicodeDecodeError) as exc:
 			errors.append(f"{yml.name}: cannot read ({exc})")
 			continue
 		refs = extract_refs(text)
@@ -91,8 +94,8 @@ def check_paths(paths: Iterable[pathlib.Path], scripts_dir: pathlib.Path) -> lis
 	errors: list[str] = []
 	for p in paths:
 		try:
-			text = p.read_text()
-		except OSError as exc:
+			text = p.read_text(encoding="utf-8")
+		except (OSError, UnicodeDecodeError) as exc:
 			errors.append(f"{p}: cannot read ({exc})")
 			continue
 		for ref in sorted(extract_refs(text)):


### PR DESCRIPTION
## Summary
Adds comprehensive validation checks to prevent hallucinated merge resolutions from being committed. Implements three hard constraints: (1) resolver may only edit files with actual merge conflicts, (2) syntax validation for modified scripts, and (3) workflow-to-script reference integrity checks.

## Key Changes

- **New script: `check_resolver_diff.sh`** — Post-resolver validation guard that enforces three invariants:
  - Touched files must be a subset of conflicted files (prevents editing unrelated code)
  - Syntax checks for modified `.sh`, `.py`, and `.json` files
  - Workflow script reference integrity via `check_workflow_script_refs.py`

- **New script: `check_workflow_script_refs.py`** — Detects three categories of script references in workflows:
  - Explicit `scripts/<name>.<ext>` paths
  - `${SUPPORT_SCRIPTS_DIR}/<name>.<ext>` variable references
  - Bare script names in bootstrap fetch loops (catches hallucinated helper scripts)

- **Enhanced `review_autofix.yml`**:
  - Captures conflicted file paths before resolver runs as canonical whitelist
  - Adds defensive error handling in bootstrap fetch loops (downgrades missing files to warnings instead of aborting)
  - Invokes `check_resolver_diff.sh` post-resolution to validate output
  - Skips merge-resolve commit and exits with error if validation fails
  - Expanded resolver prompt with explicit constraints against out-of-conflict edits and file hallucinations

- **Updated `ci.yml`**:
  - Replaces inline script-reference check with canonical `check_workflow_script_refs.py`
  - Adds py_compile check for the new validation script

## Notable Implementation Details

- The validation runs inline in the workflow before committing, catching issues immediately rather than in downstream runs
- Defensive bootstrap loop handling prevents cascading failures when a single helper script is missing
- Uses `git ls-files --unmerged` plus literal conflict marker detection to identify conflicted paths
- Pure stdlib Python implementation for the reference checker (no YAML parser dependency) to keep it lightweight for inline execution
- Detailed prompt guidance to resolver about the hard constraints and common failure modes (e.g., PR #912 hallucination pattern)

https://claude.ai/code/session_01WeFXUKrGvYqiShKS2WQacY