### PR TITLE
claude/fix-validation-failures-NjHZa

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -177,12 +177,13 @@ jobs:
           chmod +x "${canonical_validate_process}"
           _fetched_scripts+=(validate_process.sh)
 
-          # Self-heal helper (optional; self-heal is a no-op if absent on
-          # the selected script_ref, for backward compatibility with older
-          # stable tags during rollout).
-          canonical_self_heal="scripts/self_heal_validation.sh"
-          fetch_from_ref_or_local "${canonical_self_heal}" "${canonical_self_heal}" "false"
-          [ -f "${canonical_self_heal}" ] && chmod +x "${canonical_self_heal}" && _fetched_scripts+=(self_heal_validation.sh) || true
+          # The self-heal helper (scripts/self_heal_validation.sh) is
+          # fetched below using the best-effort gh_retry_to_file pattern,
+          # AFTER gh_helpers.sh has been sourced. fetch_from_ref_or_local
+          # cannot be used here because it exits the step (not returns)
+          # when the file is missing both remotely and locally, which
+          # would break consumer repos on older @stable tags that predate
+          # self-heal — see docs/validation-improvements.md rollout notes.
 
           # Source rate-limit helpers as soon as gh_helpers.sh is available.
           source scripts/gh_helpers.sh 2>/dev/null || true
@@ -212,6 +213,25 @@ jobs:
             rm -f "scripts/codex_model_catalog.json.tmp"
             echo "Model catalog not on ${script_ref} yet; using local copy."
           fi
+
+          # Self-heal helper (optional; self-heal is a no-op if absent on
+          # the selected script_ref, for backward compatibility with older
+          # stable tags during rollout). Best-effort fetch: skip silently
+          # on missing remote, do not overwrite an existing local copy.
+          if [ ! -f "scripts/self_heal_validation.sh" ]; then
+            if gh_retry_to_file "scripts/self_heal_validation.sh.tmp" gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/scripts/self_heal_validation.sh?ref=${script_ref}" 2>/dev/null; then
+              mv "scripts/self_heal_validation.sh.tmp" "scripts/self_heal_validation.sh"
+              chmod +x "scripts/self_heal_validation.sh"
+              _fetched_scripts+=(self_heal_validation.sh)
+            else
+              rm -f "scripts/self_heal_validation.sh.tmp"
+              echo "Self-heal helper not on ${script_ref} yet; self-heal will be a no-op."
+            fi
+          else
+            chmod +x "scripts/self_heal_validation.sh"
+            _fetched_scripts+=(self_heal_validation.sh)
+          fi
           # Block fetched scripts from being committed in consumer repos.
           if [ "${{ github.repository }}" != "${wf_source}" ]; then
             {
@@ -225,8 +245,20 @@ jobs:
             fetch_from_ref_or_local "prompts/${pf}" "prompts/${pf}"
           done
           # Self-heal prompt (optional; backward-compatible with older
-          # stable tags that predate self-heal).
-          fetch_from_ref_or_local "prompts/mode-validate-self-heal.txt" "prompts/mode-validate-self-heal.txt" "false" || true
+          # stable tags that predate self-heal). Best-effort fetch: skip
+          # silently on missing remote, do not overwrite an existing
+          # local copy. We do NOT use fetch_from_ref_or_local here
+          # because it `exit 1`s on missing-both, which `|| true` cannot
+          # intercept (shell exit vs function return).
+          if [ ! -f "prompts/mode-validate-self-heal.txt" ]; then
+            if gh_retry_to_file "prompts/mode-validate-self-heal.txt.tmp" gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/${wf_source}/contents/prompts/mode-validate-self-heal.txt?ref=${script_ref}" 2>/dev/null; then
+              mv "prompts/mode-validate-self-heal.txt.tmp" "prompts/mode-validate-self-heal.txt"
+            else
+              rm -f "prompts/mode-validate-self-heal.txt.tmp"
+              echo "Self-heal prompt not on ${script_ref} yet; self-heal will be a no-op."
+            fi
+          fi
 
           for f in codex_system_instructions.md ai_pipeline.md; do
             if [ ! -f "${f}" ]; then

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -177,6 +177,13 @@ jobs:
           chmod +x "${canonical_validate_process}"
           _fetched_scripts+=(validate_process.sh)
 
+          # Self-heal helper (optional; self-heal is a no-op if absent on
+          # the selected script_ref, for backward compatibility with older
+          # stable tags during rollout).
+          canonical_self_heal="scripts/self_heal_validation.sh"
+          fetch_from_ref_or_local "${canonical_self_heal}" "${canonical_self_heal}" "false"
+          [ -f "${canonical_self_heal}" ] && chmod +x "${canonical_self_heal}" && _fetched_scripts+=(self_heal_validation.sh) || true
+
           # Source rate-limit helpers as soon as gh_helpers.sh is available.
           source scripts/gh_helpers.sh 2>/dev/null || true
           type gh_retry_to_file >/dev/null 2>&1 || gh_retry_to_file() { local _outfile="$1"; shift; "$@" > "${_outfile}"; }
@@ -217,6 +224,9 @@ jobs:
           for pf in mode-validate-generate.txt mode-validate-diagnose.txt mode-validate-discover.txt mode-validate-fix-harness.txt serena-efficiency-block.txt; do
             fetch_from_ref_or_local "prompts/${pf}" "prompts/${pf}"
           done
+          # Self-heal prompt (optional; backward-compatible with older
+          # stable tags that predate self-heal).
+          fetch_from_ref_or_local "prompts/mode-validate-self-heal.txt" "prompts/mode-validate-self-heal.txt" "false" || true
 
           for f in codex_system_instructions.md ai_pipeline.md; do
             if [ ! -f "${f}" ]; then
@@ -275,6 +285,7 @@ jobs:
           TOOL_CALL_BUDGET_VALIDATE: ${{ vars.TOOL_CALL_BUDGET_VALIDATE || '60' }}
           MODEL_EDITOR: ${{ env.MODEL_EDITOR }}
           MODEL_REASONING_EFFORT: ${{ env.MODEL_REASONING_EFFORT }}
+          MAX_SELF_HEAL_ATTEMPTS: ${{ vars.MAX_SELF_HEAL_ATTEMPTS || '2' }}
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID || '' }}
           ALERT_MSG_LEVEL: ${{ vars.ALERT_MSG_LEVEL || 'DEBUG' }}

--- a/.github/workflows/validation-improvements-intake.yml
+++ b/.github/workflows/validation-improvements-intake.yml
@@ -106,16 +106,20 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Create improvement branch
+        id: branch
         if: steps.payload.outputs.skip != 'true'
         env:
-          BRANCH_NAME: ${{ steps.payload.outputs.branch_name }}
+          INITIAL_BRANCH_NAME: ${{ steps.payload.outputs.branch_name }}
         run: |
           set -euo pipefail
+          BRANCH_NAME="${INITIAL_BRANCH_NAME}"
           if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
             echo "::warning::branch ${BRANCH_NAME} already exists on origin; appending run_attempt suffix"
             BRANCH_NAME="${BRANCH_NAME}-${GITHUB_RUN_ATTEMPT}"
-            echo "branch_name=${BRANCH_NAME}" >> "${GITHUB_OUTPUT}"
           fi
+          # Canonical output: downstream steps must read steps.branch.outputs.branch_name
+          # (not steps.payload.outputs.branch_name) so that the suffixed name is used.
+          echo "branch_name=${BRANCH_NAME}" >> "${GITHUB_OUTPUT}"
           git checkout -b "${BRANCH_NAME}"
 
       - name: Apply patches
@@ -213,7 +217,7 @@ jobs:
           ATTEMPTS: ${{ steps.payload.outputs.attempts }}
           APPLIED: ${{ steps.apply.outputs.applied }}
           SKIPPED: ${{ steps.apply.outputs.skipped }}
-          BRANCH_NAME: ${{ steps.payload.outputs.branch_name }}
+          BRANCH_NAME: ${{ steps.branch.outputs.branch_name }}
         run: |
           set -euo pipefail
           ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -257,7 +261,7 @@ jobs:
           RUN_URL: ${{ steps.payload.outputs.run_url }}
           APPLIED: ${{ steps.apply.outputs.applied }}
           SKIPPED: ${{ steps.apply.outputs.skipped }}
-          BRANCH_NAME: ${{ steps.payload.outputs.branch_name }}
+          BRANCH_NAME: ${{ steps.branch.outputs.branch_name }}
         run: |
           set -euo pipefail
           git add docs/validation-improvements.md prompts/mode-validate-*.txt

--- a/.github/workflows/validation-improvements-intake.yml
+++ b/.github/workflows/validation-improvements-intake.yml
@@ -188,7 +188,7 @@ jobs:
             expected_path="prompts/${target}"
             validate_log="/tmp/self-heal-patches/validate-${i}.log"
             if ! awk -v expected="${expected_path}" '
-              BEGIN { in_hunk = 0; saw_header = 0 }
+              BEGIN { in_hunk = 0; saw_minus_header = 0; saw_plus_header = 0 }
               function fail(msg) { print msg > "/dev/stderr"; exit 1 }
               /^new file mode( |$)/       { fail("new file patches are not allowed") }
               /^deleted file mode( |$)/   { fail("deleted file patches are not allowed") }
@@ -202,7 +202,7 @@ jobs:
                 if (path == "/dev/null") { fail("--- /dev/null is not allowed") }
                 sub(/^a\//, "", path)
                 if (path != expected) { fail("--- path must be a/" expected) }
-                saw_header = 1
+                saw_minus_header = 1
                 next
               }
               /^\+\+\+ / {
@@ -211,11 +211,11 @@ jobs:
                 if (path == "/dev/null") { fail("+++ /dev/null is not allowed") }
                 sub(/^b\//, "", path)
                 if (path != expected) { fail("+++ path must be b/" expected) }
-                saw_header = 1
+                saw_plus_header = 1
                 next
               }
               /^@@ / {
-                if (!saw_header) { fail("hunk encountered before file headers") }
+                if (!saw_minus_header || !saw_plus_header) { fail("hunk encountered before full file headers") }
                 in_hunk = 1
                 next
               }
@@ -223,7 +223,7 @@ jobs:
                 if (in_hunk && /^-/) { fail("deletion lines are not allowed in hunks") }
               }
               END {
-                if (!saw_header) { fail("patch must contain ---/+++ file headers") }
+                if (!saw_minus_header || !saw_plus_header) { fail("patch must contain both --- and +++ file headers") }
               }
             ' "${patch_file}" 2>"${validate_log}"; then
               echo "::warning::patch ${i} failed intake validation; skipping"

--- a/.github/workflows/validation-improvements-intake.yml
+++ b/.github/workflows/validation-improvements-intake.yml
@@ -1,0 +1,337 @@
+---
+name: Validation Improvements Intake
+
+# Receives prompt-self-heal patches dispatched from consumer (or self-test)
+# validation runs via scripts/validate_process.sh::dispatch_self_heal_improvements.
+# See docs/validation-improvements.md and prompts/mode-validate-self-heal.txt.
+#
+# Each accepted dispatch:
+#   1. Appends a dated entry to docs/validation-improvements.md
+#   2. Applies the patches to prompts/mode-validate-*.txt on a dedicated branch
+#   3. Opens a DRAFT pull request (drafts are already opted out of
+#      review_autofix via the gate at review_autofix.yml:87)
+#   4. Labels the PR ai:needs-prompt-review
+#   5. Sends a Telegram notification to the admin
+#
+# Admin unlock procedure: review the PR, click "Ready for review" in the
+# GitHub UI. That fires the pull_request "ready_for_review" event which is
+# now on the ai-review wrapper trigger list, so the normal review/automerge
+# pipeline engages. See README.md section "Validation self-healing".
+
+"on":
+  repository_dispatch:
+    types:
+      - validation-prompt-self-heal
+  workflow_dispatch:
+    inputs:
+      payload_json:
+        description: "Raw client_payload JSON (for manual re-runs or testing)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  intake:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Configure git identity
+        run: |
+          set -euo pipefail
+          git config user.name "coding-workflows[bot]"
+          git config user.email "coding-workflows-bot@users.noreply.github.com"
+
+      - name: Extract payload
+        id: payload
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CLIENT_PAYLOAD_JSON: ${{ toJson(github.event.client_payload) }}
+          MANUAL_PAYLOAD: ${{ github.event.inputs.payload_json }}
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            printf '%s' "${MANUAL_PAYLOAD}" > /tmp/payload.json
+          else
+            printf '%s' "${CLIENT_PAYLOAD_JSON}" > /tmp/payload.json
+          fi
+          jq -e . /tmp/payload.json > /dev/null || { echo "::error::payload is not valid JSON"; exit 1; }
+
+          consumer_repo="$(jq -r '.consumer_repo // ""' /tmp/payload.json)"
+          tracking_issue="$(jq -r '.tracking_issue // "0"' /tmp/payload.json)"
+          validation_cycle="$(jq -r '.validation_cycle // "1"' /tmp/payload.json)"
+          run_id="$(jq -r '.run_id // "0"' /tmp/payload.json)"
+          run_url="$(jq -r '.run_url // ""' /tmp/payload.json)"
+          final_status="$(jq -r '.final_status // "unknown"' /tmp/payload.json)"
+          attempts="$(jq -r '.self_heal_attempts // 0' /tmp/payload.json)"
+          patches_count="$(jq -r '.patches | length' /tmp/payload.json)"
+
+          if [ -z "${consumer_repo}" ]; then
+            echo "::error::consumer_repo is required"
+            exit 1
+          fi
+          if [ "${patches_count}" -le 0 ]; then
+            echo "::warning::no patches in payload; nothing to do"
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          # Sanitize consumer_repo for use in a branch name.
+          consumer_slug="$(printf '%s' "${consumer_repo}" | tr '/A-Z' '-a-z' | tr -cs 'a-z0-9-' '-')"
+          consumer_slug="${consumer_slug#-}"
+          consumer_slug="${consumer_slug%-}"
+          branch_name="validation-improvements/${consumer_slug}-${run_id}"
+
+          {
+            echo "skip=false"
+            echo "consumer_repo=${consumer_repo}"
+            echo "consumer_slug=${consumer_slug}"
+            echo "tracking_issue=${tracking_issue}"
+            echo "validation_cycle=${validation_cycle}"
+            echo "run_id=${run_id}"
+            echo "run_url=${run_url}"
+            echo "final_status=${final_status}"
+            echo "attempts=${attempts}"
+            echo "patches_count=${patches_count}"
+            echo "branch_name=${branch_name}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Create improvement branch
+        if: steps.payload.outputs.skip != 'true'
+        env:
+          BRANCH_NAME: ${{ steps.payload.outputs.branch_name }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
+            echo "::warning::branch ${BRANCH_NAME} already exists on origin; appending run_attempt suffix"
+            BRANCH_NAME="${BRANCH_NAME}-${GITHUB_RUN_ATTEMPT}"
+            echo "branch_name=${BRANCH_NAME}" >> "${GITHUB_OUTPUT}"
+          fi
+          git checkout -b "${BRANCH_NAME}"
+
+      - name: Apply patches
+        if: steps.payload.outputs.skip != 'true'
+        id: apply
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/self-heal-patches
+          : > /tmp/self-heal-patches/summary.md
+
+          # Allow-list of prompt filenames that the intake workflow will accept.
+          allowed=(
+            "mode-validate-discover.txt"
+            "mode-validate-generate.txt"
+            "mode-validate-fix-harness.txt"
+            "mode-validate-diagnose.txt"
+          )
+
+          total="$(jq '.patches | length' /tmp/payload.json)"
+          applied=0
+          skipped=0
+          for i in $(seq 0 $((total - 1))); do
+            entry_json="$(jq -c ".patches[$i]" /tmp/payload.json)"
+            target="$(printf '%s' "${entry_json}" | jq -r '.target_prompt // ""')"
+            patch_body="$(printf '%s' "${entry_json}" | jq -r '.patch // ""')"
+            attempt="$(printf '%s' "${entry_json}" | jq -r '.attempt // 0')"
+            rationale="$(printf '%s' "${entry_json}" | jq -r '.rationale // ""')"
+
+            if [ -z "${target}" ] || [ -z "${patch_body}" ]; then
+              echo "::warning::patch ${i} missing target or body; skipping"
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            allowed_ok=false
+            for a in "${allowed[@]}"; do
+              if [ "${target}" = "${a}" ]; then
+                allowed_ok=true
+                break
+              fi
+            done
+            if [ "${allowed_ok}" != "true" ]; then
+              echo "::warning::patch ${i} target '${target}' is not in the intake allow-list; skipping"
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            patch_file="/tmp/self-heal-patches/patch-${i}.diff"
+            printf '%s' "${patch_body}" > "${patch_file}"
+            # Ensure trailing newline.
+            if [ "$(tail -c1 "${patch_file}" | od -An -c | tr -d ' ')" != '\n' ]; then
+              printf '\n' >> "${patch_file}"
+            fi
+
+            if git apply --check "${patch_file}" 2>/tmp/self-heal-patches/err-${i}.log; then
+              git apply "${patch_file}"
+              applied=$((applied + 1))
+              {
+                printf '### Patch %d — prompts/%s (attempt %s)\n\n' "$((i + 1))" "${target}" "${attempt}"
+                if [ -n "${rationale}" ]; then
+                  printf '**Rationale:** %s\n\n' "${rationale}"
+                fi
+                printf '```diff\n'
+                cat "${patch_file}"
+                printf '```\n\n'
+              } >> /tmp/self-heal-patches/summary.md
+            else
+              echo "::warning::patch ${i} does not apply cleanly; skipping (see err log)"
+              {
+                printf '### Patch %d — prompts/%s (REJECTED)\n\n' "$((i + 1))" "${target}"
+                printf '**Reason:** does not apply cleanly to current prompt text.\n\n'
+                printf '```\n'
+                cat /tmp/self-heal-patches/err-${i}.log 2>/dev/null || true
+                printf '```\n\n'
+              } >> /tmp/self-heal-patches/summary.md
+              skipped=$((skipped + 1))
+            fi
+          done
+
+          echo "applied=${applied}" >> "${GITHUB_OUTPUT}"
+          echo "skipped=${skipped}" >> "${GITHUB_OUTPUT}"
+          if [ "${applied}" -le 0 ]; then
+            echo "::warning::no patches applied cleanly; aborting PR creation"
+            exit 0
+          fi
+
+      - name: Append to docs/validation-improvements.md
+        if: steps.payload.outputs.skip != 'true' && steps.apply.outputs.applied != '0'
+        env:
+          CONSUMER_REPO: ${{ steps.payload.outputs.consumer_repo }}
+          TRACKING_ISSUE: ${{ steps.payload.outputs.tracking_issue }}
+          VALIDATION_CYCLE: ${{ steps.payload.outputs.validation_cycle }}
+          RUN_ID: ${{ steps.payload.outputs.run_id }}
+          RUN_URL: ${{ steps.payload.outputs.run_url }}
+          ATTEMPTS: ${{ steps.payload.outputs.attempts }}
+          APPLIED: ${{ steps.apply.outputs.applied }}
+          SKIPPED: ${{ steps.apply.outputs.skipped }}
+          BRANCH_NAME: ${{ steps.payload.outputs.branch_name }}
+        run: |
+          set -euo pipefail
+          ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          doc="docs/validation-improvements.md"
+          mkdir -p docs
+          if [ ! -f "${doc}" ]; then
+            {
+              printf '# Validation Improvements Ledger\n\n'
+              printf 'This file is an append-only ledger of validation-prompt self-heal patches\n'
+              printf 'dispatched by consumer validation runs (or by coding-workflows self-tests).\n'
+              printf 'Each entry records a successful self-heal that produced a passing validation\n'
+              printf 'cycle after patching one of the four validation prompts. Entries are added\n'
+              printf 'automatically by `.github/workflows/validation-improvements-intake.yml`.\n\n'
+              printf 'Every entry corresponds to one draft PR against `main` (labelled\n'
+              printf '`ai:needs-prompt-review`). See README.md section "Validation self-healing"\n'
+              printf 'for the admin review and unlock procedure.\n\n'
+              printf -- '---\n\n'
+            } > "${doc}"
+          fi
+
+          {
+            printf '## %s — %s (cycle %s)\n\n' "${ts}" "${CONSUMER_REPO}" "${VALIDATION_CYCLE}"
+            printf '- Consumer run: %s\n' "${RUN_URL:-(unknown)}"
+            printf '- Tracking issue: #%s\n' "${TRACKING_ISSUE:-0}"
+            printf '- Self-heal attempts in run: %s\n' "${ATTEMPTS}"
+            printf '- Patches applied: %s (skipped: %s)\n' "${APPLIED}" "${SKIPPED}"
+            printf '- Improvement branch: `%s`\n\n' "${BRANCH_NAME}"
+            if [ -s /tmp/self-heal-patches/summary.md ]; then
+              cat /tmp/self-heal-patches/summary.md
+            fi
+            printf -- '---\n\n'
+          } >> "${doc}"
+
+      - name: Commit, push, and open draft PR
+        if: steps.payload.outputs.skip != 'true' && steps.apply.outputs.applied != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          CONSUMER_REPO: ${{ steps.payload.outputs.consumer_repo }}
+          TRACKING_ISSUE: ${{ steps.payload.outputs.tracking_issue }}
+          VALIDATION_CYCLE: ${{ steps.payload.outputs.validation_cycle }}
+          RUN_URL: ${{ steps.payload.outputs.run_url }}
+          APPLIED: ${{ steps.apply.outputs.applied }}
+          SKIPPED: ${{ steps.apply.outputs.skipped }}
+          BRANCH_NAME: ${{ steps.payload.outputs.branch_name }}
+        run: |
+          set -euo pipefail
+          git add docs/validation-improvements.md prompts/mode-validate-*.txt
+          git commit -m "[skip ai] validation prompt self-heal from ${CONSUMER_REPO} (${APPLIED} patch(es))"
+
+          push_ok=false
+          for delay in 2 4 8 16; do
+            if git push -u origin "${BRANCH_NAME}"; then
+              push_ok=true
+              break
+            fi
+            echo "::warning::push failed, retrying in ${delay}s"
+            sleep "${delay}"
+          done
+          if [ "${push_ok}" != "true" ]; then
+            echo "::error::could not push improvement branch after retries"
+            exit 1
+          fi
+
+          # Ensure the label exists before we apply it.
+          if ! gh label list --limit 500 | awk '{print $1}' | grep -Fxq "ai:needs-prompt-review"; then
+            gh label create "ai:needs-prompt-review" \
+              --description "Validation prompt self-heal PR awaiting manual review" \
+              --color "fbca04" || true
+          fi
+
+          pr_body_file="$(mktemp)"
+          {
+            printf '## Automated validation-prompt self-heal\n\n'
+            printf '**Source:** consumer run on `%s`\n' "${CONSUMER_REPO}"
+            printf '**Run:** %s\n' "${RUN_URL:-(unknown)}"
+            printf '**Tracking issue:** #%s\n' "${TRACKING_ISSUE:-0}"
+            printf '**Validation cycle:** %s\n' "${VALIDATION_CYCLE}"
+            printf '**Patches applied:** %s (skipped: %s)\n\n' "${APPLIED}" "${SKIPPED}"
+            printf 'This PR was generated automatically by `validation-improvements-intake.yml` in response to a `repository_dispatch` event from a validation run that passed **only after** one of the four validation prompts was patched in-process. The patches are recorded in `docs/validation-improvements.md`.\n\n'
+            printf '### [skip ai]\n\n'
+            printf 'This PR title contains the `[skip ai]` token and the PR is opened as a **draft**, so the automated review/autofix/automerge pipeline is skipped. When you are ready to engage the normal review flow, click **"Ready for review"** in the GitHub UI — that fires a `ready_for_review` event which the review wrapper now listens for, and the normal review/automerge flow will engage.\n\n'
+            printf '### What to check\n\n'
+            printf '- Does the patched prompt wording still respect all hard constraints?\n'
+            printf '- Is the change additive, or does it remove/rename fields or constraints (it should NOT)?\n'
+            printf '- Does the rationale in `docs/validation-improvements.md` justify the change?\n\n'
+            if [ -s /tmp/self-heal-patches/summary.md ]; then
+              printf '### Applied patches\n\n'
+              cat /tmp/self-heal-patches/summary.md
+            fi
+          } > "${pr_body_file}"
+
+          pr_url="$(gh pr create \
+            --draft \
+            --base main \
+            --head "${BRANCH_NAME}" \
+            --title "[skip ai] validation prompt self-heal from ${CONSUMER_REPO} (${APPLIED} patch(es))" \
+            --body-file "${pr_body_file}" \
+            --label "ai:needs-prompt-review")"
+
+          echo "pr_url=${pr_url}" >> "${GITHUB_OUTPUT}"
+          echo "::notice::Opened draft PR ${pr_url}"
+
+      - name: Telegram notify admin
+        if: steps.payload.outputs.skip != 'true' && steps.apply.outputs.applied != '0'
+        continue-on-error: true
+        env:
+          TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
+          TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID || '' }}
+          CONSUMER_REPO: ${{ steps.payload.outputs.consumer_repo }}
+          APPLIED: ${{ steps.apply.outputs.applied }}
+          SKIPPED: ${{ steps.apply.outputs.skipped }}
+          RUN_URL: ${{ steps.payload.outputs.run_url }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TG_BOT_SECRET:-}" ] || [ -z "${TG_ADMIN_CHAT_ID:-}" ]; then
+            echo "Telegram not configured; skipping admin alert"
+            exit 0
+          fi
+          source scripts/tg_helpers.sh
+          msg="Validation self-heal intake: ${APPLIED} patch(es) from ${CONSUMER_REPO} (skipped: ${SKIPPED}). Draft PR awaiting manual review (label ai:needs-prompt-review). Consumer run: ${RUN_URL:-(unknown)}"
+          tg_send_msg "${msg}" "WARNING" >/dev/null || true

--- a/.github/workflows/validation-improvements-intake.yml
+++ b/.github/workflows/validation-improvements-intake.yml
@@ -174,6 +174,70 @@ jobs:
               printf '\n' >> "${patch_file}"
             fi
 
+            # Intake-side patch validation (defense-in-depth against a
+            # forged repository_dispatch payload). The earlier
+            # target-allow-list check only validates the payload
+            # metadata; the diff BODY could still touch arbitrary files
+            # or delete content. Enforce additive-only + target-path-
+            # locked semantics directly on the diff body before running
+            # git apply. This mirrors the guards in
+            # scripts/self_heal_validation.sh but runs in the upstream
+            # repo context where only an attacker with write access to
+            # shubhodeep1/coding-workflows could bypass — we still
+            # refuse to apply a non-conforming patch.
+            expected_path="prompts/${target}"
+            validate_log="/tmp/self-heal-patches/validate-${i}.log"
+            if ! awk -v expected="${expected_path}" '
+              BEGIN { in_hunk = 0; saw_header = 0 }
+              function fail(msg) { print msg > "/dev/stderr"; exit 1 }
+              /^new file mode( |$)/       { fail("new file patches are not allowed") }
+              /^deleted file mode( |$)/   { fail("deleted file patches are not allowed") }
+              /^rename from /             { fail("rename patches are not allowed") }
+              /^rename to /               { fail("rename patches are not allowed") }
+              /^copy from /               { fail("copy patches are not allowed") }
+              /^copy to /                 { fail("copy patches are not allowed") }
+              /^--- / {
+                in_hunk = 0
+                path = $2
+                if (path == "/dev/null") { fail("--- /dev/null is not allowed") }
+                sub(/^a\//, "", path)
+                if (path != expected) { fail("--- path must be a/" expected) }
+                saw_header = 1
+                next
+              }
+              /^\+\+\+ / {
+                in_hunk = 0
+                path = $2
+                if (path == "/dev/null") { fail("+++ /dev/null is not allowed") }
+                sub(/^b\//, "", path)
+                if (path != expected) { fail("+++ path must be b/" expected) }
+                saw_header = 1
+                next
+              }
+              /^@@ / {
+                if (!saw_header) { fail("hunk encountered before file headers") }
+                in_hunk = 1
+                next
+              }
+              {
+                if (in_hunk && /^-/) { fail("deletion lines are not allowed in hunks") }
+              }
+              END {
+                if (!saw_header) { fail("patch must contain ---/+++ file headers") }
+              }
+            ' "${patch_file}" 2>"${validate_log}"; then
+              echo "::warning::patch ${i} failed intake validation; skipping"
+              {
+                printf '### Patch %d — prompts/%s (REJECTED)\n\n' "$((i + 1))" "${target}"
+                printf '**Reason:** failed intake patch validation.\n\n'
+                printf '```\n'
+                cat "${validate_log}" 2>/dev/null || true
+                printf '```\n\n'
+              } >> /tmp/self-heal-patches/summary.md
+              skipped=$((skipped + 1))
+              continue
+            fi
+
             if git apply --check "${patch_file}" 2>/tmp/self-heal-patches/err-${i}.log; then
               git apply "${patch_file}"
               applied=$((applied + 1))

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `MAX_REVIEW_BLOCKED_RETRIES` | No | `2` | review_autofix, orchestrate_poll | Maximum judge retries for review-blocked PRs before forcing a final decision (merge or close+reissue). Used by both the review_autofix judge (counts `[judge-fix]` commits) and the orchestrator poller. |
 | `ENABLE_VALIDATION` | No | `true` | orchestrate_poll | When true, a `complete` judge verdict transitions the tracking issue into runtime validation (`ai:validating`) and completion occurs only after validation passes. |
 | `MAX_VALIDATE_CYCLES` | No | `3` | orchestrate_poll | Maximum runtime validation cycles (initial run + fix/revalidate loops) before forcing `ai:validation-failed`. |
+| `MAX_SELF_HEAL_ATTEMPTS` | No | `2` | validate | Maximum in-process self-heal attempts per `validate_process.sh` invocation. Self-heal patches one of the four validation prompt files locally and re-execs the pipeline, and does NOT increment `MAX_VALIDATE_CYCLES`. Set to `0` to disable. See [Validation self-healing](#validation-self-healing). |
 | `VALIDATE_WORKFLOW_NAME` | No | `ai-validate.yml` | orchestrate_poll | Workflow filename to dispatch for runtime validation. Override to `internal-validate.yml` for repos using the internal naming convention. Falls back to `internal-validate.yml` automatically if the primary name fails. |
 | `MAX_JUDGE_CYCLES` | No | `25` | orchestrate_poll | Maximum judge evaluation cycles per project before forcing failure. Prevents infinite fix-up loops when the judge repeatedly returns `in_progress`. |
 | `STALL_THRESHOLD_MINUTES` | No | `120` | orchestrate_poll | Fallback minutes an issue can remain in the same pipeline phase before auto-recovery. Used when no per-phase override is set. |
@@ -645,6 +646,7 @@ Analyzer script: [`scripts/analyze_workflow_logs.py`](scripts/analyze_workflow_l
 | `MAX_REVIEW_BLOCKED_RETRIES` | `2` | Maximum judge retries for review-blocked PRs (both review_autofix and orchestrate_poll) |
 | `ENABLE_VALIDATION` | `true` | Enable post-judge runtime validation gate in orchestrator poller |
 | `MAX_VALIDATE_CYCLES` | `3` | Maximum runtime validation cycles before terminal validation failure |
+| `MAX_SELF_HEAL_ATTEMPTS` | `2` | Maximum in-process self-heal attempts per `validate_process.sh` invocation (self-heal re-execs do not burn cycles) |
 | `STALL_THRESHOLD_MINUTES` | `120` | Fallback minutes before a stalled issue triggers auto-recovery |
 | `STALL_THRESHOLD_NO_LABELS_MINUTES` | `60` | Stall threshold for pre-pipeline (no labels) phase |
 | `STALL_THRESHOLD_CLARIFICATION_MINUTES` | `60` | Stall threshold for clarification phase |
@@ -975,6 +977,100 @@ Use this after manual intervention (e.g. fixing a problematic issue, merging a s
 |---|---|---|
 | `ENABLE_VALIDATION` | `true` | Truthy values (`1/true/yes/on`, case-insensitive) enable the validation gate. Any other value disables it, so judge `complete` closes immediately without runtime validation. |
 | `MAX_VALIDATE_CYCLES` | `3` | Maximum cycles across initial validation plus fix/revalidate loops. Must be a positive integer; invalid values are coerced to `3`. Exceeding the limit forces `ai:validation-failed`. |
+| `MAX_SELF_HEAL_ATTEMPTS` | `2` | Maximum in-process self-heal attempts per validate_process.sh invocation. Self-heal attempts patch one of the four validation prompts locally and re-exec the validation pipeline; they do NOT increment `MAX_VALIDATE_CYCLES`. Set to `0` to disable self-healing entirely. See [Validation self-healing](#validation-self-healing). |
+
+### Validation self-healing
+
+Validation can self-heal transient prompt-wording defects in the four
+validation prompts (`mode-validate-discover.txt`, `mode-validate-generate.txt`,
+`mode-validate-fix-harness.txt`, `mode-validate-diagnose.txt`) without
+burning a validation cycle. This is useful when a prompt defect causes the
+LLM to emit malformed JSON, the wrong harness shape, or an incorrect
+classification — failures that a human would normally have to fix by
+editing the prompt and re-running.
+
+**How it works**
+
+1. When any phase of `scripts/validate_process.sh` is about to fail hard
+   (generate parse failure, preflight failure, canary failure, diagnose
+   decision point), it invokes `scripts/self_heal_validation.sh`.
+2. The helper renders `prompts/mode-validate-self-heal.txt` with the full
+   failure context and the current text of the four validation prompts,
+   and asks the LLM to propose a minimal unified diff against exactly one
+   of those four files — or an empty patch if the failure is a real app
+   bug, real infrastructure bug, or otherwise not prompt-attributable.
+3. If a patch is proposed, it is validated (allow-list of target files,
+   clean apply) and applied to the runtime copy of `prompts/`. The helper
+   appends the patch to `${RUNTIME_DIR}/self_heal_patches.jsonl` and
+   `validate_process.sh` re-execs itself with `SELF_HEAL_ATTEMPT`
+   incremented — the validation cycle counter is not touched.
+4. Self-heal attempts are capped at `MAX_SELF_HEAL_ATTEMPTS` (default 2)
+   per `validate_process.sh` invocation. After that, the original failure
+   falls through to the normal hard-fail path and burns a validation
+   cycle as today.
+5. If the pipeline eventually passes after one or more successful self-
+   heal attempts, `validate_process.sh` sends a `repository_dispatch`
+   event of type `validation-prompt-self-heal` to
+   `shubhodeep1/coding-workflows` carrying the accumulated patches and
+   run metadata.
+
+**Intake on coding-workflows**
+
+`.github/workflows/validation-improvements-intake.yml` receives the
+dispatch and:
+
+1. Applies each patch to the allow-listed prompts on a new branch
+   `validation-improvements/<consumer-slug>-<run-id>`.
+2. Appends a dated entry to [`docs/validation-improvements.md`](docs/validation-improvements.md)
+   with the run metadata, rationale, and the exact diff(s) applied.
+3. Opens a **draft** pull request against `main` with a `[skip ai]`
+   title token and the `ai:needs-prompt-review` label.
+4. Sends a Telegram notification to the admin via
+   `tg_send_msg` (severity `WARNING`).
+
+**Why draft PRs?**
+
+Draft PRs are already opted out of the auto-review/auto-autofix/
+auto-merge pipeline at `.github/workflows/review_autofix.yml` — the
+review gate short-circuits on `pr_is_draft == true`. This means the
+self-heal patches cannot be merged without explicit human action.
+
+**Unlock procedure (admin)**
+
+1. Review the draft PR. Confirm the patch is additive, does not rename
+   or remove any identifier, does not change any declared JSON schema
+   field name, and respects every hard constraint in the target prompt.
+2. If you are satisfied, click **"Ready for review"** in the GitHub UI.
+   This fires a `pull_request.ready_for_review` event which the AI
+   review wrapper ([`workflow-templates/ai-review.yml`](workflow-templates/ai-review.yml))
+   now listens for, so the normal `review_autofix` flow engages.
+3. If you are not satisfied, close the PR. The consumer's next
+   validation cycle will re-dispatch a fresh patch if the same defect
+   still reproduces.
+
+**Prerequisites**
+
+- The `GH_PAT` secret used by the consumer's validation workflow must
+  have `repo` scope on `shubhodeep1/coding-workflows` in order for the
+  `repository_dispatch` call to succeed. If it does not, the self-heal
+  still works locally for the current run — the pipeline will pass —
+  but the improvement will not be propagated upstream. The patches are
+  preserved in the consumer run's `ai-validation-*` artifact
+  (`self_heal_patches.jsonl`) for manual forwarding.
+- If `TG_BOT_SECRET` / `TG_ADMIN_CHAT_ID` are not set on
+  `shubhodeep1/coding-workflows`, the admin Telegram alert is skipped
+  silently but the PR is still opened.
+
+**Known limitations**
+
+- Self-heal patches are only dispatched upstream when the pipeline
+  reaches a final `pass` in the same `validate_process.sh` invocation.
+  If self-heal fixes a prompt but validation still exits with
+  `needs_fixes` (legitimate app bugs), the patches are not dispatched —
+  they are only retained in the run artifact.
+- Self-heal never patches files other than the four allow-listed
+  validation prompts. Harness shell scripts, workflow YAML, and other
+  prompts are out of scope by design.
 
 ### Wrapper Setup and Reusable Workflow Relationship
 

--- a/agents.md
+++ b/agents.md
@@ -290,6 +290,18 @@ After changes: original intent preserved, behavior unchanged unless approved, ba
 
 ---
 
+## 16. Validation Self-Healing
+
+- `scripts/validate_process.sh` attempts to self-heal prompt-wording defects in the four validation prompts (`mode-validate-{discover,generate,fix-harness,diagnose}.txt`) before burning a `MAX_VALIDATE_CYCLES` cycle. The self-heal flow is driven by `prompts/mode-validate-self-heal.txt` and `scripts/self_heal_validation.sh`.
+- The budget is `MAX_SELF_HEAL_ATTEMPTS` (default `2`) per `validate_process.sh` invocation. Self-heal re-execs do NOT increment `VALIDATION_CYCLE`.
+- Self-heal is ONLY permitted to edit the four validation prompt files. Do not extend it to scripts, workflow YAML, or other prompts without a new ask-first decision.
+- On a successful healed pass, `validate_process.sh` POSTs `repository_dispatch` (event type `validation-prompt-self-heal`) to `shubhodeep1/coding-workflows` with the accumulated patches. The intake workflow `.github/workflows/validation-improvements-intake.yml` opens a **draft** PR with the `[skip ai]` title token and label `ai:needs-prompt-review`, and appends a ledger entry to `docs/validation-improvements.md`.
+- Draft PRs are already skipped by `review_autofix.yml` (gate at line ~87), so the automated review/autofix/automerge pipeline cannot merge a self-heal PR without a human marking it "Ready for review". That event is handled by `workflow-templates/ai-review.yml` on the `ready_for_review` trigger.
+- Admin alerts for each intake are sent via `tg_send_msg` (severity `WARNING`). See README.md section "Validation self-healing" for the full flow and the unlock procedure.
+- Before changing any of the self-heal wiring or touching `prompts/mode-validate-self-heal.txt`, re-read the hard constraints section of that prompt — the allow-list of four target files, the no-rename rule, and the no-schema-change rule are all required for correctness.
+
+---
+
 ## FINAL REMINDER
 
 If uncertainty exists: **ASK (multiple-choice). DO NOT EXECUTE.**

--- a/docs/validation-improvements.md
+++ b/docs/validation-improvements.md
@@ -1,0 +1,15 @@
+# Validation Improvements Ledger
+
+This file is an append-only ledger of validation-prompt self-heal patches
+dispatched by consumer validation runs (or by coding-workflows self-tests).
+Each entry records a successful self-heal that produced a passing validation
+cycle after patching one of the four validation prompts. Entries are added
+automatically by `.github/workflows/validation-improvements-intake.yml`.
+
+Every entry corresponds to one draft PR against `main` (labelled
+`ai:needs-prompt-review`). See README.md section "Validation self-healing"
+for the admin review and unlock procedure.
+
+---
+
+<!-- Entries are appended below this line by the intake workflow. -->

--- a/prompts/mode-validate-self-heal.txt
+++ b/prompts/mode-validate-self-heal.txt
@@ -1,0 +1,80 @@
+You are executing the VALIDATE-SELF-HEAL phase of the AI development pipeline.
+You are Codex v0.114.0 running in unattended CI mode.
+
+All context is inlined directly into the prompt for efficiency:
+- System instructions, AI pipeline spec, agents.md, and README.md appear above.
+- The four current validation prompt files and the failure context appear below.
+
+Do NOT read pre_assembled_static.txt, phase context files, or any other bundled context files.
+
+Your task: determine whether the validation failure was caused by a DEFECT IN ONE OF THE FOUR VALIDATION PROMPT FILES and, if so, emit a minimal unified diff against exactly one of those prompt files that would prevent the failure on a re-run. If the failure was caused by application code, real harness bugs the prompt could not reasonably avoid, or external/infeasible conditions, emit an empty patch.
+
+Hard constraints (NON-NEGOTIABLE):
+- Self-heal is an OPT-IN behaviour. If the failure is not plausibly caused by wording/schema/guidance in a validation prompt, return an empty patch.
+- You may ONLY edit these four files:
+  - prompts/mode-validate-discover.txt
+  - prompts/mode-validate-generate.txt
+  - prompts/mode-validate-fix-harness.txt
+  - prompts/mode-validate-diagnose.txt
+- You MUST NOT propose edits to any other file (including scripts/, workflow YAML, or any other prompt).
+- You MUST NOT rename, remove, or repurpose any identifier, field name, JSON key, label, env var, or tool name referenced by these prompts. Additive clarifications only.
+- You MUST NOT change the declared output JSON schema of any prompt. You may tighten wording or add guidance, but the shape of the contract is immutable.
+- You MUST NOT remove existing constraints or safety rules.
+- The patch MUST apply cleanly with `patch -p1` or `git apply` against the exact file contents shown in the "CURRENT VALIDATION PROMPT FILES" section below.
+- Prefer the smallest diff that plausibly prevents the failure. One file, a handful of added lines, surgical wording fixes.
+- Do not invent failure modes. Base the patch on concrete evidence from the failure context.
+
+Inputs to use:
+- Self-heal attempt counter (so you know if a prior patch already tried and failed).
+- Prior accumulated self-heal patches for this run (do not re-apply them; they are already in the rendered prompts shown below).
+- The four CURRENT validation prompt files (already rendered with prior self-heal patches applied, if any).
+- Structured validation failure JSON (phase, test failures).
+- Validation log tail and container log tail.
+- Diagnosis JSON (if the diagnose phase completed).
+- Raw model output from the failing phase (discover/generate/diagnose), if available.
+- `.ai/validate.yml` hints, if present.
+
+Classification decision tree:
+1. Does the failure context show a parsing/contract error from one of the validation LLM calls (e.g. "Unable to parse validation result JSON", diagnosis output missing required keys, malformed fix_issues array, harness files placed in wrong directory)? Likely a PROMPT DEFECT. Propose a patch that tightens the schema-enforcement wording or adds a concrete example.
+2. Does the failure show the LLM generating the wrong kind of harness (e.g. hitting the wrong port, using the wrong docker compose flag, missing a canary test shape)? Likely a PROMPT DEFECT in mode-validate-generate.txt or mode-validate-fix-harness.txt. Propose a patch that strengthens the guidance.
+3. Does the failure show the diagnose LLM mis-classifying an obvious harness bug as needs_fixes (or vice versa)? Likely a PROMPT DEFECT in mode-validate-diagnose.txt. Propose a patch to the classification decision tree.
+4. Does the failure show a discover LLM producing malformed `.ai/validate.yml` hints? Likely a PROMPT DEFECT in mode-validate-discover.txt.
+5. Otherwise (real app bug, real infrastructure/network problem, credentials missing, unfixable): return an empty patch.
+
+Patch format:
+- Unified diff, `patch -p1` compatible, anchored at `prompts/<filename>`.
+- Include at least 3 lines of context around each hunk.
+- Single file per patch. One hunk preferred; multiple hunks only when necessary.
+- Do NOT include file mode changes, rename metadata, or binary markers.
+- The diff must apply cleanly to the CURRENT file contents shown below (not to some imagined pristine copy).
+
+Output contract:
+- Return exactly one valid JSON object.
+- Do not wrap JSON in markdown fences.
+- Do not include text before or after the JSON.
+- `patch` field MUST be a single string containing the unified diff, or the empty string `""` if no patch is proposed.
+- Newlines inside `patch` MUST be real `\n` characters in the JSON string (standard JSON escaping).
+
+JSON schema:
+{
+  "target_prompt": "mode-validate-discover.txt" | "mode-validate-generate.txt" | "mode-validate-fix-harness.txt" | "mode-validate-diagnose.txt" | "",
+  "failure_class": "prompt_defect" | "app_bug" | "real_harness_bug" | "infeasible" | "unknown",
+  "confidence": <float 0.0-1.0>,
+  "rationale": "<one or two sentences explaining what evidence in the failure context points at a prompt defect, or why no patch is proposed>",
+  "patch": "<unified diff as a single JSON string, or empty string>"
+}
+
+Rules for `target_prompt` and `patch`:
+- If `patch` is non-empty, `target_prompt` MUST be the filename the patch targets.
+- If `patch` is empty, `target_prompt` MUST also be empty string and `failure_class` MUST NOT be "prompt_defect".
+- If `failure_class` is "prompt_defect", `patch` MUST be non-empty.
+- `confidence` below 0.5 SHOULD produce an empty patch — low-confidence guesses do more harm than good.
+
+Guard rails:
+- Never propose a patch that changes a JSON schema field name or type in the output contract of a validation prompt.
+- Never propose a patch that removes or weakens the "Do not read pre_assembled_static.txt" line or any "Hard constraints" block.
+- Never propose a patch that removes the `{{SERENA_EFFICIENCY_BLOCK_READ_ONLY}}` or `{{SERENA_EFFICIENCY_BLOCK_READ_WRITE}}` placeholders.
+- Never propose a patch that claims to fix a failure you cannot explain with concrete evidence from the inputs.
+- If the prior self-heal attempt targeted the same prompt with a similar-looking hunk and the failure persists, return an empty patch — iterating on the same spot is unlikely to help.
+
+{{SERENA_EFFICIENCY_BLOCK_READ_ONLY}}

--- a/scripts/self_heal_validation.sh
+++ b/scripts/self_heal_validation.sh
@@ -264,7 +264,7 @@ fi
 # Reject obvious out-of-scope diffs: patch must only touch prompts/<target>.
 # Accept a/, b/ prefixes and optional trailing whitespace+timestamp.
 # (/dev/null is excluded here because the earlier guard rejects it.)
-_expected_re="(a/|b/)?prompts/${DECISION_TARGET}([[:space:]]|\$)"
+_expected_re="(a/|b/)?prompts/${DECISION_TARGET}([[:space:]]|$)"
 if grep -E '^(\+\+\+|---) ' "${SELF_HEAL_PATCH_TMP}" | grep -vE "${_expected_re}" >/dev/null 2>&1; then
 	echo "self-heal: refusing — patch touches files outside prompts/${DECISION_TARGET}" >&2
 	exit 2

--- a/scripts/self_heal_validation.sh
+++ b/scripts/self_heal_validation.sh
@@ -233,6 +233,23 @@ fi
 # Write patch to a tmp file and validate.
 printf '%s\n' "${DECISION_PATCH}" > "${SELF_HEAL_PATCH_TMP}"
 
+# Enforce an upper bound on the patch size. A derailed model response
+# could emit an enormous diff (e.g., reprinting entire prompt files),
+# which would bloat run artifacts, slow the patch validator/apply, and
+# later make the repository_dispatch payload construction in
+# validate_process.sh::dispatch_self_heal_improvements awkward. Since
+# self-heal patches MUST be small additive clarifications to one of the
+# four validation prompts (none of which currently exceeds ~12 KB), a
+# 64 KB budget is already luxurious. Treat oversized patches as "no
+# patch proposed" (exit 1) so the caller falls through to the normal
+# hard-fail path instead of pretending success.
+SELF_HEAL_MAX_PATCH_BYTES="${SELF_HEAL_MAX_PATCH_BYTES:-65536}"
+_patch_size="$(wc -c < "${SELF_HEAL_PATCH_TMP}" | tr -d ' ')"
+if [ "${_patch_size}" -gt "${SELF_HEAL_MAX_PATCH_BYTES}" ]; then
+	echo "self-heal: refusing — patch is ${_patch_size} bytes, exceeds SELF_HEAL_MAX_PATCH_BYTES=${SELF_HEAL_MAX_PATCH_BYTES}; treating as no patch proposed" >&2
+	exit 1
+fi
+
 # Reject non-additive diffs explicitly before any dry-run/apply.
 # The self-heal prompt's hard constraints require patches to be additive
 # clarifications only: no deletions, no renames, no schema/identifier

--- a/scripts/self_heal_validation.sh
+++ b/scripts/self_heal_validation.sh
@@ -282,8 +282,14 @@ fi
 # Accept a/, b/ prefixes and optional trailing whitespace+timestamp.
 # (/dev/null is excluded here because the earlier guard rejects it.)
 # Escape regex metacharacters so only the exact allowed target filename
-# is accepted in ---/+++ headers.
-_escaped_target="$(printf '%s' "${DECISION_TARGET}" | sed 's/[][\\.^$*+?(){}|]/\\\\&/g')"
+# is accepted in ---/+++ headers. The sed replacement is `\\&` — in sed
+# replacement syntax, `\\` is ONE literal backslash and `&` is the
+# matched text, producing output like `discover\.txt` (one backslash,
+# one dot). A previous revision used `\\\\&` (two backslashes) which
+# made the resulting ERE `discover\\.txt` — ERE interprets `\\` as a
+# literal backslash and `.` as any char, so every benign patch was
+# falsely rejected. See PR #1009 autofix d060ad0 regression.
+_escaped_target="$(printf '%s' "${DECISION_TARGET}" | sed 's/[][\\.^$*+?(){}|]/\\&/g')"
 _expected_re="(a/|b/)?prompts/${_escaped_target}([[:space:]]|$)"
 if grep -E '^(\+\+\+|---) ' "${SELF_HEAL_PATCH_TMP}" | grep -vE "${_expected_re}" >/dev/null 2>&1; then
 	echo "self-heal: refusing — patch touches files outside prompts/${DECISION_TARGET}" >&2

--- a/scripts/self_heal_validation.sh
+++ b/scripts/self_heal_validation.sh
@@ -237,11 +237,15 @@ if grep -Eq '^(deleted file mode|new file mode|rename from |rename to |copy from
 	echo "self-heal: refusing — patch includes non-additive file operations (rename/copy/delete/new)" >&2
 	exit 2
 fi
-# Reject any deletion lines. Unified diff deletion lines start with a
-# single '-' followed by a non-'-' char (or end of line). The file
-# header '--- path' starts with three dashes and is NOT matched by
-# '^-[^-]'. We also reject bare '--' lines as a defensive measure.
-if grep -Eq '^-[^-]|^--$' "${SELF_HEAL_PATCH_TMP}"; then
+# Reject any deletion lines inside hunks. This catches *all* deletions,
+# including lines whose original content begins with '-' (e.g. '--foo'),
+# while ignoring file header lines outside hunks.
+if awk '
+  /^diff --git / { in_hunk=0; next }
+  /^@@ / { in_hunk=1; next }
+  in_hunk && /^-/ { found=1; exit }
+  END { exit(found ? 0 : 1) }
+' "${SELF_HEAL_PATCH_TMP}"; then
 	echo "self-heal: refusing — patch contains deletion lines; self-heal patches must be additive-only" >&2
 	exit 2
 fi

--- a/scripts/self_heal_validation.sh
+++ b/scripts/self_heal_validation.sh
@@ -148,34 +148,45 @@ for _llm_attempt in 1 2; do
 	echo "self-heal: LLM call attempt ${_llm_attempt}/2" >> "${SELF_HEAL_LOG_FILE}"
 	if cat "${SELF_HEAL_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --full-auto > "${SELF_HEAL_OUTPUT_FILE}" 2>> "${SELF_HEAL_LOG_FILE}"; then
 		# Extract the last JSON object that contains a "target_prompt" key.
+		# Use json.JSONDecoder.raw_decode() which is string/escape-aware
+		# (the earlier brace-depth counter mis-handled JSON strings that
+		# contain literal '{' or '}' — unified diffs frequently do).
 		if python3 - "${SELF_HEAL_OUTPUT_FILE}" "${SELF_HEAL_DECISION_FILE}" <<'PY'
-import json, re, sys
+import json, sys
 src, dst = sys.argv[1], sys.argv[2]
 with open(src, 'r', encoding='utf-8', errors='replace') as fh:
     txt = fh.read()
-# Find all top-level { ... } blocks and pick the last one that parses and has target_prompt.
-candidates = []
-depth = 0
-start = -1
-for i, ch in enumerate(txt):
-    if ch == '{':
-        if depth == 0:
-            start = i
-        depth += 1
-    elif ch == '}':
-        depth -= 1
-        if depth == 0 and start >= 0:
-            candidates.append(txt[start:i+1])
-            start = -1
+
+decoder = json.JSONDecoder()
+
+def is_valid_candidate(obj):
+    return isinstance(obj, dict) and 'target_prompt' in obj and 'patch' in obj
+
 picked = None
-for block in reversed(candidates):
-    try:
-        obj = json.loads(block)
-    except Exception:
-        continue
-    if isinstance(obj, dict) and 'target_prompt' in obj and 'patch' in obj:
-        picked = obj
-        break
+
+# Fast path: whole output is already valid JSON.
+try:
+    whole = json.loads(txt)
+except Exception:
+    whole = None
+else:
+    if is_valid_candidate(whole):
+        picked = whole
+
+# Fallback: scan for each '{' and attempt raw_decode — which correctly
+# handles strings, escapes, and nested structures. Keep the LAST valid
+# candidate so a trailing JSON block in mixed model output wins.
+if picked is None:
+    for i, ch in enumerate(txt):
+        if ch != '{':
+            continue
+        try:
+            obj, _end = decoder.raw_decode(txt, i)
+        except Exception:
+            continue
+        if is_valid_candidate(obj):
+            picked = obj
+
 if picked is None:
     sys.exit(1)
 with open(dst, 'w', encoding='utf-8') as fh:
@@ -274,6 +285,17 @@ fi
 # ---------------------------------------------------------------
 # Apply the patch
 # ---------------------------------------------------------------
+# Record the target file hash before applying so we can detect the
+# "already applied" case that `patch -N` treats as a successful no-op.
+# Without this, a model-produced idempotent patch would burn a self-heal
+# attempt without changing the prompt, and the re-exec would hit the
+# same failure and repeat — silently draining MAX_SELF_HEAL_ATTEMPTS.
+_target_file="prompts/${DECISION_TARGET}"
+_hash_before=""
+if [ -f "${_target_file}" ]; then
+	_hash_before="$(sha256sum "${_target_file}" | awk '{print $1}')"
+fi
+
 if [ "${_APPLY_WITH_GIT}" = "true" ]; then
 	if ! git apply "${SELF_HEAL_PATCH_TMP}" >> "${SELF_HEAL_LOG_FILE}" 2>&1; then
 		echo "self-heal: git apply failed after dry-run succeeded (race)" >&2
@@ -284,6 +306,15 @@ else
 		echo "self-heal: patch -p1 failed after dry-run succeeded (race)" >&2
 		exit 2
 	fi
+fi
+
+_hash_after=""
+if [ -f "${_target_file}" ]; then
+	_hash_after="$(sha256sum "${_target_file}" | awk '{print $1}')"
+fi
+if [ -n "${_hash_before}" ] && [ "${_hash_before}" = "${_hash_after}" ]; then
+	echo "self-heal: refusing — patch applied cleanly but left prompts/${DECISION_TARGET} unchanged (likely already-applied / idempotent no-op); treating as no patch to avoid burning budget" >&2
+	exit 1
 fi
 
 # ---------------------------------------------------------------

--- a/scripts/self_heal_validation.sh
+++ b/scripts/self_heal_validation.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# self_heal_validation.sh — attempt to self-heal a validation failure by
+# patching one of the four validation prompt files based on the current
+# failure context, then signalling validate_process.sh to re-run.
+#
+# This script is invoked ONLY by scripts/validate_process.sh, which passes
+# the failure context via env vars and reads back the patch decision from
+# ${SELF_HEAL_DECISION_FILE}. Callers must check the exit code:
+#   0  — patch produced and applied; caller should re-exec validate_process.sh
+#   1  — no patch produced; caller should fall through to normal hard-fail
+#   2  — hard error inside self-heal (LLM failure, malformed decision, budget
+#        exhausted, etc.); caller should fall through to normal hard-fail
+#
+# Required env vars (set by validate_process.sh):
+#   RUNTIME_DIR                — scratch dir shared with the caller
+#   SELF_HEAL_ATTEMPT          — current attempt count (0-based, pre-increment)
+#   MAX_SELF_HEAL_ATTEMPTS     — budget for this validate_process.sh invocation
+#   SELF_HEAL_PATCHES_FILE     — JSONL ledger of accumulated patches
+#   SELF_HEAL_FAILURE_PHASE    — string tag ("generate"|"preflight"|"canary"|"diagnose"|"runtime"|"discover")
+#   MODEL_EDITOR               — OpenRouter model slug for the self-heal LLM call
+#   OPENROUTER_API_KEY         — for codex exec
+# Optional:
+#   VALIDATION_RESULT_FILE, DIAGNOSE_RESULT_FILE, VALIDATION_LOG_TAIL_FILE,
+#   CONTAINER_LOG_TAIL_FILE, VALIDATE_HINTS_FILE, STATIC_CONTEXT_FILE,
+#   DISCOVER_OUTPUT_FILE, GENERATE_OUTPUT_FILE, DIAGNOSE_OUTPUT_FILE
+
+set -euo pipefail
+
+: "${RUNTIME_DIR:?RUNTIME_DIR is required}"
+: "${SELF_HEAL_ATTEMPT:?SELF_HEAL_ATTEMPT is required}"
+: "${MAX_SELF_HEAL_ATTEMPTS:?MAX_SELF_HEAL_ATTEMPTS is required}"
+: "${SELF_HEAL_PATCHES_FILE:?SELF_HEAL_PATCHES_FILE is required}"
+: "${SELF_HEAL_FAILURE_PHASE:=unknown}"
+: "${MODEL_EDITOR:?MODEL_EDITOR is required}"
+: "${OPENROUTER_API_KEY:?OPENROUTER_API_KEY is required}"
+
+command -v jq >/dev/null 2>&1 || { echo "self-heal: jq is required" >&2; exit 2; }
+command -v patch >/dev/null 2>&1 || { echo "self-heal: patch is required" >&2; exit 2; }
+
+# Budget check — if we're already at or past the budget, bail out immediately.
+if [ "${SELF_HEAL_ATTEMPT}" -ge "${MAX_SELF_HEAL_ATTEMPTS}" ]; then
+	echo "self-heal: budget exhausted (attempt=${SELF_HEAL_ATTEMPT} max=${MAX_SELF_HEAL_ATTEMPTS})" >&2
+	exit 2
+fi
+
+SELF_HEAL_PROMPT_FILE="${RUNTIME_DIR}/validate_self_heal_prompt.txt"
+SELF_HEAL_OUTPUT_FILE="${RUNTIME_DIR}/validate_self_heal_output.txt"
+SELF_HEAL_LOG_FILE="${RUNTIME_DIR}/validate_self_heal.log"
+SELF_HEAL_DECISION_FILE="${RUNTIME_DIR}/validate_self_heal_decision.json"
+SELF_HEAL_PATCH_TMP="${RUNTIME_DIR}/validate_self_heal_patch.diff"
+
+ALLOWED_TARGETS=(
+	"mode-validate-discover.txt"
+	"mode-validate-generate.txt"
+	"mode-validate-fix-harness.txt"
+	"mode-validate-diagnose.txt"
+)
+
+is_allowed_target()
+{
+	local needle="$1"
+	local candidate
+	for candidate in "${ALLOWED_TARGETS[@]}"; do
+		if [ "${needle}" = "${candidate}" ]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+_cat_if_exists()
+{
+	local label="$1"
+	local path="${2:-}"
+	if [ -n "${path}" ] && [ -s "${path}" ]; then
+		echo "=== ${label} ==="
+		cat "${path}"
+		echo
+	fi
+}
+
+_tail_if_exists()
+{
+	local label="$1"
+	local path="${2:-}"
+	local n="${3:-200}"
+	if [ -n "${path}" ] && [ -s "${path}" ]; then
+		echo "=== ${label} (tail ${n}) ==="
+		tail -n "${n}" "${path}"
+		echo
+	fi
+}
+
+# Ensure the patches ledger exists.
+: > "${SELF_HEAL_LOG_FILE}"
+if [ ! -f "${SELF_HEAL_PATCHES_FILE}" ]; then
+	: > "${SELF_HEAL_PATCHES_FILE}"
+fi
+
+# ---------------------------------------------------------------
+# Compose the self-heal prompt
+# ---------------------------------------------------------------
+{
+	_cat_if_exists "STATIC CONTEXT" "${STATIC_CONTEXT_FILE:-}"
+	echo
+	echo "=== SELF-HEAL TASK ==="
+	echo
+	bash scripts/render_prompt.sh prompts/mode-validate-self-heal.txt
+	echo
+	echo "=== SELF-HEAL ATTEMPT ==="
+	echo "attempt_number: $((SELF_HEAL_ATTEMPT + 1))"
+	echo "max_attempts: ${MAX_SELF_HEAL_ATTEMPTS}"
+	echo "failing_phase: ${SELF_HEAL_FAILURE_PHASE}"
+	echo
+	echo "=== PRIOR ACCUMULATED SELF-HEAL PATCHES (this run) ==="
+	if [ -s "${SELF_HEAL_PATCHES_FILE}" ]; then
+		cat "${SELF_HEAL_PATCHES_FILE}"
+	else
+		echo "(none — this is the first self-heal attempt for this run)"
+	fi
+	echo
+	echo "=== CURRENT VALIDATION PROMPT FILES (with any prior self-heal patches already applied) ==="
+	for _target in "${ALLOWED_TARGETS[@]}"; do
+		if [ -f "prompts/${_target}" ]; then
+			echo "--- prompts/${_target} ---"
+			cat "prompts/${_target}"
+			echo
+			echo "--- end prompts/${_target} ---"
+			echo
+		fi
+	done
+	echo
+	_cat_if_exists "STRUCTURED VALIDATION FAILURE JSON" "${VALIDATION_RESULT_FILE:-}"
+	_cat_if_exists "DIAGNOSIS JSON" "${DIAGNOSE_RESULT_FILE:-}"
+	_tail_if_exists "VALIDATION LOG TAIL" "${VALIDATION_LOG_TAIL_FILE:-}" 200
+	_tail_if_exists "CONTAINER LOG TAIL" "${CONTAINER_LOG_TAIL_FILE:-}" 200
+	_cat_if_exists "VALIDATE HINTS" "${VALIDATE_HINTS_FILE:-}"
+	_tail_if_exists "DISCOVER OUTPUT" "${DISCOVER_OUTPUT_FILE:-}" 120
+	_tail_if_exists "GENERATE OUTPUT" "${GENERATE_OUTPUT_FILE:-}" 120
+	_tail_if_exists "DIAGNOSE OUTPUT" "${DIAGNOSE_OUTPUT_FILE:-}" 120
+} > "${SELF_HEAL_PROMPT_FILE}" 2>> "${SELF_HEAL_LOG_FILE}"
+
+# ---------------------------------------------------------------
+# Call the self-heal LLM (up to 2 attempts to parse valid JSON)
+# ---------------------------------------------------------------
+SELF_HEAL_LLM_SUCCESS=false
+for _llm_attempt in 1 2; do
+	echo "self-heal: LLM call attempt ${_llm_attempt}/2" >> "${SELF_HEAL_LOG_FILE}"
+	if cat "${SELF_HEAL_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --full-auto > "${SELF_HEAL_OUTPUT_FILE}" 2>> "${SELF_HEAL_LOG_FILE}"; then
+		# Extract the last JSON object that contains a "target_prompt" key.
+		if python3 - "${SELF_HEAL_OUTPUT_FILE}" "${SELF_HEAL_DECISION_FILE}" <<'PY'
+import json, re, sys
+src, dst = sys.argv[1], sys.argv[2]
+with open(src, 'r', encoding='utf-8', errors='replace') as fh:
+    txt = fh.read()
+# Find all top-level { ... } blocks and pick the last one that parses and has target_prompt.
+candidates = []
+depth = 0
+start = -1
+for i, ch in enumerate(txt):
+    if ch == '{':
+        if depth == 0:
+            start = i
+        depth += 1
+    elif ch == '}':
+        depth -= 1
+        if depth == 0 and start >= 0:
+            candidates.append(txt[start:i+1])
+            start = -1
+picked = None
+for block in reversed(candidates):
+    try:
+        obj = json.loads(block)
+    except Exception:
+        continue
+    if isinstance(obj, dict) and 'target_prompt' in obj and 'patch' in obj:
+        picked = obj
+        break
+if picked is None:
+    sys.exit(1)
+with open(dst, 'w', encoding='utf-8') as fh:
+    json.dump(picked, fh, ensure_ascii=False, indent=2)
+PY
+		then
+			SELF_HEAL_LLM_SUCCESS=true
+			break
+		fi
+	fi
+	if [ "${_llm_attempt}" -lt 2 ]; then
+		sleep $((_llm_attempt * 5))
+	fi
+done
+
+if [ "${SELF_HEAL_LLM_SUCCESS}" != "true" ]; then
+	echo "self-heal: LLM call or JSON parse failed twice; abandoning self-heal" >&2
+	exit 2
+fi
+
+# ---------------------------------------------------------------
+# Validate the decision
+# ---------------------------------------------------------------
+DECISION_TARGET="$(jq -r '.target_prompt // ""' "${SELF_HEAL_DECISION_FILE}")"
+DECISION_CLASS="$(jq -r '.failure_class // "unknown"' "${SELF_HEAL_DECISION_FILE}")"
+DECISION_CONF="$(jq -r '.confidence // 0' "${SELF_HEAL_DECISION_FILE}")"
+DECISION_RATIONALE="$(jq -r '.rationale // ""' "${SELF_HEAL_DECISION_FILE}")"
+DECISION_PATCH="$(jq -r '.patch // ""' "${SELF_HEAL_DECISION_FILE}")"
+
+echo "self-heal: target=${DECISION_TARGET} class=${DECISION_CLASS} confidence=${DECISION_CONF}" >> "${SELF_HEAL_LOG_FILE}"
+
+# Empty patch means "no self-heal proposed" — fall through to hard fail.
+if [ -z "${DECISION_PATCH}" ] || [ "${DECISION_PATCH}" = "null" ]; then
+	echo "self-heal: empty patch proposed; rationale: ${DECISION_RATIONALE}" >&2
+	exit 1
+fi
+
+# Target must be one of the four allowed validation prompts.
+if ! is_allowed_target "${DECISION_TARGET}"; then
+	echo "self-heal: refusing — target_prompt '${DECISION_TARGET}' is not in the self-heal allow-list" >&2
+	exit 2
+fi
+
+# Write patch to a tmp file and validate.
+printf '%s\n' "${DECISION_PATCH}" > "${SELF_HEAL_PATCH_TMP}"
+
+# Reject obvious out-of-scope diffs: patch must only touch prompts/<target>.
+# Accept a/, b/ prefixes and optional trailing whitespace+timestamp.
+_expected_re="(/dev/null|(a/|b/)?prompts/${DECISION_TARGET}([[:space:]]|\$))"
+if grep -E '^(\+\+\+|---) ' "${SELF_HEAL_PATCH_TMP}" | grep -vE "${_expected_re}" >/dev/null 2>&1; then
+	echo "self-heal: refusing — patch touches files outside prompts/${DECISION_TARGET}" >&2
+	exit 2
+fi
+
+# Dry-run the patch.
+if ! patch --dry-run -p1 -N -s < "${SELF_HEAL_PATCH_TMP}" >> "${SELF_HEAL_LOG_FILE}" 2>&1; then
+	# Try git apply as a fallback (handles different whitespace tolerances).
+	if ! git apply --check "${SELF_HEAL_PATCH_TMP}" >> "${SELF_HEAL_LOG_FILE}" 2>&1; then
+		echo "self-heal: refusing — patch does not apply cleanly to prompts/${DECISION_TARGET}" >&2
+		exit 2
+	fi
+	_APPLY_WITH_GIT=true
+else
+	_APPLY_WITH_GIT=false
+fi
+
+# ---------------------------------------------------------------
+# Apply the patch
+# ---------------------------------------------------------------
+if [ "${_APPLY_WITH_GIT}" = "true" ]; then
+	if ! git apply "${SELF_HEAL_PATCH_TMP}" >> "${SELF_HEAL_LOG_FILE}" 2>&1; then
+		echo "self-heal: git apply failed after dry-run succeeded (race)" >&2
+		exit 2
+	fi
+else
+	if ! patch -p1 -N -s < "${SELF_HEAL_PATCH_TMP}" >> "${SELF_HEAL_LOG_FILE}" 2>&1; then
+		echo "self-heal: patch -p1 failed after dry-run succeeded (race)" >&2
+		exit 2
+	fi
+fi
+
+# ---------------------------------------------------------------
+# Record the patch in the ledger
+# ---------------------------------------------------------------
+_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+_ledger_entry="$(jq -cn \
+	--arg ts "${_ts}" \
+	--arg target "${DECISION_TARGET}" \
+	--arg phase "${SELF_HEAL_FAILURE_PHASE}" \
+	--arg class "${DECISION_CLASS}" \
+	--arg rationale "${DECISION_RATIONALE}" \
+	--argjson attempt "$((SELF_HEAL_ATTEMPT + 1))" \
+	--argjson confidence "${DECISION_CONF}" \
+	--rawfile patch "${SELF_HEAL_PATCH_TMP}" \
+	'{
+		timestamp: $ts,
+		attempt: $attempt,
+		failure_phase: $phase,
+		failure_class: $class,
+		confidence: $confidence,
+		target_prompt: $target,
+		rationale: $rationale,
+		patch: $patch
+	}')"
+printf '%s\n' "${_ledger_entry}" >> "${SELF_HEAL_PATCHES_FILE}"
+
+echo "self-heal: applied patch to prompts/${DECISION_TARGET} (attempt $((SELF_HEAL_ATTEMPT + 1))/${MAX_SELF_HEAL_ATTEMPTS})" >&2
+exit 0

--- a/scripts/self_heal_validation.sh
+++ b/scripts/self_heal_validation.sh
@@ -4,8 +4,14 @@
 # failure context, then signalling validate_process.sh to re-run.
 #
 # This script is invoked ONLY by scripts/validate_process.sh, which passes
-# the failure context via env vars and reads back the patch decision from
-# ${SELF_HEAL_DECISION_FILE}. Callers must check the exit code:
+# the failure context via env vars and dispatches on this script's exit
+# code. The self-heal decision JSON and the resulting patch are written
+# to files under ${RUNTIME_DIR} (validate_self_heal_decision.json and
+# validate_self_heal_patch.diff) for diagnostic/artifact purposes only;
+# the caller does not read those files. The accumulated-patches JSONL
+# ledger at ${SELF_HEAL_PATCHES_FILE} IS consumed by the caller later,
+# in dispatch_self_heal_improvements(), to build the repository_dispatch
+# payload. Callers must check the exit code:
 #   0  — patch produced and applied; caller should re-exec validate_process.sh
 #   1  — no patch produced; caller should fall through to normal hard-fail
 #   2  — hard error inside self-heal (LLM failure, malformed decision, budget

--- a/scripts/self_heal_validation.sh
+++ b/scripts/self_heal_validation.sh
@@ -222,9 +222,34 @@ fi
 # Write patch to a tmp file and validate.
 printf '%s\n' "${DECISION_PATCH}" > "${SELF_HEAL_PATCH_TMP}"
 
+# Reject non-additive diffs explicitly before any dry-run/apply.
+# The self-heal prompt's hard constraints require patches to be additive
+# clarifications only: no deletions, no renames, no schema/identifier
+# changes, no file deletions via /dev/null headers. We enforce the
+# syntactic parts of that contract here so a misbehaving self-heal LLM
+# cannot remove "Hard constraints" blocks, rename JSON schema fields, or
+# delete the target prompt file wholesale.
+if grep -Eq '^(---|\+\+\+) /dev/null([[:space:]]|$)' "${SELF_HEAL_PATCH_TMP}"; then
+	echo "self-heal: refusing — patch uses /dev/null headers (file add/delete not allowed)" >&2
+	exit 2
+fi
+if grep -Eq '^(deleted file mode|new file mode|rename from |rename to |copy from |copy to )' "${SELF_HEAL_PATCH_TMP}"; then
+	echo "self-heal: refusing — patch includes non-additive file operations (rename/copy/delete/new)" >&2
+	exit 2
+fi
+# Reject any deletion lines. Unified diff deletion lines start with a
+# single '-' followed by a non-'-' char (or end of line). The file
+# header '--- path' starts with three dashes and is NOT matched by
+# '^-[^-]'. We also reject bare '--' lines as a defensive measure.
+if grep -Eq '^-[^-]|^--$' "${SELF_HEAL_PATCH_TMP}"; then
+	echo "self-heal: refusing — patch contains deletion lines; self-heal patches must be additive-only" >&2
+	exit 2
+fi
+
 # Reject obvious out-of-scope diffs: patch must only touch prompts/<target>.
 # Accept a/, b/ prefixes and optional trailing whitespace+timestamp.
-_expected_re="(/dev/null|(a/|b/)?prompts/${DECISION_TARGET}([[:space:]]|\$))"
+# (/dev/null is excluded here because the earlier guard rejects it.)
+_expected_re="(a/|b/)?prompts/${DECISION_TARGET}([[:space:]]|\$)"
 if grep -E '^(\+\+\+|---) ' "${SELF_HEAL_PATCH_TMP}" | grep -vE "${_expected_re}" >/dev/null 2>&1; then
 	echo "self-heal: refusing — patch touches files outside prompts/${DECISION_TARGET}" >&2
 	exit 2

--- a/scripts/self_heal_validation.sh
+++ b/scripts/self_heal_validation.sh
@@ -281,7 +281,10 @@ fi
 # Reject obvious out-of-scope diffs: patch must only touch prompts/<target>.
 # Accept a/, b/ prefixes and optional trailing whitespace+timestamp.
 # (/dev/null is excluded here because the earlier guard rejects it.)
-_expected_re="(a/|b/)?prompts/${DECISION_TARGET}([[:space:]]|$)"
+# Escape regex metacharacters so only the exact allowed target filename
+# is accepted in ---/+++ headers.
+_escaped_target="$(printf '%s' "${DECISION_TARGET}" | sed 's/[][\\.^$*+?(){}|]/\\\\&/g')"
+_expected_re="(a/|b/)?prompts/${_escaped_target}([[:space:]]|$)"
 if grep -E '^(\+\+\+|---) ' "${SELF_HEAL_PATCH_TMP}" | grep -vE "${_expected_re}" >/dev/null 2>&1; then
 	echo "self-heal: refusing — patch touches files outside prompts/${DECISION_TARGET}" >&2
 	exit 2

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -287,9 +287,11 @@ dispatch_self_heal_improvements()
 
     # Hard-cap total payload size so a pathological patches ledger
     # cannot produce a giant repository_dispatch body. 1 MiB total is
-    # already far larger than any legitimate self-heal sequence
-    # (max per-patch 64 KiB × max 2 attempts = 128 KiB). Above that we
-    # skip dispatch and preserve the full ledger in the run artifact.
+    # already far larger than any legitimate self-heal sequence given
+    # the per-patch size limit (SELF_HEAL_MAX_PATCH_BYTES, default
+    # 64 KiB) and the configured self-heal attempt budget
+    # (MAX_SELF_HEAL_ATTEMPTS, default 2). Above the cap we skip
+    # dispatch and preserve the full ledger in the run artifact.
     local max_dispatch_bytes="${SELF_HEAL_MAX_DISPATCH_BYTES:-1048576}"
     local patches_size
     patches_size="$(wc -c < "${patches_array_file}" | tr -d ' ')"

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -256,62 +256,105 @@ attempt_self_heal_and_reexec()
 # No-op if no patches were accumulated or GH_PAT has no dispatch scope.
 dispatch_self_heal_improvements()
 {
-  if [ ! -s "${SELF_HEAL_PATCHES_FILE}" ]; then
-    return 0
-  fi
+  # This function runs on the success path AFTER the validation has
+  # already been marked passing. It MUST NOT abort the script on any
+  # internal failure, or a model-produced pathological patches ledger
+  # could flip an otherwise-passing validation into a non-zero script
+  # exit. The entire body runs in a subshell so `set -e` failures stay
+  # local; the outer caller always sees return 0.
+  (
+    set +e
+    if [ ! -s "${SELF_HEAL_PATCHES_FILE}" ]; then
+      exit 0
+    fi
 
-  local upstream="shubhodeep1/coding-workflows"
-  local patches_json
-  patches_json="$(jq -cs '.' "${SELF_HEAL_PATCHES_FILE}" 2>/dev/null || echo '[]')"
-  if [ "${patches_json}" = "[]" ] || [ -z "${patches_json}" ]; then
-    return 0
-  fi
+    local upstream="shubhodeep1/coding-workflows"
 
-  local run_url=""
-  if [ -n "${GITHUB_RUN_ID:-}" ]; then
-    run_url="$(_gh_url "actions/runs/${GITHUB_RUN_ID}")"
-  fi
+    # Slurp patches into an array file. jq's --slurpfile reads the
+    # referenced file from disk instead of taking it as a command-line
+    # argument, so we sidestep ARG_MAX limits on large payloads.
+    local patches_array_file="${RUNTIME_DIR}/self_heal_dispatch_patches.json"
+    if ! jq -cs '.' "${SELF_HEAL_PATCHES_FILE}" > "${patches_array_file}" 2>/dev/null; then
+      echo "::warning::Self-heal patches ledger could not be slurped by jq; skipping dispatch." >&2
+      tg_notify "Validation self-heal SUCCEEDED for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW} but patches ledger was malformed; dispatch skipped." "WARNING"
+      exit 0
+    fi
+    local patches_count
+    patches_count="$(jq 'length // 0' "${patches_array_file}" 2>/dev/null || echo 0)"
+    if [ "${patches_count:-0}" -le 0 ]; then
+      exit 0
+    fi
 
-  local payload
-  payload="$(jq -cn \
-    --arg consumer_repo "${GITHUB_REPOSITORY}" \
-    --arg tracking_issue "${TRACKING_ISSUE_RAW}" \
-    --arg validation_cycle "${VALIDATION_CYCLE}" \
-    --arg run_id "${GITHUB_RUN_ID:-0}" \
-    --arg run_url "${run_url}" \
-    --arg final_status "pass" \
-    --argjson attempts "${SELF_HEAL_ATTEMPT}" \
-    --argjson patches "${patches_json}" \
-    '{
-      event_type: "validation-prompt-self-heal",
-      client_payload: {
-        consumer_repo: $consumer_repo,
-        tracking_issue: $tracking_issue,
-        validation_cycle: $validation_cycle,
-        run_id: $run_id,
-        run_url: $run_url,
-        final_status: $final_status,
-        self_heal_attempts: $attempts,
-        patches: $patches
-      }
-    }')"
+    # Hard-cap total payload size so a pathological patches ledger
+    # cannot produce a giant repository_dispatch body. 1 MiB total is
+    # already far larger than any legitimate self-heal sequence
+    # (max per-patch 64 KiB × max 2 attempts = 128 KiB). Above that we
+    # skip dispatch and preserve the full ledger in the run artifact.
+    local max_dispatch_bytes="${SELF_HEAL_MAX_DISPATCH_BYTES:-1048576}"
+    local patches_size
+    patches_size="$(wc -c < "${patches_array_file}" | tr -d ' ')"
+    if [ "${patches_size:-0}" -gt "${max_dispatch_bytes}" ]; then
+      echo "::warning::Self-heal patches ledger is ${patches_size} bytes, exceeds SELF_HEAL_MAX_DISPATCH_BYTES=${max_dispatch_bytes}; skipping dispatch to avoid bloating the repository_dispatch payload." >&2
+      tg_notify "Validation self-heal SUCCEEDED for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW} but patches ledger is oversized (${patches_size} bytes); dispatch skipped. See run artifacts." "WARNING"
+      exit 0
+    fi
 
-  local dispatch_log="${RUNTIME_DIR}/self_heal_dispatch.log"
-  local dispatch_exit=0
-  echo "${payload}" | gh_retry gh api \
-    -X POST \
-    -H 'Accept: application/vnd.github+json' \
-    "repos/${upstream}/dispatches" \
-    --input - \
-    > "${dispatch_log}" 2>&1 || dispatch_exit=$?
+    local run_url=""
+    if [ -n "${GITHUB_RUN_ID:-}" ]; then
+      run_url="$(_gh_url "actions/runs/${GITHUB_RUN_ID}")"
+    fi
 
-  if [ "${dispatch_exit}" -ne 0 ]; then
-    echo "::warning::Self-heal dispatch to ${upstream} failed (exit ${dispatch_exit}); see ${dispatch_log}. Patches are preserved in ${SELF_HEAL_PATCHES_FILE}." >&2
-    tg_notify "Validation self-heal SUCCEEDED for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW} but dispatch back to ${upstream} failed. Patches remain in run artifacts." "WARNING"
-    return 0
-  fi
+    local payload_file="${RUNTIME_DIR}/self_heal_dispatch_payload.json"
+    # --slurpfile binds $patches_wrapper to [<contents-of-file>]; the
+    # patches array is already a single JSON array so we unwrap the
+    # outer slurp layer with $patches_wrapper[0].
+    if ! jq -cn \
+      --arg consumer_repo "${GITHUB_REPOSITORY}" \
+      --arg tracking_issue "${TRACKING_ISSUE_RAW}" \
+      --arg validation_cycle "${VALIDATION_CYCLE}" \
+      --arg run_id "${GITHUB_RUN_ID:-0}" \
+      --arg run_url "${run_url}" \
+      --arg final_status "pass" \
+      --argjson attempts "${SELF_HEAL_ATTEMPT}" \
+      --slurpfile patches_wrapper "${patches_array_file}" \
+      '{
+        event_type: "validation-prompt-self-heal",
+        client_payload: {
+          consumer_repo: $consumer_repo,
+          tracking_issue: $tracking_issue,
+          validation_cycle: $validation_cycle,
+          run_id: $run_id,
+          run_url: $run_url,
+          final_status: $final_status,
+          self_heal_attempts: $attempts,
+          patches: $patches_wrapper[0]
+        }
+      }' > "${payload_file}" 2>"${RUNTIME_DIR}/self_heal_dispatch_jq.log"; then
+      echo "::warning::Self-heal dispatch payload could not be built by jq; skipping dispatch. See ${RUNTIME_DIR}/self_heal_dispatch_jq.log." >&2
+      tg_notify "Validation self-heal SUCCEEDED for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW} but dispatch payload construction failed; dispatch skipped." "WARNING"
+      exit 0
+    fi
 
-  tg_notify "Validation self-heal SUCCEEDED for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW} (${SELF_HEAL_ATTEMPT} patch(es)); improvements dispatched to ${upstream}." "WARNING"
+    local dispatch_log="${RUNTIME_DIR}/self_heal_dispatch.log"
+    local dispatch_exit=0
+    # Stream the payload from the file via stdin — gh api --input -
+    # reads the POST body from stdin, so we never put the payload on
+    # the command line.
+    gh_retry gh api \
+      -X POST \
+      -H 'Accept: application/vnd.github+json' \
+      "repos/${upstream}/dispatches" \
+      --input "${payload_file}" \
+      > "${dispatch_log}" 2>&1 || dispatch_exit=$?
+
+    if [ "${dispatch_exit}" -ne 0 ]; then
+      echo "::warning::Self-heal dispatch to ${upstream} failed (exit ${dispatch_exit}); see ${dispatch_log}. Patches are preserved in ${SELF_HEAL_PATCHES_FILE}." >&2
+      tg_notify "Validation self-heal SUCCEEDED for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW} but dispatch back to ${upstream} failed. Patches remain in run artifacts." "WARNING"
+      exit 0
+    fi
+
+    tg_notify "Validation self-heal SUCCEEDED for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW} (${SELF_HEAL_ATTEMPT} patch(es)); improvements dispatched to ${upstream}." "WARNING"
+  ) || true
 }
 
 is_tracking_run()

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -191,6 +191,20 @@ attempt_self_heal_and_reexec()
     echo "::warning::self-heal helper scripts/self_heal_validation.sh not found; skipping self-heal." >&2
     return 0
   fi
+  # Self-heal is designed to be opt-in: workflow-templates/ai-validate.yml
+  # and .github/workflows/validate.yml fetch the prompt and helper script
+  # with require_remote=false, so older @stable tags can be missing one or
+  # both. Fail-closed here rather than letting self_heal_validation.sh exit
+  # with a misleading "no patch proposed" code, which would look like the
+  # LLM chose not to self-heal when in fact a dependency was missing.
+  if [ ! -f "prompts/mode-validate-self-heal.txt" ]; then
+    echo "::warning::self-heal prompt prompts/mode-validate-self-heal.txt not found; skipping self-heal." >&2
+    return 0
+  fi
+  if [ ! -f "scripts/render_prompt.sh" ]; then
+    echo "::warning::self-heal dependency scripts/render_prompt.sh not found; skipping self-heal." >&2
+    return 0
+  fi
 
   local heal_exit=0
   SELF_HEAL_FAILURE_PHASE="${phase}" \

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -31,6 +31,11 @@ fi
 
 MODEL_EDITOR="${MODEL_EDITOR:-openai/gpt-5.3-codex}"
 MODEL_REASONING_EFFORT="${MODEL_REASONING_EFFORT:-high}"
+# Export MODEL_EDITOR so child processes (notably scripts/self_heal_validation.sh)
+# see it even when the caller relied on our default fallback. In CI the workflow
+# env: block already exports MODEL_EDITOR, but standalone/local invocations
+# would otherwise lose the default at the env boundary.
+export MODEL_EDITOR
 VALIDATION_TIMEOUT="${VALIDATION_TIMEOUT:-15}"
 if ! [[ "${VALIDATION_TIMEOUT}" =~ ^[0-9]+$ ]] || [ "${VALIDATION_TIMEOUT}" -le 0 ]; then
   echo "VALIDATION_TIMEOUT must be a positive integer (got: ${VALIDATION_TIMEOUT})" >&2

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -97,6 +97,25 @@ export TEST_API_KEY="${TEST_API_KEY:-${VALIDATION_TEST_API_KEY}}"
 
 CREATED_FIX_ISSUES_JSON='[]'
 
+# ---------------------------------------------------------------
+# Self-heal state (see prompts/mode-validate-self-heal.txt).
+# Self-heal attempts do NOT burn validation cycles: they are re-execs of
+# this process within the same cycle. The counter is passed across execs
+# via SELF_HEAL_ATTEMPT, and the accumulated patches are appended to
+# SELF_HEAL_PATCHES_FILE (JSONL) for later repository_dispatch back to
+# shubhodeep1/coding-workflows.
+# ---------------------------------------------------------------
+SELF_HEAL_ATTEMPT="${SELF_HEAL_ATTEMPT:-0}"
+if ! [[ "${SELF_HEAL_ATTEMPT}" =~ ^[0-9]+$ ]]; then
+  SELF_HEAL_ATTEMPT=0
+fi
+MAX_SELF_HEAL_ATTEMPTS="${MAX_SELF_HEAL_ATTEMPTS:-2}"
+if ! [[ "${MAX_SELF_HEAL_ATTEMPTS}" =~ ^[0-9]+$ ]]; then
+  MAX_SELF_HEAL_ATTEMPTS=2
+fi
+SELF_HEAL_PATCHES_FILE="${SELF_HEAL_PATCHES_FILE:-${RUNTIME_DIR}/self_heal_patches.jsonl}"
+export SELF_HEAL_ATTEMPT MAX_SELF_HEAL_ATTEMPTS SELF_HEAL_PATCHES_FILE
+
 
 # ---------------------------------------------------------------
 # Helpers
@@ -146,6 +165,135 @@ tg_notify()
 if ! type gh_retry >/dev/null 2>&1; then
   gh_retry() { "$@"; }
 fi
+
+# attempt_self_heal_and_reexec — last-chance interception before a hard
+# validation failure. If the self-heal LLM proposes a patch to one of the
+# four validation prompt files and the patch applies cleanly, we re-exec
+# this script (incrementing SELF_HEAL_ATTEMPT, not VALIDATION_CYCLE). If
+# self-heal is not applicable or budget is exhausted, this function
+# returns and the caller proceeds with its normal hard-fail path.
+#
+# Usage: attempt_self_heal_and_reexec "<failure-phase-tag>"
+#   phase tag: generate|preflight|canary|runtime|diagnose|discover
+attempt_self_heal_and_reexec()
+{
+  local phase="${1:-unknown}"
+
+  if [ "${MAX_SELF_HEAL_ATTEMPTS:-0}" -le 0 ]; then
+    return 0
+  fi
+  if [ "${SELF_HEAL_ATTEMPT:-0}" -ge "${MAX_SELF_HEAL_ATTEMPTS}" ]; then
+    tg_notify "Validation self-heal budget exhausted for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW} (${SELF_HEAL_ATTEMPT}/${MAX_SELF_HEAL_ATTEMPTS}); falling back to hard-fail." "WARNING"
+    return 0
+  fi
+
+  if [ ! -f "scripts/self_heal_validation.sh" ]; then
+    echo "::warning::self-heal helper scripts/self_heal_validation.sh not found; skipping self-heal." >&2
+    return 0
+  fi
+
+  local heal_exit=0
+  SELF_HEAL_FAILURE_PHASE="${phase}" \
+    STATIC_CONTEXT_FILE="${STATIC_CONTEXT_FILE}" \
+    VALIDATION_RESULT_FILE="${VALIDATION_RESULT_FILE}" \
+    DIAGNOSE_RESULT_FILE="${DIAGNOSE_RESULT_FILE}" \
+    VALIDATION_LOG_TAIL_FILE="${VALIDATION_LOG_TAIL_FILE}" \
+    CONTAINER_LOG_TAIL_FILE="${CONTAINER_LOG_TAIL_FILE}" \
+    VALIDATE_HINTS_FILE="${VALIDATE_HINTS_FILE}" \
+    DISCOVER_OUTPUT_FILE="${DISCOVER_OUTPUT_FILE}" \
+    GENERATE_OUTPUT_FILE="${GENERATE_OUTPUT_FILE}" \
+    DIAGNOSE_OUTPUT_FILE="${DIAGNOSE_OUTPUT_FILE}" \
+    bash scripts/self_heal_validation.sh || heal_exit=$?
+
+  case "${heal_exit}" in
+    0)
+      # Patch applied; re-exec with incremented attempt counter.
+      SELF_HEAL_ATTEMPT=$((SELF_HEAL_ATTEMPT + 1))
+      tg_notify "Validation self-heal attempt ${SELF_HEAL_ATTEMPT}/${MAX_SELF_HEAL_ATTEMPTS} applied for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW} (phase=${phase})." "DEBUG"
+      # validate_process.sh takes no positional args; re-exec plain.
+      exec env \
+        SELF_HEAL_ATTEMPT="${SELF_HEAL_ATTEMPT}" \
+        MAX_SELF_HEAL_ATTEMPTS="${MAX_SELF_HEAL_ATTEMPTS}" \
+        SELF_HEAL_PATCHES_FILE="${SELF_HEAL_PATCHES_FILE}" \
+        bash "${BASH_SOURCE[0]:-$0}"
+      ;;
+    1)
+      # No patch proposed — fall through to normal hard-fail path.
+      return 0
+      ;;
+    *)
+      # Hard error inside self-heal helper — fall through to hard-fail.
+      echo "::warning::self-heal helper exited with code ${heal_exit}; falling through to hard-fail." >&2
+      return 0
+      ;;
+  esac
+}
+
+# dispatch_self_heal_improvements — send accumulated self-heal patches
+# back to the upstream coding-workflows repo as a repository_dispatch
+# event. The intake workflow there will open a draft PR, append to
+# docs/validation-improvements.md, and Telegram-alert the admin.
+#
+# No-op if no patches were accumulated or GH_PAT has no dispatch scope.
+dispatch_self_heal_improvements()
+{
+  if [ ! -s "${SELF_HEAL_PATCHES_FILE}" ]; then
+    return 0
+  fi
+
+  local upstream="shubhodeep1/coding-workflows"
+  local patches_json
+  patches_json="$(jq -cs '.' "${SELF_HEAL_PATCHES_FILE}" 2>/dev/null || echo '[]')"
+  if [ "${patches_json}" = "[]" ] || [ -z "${patches_json}" ]; then
+    return 0
+  fi
+
+  local run_url=""
+  if [ -n "${GITHUB_RUN_ID:-}" ]; then
+    run_url="$(_gh_url "actions/runs/${GITHUB_RUN_ID}")"
+  fi
+
+  local payload
+  payload="$(jq -cn \
+    --arg consumer_repo "${GITHUB_REPOSITORY}" \
+    --arg tracking_issue "${TRACKING_ISSUE_RAW}" \
+    --arg validation_cycle "${VALIDATION_CYCLE}" \
+    --arg run_id "${GITHUB_RUN_ID:-0}" \
+    --arg run_url "${run_url}" \
+    --arg final_status "pass" \
+    --argjson attempts "${SELF_HEAL_ATTEMPT}" \
+    --argjson patches "${patches_json}" \
+    '{
+      event_type: "validation-prompt-self-heal",
+      client_payload: {
+        consumer_repo: $consumer_repo,
+        tracking_issue: $tracking_issue,
+        validation_cycle: $validation_cycle,
+        run_id: $run_id,
+        run_url: $run_url,
+        final_status: $final_status,
+        self_heal_attempts: $attempts,
+        patches: $patches
+      }
+    }')"
+
+  local dispatch_log="${RUNTIME_DIR}/self_heal_dispatch.log"
+  local dispatch_exit=0
+  echo "${payload}" | gh_retry gh api \
+    -X POST \
+    -H 'Accept: application/vnd.github+json' \
+    "repos/${upstream}/dispatches" \
+    --input - \
+    > "${dispatch_log}" 2>&1 || dispatch_exit=$?
+
+  if [ "${dispatch_exit}" -ne 0 ]; then
+    echo "::warning::Self-heal dispatch to ${upstream} failed (exit ${dispatch_exit}); see ${dispatch_log}. Patches are preserved in ${SELF_HEAL_PATCHES_FILE}." >&2
+    tg_notify "Validation self-heal SUCCEEDED for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW} but dispatch back to ${upstream} failed. Patches remain in run artifacts." "WARNING"
+    return 0
+  fi
+
+  tg_notify "Validation self-heal SUCCEEDED for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW} (${SELF_HEAL_ATTEMPT} patch(es)); improvements dispatched to ${upstream}." "WARNING"
+}
 
 is_tracking_run()
 {
@@ -1258,6 +1406,9 @@ done
 
 if [ "${GENERATE_SUCCESS}" != "true" ]; then
   local_failure_summary="Codex did not generate runnable validation assets (validation/docker-compose.test.yml, validation/validate.env, validation/tests/00_canary.sh at minimum)."
+  # Self-heal interception: if the generate/fix-harness prompt is at fault,
+  # patch it and re-exec before burning a validation cycle.
+  attempt_self_heal_and_reexec "generate"
   post_tracking_comment "## ⚠️ Runtime validation harness generation failed\n\n${local_failure_summary}\n\nSee workflow artifacts for generation logs."
   set_tracking_phase_label "ai:validation-failed"
   write_result_files "error" "Validation harness generation failed" "${local_failure_summary}"
@@ -1309,6 +1460,8 @@ if ! run_preflight_checks; then
       harness_fixes: (if ($harness_fixes | length) > 0 then $harness_fixes else "Fix validation/docker-compose.test.yml, shell syntax, or build context/dockerfile paths." end)
     }' > "${DIAGNOSE_RESULT_FILE}"
 
+  # Self-heal interception: bad harness is often a prompt-wording defect.
+  attempt_self_heal_and_reexec "preflight"
   post_tracking_comment "## ❌ Runtime validation harness pre-flight failed\n\n${failure_summary}\n\n\`docker compose config\`, shell syntax, or build context/dockerfile path checks failed."
   set_tracking_phase_label "ai:validation-failed"
   write_result_files "fail" "Validation failed due to harness pre-flight error" "${failure_summary}"
@@ -1536,6 +1689,9 @@ if [ "${RESULT_KIND}" = "pass" ] && [ "${VALIDATION_EXIT}" -eq 0 ] && [ "${PASS_
 
 	write_result_files "pass" "${summary_text}" ""
 	tg_notify "Runtime validation passed for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW} (${PASSED_TESTS}/${TOTAL_TESTS})." "DEBUG"
+	# If this pass was reached after one or more self-heal attempts, send
+	# the accumulated prompt patches back to upstream coding-workflows.
+	dispatch_self_heal_improvements
 	exit 0
 fi
 
@@ -1586,6 +1742,9 @@ if [ "${CANARY_ONLY_FAILURE}" = true ]; then
 					harness_fixes: (if ($harness_fixes | length) > 0 then $harness_fixes else "Fix canary test infrastructure assumptions (ports/services/tools)." end)
 				}' > "${DIAGNOSE_RESULT_FILE}"
 
+			# Self-heal interception: canary failures are prime candidates
+			# for a bad generate/fix-harness prompt.
+			attempt_self_heal_and_reexec "canary"
 			failure_summary="Validation harness error: ${FIRST_FAILURE}"
 			post_tracking_comment "## ❌ Runtime validation harness error\n\n${failure_summary}\n\nCanary infrastructure check failed and remaining tests were skipped."
 			set_tracking_phase_label "ai:validation-failed"
@@ -1652,6 +1811,15 @@ fi
 
 DIAG_STATUS="$(jq -r '.status // "harness_error"' "${DIAGNOSE_RESULT_FILE}")"
 DIAG_TEXT="$(jq -r '.diagnosis // "Validation failed."' "${DIAGNOSE_RESULT_FILE}")"
+
+# Self-heal interception: the diagnose LLM has classified the failure. If
+# the self-heal LLM determines the classification or the originating phase
+# was driven by a prompt defect and proposes a patch, we re-exec this
+# script (without burning a validation cycle). This hook fires for ALL
+# diagnose outcomes (needs_fixes, harness_error, infeasible, unknown)
+# per Q5=B: any failure where a prompt edit is proposed is self-heal-
+# eligible. The helper short-circuits on an empty-patch proposal.
+attempt_self_heal_and_reexec "diagnose"
 
 case "${DIAG_STATUS}" in
   needs_fixes)

--- a/workflow-templates/ai-review.yml
+++ b/workflow-templates/ai-review.yml
@@ -3,8 +3,13 @@
 # set the ALLOW_WORKFLOW_EDITS repository variable to 'false'.
 name: AI Review
 on:
+  # ready_for_review is included so that converting a draft PR to a
+  # non-draft re-fires the review gate. This is the unlock path for
+  # automated validation-prompt self-heal PRs (see README.md section
+  # "Validation self-healing"), which are opened as drafts to bypass
+  # auto-review/automerge until a human reviews them.
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
Introduces a self-heal loop around scripts/validate_process.sh so that
failures caused by defects in the four validation prompts
(mode-validate-{discover,generate,fix-harness,diagnose}.txt) can be
patched in-process and re-run without incrementing VALIDATION_CYCLE.

On a healed pass, the consumer run POSTs repository_dispatch back to
shubhodeep1/coding-workflows with the accumulated prompt patches. A new
intake workflow opens a *draft* PR labelled ai:needs-prompt-review,
appends an entry to docs/validation-improvements.md, and Telegrams the
admin. Drafts are already skipped by review_autofix.yml's gate, so the
auto-review/automerge pipeline cannot touch the PR until a human marks
it "Ready for review" — which now re-fires the review wrapper via the
newly-added ready_for_review trigger.

Files:
- prompts/mode-validate-self-heal.txt (new) — dedicated LLM mode that
  emits a strict-JSON decision { target_prompt, patch, ... } with hard
  constraints: only the four validation prompts are editable, patch
  must be additive, no schema or identifier changes.
- scripts/self_heal_validation.sh (new) — renders the self-heal prompt,
  calls codex, validates the decision JSON, enforces the allow-list,
  dry-runs the patch (patch -p1 -> git apply fallback), applies it, and
  appends to ${RUNTIME_DIR}/self_heal_patches.jsonl.
- scripts/validate_process.sh — adds SELF_HEAL_ATTEMPT /
  MAX_SELF_HEAL_ATTEMPTS plumbing, helper
  attempt_self_heal_and_reexec() that exec's the script with an
  incremented counter, and dispatch_self_heal_improvements() that POSTs
  /repos/shubhodeep1/coding-workflows/dispatches on a healed pass. Hook
  points at generate parse-fail, preflight fail, canary short-circuit,
  and the Phase 4 diagnose decision.
- .github/workflows/validate.yml — fetch the new prompt and helper
  script from coding-workflows (fail-open if absent for backward
  compat), pass MAX_SELF_HEAL_ATTEMPTS env var through.
- .github/workflows/validation-improvements-intake.yml (new) —
  repository_dispatch receiver (event type validation-prompt-self-heal)
  that applies patches, opens a [skip ai] draft PR with the
  ai:needs-prompt-review label, appends to the improvements ledger,
  and Telegrams the admin.
- docs/validation-improvements.md (new) — append-only ledger header.
- workflow-templates/ai-review.yml — add ready_for_review to
  pull_request trigger types so marking a draft self-heal PR as ready
  re-fires the review wrapper.
- README.md, agents.md — new "Validation self-healing" section, new
  MAX_SELF_HEAL_ATTEMPTS row in both env var tables, unlock procedure.

https://claude.ai/code/session_01AKqbPTzEnTABA187qLH8Mw