### PR TITLE
claude/suppress-autofix-alerts-1xJLp

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2959,7 +2959,7 @@ jobs:
           tg_send_tracked "${PR_NUMBER}" "${MSG}" "CRITICAL"
 
       - name: Check PR state before failure alerts
-        if: (failure() || cancelled()) && env.PR_CLOSED != 'true'
+        if: failure() && env.PR_CLOSED != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
@@ -2971,7 +2971,7 @@ jobs:
           fi
 
       - name: Mark linked issues review-blocked (workflow failure)
-        if: (failure() || cancelled()) && env.PR_CLOSED != 'true'
+        if: failure() && env.PR_CLOSED != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           REPOSITORY: ${{ github.repository }}
@@ -3011,7 +3011,7 @@ jobs:
           done <<< "${ISSUE_NUMBERS}"
 
       - name: Post review-blocked comment on PR (workflow failure)
-        if: (failure() || cancelled()) && env.PR_CLOSED != 'true'
+        if: failure() && env.PR_CLOSED != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
@@ -3034,7 +3034,7 @@ jobs:
           gh_retry gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -f body="${BODY}" >/dev/null 2>&1 || true
 
       - name: Telegram failure
-        if: (failure() || cancelled()) && env.PR_CLOSED != 'true'
+        if: failure() && env.PR_CLOSED != 'true'
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
@@ -3053,11 +3053,7 @@ jobs:
             -F number="${PR_NUMBER}" \
             -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){closingIssuesReferences(first:1){nodes{number}}}}}' \
             --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[0].number // empty' 2>/dev/null || true)"
-          if [ "${{ job.status }}" = "cancelled" ]; then
-            MSG="PR autofix cancelled/timed out"
-          else
-            MSG="PR autofix failed"
-          fi
+          MSG="PR autofix failed"
           MSG+=$'\n'
           MSG+="PR: ${PR_URL}"
           if [ -n "${ISSUE_NUM}" ]; then


### PR DESCRIPTION
Gate the review_autofix failure-path steps (PR state check, review-blocked
labeling, PR comment, Telegram alert) on failure() only, so cancellations
(concurrency supersedes or manual cancel) no longer trigger spurious
"PR autofix cancelled/timed out" notifications. A superseding run or the
orchestrate poller handles the PR; real failures still alert.