### PR TITLE
chore(workflow-log-analysis): pilot Gemini 3.1 Pro Preview as analyzer model

### DIFF
--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -163,6 +163,10 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENROUTER_PROMPT_CACHE_DISABLED: ${{ vars.OPENROUTER_PROMPT_CACHE_DISABLED || 'false' }}
           THINKING_LEVEL_ANALYSIS: ${{ vars.THINKING_LEVEL_ANALYSIS || '' }}
+          # Pilot: route the analyzer through Gemini 3.1 Pro Preview by default for this workflow only.
+          # Override with repo variable WORKFLOW_LOG_ANALYSIS_MODEL (e.g. openai/gpt-5.3-codex) to revert.
+          # Scoped to this step's env so other workflows still resolve WORKFLOW_EDITOR_MODEL from repo vars.
+          WORKFLOW_EDITOR_MODEL: ${{ vars.WORKFLOW_LOG_ANALYSIS_MODEL || 'google/gemini-3.1-pro-preview' }}
           BATCH_API_DISABLED: ${{ vars.BATCH_API_DISABLED || 'false' }}
           BATCH_API_PROVIDER: ${{ vars.BATCH_API_PROVIDER || 'auto' }}
           BATCH_API_POLL_TIMEOUT_HOURS: ${{ vars.BATCH_API_POLL_TIMEOUT_HOURS || '24' }}
@@ -197,6 +201,13 @@ jobs:
           if [ -n "${THINKING_LEVEL_ANALYSIS}" ]; then
             cmd+=(--thinking-level "${THINKING_LEVEL_ANALYSIS}")
           fi
+          # Gemini 3.1 Pro Preview caps max output at 65536 tokens. The analyzer's default
+          # --max-output-tokens is 100000, which would be rejected by Gemini routes. Cap it
+          # only when the resolved model id contains "gemini" so non-Gemini models keep the
+          # script default.
+          case "${WORKFLOW_EDITOR_MODEL:-}" in
+            *gemini*) cmd+=(--max-output-tokens 60000) ;;
+          esac
 
           ANALYZE_EXIT=0
           REPORT_FILE=""

--- a/README.md
+++ b/README.md
@@ -592,7 +592,8 @@ Generated JSON report (`workflow_log_report.json`) includes:
 Analyzer script: [`scripts/analyze_workflow_logs.py`](scripts/analyze_workflow_logs.py)
 
 - Workflow invocation: `python3 scripts/analyze_workflow_logs.py --input workflow_log_report.json`
-- `--max-output-tokens` default is `100000`.
+- `--max-output-tokens` default is `100000`. The workflow auto-caps this to `60000` when the resolved `WORKFLOW_EDITOR_MODEL` contains `gemini` (Gemini 3.1 Pro Preview's max output is 65536).
+- Model resolution for this workflow only: the `Run workflow log analysis` step pins `WORKFLOW_EDITOR_MODEL` to `google/gemini-3.1-pro-preview` by default (pilot). Override via repo variable `WORKFLOW_LOG_ANALYSIS_MODEL` (e.g. `openai/gpt-5.3-codex`) to revert. This override is scoped to the analysis step env and does not affect the global `WORKFLOW_EDITOR_MODEL` used by `clarify`/`plan`/`implement`/`review_autofix`/`validate`/`orchestrate`.
 - `load_input_data` accepts either:
   - `--input` with a collector report (`runs` list; `runs[].log_excerpts` are flattened into `deep_dive_logs` as `{name: <repo>/<run_id>/<step_name>, excerpt}`), a combined bundle object (`run_metrics`, `summary_stats`, optional `deep_dive_logs`), or a JSON array of run metrics
   - `--data-dir` containing `workflow_log_report.json` or `run_metrics.json` + `summary_stats.json` (optionally `run_logs/`)


### PR DESCRIPTION
## Summary

- Pilot routing **only** the `workflow-log-analysis.yml` job through `google/gemini-3.1-pro-preview` instead of the default `openai/gpt-5.3-codex`. Override is scoped to the analyze step's `env` block, so all other workflows (`clarify`, `plan`, `implement`, `review_autofix`, `validate`, `orchestrate`, `orchestrate_poll`) continue to resolve `WORKFLOW_EDITOR_MODEL` from repo vars and remain on Codex.
- New repo variable `WORKFLOW_LOG_ANALYSIS_MODEL` lets you flip back to `openai/gpt-5.3-codex` (or any other id) without code changes.
- Auto-cap `--max-output-tokens` to `60000` when the resolved model id contains `gemini`, because Gemini 3.1 Pro Preview's max output is 65536 and the script default of 100000 would be rejected. Non-Gemini models keep the existing default.
- README updated to document both the per-workflow model pin and the conditional output cap.

## Why Gemini for the analyzer specifically

Per published benchmarks (Artificial Analysis, NxCode, llm-stats, Alex Lavaee technical breakdown — all Q1 2026):

| Benchmark | gpt-5.3-codex | gemini-3.1-pro-preview |
|---|---|---|
| SWE-bench Verified | 80.0% | **80.6%** |
| SWE-bench Pro | **56.8%** | 54.2% |
| Terminal-Bench 2.0 | **77.3%** | 68.5% |
| Context window | (Codex CLI) | 1,048,576 tokens |
| Pricing (OpenRouter) | — | $2.00 in / $12.00 out per MTok |

Gemini's reasoning strength + 1M context is well-matched to single-shot log analysis over large telemetry dumps. The Terminal-Bench gap (−8.8 pts) is why this swap is **not** propagated to the editor surfaces — those run through `codex exec --full-auto`, which is exactly what Terminal-Bench measures and where Codex still leads.

## Why this is safe to land as a pilot

I read `scripts/analyze_workflow_logs.py` end-to-end before making changes:

- **Cache layer is already Gemini-aware** — `scripts/openrouter_prompt_cache.py:29-38` defines `is_gemini_model()` and `should_add_explicit_breakpoint()` skips the Anthropic-style `cache_control: {type: ephemeral}` breakpoint for any model id containing `gemini`. Plus `should_retry_without_breakpoint` is a safety net for HTTP 400/422 cache errors.
- **Provider routing is auto** — `_normalize_batch_provider` (line 614) only honors `openai`/`anthropic` hints; everything else (including Gemini) becomes `auto`, and no `provider.order` clamp is sent.
- **Batch path degrades gracefully** — `_batch_capability_decision` (line 741) probes `/models/{author}/{slug}/endpoints` and falls back to sync (`run_sync("background_param_not_supported")`) if Gemini's OpenRouter route doesn't expose `background: true`. No crash.
- **Reasoning effort** — passed as a plain `"medium"`/`"high"` string in the `reasoning` field; OpenRouter's universal cross-provider reasoning shim translates this into Gemini's thinking-budget representation.
- **Response parsing** — `_extract_response_text` (line 844) handles both Responses-API shapes (`output_text`, `output[].content[].text`) and Chat-Completions shapes, so it's provider-agnostic.

The **only** real blocker found was the 100k `--max-output-tokens` default exceeding Gemini's 65536 cap, which is why this PR adds the conditional cap.

## Test plan

- [ ] **Manual dispatch:** Actions → Workflow Log Analysis → Run workflow with `lookback_days=7`. Verify the run uses Gemini (look for `model=google/gemini-3.1-pro-preview` in the analyzer's structured `INFO: openrouter usage` log line).
- [ ] **Output sanity:** confirm a `analysis/workflow-optimization-YYYY-MM-DD.md` report is committed and renders coherently. Compare against the most recent Codex-generated report in `analysis/` for quality.
- [ ] **Cost check:** capture `prompt_tokens` / `completion_tokens` from the structured usage log and compare against a recent Codex baseline run. At $2/$12 per MTok, Gemini should be cheaper per run than Codex on input-heavy log analysis.
- [ ] **Cache telemetry:** confirm the structured usage log shows `cache_breakpoint_enabled=false` (expected — `should_add_explicit_breakpoint` returns False for `gemini*`) and that no HTTP 400/422 cache errors appear.
- [ ] **Batch path:** if the Gemini OpenRouter route doesn't expose background mode, verify the run logs a structured `batch_fallback` warning with `reason=background_param_not_supported` and continues synchronously.
- [ ] **Token cap:** confirm `--max-output-tokens 60000` appears in the run log's command echo (or that the analyzer doesn't error with a max-output validation message from OpenRouter).
- [ ] **Revert path:** set repo variable `WORKFLOW_LOG_ANALYSIS_MODEL=openai/gpt-5.3-codex`, dispatch again, and verify the analyzer falls back to Codex with the script's default 100k token cap (no Gemini cap branch taken).

## Files changed

- `.github/workflows/workflow-log-analysis.yml` (lines 162-175, 200-211): step env now sets `WORKFLOW_EDITOR_MODEL`; cmd assembly conditionally appends `--max-output-tokens 60000` for Gemini routes.
- `README.md` (lines 594-596): documents the per-workflow model pin and the conditional output cap in the "Analyzer input/output contract" section.

## Rollback

Revert this commit, **or** set repo variable `WORKFLOW_LOG_ANALYSIS_MODEL=openai/gpt-5.3-codex`. Either restores the previous behavior fully — no schema/state migration needed (the batch state file's `model` field is informational only and `poll_openrouter_batch` keys off `batch_id`).

https://claude.ai/code/session_01CaGXsxkamshJg7boRFEU3g