### PR TITLE
claude/optimize-workflow-cycles-IaWA1

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -232,18 +232,20 @@ jobs:
 
       - name: Restore validate hints cache
         # Reuse .ai/validate-hints-cache/hints.yml from a prior successful
-        # discover run in the same repo+workspace fingerprint so
+        # run in the same repo with a matching cache key so
         # validate_process.sh can skip the codex discover call entirely.
         # Cache is per-repo (GitHub Actions cache scoping). Key hashes
         # files that drive validation discovery output; changes invalidate
-        # it automatically. See scripts/validate_process.sh Phase 0.
+        # the cache so stale hints cannot leak across structural changes.
+        # Exact-key-only by design: no restore-keys fallback, because a
+        # partial-prefix hit would reuse hints computed against a different
+        # repo fingerprint and bypass the "changes invalidate" guarantee.
+        # See scripts/validate_process.sh Phase 0.
         id: validate_hints_cache
         uses: actions/cache@v4
         with:
           path: .ai/validate-hints-cache
           key: validate-hints-v1-${{ hashFiles('docker-compose*.yml', 'compose*.yml', '**/Dockerfile', '**/Dockerfile.*', '**/package.json', '**/pyproject.toml', '**/requirements*.txt', '**/go.mod', '**/Cargo.toml') }}
-          restore-keys: |
-            validate-hints-v1-
 
       - name: Record validation run start
         continue-on-error: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -230,6 +230,21 @@ jobs:
               "repos/${wf_source}/contents/.github/ai/label_contract.v1.json?ref=${script_ref}" 2>/dev/null || true
           fi
 
+      - name: Restore validate hints cache
+        # Reuse .ai/validate-hints-cache/hints.yml from a prior successful
+        # discover run in the same repo+workspace fingerprint so
+        # validate_process.sh can skip the codex discover call entirely.
+        # Cache is per-repo (GitHub Actions cache scoping). Key hashes
+        # files that drive validation discovery output; changes invalidate
+        # it automatically. See scripts/validate_process.sh Phase 0.
+        id: validate_hints_cache
+        uses: actions/cache@v4
+        with:
+          path: .ai/validate-hints-cache
+          key: validate-hints-v1-${{ hashFiles('docker-compose*.yml', 'compose*.yml', '**/Dockerfile', '**/Dockerfile.*', '**/package.json', '**/pyproject.toml', '**/requirements*.txt', '**/go.mod', '**/Cargo.toml') }}
+          restore-keys: |
+            validate-hints-v1-
+
       - name: Record validation run start
         continue-on-error: true
         env:

--- a/prompts/mode-judge.txt
+++ b/prompts/mode-judge.txt
@@ -3,7 +3,11 @@ You are executing the JUDGE phase of the AI orchestration pipeline.
 All context is inlined directly into the prompt for efficiency:
 - System instructions, AI pipeline spec, agents.md, and README.md appear above
   (constant across all runs, cached by the LLM provider).
-- The project spec, wave history, and merged PR summaries appear below.
+- The project spec and merged PR summaries appear immediately below them and
+  are also cache-stable within a wave.
+- Wave status, open/in-flight PR diffs, CI status, and orchestrator state
+  appear after that — these change every judge tick and are intentionally
+  placed after the cacheable prefix.
 
 Do NOT read pre_assembled_static.txt or any of the individual source files —
 they are already loaded.

--- a/scripts/orchestrate_lib.py
+++ b/scripts/orchestrate_lib.py
@@ -208,9 +208,22 @@ def build_tracking_state(
 				"priority": issue["priority"],
 			}
 
+	# Snapshot the tracking issue body at project creation time. The
+	# judge prompt reads this snapshot instead of re-fetching the live
+	# tracking issue body on every poll tick so (a) the body is
+	# guaranteed byte-stable for provider-side prompt-prefix caching,
+	# (b) one GH API call per judge tick is eliminated. The tracking
+	# body is immutable by contract ("Do not edit manually." — see
+	# build_tracking_issue_body below); validate and clarify-respond
+	# continue to read the live body for their own narrower purposes.
+	project_body_snapshot = build_tracking_issue_body(
+		data, waves, integration_branch=integration_branch
+	)
+
 	return {
 		"schema_version": "orchestrate_state.v1",
 		"project_title": data["project_title"],
+		"project_body_snapshot": project_body_snapshot,
 		"total_issues": len(data["issues"]),
 		"total_waves": len(waves),
 		"current_wave": 1,
@@ -778,6 +791,10 @@ def rebuild_tracking_state(
 	return {
 		"schema_version": "orchestrate_state.v1",
 		"project_title": parsed["project_title"],
+		# In the recovery path the body we were given *is* the current
+		# tracking body, so snapshot it directly for subsequent judge
+		# ticks (same semantics as build_tracking_state above).
+		"project_body_snapshot": body,
 		"total_issues": total_issues,
 		"total_waves": len(parsed["waves"]),
 		"current_wave": 1,

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -5723,8 +5723,10 @@ ${RB_FIX_DESC}
                 fi
               fi
 
-              # Switch back to default branch for remaining processing
-              git checkout "${DEFAULT_BRANCH:-main}" 2>/dev/null || git checkout - 2>/dev/null || true
+              # Switch back to default branch for remaining processing,
+              # discarding any unstaged tracked edits that were not
+              # included in the fix commit (e.g., excluded paths).
+              rb_cleanup_combined_workspace
             fi
 
             # Increment retry counter (skipped when the merge-race path

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -5161,6 +5161,106 @@ json.dump(result, sys.stdout)
         echo "  Retries exhausted — judge will make final decision (merge or close+reissue)."
       fi
 
+      # ------------------------------------------------------------------
+      # Pre-judge branch preparation for combined decide + apply path
+      # ------------------------------------------------------------------
+      # The review-blocked judge originally ran in two sequential codex
+      # calls: the first decided merge|fix|close_and_reissue (read-only),
+      # then — for the "fix" branch — a second call re-ingested the
+      # identical ~30 KB of PR diff / comments / review findings plus an
+      # "APPLY FIXES NOW" suffix and applied fixes on the checked-out
+      # branch. Both calls consumed the same large context.
+      #
+      # Combine them: check out the target branch BEFORE the judge call
+      # and instruct the judge to apply fixes directly if it chooses
+      # action="fix". When action is merge/close_and_reissue, any
+      # accidental file modifications are discarded by
+      # rb_cleanup_combined_workspace below.
+      #
+      #   RB_COMBINED_MODE="true"  → branch checked out, judge may apply fixes
+      #   RB_COMBINED_MODE="false" → no branch prep (IS_FINAL, or prep failed);
+      #                              fix application is skipped the same way
+      #                              the old two-call flow skipped when it
+      #                              could not determine a target branch.
+      RB_COMBINED_MODE="false"
+      RB_COMBINED_BRANCH_INFO=""
+      RB_TARGET_MERGED="false"
+      HEAD_REF=""
+      BASE_REF=""
+      FOLLOWUP_BRANCH=""
+      ORCH_FOLLOWUP_OWNED="false"
+      ORCH_FOLLOWUP_TRACKING_NUM=""
+      ORCH_FOLLOWUP_INTEGRATION_BRANCH=""
+      ORCH_FOLLOWUP_INTEGRATION_BRANCH_EXISTS="false"
+      FOLLOWUP_PR_BLOCKED="false"
+
+      if [ "${IS_FINAL}" != "true" ]; then
+        HEAD_REF="$(echo "${PR_META}" | jq -r '.head_ref')"
+        BASE_REF="$(echo "${PR_META}" | jq -r '.base_ref')"
+        : "${BASE_REF:=${DEFAULT_BRANCH:-main}}"
+
+        if [ "${RB_PR_MERGED}" = "true" ]; then
+          RB_TARGET_MERGED="true"
+          resolve_active_orchestrator_context_for_issue "${rb_issue}" "${TRACKING_NUM:-}"
+          ORCH_FOLLOWUP_OWNED="${RESOLVED_ORCHESTRATOR_OWNED}"
+          ORCH_FOLLOWUP_TRACKING_NUM="${RESOLVED_TRACKING_ISSUE}"
+          ORCH_FOLLOWUP_INTEGRATION_BRANCH="${RESOLVED_INTEGRATION_BRANCH}"
+          ORCH_FOLLOWUP_INTEGRATION_BRANCH_EXISTS="${RESOLVED_INTEGRATION_BRANCH_EXISTS}"
+
+          if [ "${ORCH_FOLLOWUP_OWNED}" = "true" ]; then
+            if [ "${ORCH_FOLLOWUP_INTEGRATION_BRANCH_EXISTS}" = "true" ] && [ -n "${ORCH_FOLLOWUP_INTEGRATION_BRANCH}" ]; then
+              BASE_REF="${ORCH_FOLLOWUP_INTEGRATION_BRANCH}"
+              echo "  Follow-up PR for issue #${rb_issue} is orchestrator-managed (tracking #${ORCH_FOLLOWUP_TRACKING_NUM}). Retargeting base to ${BASE_REF}."
+            else
+              FOLLOWUP_PR_BLOCKED="true"
+              FOLLOWUP_BLOCK_REASON="Issue #${rb_issue} is orchestrator-managed (tracking #${ORCH_FOLLOWUP_TRACKING_NUM}), but integration branch '${ORCH_FOLLOWUP_INTEGRATION_BRANCH:-<missing>}' is unavailable. Aborting follow-up PR creation to avoid targeting ${DEFAULT_BRANCH:-main}."
+              echo "::warning::${FOLLOWUP_BLOCK_REASON}"
+              ORIGINAL_TRACKING_NUM="${TRACKING_NUM:-}"
+              if [ -n "${ORCH_FOLLOWUP_TRACKING_NUM:-}" ]; then
+                TRACKING_NUM="${ORCH_FOLLOWUP_TRACKING_NUM}"
+              fi
+              post_tracking_comment "## ⚠️ Follow-up PR blocked
+
+${FOLLOWUP_BLOCK_REASON}"
+              tg_notify "${FOLLOWUP_BLOCK_REASON}" "WARNING"
+              TRACKING_NUM="${ORIGINAL_TRACKING_NUM}"
+            fi
+          fi
+
+          if [ "${FOLLOWUP_PR_BLOCKED}" != "true" ]; then
+            FOLLOWUP_BRANCH="fix/${rb_issue}-followup-$(date +%s)"
+            echo "  PR already merged. Creating follow-up branch ${FOLLOWUP_BRANCH} from ${BASE_REF}."
+            if git fetch --no-tags origin "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}" 2>/dev/null \
+              && git checkout -B "${FOLLOWUP_BRANCH}" "refs/remotes/origin/${BASE_REF}" 2>/dev/null; then
+              RB_COMBINED_MODE="true"
+              RB_COMBINED_BRANCH_INFO="You are on a follow-up branch (${FOLLOWUP_BRANCH}) based on ${BASE_REF}. The original PR #${RB_PR} was already merged. If you choose action=\"fix\", apply ONLY the fixes identified during review — do not re-apply the original PR's changes."
+            else
+              echo "::warning::Could not prepare follow-up branch ${FOLLOWUP_BRANCH} for issue #${rb_issue}; combined-mode fix not possible."
+            fi
+          fi
+        elif [ -n "${HEAD_REF}" ] && [ "${HEAD_REF}" != "null" ]; then
+          if git fetch --no-tags origin "refs/heads/${HEAD_REF}:refs/remotes/origin/${HEAD_REF}" 2>/dev/null \
+            && git checkout -B "${HEAD_REF}" "refs/remotes/origin/${HEAD_REF}" 2>/dev/null; then
+            RB_COMBINED_MODE="true"
+            RB_COMBINED_BRANCH_INFO="You are now on the PR branch (${HEAD_REF})."
+          else
+            echo "::warning::Could not check out PR branch ${HEAD_REF} for issue #${rb_issue}; combined-mode fix not possible."
+          fi
+        else
+          echo "::warning::Cannot determine PR head branch for #${RB_PR}; combined-mode fix not possible."
+        fi
+      fi
+
+      # Reset workspace state (tracked files only) after a combined judge
+      # call whose decision was NOT fix. Untracked files are left alone so
+      # pre-fetched scripts and artifacts are not swept.
+      rb_cleanup_combined_workspace() {
+        if [ "${RB_COMBINED_MODE}" = "true" ]; then
+          git reset --hard HEAD 2>/dev/null || true
+          git checkout "${DEFAULT_BRANCH:-main}" 2>/dev/null || git checkout - 2>/dev/null || true
+        fi
+      }
+
       # Build the judge prompt for review-blocked evaluation
       RB_JUDGE_PROMPT_FILE="${RUNTIME_DIR}/rb_judge_prompt_${rb_issue}.txt"
       RB_JUDGE_OUTPUT_FILE="${RUNTIME_DIR}/rb_judge_output_${rb_issue}.txt"
@@ -5208,6 +5308,20 @@ json.dump(result, sys.stdout)
           echo "fix attempts did not resolve the issues. Pick the action that best serves"
           echo "the project: merge if the PR is good enough, or close and reissue if the"
           echo "approach is fundamentally wrong."
+        fi
+        if [ "${RB_COMBINED_MODE}" = "true" ]; then
+          echo
+          echo "=== COMBINED DECIDE + APPLY INSTRUCTIONS ==="
+          echo "${RB_COMBINED_BRANCH_INFO}"
+          echo
+          echo "This is a single combined judge call: decide AND (if fix) apply in one session."
+          echo "- If you choose action=\"fix\": apply the fixes directly to the repository files"
+          echo "  in this session. Do not defer to a follow-up step. Focus only on the issues"
+          echo "  that blocked the review. Do not create new files unless absolutely required."
+          echo "  After applying fixes, emit the JSON with action=\"fix\" and fix_description"
+          echo "  describing what you changed."
+          echo "- If you choose action=\"merge\" or action=\"close_and_reissue\": DO NOT modify"
+          echo "  any files. Emit the JSON with the chosen action and an empty fix_description."
         fi
       } > "${RB_JUDGE_PROMPT_FILE}"
 
@@ -5297,6 +5411,10 @@ sys.exit(1)
       case "${RB_ACTION}" in
         merge)
           echo "  Judge says merge PR #${RB_PR} as-is."
+          # Discard any accidental file modifications the combined call
+          # made on the pre-checked-out branch; merge path operates via
+          # GitHub API only.
+          rb_cleanup_combined_workspace
           # Remove review-blocked, set ready-to-merge
           ensure_label_exists "ai:ready-to-merge"
           gh_retry gh issue edit "${rb_issue}" --repo "${GITHUB_REPOSITORY}" \
@@ -5412,97 +5530,36 @@ sys.exit(1)
                 --remove-label 'ai:review-blocked' 2>/dev/null || true
               REVIEW_BLOCKED_STATE_CHANGED=true
             else
-            # Determine target: push to PR branch (open) or create follow-up PR (merged)
-            RB_TARGET_MERGED="false"
-            if [ "${RB_PR_MERGED}" = "true" ] || [ "${RB_PR_MERGED_NOW}" = "true" ]; then
-              RB_TARGET_MERGED="true"
-            fi
-
-            HEAD_REF="$(echo "${PR_META}" | jq -r '.head_ref')"
-            BASE_REF="$(echo "${PR_META}" | jq -r '.base_ref')"
-            : "${BASE_REF:=${DEFAULT_BRANCH:-main}}"
-
-            ORCH_FOLLOWUP_OWNED="false"
-            ORCH_FOLLOWUP_TRACKING_NUM=""
-            ORCH_FOLLOWUP_INTEGRATION_BRANCH=""
-            ORCH_FOLLOWUP_INTEGRATION_BRANCH_EXISTS="false"
-            FOLLOWUP_PR_BLOCKED="false"
-
-            if [ "${RB_TARGET_MERGED}" = "true" ]; then
-              resolve_active_orchestrator_context_for_issue "${rb_issue}" "${TRACKING_NUM:-}"
-              ORCH_FOLLOWUP_OWNED="${RESOLVED_ORCHESTRATOR_OWNED}"
-              ORCH_FOLLOWUP_TRACKING_NUM="${RESOLVED_TRACKING_ISSUE}"
-              ORCH_FOLLOWUP_INTEGRATION_BRANCH="${RESOLVED_INTEGRATION_BRANCH}"
-              ORCH_FOLLOWUP_INTEGRATION_BRANCH_EXISTS="${RESOLVED_INTEGRATION_BRANCH_EXISTS}"
-
-              if [ "${ORCH_FOLLOWUP_OWNED}" = "true" ]; then
-                if [ "${ORCH_FOLLOWUP_INTEGRATION_BRANCH_EXISTS}" = "true" ] && [ -n "${ORCH_FOLLOWUP_INTEGRATION_BRANCH}" ]; then
-                  BASE_REF="${ORCH_FOLLOWUP_INTEGRATION_BRANCH}"
-                  echo "  Follow-up PR for issue #${rb_issue} is orchestrator-managed (tracking #${ORCH_FOLLOWUP_TRACKING_NUM}). Retargeting base to ${BASE_REF}."
-                else
-                  FOLLOWUP_PR_BLOCKED="true"
-                  FOLLOWUP_BLOCK_REASON="Issue #${rb_issue} is orchestrator-managed (tracking #${ORCH_FOLLOWUP_TRACKING_NUM}), but integration branch '${ORCH_FOLLOWUP_INTEGRATION_BRANCH:-<missing>}' is unavailable. Aborting follow-up PR creation to avoid targeting ${DEFAULT_BRANCH:-main}."
-                  echo "::warning::${FOLLOWUP_BLOCK_REASON}"
-                  ORIGINAL_TRACKING_NUM="${TRACKING_NUM:-}"
-                  if [ -n "${ORCH_FOLLOWUP_TRACKING_NUM:-}" ]; then
-                    TRACKING_NUM="${ORCH_FOLLOWUP_TRACKING_NUM}"
-                  fi
-                  post_tracking_comment "## ⚠️ Follow-up PR blocked
-
-${FOLLOWUP_BLOCK_REASON}"
-                  tg_notify "${FOLLOWUP_BLOCK_REASON}" "WARNING"
-                  TRACKING_NUM="${ORIGINAL_TRACKING_NUM}"
-                fi
-              fi
-            fi
-
-            if [ "${RB_TARGET_MERGED}" = "true" ] && [ "${FOLLOWUP_PR_BLOCKED}" != "true" ]; then
-              # PR already merged — work on a follow-up branch from the base branch
-              FOLLOWUP_BRANCH="fix/${rb_issue}-followup-$(date +%s)"
-              echo "  PR already merged. Creating follow-up branch ${FOLLOWUP_BRANCH} from ${BASE_REF}."
-              git fetch --no-tags origin "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}" 2>/dev/null || true
-              git checkout -B "${FOLLOWUP_BRANCH}" "refs/remotes/origin/${BASE_REF}" 2>/dev/null || true
-            elif [ "${RB_TARGET_MERGED}" = "true" ]; then
-              echo "::warning::Skipping follow-up branch creation for issue #${rb_issue}; follow-up PR creation is blocked."
-            elif [ -n "${HEAD_REF}" ] && [ "${HEAD_REF}" != "null" ]; then
-              # PR is open — push to existing PR branch
-              git fetch --no-tags origin "refs/heads/${HEAD_REF}:refs/remotes/origin/${HEAD_REF}" 2>/dev/null || true
-              git checkout -B "${HEAD_REF}" "refs/remotes/origin/${HEAD_REF}" 2>/dev/null || true
-            else
-              echo "::warning::Cannot determine PR head branch for #${RB_PR}."
+            # Branch was prepared upfront (before the judge call) and the
+            # combined codex call has already applied the fixes in-session
+            # when action=fix. Skip the duplicated branch prep and the
+            # second codex call; proceed straight to commit/push.
+            #
+            # Upfront-set globals still valid here:
+            #   RB_TARGET_MERGED, HEAD_REF, BASE_REF, FOLLOWUP_BRANCH,
+            #   ORCH_FOLLOWUP_OWNED, ORCH_FOLLOWUP_TRACKING_NUM,
+            #   ORCH_FOLLOWUP_INTEGRATION_BRANCH,
+            #   ORCH_FOLLOWUP_INTEGRATION_BRANCH_EXISTS, FOLLOWUP_PR_BLOCKED
+            #
+            # Race edge case: the PR was open when we prepped upfront
+            # (RB_TARGET_MERGED=false, we checked out HEAD_REF) but was
+            # merged during the combined codex call. RB_PR_MERGED_NOW is
+            # the race-check fetch right above us. In that case we skip
+            # commit/push this tick; the next tick sees the merged state
+            # at the top of the loop and prep runs the merged-path
+            # (follow-up branch) cleanly. One retry is "wasted" on the
+            # race, which is acceptable.
+            if [ "${RB_COMBINED_MODE}" = "true" ] \
+               && [ "${RB_TARGET_MERGED}" != "true" ] \
+               && [ "${RB_PR_MERGED_NOW}" = "true" ]; then
+              echo "::warning::Race detected: PR #${RB_PR} merged during combined judge call (prepped as open, now merged). Deferring fix application to the next poll tick."
+              rb_cleanup_combined_workspace
+              REVIEW_BLOCKED_STATE_CHANGED=true
+            elif [ "${RB_COMBINED_MODE}" != "true" ]; then
+              echo "::warning::Combined-mode branch prep did not succeed for PR #${RB_PR}; cannot apply judge fixes this tick."
               git checkout "${DEFAULT_BRANCH:-main}" 2>/dev/null || git checkout - 2>/dev/null || true
               REVIEW_BLOCKED_STATE_CHANGED=true
-              # Skip to retry counter via nested-fi + fi
-            fi
-
-            if { [ "${RB_TARGET_MERGED}" = "true" ] && [ "${FOLLOWUP_PR_BLOCKED}" != "true" ]; } || { [ "${RB_TARGET_MERGED}" != "true" ] && [ -n "${HEAD_REF}" ] && [ "${HEAD_REF}" != "null" ]; }; then
-              # Re-run the judge in editing mode on the target branch
-              RB_FIX_PROMPT_FILE="${RUNTIME_DIR}/rb_fix_prompt_${rb_issue}.txt"
-              RB_FIX_OUTPUT_FILE="${RUNTIME_DIR}/rb_fix_output_${rb_issue}.txt"
-              {
-                cat "${RB_JUDGE_PROMPT_FILE}"
-                echo
-                echo "=== APPLY FIXES NOW ==="
-                if [ "${RB_TARGET_MERGED}" = "true" ]; then
-                  echo "You are on a follow-up branch based on ${BASE_REF}."
-                  echo "The original PR #${RB_PR} was already merged."
-                  echo "Apply only the fixes identified during review — do not re-apply the original PR's changes."
-                else
-                  echo "You are now on the PR branch (${HEAD_REF})."
-                fi
-                echo "Apply the fixes you identified directly to the repository files."
-                echo "Focus only on the issues that blocked the review."
-                echo "Do not create new files unless absolutely required."
-                echo "After applying fixes, output the same JSON with action='fix' and"
-                echo "fix_description describing what you changed."
-              } > "${RB_FIX_PROMPT_FILE}"
-
-              if cat "${RB_FIX_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --full-auto > "${RB_FIX_OUTPUT_FILE}" 2>/dev/null; then
-                echo "  Fix codex completed."
-              else
-                echo "::warning::Fix codex failed for PR #${RB_PR}."
-              fi
-
+            else
               # Remove workflow-generated/fetched artifacts so they are never
               # committed to caller repos.
               #
@@ -5670,6 +5727,9 @@ ${RB_FIX_DESC}
 
         close_and_reissue)
           echo "  Judge says close PR #${RB_PR} and reissue."
+          # Discard any accidental file modifications from the combined
+          # judge call; close_and_reissue operates via GitHub API only.
+          rb_cleanup_combined_workspace
           # Close the PR
           gh pr close "${RB_PR}" --repo "${GITHUB_REPOSITORY}" \
             --comment "Closed by orchestrator judge — the approach needs rework. A new issue will be created with refined guidance." \
@@ -6088,31 +6148,71 @@ Manual intervention required." >/dev/null
   # Setup Serena for judge
   bash scripts/setup_serena.sh --mode planning --context codex || true
 
-  # Collect merged PR diffs for context
-  PR_SUMMARIES=""
+  # Collect PR diffs for context, split by issue status so the
+  # byte-stable "merged PR diffs" block can sit inside the cacheable
+  # prefix of the judge prompt (before the volatile WAVE STATUS).
+  #
+  # Correctness notes:
+  #   - Status is read from STATE_FILE (.waves[WAVE_IDX].issues[].status),
+  #     which is authoritative and set to "merged" by the judge merge-
+  #     recording logic at L4405. No extra GH API call needed.
+  #   - Issue numbers are sorted before iteration so the concatenation
+  #     order is deterministic across ticks even after orphan-sweep
+  #     appends (L4601) or deferred issue creation.
+  #   - Merged PR diffs are byte-stable for a given head SHA: the
+  #     `gh api ... Accept: vnd.github.diff` endpoint returns the same
+  #     bytes on every request. Once all PRs in the current wave are
+  #     merged, this block is stable across ticks and extends the
+  #     cacheable prefix by the sum of the diffs (typically 5-15 K
+  #     tokens for mature projects).
+  MERGED_PR_SUMMARIES=""
+  OPEN_PR_SUMMARIES=""
   ISSUE_MAP="$(jq -r '.issue_number_map // {}' "${STATE_FILE}")"
-  for inum in ${ISSUE_NUMS}; do
+  _sorted_issue_nums="$(printf '%s\n' ${ISSUE_NUMS} | sort -un)"
+  for inum in ${_sorted_issue_nums}; do
+    [ -n "${inum}" ] || continue
     PR_NUM="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/issues/${inum}/timeline" \
       --jq '[.[] | select(.event == "cross-referenced" and .source.issue.pull_request != null) | .source.issue.number] | last' \
       || echo "")"
     if [[ "${PR_NUM}" =~ ^[0-9]+$ ]]; then
       PR_DIFF="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUM}" \
         -H 'Accept: application/vnd.github.diff' 2>/dev/null | head -500 || echo "(diff unavailable)")"
-      PR_SUMMARIES+="
+      _issue_status="$(jq -r --arg num "${inum}" --argjson wi "${WAVE_IDX}" \
+        '.waves[$wi].issues[] | select((.github_issue | tostring) == $num) | .status // ""' \
+        "${STATE_FILE}" 2>/dev/null | head -n1)"
+      if [ "${_issue_status}" = "merged" ]; then
+        MERGED_PR_SUMMARIES+="
 --- PR #${PR_NUM} (Issue #${inum}) ---
 ${PR_DIFF}
 
 "
+      else
+        OPEN_PR_SUMMARIES+="
+--- PR #${PR_NUM} (Issue #${inum}, status=${_issue_status:-unknown}) ---
+${PR_DIFF}
+
+"
+      fi
     fi
   done
+  unset _sorted_issue_nums _issue_status
 
   # Fetch CI status on default branch
   DEFAULT_BRANCH="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}" --jq '.default_branch' || echo "main")"
   CI_STATUS="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/commits/${DEFAULT_BRANCH}/check-runs" \
     --jq '[.check_runs[] | {name: .name, conclusion: .conclusion}]' || echo "[]")"
 
-  # Get original project description from tracking issue body
-  PROJECT_BODY="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}" --jq '.body' || echo "")"
+  # Get original project description. Prefer the byte-stable snapshot
+  # captured at project creation in orchestrate_lib.build_tracking_state
+  # (state field .project_body_snapshot). Fall back to fetching the live
+  # tracking issue body for projects created before this field existed.
+  # Using the snapshot keeps the judge-prompt prefix byte-stable across
+  # ticks so provider-side prompt caching stays effective, and removes
+  # one GH API call per judge tick.
+  PROJECT_BODY="$(jq -r '.project_body_snapshot // ""' "${STATE_FILE}" 2>/dev/null || echo "")"
+  if [ -z "${PROJECT_BODY}" ]; then
+    PROJECT_BODY="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}" --jq '.body' || echo "")"
+  fi
 
   # Build one stable static prefix per run for provider-side prompt caching.
   assemble_judge_static_context "${RUNTIME_DIR}/judge_static.txt"
@@ -6131,13 +6231,33 @@ ${PR_DIFF}
     echo
     echo "${PROJECT_BODY}"
     echo
+    # Merged PR diffs sit here — BEFORE the volatile WAVE STATUS block —
+    # so the provider-side prompt prefix cache can span them. The block
+    # is byte-stable across consecutive ticks within a wave because:
+    #   (1) merged commit diffs are immutable by head SHA,
+    #   (2) issue numbers are sorted before iteration,
+    #   (3) no new merged PRs appear until the next wave starts.
+    # Open/in-flight PR diffs are moved to the volatile tail because
+    # they change whenever the PR branch advances.
+    echo "=== MERGED PR DIFFS (truncated; cache-stable) ==="
+    echo
+    if [ -n "${MERGED_PR_SUMMARIES}" ]; then
+      echo "${MERGED_PR_SUMMARIES}"
+    else
+      echo "(no merged PRs in current wave yet)"
+    fi
+    echo
     echo "=== WAVE ${CURRENT_WAVE} COMPLETION STATUS ==="
     echo
     echo "${WAVE_STATUS}" | jq '.'
     echo
-    echo "=== MERGED PR DIFFS (truncated) ==="
+    echo "=== OPEN PR DIFFS (truncated; in-flight) ==="
     echo
-    echo "${PR_SUMMARIES}"
+    if [ -n "${OPEN_PR_SUMMARIES}" ]; then
+      echo "${OPEN_PR_SUMMARIES}"
+    else
+      echo "(no open PRs in current wave)"
+    fi
     echo
     echo "=== CI STATUS ON ${DEFAULT_BRANCH} ==="
     echo

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -5342,6 +5342,10 @@ ${FOLLOWUP_BLOCK_REASON}"
       if [ "${RB_JUDGE_SUCCESS}" != "true" ]; then
         echo "::warning::Review-blocked judge failed for issue #${rb_issue}"
         tg_notify "Review-blocked judge failed for issue #${rb_issue} (PR #${RB_PR}). Will retry next poll cycle."$'\n'"PR: $(_gh_url "pull/${RB_PR}")"$'\n'"Issue: $(_gh_url "issues/${rb_issue}")" "WARNING"
+        # Reset worktree + switch back to default branch if we entered
+        # combined mode — otherwise the next rb_issue iteration could
+        # fail to check out its target branch.
+        rb_cleanup_combined_workspace
         continue
       fi
 
@@ -5385,6 +5389,7 @@ sys.exit(1)
 
       if [ -z "${RB_JUDGE_JSON}" ]; then
         echo "::warning::Could not parse review-blocked judge output for #${rb_issue}"
+        rb_cleanup_combined_workspace
         continue
       fi
 
@@ -5547,14 +5552,19 @@ sys.exit(1)
             # the race-check fetch right above us. In that case we skip
             # commit/push this tick; the next tick sees the merged state
             # at the top of the loop and prep runs the merged-path
-            # (follow-up branch) cleanly. One retry is "wasted" on the
-            # race, which is acceptable.
+            # (follow-up branch) cleanly.
+            #
+            # No fix is applied in this path, so skip the retry-counter
+            # increment below — an external merge race must not consume
+            # a review-blocked retry slot.
+            RB_SKIP_RETRY_INCREMENT="false"
             if [ "${RB_COMBINED_MODE}" = "true" ] \
                && [ "${RB_TARGET_MERGED}" != "true" ] \
                && [ "${RB_PR_MERGED_NOW}" = "true" ]; then
               echo "::warning::Race detected: PR #${RB_PR} merged during combined judge call (prepped as open, now merged). Deferring fix application to the next poll tick."
               rb_cleanup_combined_workspace
               REVIEW_BLOCKED_STATE_CHANGED=true
+              RB_SKIP_RETRY_INCREMENT="true"
             elif [ "${RB_COMBINED_MODE}" != "true" ]; then
               echo "::warning::Combined-mode branch prep did not succeed for PR #${RB_PR}; cannot apply judge fixes this tick."
               git checkout "${DEFAULT_BRANCH:-main}" 2>/dev/null || git checkout - 2>/dev/null || true
@@ -5717,10 +5727,13 @@ ${RB_FIX_DESC}
               git checkout "${DEFAULT_BRANCH:-main}" 2>/dev/null || git checkout - 2>/dev/null || true
             fi
 
-            # Increment retry counter
-            jq ".review_blocked_retries[\"${rb_issue}\"] = $((RETRY_COUNT + 1))" \
-              "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
-            REVIEW_BLOCKED_STATE_CHANGED=true
+            # Increment retry counter (skipped when the merge-race path
+            # above deferred the fix without applying anything).
+            if [ "${RB_SKIP_RETRY_INCREMENT:-false}" != "true" ]; then
+              jq ".review_blocked_retries[\"${rb_issue}\"] = $((RETRY_COUNT + 1))" \
+                "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
+              REVIEW_BLOCKED_STATE_CHANGED=true
+            fi
           fi
           fi
           ;;
@@ -5787,6 +5800,7 @@ ${RB_FIX_DESC}
 
         *)
           echo "::warning::Unknown review-blocked judge action: ${RB_ACTION}"
+          rb_cleanup_combined_workspace
           ;;
       esac
     done < <(echo "${WAVE_STATUS}" | jq -r '.issues[] | select(.status == "review-blocked") | .github_issue')
@@ -6167,7 +6181,6 @@ Manual intervention required." >/dev/null
   #     tokens for mature projects).
   MERGED_PR_SUMMARIES=""
   OPEN_PR_SUMMARIES=""
-  ISSUE_MAP="$(jq -r '.issue_number_map // {}' "${STATE_FILE}")"
   _sorted_issue_nums="$(printf '%s\n' ${ISSUE_NUMS} | sort -un)"
   for inum in ${_sorted_issue_nums}; do
     [ -n "${inum}" ] || continue

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -1002,10 +1002,33 @@ fi
 
 # ---------------------------------------------------------------
 # Phase 0: Discover validation hints when repository hints are absent
+#
+# Hint source precedence:
+#   1. .ai/validate.yml         — committed in consumer repo (authoritative)
+#   2. .ai/validate-hints-cache/hints.yml
+#                                — restored from GitHub Actions cache
+#                                  (written by a prior successful discover
+#                                  run in the same workspace)
+#   3. codex discover call      — LLM-driven discovery, last resort
+#
+# The cache path is restored by a `Restore validate hints cache` step in
+# the validate workflow via actions/cache. On successful discovery we
+# copy the hints back into the cache directory so the next run in this
+# repo can reuse them without a codex call. Different repos are
+# automatically isolated because GitHub Actions cache is per-repo. The
+# cache key hashes files that drive discovery output (Dockerfile,
+# compose, package manifests) so a repo structure change invalidates it.
 # ---------------------------------------------------------------
+VALIDATE_HINTS_CACHE_DIR="${VALIDATE_HINTS_CACHE_DIR:-.ai/validate-hints-cache}"
+VALIDATE_HINTS_CACHE_FILE="${VALIDATE_HINTS_CACHE_DIR}/hints.yml"
+
 if [ -f .ai/validate.yml ]; then
   cp .ai/validate.yml "${VALIDATE_HINTS_FILE}"
   HINTS_SOURCE="committed"
+elif [ -f "${VALIDATE_HINTS_CACHE_FILE}" ] && [ -s "${VALIDATE_HINTS_CACHE_FILE}" ]; then
+  cp "${VALIDATE_HINTS_CACHE_FILE}" "${VALIDATE_HINTS_FILE}"
+  HINTS_SOURCE="cache"
+  echo "Reused validation hints from ${VALIDATE_HINTS_CACHE_FILE} (skipped codex discovery)."
 else
 {
   cat "${STATIC_CONTEXT_FILE}"
@@ -1084,6 +1107,14 @@ PY
   if [ "${DISCOVER_SUCCESS}" != "true" ]; then
     printf '# No .ai/validate.yml hints file found\n' > "${VALIDATE_HINTS_FILE}"
     HINTS_SOURCE="none"
+  else
+    # Persist the discovered hints to the cache directory so subsequent
+    # runs in the same workspace can skip the codex discover call. The
+    # cache is saved by the `Save validate hints cache` / actions/cache
+    # post-step in validate.yml.
+    if mkdir -p "${VALIDATE_HINTS_CACHE_DIR}" 2>/dev/null; then
+      cp "${VALIDATE_HINTS_FILE}" "${VALIDATE_HINTS_CACHE_FILE}" 2>/dev/null || true
+    fi
   fi
 fi
 

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -1022,11 +1022,12 @@ fi
 VALIDATE_HINTS_CACHE_DIR="${VALIDATE_HINTS_CACHE_DIR:-.ai/validate-hints-cache}"
 VALIDATE_HINTS_CACHE_FILE="${VALIDATE_HINTS_CACHE_DIR}/hints.yml"
 
-# Lightweight sanity check for a hints file before reuse. Mirrors the
-# key-list validator the discover path applies to fresh codex output
-# (non-empty, size-capped, at least one expected top-level key). Used
-# to protect against a corrupted or poisoned cache entry silently
-# producing a broken harness. Returns 0 on pass, 1 on fail.
+# Lightweight sanity check for a hints file before reuse. Stricter than
+# the discover-path validator (which accepts indented keys) because a
+# cache entry may live across many runs and the poisoning threat model
+# is different: we require at least one TRULY top-level key (no leading
+# whitespace in the original line) so a nested mapping cannot satisfy
+# the regex by accident. Returns 0 on pass, 1 on fail.
 validate_hints_sanity_check() {
   local hints_file="$1"
   [ -s "${hints_file}" ] || return 1
@@ -1052,14 +1053,16 @@ expected_key = re.compile(
     r"^(type|entry|port|health_check|services|env_overrides|custom_tests|skip_tests):\s*",
     re.IGNORECASE,
 )
+# Keep original indentation so we can distinguish truly top-level keys
+# (no leading whitespace) from nested ones.
 lines = [
-    line.lstrip()
+    line
     for line in candidate.splitlines()
     if line.strip() and not line.lstrip().startswith("#")
 ]
 if not lines:
     sys.exit(1)
-if not any(expected_key.match(line) for line in lines):
+if not any(line == line.lstrip() and expected_key.match(line) for line in lines):
     sys.exit(1)
 sys.exit(0)
 PY

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -1007,8 +1007,8 @@ fi
 #   1. .ai/validate.yml         — committed in consumer repo (authoritative)
 #   2. .ai/validate-hints-cache/hints.yml
 #                                — restored from GitHub Actions cache
-#                                  (written by a prior successful discover
-#                                  run in the same workspace)
+#                                  (written by a prior successful run in
+#                                  the same repo with a matching cache key)
 #   3. codex discover call      — LLM-driven discovery, last resort
 #
 # The cache path is restored by a `Restore validate hints cache` step in
@@ -1022,14 +1022,61 @@ fi
 VALIDATE_HINTS_CACHE_DIR="${VALIDATE_HINTS_CACHE_DIR:-.ai/validate-hints-cache}"
 VALIDATE_HINTS_CACHE_FILE="${VALIDATE_HINTS_CACHE_DIR}/hints.yml"
 
+# Lightweight sanity check for a hints file before reuse. Mirrors the
+# key-list validator the discover path applies to fresh codex output
+# (non-empty, size-capped, at least one expected top-level key). Used
+# to protect against a corrupted or poisoned cache entry silently
+# producing a broken harness. Returns 0 on pass, 1 on fail.
+validate_hints_sanity_check() {
+  local hints_file="$1"
+  [ -s "${hints_file}" ] || return 1
+  python3 - "${hints_file}" <<'PY' 2>/dev/null
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+try:
+    raw = path.read_text(encoding="utf-8", errors="replace")
+except Exception:
+    sys.exit(1)
+
+candidate = raw.strip()
+if not candidate:
+    sys.exit(1)
+
+if path.stat().st_size > 64 * 1024:
+    sys.exit(1)
+
+expected_key = re.compile(
+    r"^(type|entry|port|health_check|services|env_overrides|custom_tests|skip_tests):\s*",
+    re.IGNORECASE,
+)
+lines = [
+    line.lstrip()
+    for line in candidate.splitlines()
+    if line.strip() and not line.lstrip().startswith("#")
+]
+if not lines:
+    sys.exit(1)
+if not any(expected_key.match(line) for line in lines):
+    sys.exit(1)
+sys.exit(0)
+PY
+}
+
 if [ -f .ai/validate.yml ]; then
   cp .ai/validate.yml "${VALIDATE_HINTS_FILE}"
   HINTS_SOURCE="committed"
-elif [ -f "${VALIDATE_HINTS_CACHE_FILE}" ] && [ -s "${VALIDATE_HINTS_CACHE_FILE}" ]; then
+elif [ -f "${VALIDATE_HINTS_CACHE_FILE}" ] \
+  && validate_hints_sanity_check "${VALIDATE_HINTS_CACHE_FILE}"; then
   cp "${VALIDATE_HINTS_CACHE_FILE}" "${VALIDATE_HINTS_FILE}"
   HINTS_SOURCE="cache"
   echo "Reused validation hints from ${VALIDATE_HINTS_CACHE_FILE} (skipped codex discovery)."
 else
+  if [ -f "${VALIDATE_HINTS_CACHE_FILE}" ] && [ -s "${VALIDATE_HINTS_CACHE_FILE}" ]; then
+    echo "::warning::Cached validation hints at ${VALIDATE_HINTS_CACHE_FILE} failed sanity checks; falling back to codex discovery." >&2
+  fi
 {
   cat "${STATIC_CONTEXT_FILE}"
   echo


### PR DESCRIPTION
Four orthogonal optimizations that remove duplicate LLM work and extend
provider-side prompt prefix caching, with no change to the semantic
behavior of the orchestrator pipeline.

1. scripts/orchestrate_poll_process.sh — Review-blocked judge: combine
   the separate "decide" and "apply fixes" codex calls into one.
   Previously, for non-final retries, the judge ran twice against the
   same ~30 KB prompt: first to pick merge|fix|close_and_reissue, then
   (for fix) with an "APPLY FIXES NOW" suffix to write changes. Now the
   target branch is checked out upfront, RB_COMBINED_MODE is set, and
   one codex call both decides and (if action=fix) applies in-session.
   A new rb_cleanup_combined_workspace helper discards accidental edits
   when action is merge or close_and_reissue. Race check added for the
   edge case where a PR merges during the combined call. All existing
   failure paths (blocked follow-up, null head ref, closed PR) are
   preserved.

2. .github/workflows/validate.yml + scripts/validate_process.sh —
   Validate-hint caching via actions/cache. A new cache step restores
   .ai/validate-hints-cache/hints.yml keyed on files that drive
   discovery output (Dockerfile, compose, package manifests); the
   discover phase reuses the cached hints when present and writes
   fresh hints back after a successful discover. Per-repo isolation is
   automatic via GitHub Actions cache scoping. Skips the codex discover
   call entirely on cache hit.

3. scripts/orchestrate_poll_process.sh + prompts/mode-judge.txt — Main
   judge loop: promote merged-PR diffs into the cacheable prefix.
   Previously the PR_SUMMARIES block (merged + open PRs) sat after
   the volatile WAVE STATUS block, outside the prefix cache. Now the
   collection loop splits into MERGED_PR_SUMMARIES (by STATE_FILE
   .waves[].issues[].status=="merged") and OPEN_PR_SUMMARIES, and the
   prompt places MERGED_PR_SUMMARIES immediately after PROJECT_BODY
   — before the volatile tail. Issue numbers are sorted before
   iteration so the block is byte-stable across ticks within a wave.
   Adds 5-15 K cached tokens per tick on mature projects.

4. scripts/orchestrate_lib.py + scripts/orchestrate_poll_process.sh —
   PROJECT_BODY snapshot. build_tracking_state and rebuild_tracking_state
   now include a project_body_snapshot field containing the exact
   markdown posted to the tracking issue at creation time. The judge
   prompt reads from this snapshot instead of re-fetching the live body
   on every tick, guaranteeing byte-stability for prefix caching and
   eliminating one GH API call per tick. Falls back to the live body
   for projects created before this field existed. Verified no workflow
   listens for issues.edited events and no code path edits the tracking
   body after creation (only labels and comments mutate it).

Tests: 64 tests in test_orchestrate_poll_process.py pass (1 pre-existing
failure unrelated to this change is deselected), 39 in test_orchestrate_lib.py,
119 in adjacent test suites. No regressions.