### PR TITLE
Add critical Dockerfile PID 1 signal handling guidance

### DIFF
--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -298,6 +298,22 @@ CRITICAL — Ethereum / Hardhat JSON-RPC health checks:
 - For `eth_blockNumber` probes, parse `.result` the same way (it is a hex string like `"0x0"`).
 - If the project uses Hardhat, Anvil, or Ganache as a local node, apply this exact pattern for the canary health check. Never assume an array-shaped response.
 
+CRITICAL — Dockerfile PID 1 signal handling (prevents exit 137 in graceful_shutdown):
+- Any generated `validation/Dockerfile*` MUST use **exec-form** (JSON array) `CMD` and `ENTRYPOINT` so PID 1 is the actual application process and receives SIGTERM directly from `docker compose stop`.
+- CORRECT (exec-form, PID 1 is the app):
+    CMD ["python3", "-m", "http.server", "18080"]
+    CMD ["node", "server.js"]
+    ENTRYPOINT ["/usr/local/bin/app"]
+- WRONG (shell-form, PID 1 is `/bin/sh -c` which does NOT forward signals):
+    CMD python3 -m http.server 18080
+    CMD node server.js
+  Shell-form makes `/bin/sh -c "..."` PID 1. POSIX `sh` does not forward SIGTERM to its child by default, so `docker compose stop` times out and docker escalates to SIGKILL. The container exits with code **137** (= 128 + SIGKILL), which fails the `graceful_shutdown` assertion even though the app itself was perfectly healthy right up to teardown. This is the single most common cause of false-negative shutdown failures in this harness.
+- If the app genuinely cannot install a SIGTERM handler and exec-form alone is not sufficient (rare — applies to some wrapper scripts and a few legacy Python stdlib servers), pick ONE of:
+  1. Add `init: true` to the compose service so Docker injects `tini` as PID 1; tini reaps children and forwards SIGTERM correctly.
+  2. Install `tini` in the image and use `ENTRYPOINT ["/sbin/tini", "--"]` with the real command as `CMD`.
+- Do NOT "fix" this by relaxing the shutdown assertion to accept exit code 137. Exit 137 can also be produced by OOM kills, livelocks, and real SIGKILLs from the host — accepting it would hide genuine failures. Fix the PID 1 process model instead.
+- After generating the Dockerfile, mentally verify: "If I ran `docker run <image>` and then `docker stop`, would PID 1 itself receive SIGTERM?" If PID 1 is `/bin/sh -c …` or an un-exec'd wrapper script, the answer is no — rewrite to exec-form.
+
 CRITICAL — graceful shutdown container resolution:
 - After `docker compose stop <service>`, the container moves to `exited` state.
 - `docker compose ps -q <service>` only returns RUNNING containers and will return empty after stop.
@@ -308,6 +324,7 @@ CRITICAL — graceful shutdown container resolution:
     2. Exit code 143 (= 128 + SIGTERM) — PID 1 was terminated by SIGTERM without a custom handler; this is the documented signal-exit convention.
     3. Exit code 1 when PID 1 is an `npm` / `yarn` / `pnpm` wrapper AND the compose log contains a wrapper SIGTERM marker (for example `npm ERR! signal SIGTERM` or `Command failed with signal "SIGTERM"`) for the wrapped command. npm translates signal-termination of its child into exit code 1 instead of propagating 143; this is a wrapper artifact, NOT an application crash.
 - NEVER hardcode a strict `EXIT_CODE == 0` check when the service is launched via an `npm` / `yarn` / `pnpm` script — you will get false failures on every clean `docker stop` because of (3) above.
+- Exit code **137** (= 128 + SIGKILL) is NOT a graceful shutdown. It is the signature of shell-form `CMD` / missing signal forwarding — `/bin/sh -c` was PID 1, swallowed SIGTERM, and docker had to escalate to SIGKILL after the stop-timeout. Fix this at the Dockerfile layer per the "Dockerfile PID 1 signal handling" section above, not by loosening this assertion.
 - Recommended pattern:
     COMPOSE_FILE="validation/docker-compose.test.yml"
     COMPOSE_LOG="validation/logs/compose.log"


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation to the validation prompt about proper Dockerfile signal handling, specifically addressing the root cause of exit code 137 failures in graceful shutdown tests.

## Key Changes
- **New section: "Dockerfile PID 1 signal handling"** — Explains why shell-form `CMD`/`ENTRYPOINT` causes graceful shutdown failures
  - Documents the difference between exec-form (JSON array) and shell-form syntax
  - Clarifies that shell-form makes `/bin/sh -c` PID 1, which does not forward SIGTERM to child processes
  - Shows how this leads to docker escalating to SIGKILL and exit code 137
  
- **Provided remediation strategies:**
  - Use exec-form `CMD` and `ENTRYPOINT` (preferred)
  - Use `init: true` in compose to inject `tini` as PID 1
  - Install and use `tini` explicitly in the image
  
- **Added mental verification checklist** — Helps developers validate their Dockerfile before submission by asking: "Would PID 1 itself receive SIGTERM?"

- **Enhanced graceful shutdown assertion guidance** — Added explicit note that exit code 137 is NOT graceful and must be fixed at the Dockerfile layer, not by relaxing assertions
  - Clarifies that accepting 137 would hide genuine failures (OOM kills, livelocks, real SIGKILLs)

## Implementation Details
- Inserted new critical section immediately before the existing "graceful shutdown container resolution" section for logical flow
- Provided concrete examples of correct vs. incorrect syntax
- Explained the technical mechanism (POSIX `sh` signal forwarding behavior) to help developers understand the "why"
- Positioned the guidance to prevent the most common false-negative shutdown failures in the validation harness

https://claude.ai/code/session_012WSuiBFKBqkUXGwJ9L5QNW