### PR TITLE
claude/analyze-job-logs-y0ard

### DIFF
--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -2522,7 +2522,11 @@ def test_stall_judge_unknown_action_falls_back_to_declarative_recovery():
 	issue_comments = [c.get("body", "") for c in result["issues"]["10"]["comments"]]
 	tracking_comments = [c.get("body", "") for c in result["issues"]["192"]["comments"]]
 	assert any("Stall Judge — Issue #10" in body for body in tracking_comments)
-	assert any("/approved" in body for body in issue_comments)
+	# At stall_recovery_count=2 for phase ai:awaiting-approval, the declarative
+	# ladder (STALL_RECOVERY_ACTIONS) selects escalate_human at index 2, so the
+	# fallback adds the ai:needs-human label and does not post /approved.
+	assert "ai:needs-human" in result["issues"]["10"]["labels"]
+	assert not any("/approved" in body for body in issue_comments)
 	issue_entry = result["latest_state"]["waves"][0]["issues"][0]
 	assert issue_entry["stall_recovery_count"] == 3
 


### PR DESCRIPTION
The test seeded stall_recovery_count=2 for phase ai:awaiting-approval and
asserted /approved was posted. At count 2 the declarative ladder
(STALL_RECOVERY_ACTIONS) picks index 2, which was changed to escalate_human
in the same commit that added this test (f4921cf / PR #961). The fallback
therefore adds ai:needs-human and does not post /approved, causing the sole
CI failure in validate-scripts.

Update the assertions to match the documented fallback-to-ladder behavior:
expect ai:needs-human on the issue and no /approved comment. The
stall_recovery_count == 3 assertion is unchanged because escalate_human also
sets STALL_RECOVERY_SHOULD_INCREMENT=true.