### PR TITLE
Fix script cleanup in workflow source repo merge resolution

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2064,7 +2064,18 @@ jobs:
           # collide with files from origin/BASE_BRANCH during the merge.
           # First, explicitly remove known CI-generated files that may be
           # untracked in consumer repos (see "Detect merge conflicts" step).
-          rm -f scripts/ai_memory.py scripts/ai_memory_lib.py scripts/memory_helpers.sh scripts/openrouter_prompt_cache.py scripts/review_run_reviewers.sh scripts/review_apply_fixes.sh scripts/review_rb_judge.sh 2>/dev/null || true
+          # Skipped on the workflow source repo, where these paths are
+          # tracked source files — removing them here would leave them
+          # missing for the rest of this step because the consumer-repo
+          # restore block below (git reset/checkout on 'scripts' etc.) is
+          # intentionally skipped when IS_WORKFLOW_SOURCE_REPO=true, and
+          # `git merge --no-commit` does not rewrite paths whose content
+          # is identical between HEAD and BASE.  Downstream
+          # check_workflow_script_refs.py then fails the [ai-merge-resolve]
+          # commit because the referenced scripts are missing from disk.
+          if [ "${IS_WORKFLOW_SOURCE_REPO:-false}" != "true" ]; then
+            rm -f scripts/ai_memory.py scripts/ai_memory_lib.py scripts/memory_helpers.sh scripts/openrouter_prompt_cache.py scripts/review_run_reviewers.sh scripts/review_apply_fixes.sh scripts/review_rb_judge.sh 2>/dev/null || true
+          fi
           RESOLVE_STASH="$(mktemp -d)"
           for d in scripts .serena prompts ai-memory; do
             if [ -d "${d}" ]; then


### PR DESCRIPTION
## Summary
Fixed a bug in the merge conflict resolution step of the review autofix workflow where CI-generated scripts were being incorrectly removed from the workflow source repository itself, causing downstream validation failures.

## Key Changes
- Added a conditional check to skip script removal when running in the workflow source repository (`IS_WORKFLOW_SOURCE_REPO=true`)
- This prevents deletion of tracked source files that are needed for the rest of the merge resolution process
- Preserves scripts on disk for the `check_workflow_script_refs.py` validation step that runs after merge resolution

## Implementation Details
The issue occurred because:
1. The script removal step was unconditionally deleting files like `scripts/ai_memory.py`, `scripts/review_apply_fixes.sh`, etc.
2. In the workflow source repo, these are tracked source files, not CI-generated artifacts
3. The consumer-repo restore block below is intentionally skipped when `IS_WORKFLOW_SOURCE_REPO=true`
4. Since `git merge --no-commit` doesn't rewrite paths with identical content between HEAD and BASE, the deleted scripts remained missing
5. This caused `check_workflow_script_refs.py` to fail during the `[ai-merge-resolve]` commit

The fix wraps the removal command in a conditional that only executes for consumer repositories, not the workflow source repository itself.

https://claude.ai/code/session_01RcFe9jV7bBfy3w73fCCs8i