### PR TITLE
claude/analyze-job-logs-gDmKb

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1178,11 +1178,19 @@ jobs:
             TOTAL_JOBS=$(echo "$JOBS_JSON" | jq '.jobs | length')
             SKIPPED_JOBS=$(echo "$JOBS_JSON" | jq '[.jobs[] | select(.conclusion == "skipped")] | length')
             if [ "$TOTAL_JOBS" -eq 0 ]; then
-              # No jobs at all — typically a spurious re-trigger where the reusable
-              # workflow's job-level if: condition filtered out the only job before
-              # it materialized, so GitHub reports the run with zero jobs. Treat this
-              # the same as the all-skipped case: non-fatal.
-              echo "  │  ⊘ Run has no jobs (spurious re-trigger or not yet indexed) — OK"
+              # GitHub can briefly report zero jobs before the run is fully indexed.
+              # Re-fetch a few times so we don't false-pass real runs as spurious.
+              echo "  │  ⚠ Run has no jobs yet — rechecking for indexing delay..."
+              for _jobs_retry in 1 2 3; do
+                sleep $((_jobs_retry * 2))
+                JOBS_JSON=$(gh api "repos/${TEST_REPO}/actions/runs/${run_id}/jobs?per_page=100" 2>/dev/null || echo '{"jobs":[]}')
+                TOTAL_JOBS=$(echo "$JOBS_JSON" | jq '.jobs | length')
+                SKIPPED_JOBS=$(echo "$JOBS_JSON" | jq '[.jobs[] | select(.conclusion == "skipped")] | length')
+                [ "$TOTAL_JOBS" -gt 0 ] && break
+              done
+            fi
+            if [ "$TOTAL_JOBS" -eq 0 ]; then
+              echo "  │  ⊘ Run has no jobs after retries (spurious re-trigger) — OK"
               echo "  └─"
               return 0
             fi

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1177,7 +1177,16 @@ jobs:
             # internal-implement.yml but the reusable workflow skips the job.
             TOTAL_JOBS=$(echo "$JOBS_JSON" | jq '.jobs | length')
             SKIPPED_JOBS=$(echo "$JOBS_JSON" | jq '[.jobs[] | select(.conclusion == "skipped")] | length')
-            if [ "$TOTAL_JOBS" -gt 0 ] && [ "$SKIPPED_JOBS" -eq "$TOTAL_JOBS" ]; then
+            if [ "$TOTAL_JOBS" -eq 0 ]; then
+              # No jobs at all — typically a spurious re-trigger where the reusable
+              # workflow's job-level if: condition filtered out the only job before
+              # it materialized, so GitHub reports the run with zero jobs. Treat this
+              # the same as the all-skipped case: non-fatal.
+              echo "  │  ⊘ Run has no jobs (spurious re-trigger or not yet indexed) — OK"
+              echo "  └─"
+              return 0
+            fi
+            if [ "$SKIPPED_JOBS" -eq "$TOTAL_JOBS" ]; then
               echo "  │  ⊘ All ${TOTAL_JOBS} job(s) were skipped (spurious re-trigger) — OK"
               echo "  └─"
               return 0
@@ -1257,7 +1266,10 @@ jobs:
           echo "  Totals: ${TOTAL_OK} ok, ${TOTAL_FAILED} failed, ${TOTAL_SKIPPED} skipped"
           echo "───────────────────────────────────────────"
 
-          if [ "$TOTAL_FAILED" -gt 0 ]; then
+          # Print the failed-steps list whenever deep verify did not fully pass,
+          # so "no steps found in run" / "run ID not found" entries (which do not
+          # increment TOTAL_FAILED) are still surfaced in the summary.
+          if [ "$DEEP_PASS" != "true" ] || [ "$TOTAL_FAILED" -gt 0 ]; then
             echo ""
             echo "  Failed steps:"
             echo -e "$FAILED_STEPS"


### PR DESCRIPTION
The E2E smoke test deep-verify step was marking the run as failed when
the GitHub API returned 0 jobs for a workflow run (typically a spurious
re-trigger whose reusable job was filtered out before materializing).
The existing all-skipped guard only caught the TOTAL_JOBS > 0 case, so
TOTAL_JOBS == 0 fell through to the fatal "no steps found" branch.

Also fix the summary output gate so "no steps found" / "run ID not
found" entries (which do not bump TOTAL_FAILED) are still surfaced
under the "Failed steps:" section whenever DEEP_PASS is false.