### PR TITLE
claude/analyze-job-logs-MkOoH

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1172,6 +1172,22 @@ jobs:
             # iterate over null (null)" on any error-body document whose .jobs
             # key is missing. Always assign the fallback outside the command
             # substitution so the two outputs can't concatenate.
+            #
+            # Single source of truth for the schema predicate. Uses `jq -se`
+            # (slurp + exit-status) so multi-document input fails the
+            # predicate — without `-s`, `jq -e` evaluates each document
+            # independently and exits with the truthiness of the *last*
+            # document, so a multi-doc blob whose tail happens to satisfy
+            # the schema would pass through and break downstream
+            # `jq '.jobs | length'` with mixed-line output. Extracted into a
+            # helper so the outer retry and the indexing-delay recheck stay
+            # in lock-step.
+            _jobs_json_valid() {
+              printf '%s' "$1" \
+                | jq -se 'length == 1 and (.[0] | type == "object" and (.jobs | type == "array"))' \
+                >/dev/null 2>&1
+            }
+
             JOBS_JSON='{"jobs":[]}'
             for _attempt in 1 2 3; do
               if _JOBS_OUT=$(gh api "repos/${TEST_REPO}/actions/runs/${run_id}/jobs?per_page=100" 2>/dev/null); then
@@ -1182,18 +1198,11 @@ jobs:
               sleep 2
             done
             unset _JOBS_OUT
-            # Shape check: reject anything that isn't a single JSON object with
-            # a `.jobs` array. This catches (a) all-retries-failed with an empty
-            # JOBS_JSON, (b) error-body responses that happen to parse, and
-            # (c) any future accidental multi-doc concatenation.
-            # Use `jq -se` (slurp + exit-status) so multi-document input
-            # (concatenated objects) fails the predicate. Without `-s`,
-            # `jq -e` evaluates each document independently and exits with
-            # the truthiness of the *last* document, so a multi-doc blob
-            # whose tail happens to satisfy the schema would pass through
-            # and break downstream `jq '.jobs | length'` with mixed-line
-            # output.
-            if ! printf '%s' "$JOBS_JSON" | jq -se 'length == 1 and (.[0] | type == "object" and (.jobs | type == "array"))' >/dev/null 2>&1; then
+            # Shape check: reject anything that isn't a single JSON object
+            # with a `.jobs` array. Catches (a) all-retries-failed with an
+            # empty JOBS_JSON, (b) error-body responses that happen to parse,
+            # and (c) any future accidental multi-doc concatenation.
+            if ! _jobs_json_valid "$JOBS_JSON"; then
               JOBS_JSON='{"jobs":[]}'
             fi
 
@@ -1218,9 +1227,7 @@ jobs:
                   JOBS_JSON='{"jobs":[]}'
                 fi
                 unset _JOBS_OUT
-                # Slurp + length==1 (see outer retry comment) so multi-doc
-                # blobs don't pass the per-document evaluation of `jq -e`.
-                if ! printf '%s' "$JOBS_JSON" | jq -se 'length == 1 and (.[0] | type == "object" and (.jobs | type == "array"))' >/dev/null 2>&1; then
+                if ! _jobs_json_valid "$JOBS_JSON"; then
                   JOBS_JSON='{"jobs":[]}'
                 fi
                 TOTAL_JOBS=$(echo "$JOBS_JSON" | jq '.jobs | length')

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1159,15 +1159,34 @@ jobs:
             echo ""
             echo "  ┌─ ${phase_name} (run #${run_id})"
 
-            # Fetch all jobs and their steps (retry up to 3 times on transient failures)
+            # Fetch all jobs and their steps (retry up to 3 times on transient failures).
+            #
+            # IMPORTANT: Do NOT use `JOBS_JSON=$(gh api ... || echo fallback)`.
+            # On non-zero exit, `gh api` still writes the API error body (e.g.
+            # `{"message":"Not Found",...}`) to stdout; inside `$(...)`, the
+            # `|| echo` branch runs anyway and its output is *concatenated*
+            # with gh's stdout, producing a multi-document JSON blob. Downstream
+            # `jq '.jobs | length'` then emits multiple lines (one per document),
+            # `[ "$TOTAL_JOBS" -eq 0 ]` trips with "integer expression expected",
+            # and `jq '[.jobs[] | select(...)] | length'` errors with "Cannot
+            # iterate over null (null)" on any error-body document whose .jobs
+            # key is missing. Always assign the fallback outside the command
+            # substitution so the two outputs can't concatenate.
             JOBS_JSON='{"jobs":[]}'
             for _attempt in 1 2 3; do
-              JOBS_JSON=$(gh api "repos/${TEST_REPO}/actions/runs/${run_id}/jobs?per_page=100" 2>/dev/null) && break
+              if _JOBS_OUT=$(gh api "repos/${TEST_REPO}/actions/runs/${run_id}/jobs?per_page=100" 2>/dev/null); then
+                JOBS_JSON="$_JOBS_OUT"
+                break
+              fi
               echo "  │  ⚠ API attempt ${_attempt}/3 failed — retrying in 2s..."
               sleep 2
             done
-            # Final fallback if all retries failed
-            if ! echo "$JOBS_JSON" | jq -e '.jobs' >/dev/null 2>&1; then
+            unset _JOBS_OUT
+            # Shape check: reject anything that isn't a single JSON object with
+            # a `.jobs` array. This catches (a) all-retries-failed with an empty
+            # JOBS_JSON, (b) error-body responses that happen to parse, and
+            # (c) any future accidental multi-doc concatenation.
+            if ! printf '%s' "$JOBS_JSON" | jq -e 'type == "object" and (.jobs | type == "array")' >/dev/null 2>&1; then
               JOBS_JSON='{"jobs":[]}'
             fi
 
@@ -1183,7 +1202,18 @@ jobs:
               echo "  │  ⚠ Run has no jobs yet — rechecking for indexing delay..."
               for _jobs_retry in 1 2 3; do
                 sleep $((_jobs_retry * 2))
-                JOBS_JSON=$(gh api "repos/${TEST_REPO}/actions/runs/${run_id}/jobs?per_page=100" 2>/dev/null || echo '{"jobs":[]}')
+                # Same hazard as the outer retry — assign fallback outside the
+                # command substitution so gh's error-body stdout cannot
+                # concatenate with the literal fallback JSON.
+                if _JOBS_OUT=$(gh api "repos/${TEST_REPO}/actions/runs/${run_id}/jobs?per_page=100" 2>/dev/null); then
+                  JOBS_JSON="$_JOBS_OUT"
+                else
+                  JOBS_JSON='{"jobs":[]}'
+                fi
+                unset _JOBS_OUT
+                if ! printf '%s' "$JOBS_JSON" | jq -e 'type == "object" and (.jobs | type == "array")' >/dev/null 2>&1; then
+                  JOBS_JSON='{"jobs":[]}'
+                fi
                 TOTAL_JOBS=$(echo "$JOBS_JSON" | jq '.jobs | length')
                 SKIPPED_JOBS=$(echo "$JOBS_JSON" | jq '[.jobs[] | select(.conclusion == "skipped")] | length')
                 [ "$TOTAL_JOBS" -gt 0 ] && break

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1186,7 +1186,14 @@ jobs:
             # a `.jobs` array. This catches (a) all-retries-failed with an empty
             # JOBS_JSON, (b) error-body responses that happen to parse, and
             # (c) any future accidental multi-doc concatenation.
-            if ! printf '%s' "$JOBS_JSON" | jq -e 'type == "object" and (.jobs | type == "array")' >/dev/null 2>&1; then
+            # Use `jq -se` (slurp + exit-status) so multi-document input
+            # (concatenated objects) fails the predicate. Without `-s`,
+            # `jq -e` evaluates each document independently and exits with
+            # the truthiness of the *last* document, so a multi-doc blob
+            # whose tail happens to satisfy the schema would pass through
+            # and break downstream `jq '.jobs | length'` with mixed-line
+            # output.
+            if ! printf '%s' "$JOBS_JSON" | jq -se 'length == 1 and (.[0] | type == "object" and (.jobs | type == "array"))' >/dev/null 2>&1; then
               JOBS_JSON='{"jobs":[]}'
             fi
 
@@ -1211,7 +1218,9 @@ jobs:
                   JOBS_JSON='{"jobs":[]}'
                 fi
                 unset _JOBS_OUT
-                if ! printf '%s' "$JOBS_JSON" | jq -e 'type == "object" and (.jobs | type == "array")' >/dev/null 2>&1; then
+                # Slurp + length==1 (see outer retry comment) so multi-doc
+                # blobs don't pass the per-document evaluation of `jq -e`.
+                if ! printf '%s' "$JOBS_JSON" | jq -se 'length == 1 and (.[0] | type == "object" and (.jobs | type == "array"))' >/dev/null 2>&1; then
                   JOBS_JSON='{"jobs":[]}'
                 fi
                 TOTAL_JOBS=$(echo "$JOBS_JSON" | jq '.jobs | length')

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -5257,18 +5257,29 @@ json.dump(result, sys.stdout)
         # late to correct the branch-prep decision. Keep _rb_pr_json in
         # sync so downstream consumers (e.g. RB_PR_MERGEABLE_STATE) see
         # the same snapshot.
+        # Snapshot the pre-refetch derived flags so we can roll back if the
+        # refreshed payload is invalid. _rb_pr_json itself is only replaced
+        # on success, so downstream consumers of _rb_pr_json stay in sync
+        # with RB_PR_STATE/RB_PR_MERGED regardless of which path we take.
         _rb_prev_pr_state="${RB_PR_STATE:-}"
         _rb_prev_pr_merged="${RB_PR_MERGED:-false}"
-        _rb_pr_json="$(_fetch_pr_json "${RB_PR}")"
-        RB_PR_STATE="$(_jq_field "${_rb_pr_json}" '.state' 'open|closed|merged')"
-        RB_PR_MERGED="$(_jq_field "${_rb_pr_json}" '.merged_at != null' 'true|false')"
-        [ -n "${RB_PR_MERGED}" ] || RB_PR_MERGED="false"
-        if [ "${_rb_pr_json}" = "{}" ] && [ "${_rb_prev_pr_merged}" = "true" ]; then
-          echo "::warning::[review-blocked] PR #${RB_PR} state refresh failed during branch prep; preserving earlier merged state to avoid misrouting follow-up preparation."
+        _rb_pr_json_refetched="$(_fetch_pr_json "${RB_PR}")"
+        if printf '%s' "${_rb_pr_json_refetched}" | jq -e 'type == "object" and ((.state // "") | IN("open","closed","merged"))' >/dev/null 2>&1; then
+          _rb_pr_json="${_rb_pr_json_refetched}"
+          RB_PR_STATE="$(_jq_field "${_rb_pr_json}" '.state' 'open|closed|merged')"
+          RB_PR_MERGED="$(_jq_field "${_rb_pr_json}" '.merged_at != null' 'true|false')"
+          : "${RB_PR_MERGED:=false}"
+        else
+          # Transient API failure or malformed response: keep the earlier
+          # snapshot entirely (both the JSON blob and the derived flags) so
+          # downstream consumers of _rb_pr_json — mergeable_state, head.sha,
+          # etc. — stay in sync with RB_PR_STATE/RB_PR_MERGED instead of
+          # getting a `{}` payload while the flags still say "merged".
+          echo "::warning::[review-blocked] Failed to refresh PR #${RB_PR} state with a valid payload during branch prep; keeping earlier snapshot."
           RB_PR_STATE="${_rb_prev_pr_state}"
           RB_PR_MERGED="${_rb_prev_pr_merged}"
         fi
-        unset _rb_prev_pr_state _rb_prev_pr_merged
+        unset _rb_prev_pr_state _rb_prev_pr_merged _rb_pr_json_refetched
 
         if [ "${RB_PR_MERGED}" = "true" ]; then
           RB_TARGET_MERGED="true"
@@ -5331,24 +5342,32 @@ ${FOLLOWUP_BLOCK_REASON}"
             #      so the resulting PR diff may be larger than intended.
             #      A warning is emitted so operators can intervene.
             _rb_co_src=""
+            _rb_co_src_desc=""
             if git fetch --no-tags origin "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}" 2>/dev/null \
               && git rev-parse --verify "refs/remotes/origin/${BASE_REF}" >/dev/null 2>&1; then
               _rb_co_src="refs/remotes/origin/${BASE_REF}"
+              _rb_co_src_desc="${BASE_REF} (fetched from origin)"
             elif git rev-parse --verify "refs/heads/${BASE_REF}" >/dev/null 2>&1; then
               _rb_co_src="refs/heads/${BASE_REF}"
+              _rb_co_src_desc="${BASE_REF} (existing local ref)"
               echo "  [follow-up] Using existing local ref for ${BASE_REF} (fetch from origin did not produce a fresh remote-tracking ref)."
             elif git rev-parse --verify HEAD >/dev/null 2>&1; then
               _rb_co_src="HEAD"
+              _rb_co_src_desc="current HEAD (NOT ${BASE_REF}; fetch and local lookup both failed)"
               echo "::warning::Could not fetch or locate base ref '${BASE_REF}' for issue #${rb_issue}; creating follow-up branch from current HEAD as a best-effort fallback. The resulting PR diff may be larger than intended."
             fi
             if [ -n "${_rb_co_src}" ] \
               && git checkout -B "${FOLLOWUP_BRANCH}" "${_rb_co_src}" 2>/dev/null; then
               RB_COMBINED_MODE="true"
-              RB_COMBINED_BRANCH_INFO="You are on a follow-up branch (${FOLLOWUP_BRANCH}) based on ${BASE_REF}. The original PR #${RB_PR} was already merged. If you choose action=\"fix\", apply ONLY the fixes identified during review — do not re-apply the original PR's changes."
+              # Reflect the *actual* checkout source in the judge prompt
+              # context. When the HEAD fallback fires, the follow-up branch
+              # is NOT based on ${BASE_REF}; saying otherwise misleads the
+              # judge into applying fixes on a wrong base.
+              RB_COMBINED_BRANCH_INFO="You are on a follow-up branch (${FOLLOWUP_BRANCH}) based on ${_rb_co_src_desc}. The original PR #${RB_PR} was already merged. If you choose action=\"fix\", apply ONLY the fixes identified during review — do not re-apply the original PR's changes."
             else
               echo "::warning::Could not prepare follow-up branch ${FOLLOWUP_BRANCH} for issue #${rb_issue}; combined-mode fix not possible."
             fi
-            unset _rb_co_src
+            unset _rb_co_src _rb_co_src_desc
           fi
         elif [ -n "${HEAD_REF}" ] && [ "${HEAD_REF}" != "null" ]; then
           if git fetch --no-tags origin "refs/heads/${HEAD_REF}:refs/remotes/origin/${HEAD_REF}" 2>/dev/null \

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -5257,10 +5257,18 @@ json.dump(result, sys.stdout)
         # late to correct the branch-prep decision. Keep _rb_pr_json in
         # sync so downstream consumers (e.g. RB_PR_MERGEABLE_STATE) see
         # the same snapshot.
+        _rb_prev_pr_state="${RB_PR_STATE:-}"
+        _rb_prev_pr_merged="${RB_PR_MERGED:-false}"
         _rb_pr_json="$(_fetch_pr_json "${RB_PR}")"
         RB_PR_STATE="$(_jq_field "${_rb_pr_json}" '.state' 'open|closed|merged')"
         RB_PR_MERGED="$(_jq_field "${_rb_pr_json}" '.merged_at != null' 'true|false')"
         [ -n "${RB_PR_MERGED}" ] || RB_PR_MERGED="false"
+        if [ "${_rb_pr_json}" = "{}" ] && [ "${_rb_prev_pr_merged}" = "true" ]; then
+          echo "::warning::[review-blocked] PR #${RB_PR} state refresh failed during branch prep; preserving earlier merged state to avoid misrouting follow-up preparation."
+          RB_PR_STATE="${_rb_prev_pr_state}"
+          RB_PR_MERGED="${_rb_prev_pr_merged}"
+        fi
+        unset _rb_prev_pr_state _rb_prev_pr_merged
 
         if [ "${RB_PR_MERGED}" = "true" ]; then
           RB_TARGET_MERGED="true"

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -5245,6 +5245,23 @@ json.dump(result, sys.stdout)
         BASE_REF="$(echo "${PR_META}" | jq -r '.base_ref')"
         : "${BASE_REF:=${DEFAULT_BRANCH:-main}}"
 
+        # Re-fetch PR state just before branch prep: the initial check at
+        # line 5054 and the auto-unstick block above can together span
+        # several seconds worth of gh API calls, during which an external
+        # actor (or a human merging via the GitHub UI) may have merged the
+        # PR. Without this re-check, a merge that lands between the initial
+        # fetch and this branch-prep decision sends us down the open-PR
+        # HEAD_REF checkout path instead of the merged-PR follow-up branch
+        # path, so the judge's fixes never produce a follow-up PR. The
+        # race-check at line 5614 catches the same race later but is too
+        # late to correct the branch-prep decision. Keep _rb_pr_json in
+        # sync so downstream consumers (e.g. RB_PR_MERGEABLE_STATE) see
+        # the same snapshot.
+        _rb_pr_json="$(_fetch_pr_json "${RB_PR}")"
+        RB_PR_STATE="$(_jq_field "${_rb_pr_json}" '.state' 'open|closed|merged')"
+        RB_PR_MERGED="$(_jq_field "${_rb_pr_json}" '.merged_at != null' 'true|false')"
+        [ -n "${RB_PR_MERGED}" ] || RB_PR_MERGED="false"
+
         if [ "${RB_PR_MERGED}" = "true" ]; then
           RB_TARGET_MERGED="true"
           resolve_active_orchestrator_context_for_issue "${rb_issue}" "${TRACKING_NUM:-}"
@@ -5257,7 +5274,12 @@ json.dump(result, sys.stdout)
             if [ "${ORCH_FOLLOWUP_INTEGRATION_BRANCH_EXISTS}" = "true" ] && [ -n "${ORCH_FOLLOWUP_INTEGRATION_BRANCH}" ]; then
               BASE_REF="${ORCH_FOLLOWUP_INTEGRATION_BRANCH}"
               echo "  Follow-up PR for issue #${rb_issue} is orchestrator-managed (tracking #${ORCH_FOLLOWUP_TRACKING_NUM}). Retargeting base to ${BASE_REF}."
-            else
+            elif [ -n "${ORCH_FOLLOWUP_INTEGRATION_BRANCH}" ]; then
+              # Integration branch NAME is present in the orchestrator state
+              # but the branch itself is not reachable (deleted externally or
+              # transient API failure). Block the follow-up PR — creating it
+              # against the default branch would bypass the integration-branch
+              # safety check (see PR #1016).
               FOLLOWUP_PR_BLOCKED="true"
               FOLLOWUP_BLOCK_REASON="Issue #${rb_issue} is orchestrator-managed (tracking #${ORCH_FOLLOWUP_TRACKING_NUM}), but integration branch '${ORCH_FOLLOWUP_INTEGRATION_BRANCH:-<missing>}' is unavailable. Aborting follow-up PR creation to avoid targeting ${DEFAULT_BRANCH:-main}."
               echo "::warning::${FOLLOWUP_BLOCK_REASON}"
@@ -5270,19 +5292,55 @@ json.dump(result, sys.stdout)
 ${FOLLOWUP_BLOCK_REASON}"
               tg_notify "${FOLLOWUP_BLOCK_REASON}" "WARNING"
               TRACKING_NUM="${ORIGINAL_TRACKING_NUM}"
+            else
+              # No integration branch context at all — the orchestrator state
+              # does not track this work under an integration branch. Keep the
+              # default base (${BASE_REF} was initialised from PR_META at the
+              # top of this block, which falls back to ${DEFAULT_BRANCH:-main}).
+              # This path is exercised when a review-blocked merged PR is
+              # orchestrator-managed but the project was never set up with an
+              # integration branch (e.g. single-wave project) — the follow-up
+              # still needs to land against whatever the original PR targeted.
+              echo "  Follow-up PR for issue #${rb_issue}: orchestrator state has no integration branch context; keeping default base '${BASE_REF}'."
             fi
           fi
 
           if [ "${FOLLOWUP_PR_BLOCKED}" != "true" ]; then
             FOLLOWUP_BRANCH="fix/${rb_issue}-followup-$(date +%s)"
             echo "  PR already merged. Creating follow-up branch ${FOLLOWUP_BRANCH} from ${BASE_REF}."
+            # Try three strategies in order to obtain a checkout source for
+            # the follow-up branch:
+            #   1. Fetch ${BASE_REF} from origin and use the remote-tracking ref.
+            #      This is the production-preferred path — it guarantees the
+            #      follow-up branch is based on the current upstream tip.
+            #   2. If the fetch fails or the remote ref didn't land, fall back
+            #      to a pre-existing local ref for ${BASE_REF}. This covers
+            #      (a) test harnesses whose origin URL is not real and
+            #      (b) production runs where the base branch was already
+            #      fetched earlier in the same poll cycle.
+            #   3. Last-resort fallback: current HEAD. In this mode the
+            #      follow-up branch's content may not be based on ${BASE_REF},
+            #      so the resulting PR diff may be larger than intended.
+            #      A warning is emitted so operators can intervene.
+            _rb_co_src=""
             if git fetch --no-tags origin "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}" 2>/dev/null \
-              && git checkout -B "${FOLLOWUP_BRANCH}" "refs/remotes/origin/${BASE_REF}" 2>/dev/null; then
+              && git rev-parse --verify "refs/remotes/origin/${BASE_REF}" >/dev/null 2>&1; then
+              _rb_co_src="refs/remotes/origin/${BASE_REF}"
+            elif git rev-parse --verify "refs/heads/${BASE_REF}" >/dev/null 2>&1; then
+              _rb_co_src="refs/heads/${BASE_REF}"
+              echo "  [follow-up] Using existing local ref for ${BASE_REF} (fetch from origin did not produce a fresh remote-tracking ref)."
+            elif git rev-parse --verify HEAD >/dev/null 2>&1; then
+              _rb_co_src="HEAD"
+              echo "::warning::Could not fetch or locate base ref '${BASE_REF}' for issue #${rb_issue}; creating follow-up branch from current HEAD as a best-effort fallback. The resulting PR diff may be larger than intended."
+            fi
+            if [ -n "${_rb_co_src}" ] \
+              && git checkout -B "${FOLLOWUP_BRANCH}" "${_rb_co_src}" 2>/dev/null; then
               RB_COMBINED_MODE="true"
               RB_COMBINED_BRANCH_INFO="You are on a follow-up branch (${FOLLOWUP_BRANCH}) based on ${BASE_REF}. The original PR #${RB_PR} was already merged. If you choose action=\"fix\", apply ONLY the fixes identified during review — do not re-apply the original PR's changes."
             else
               echo "::warning::Could not prepare follow-up branch ${FOLLOWUP_BRANCH} for issue #${rb_issue}; combined-mode fix not possible."
             fi
+            unset _rb_co_src
           fi
         elif [ -n "${HEAD_REF}" ] && [ "${HEAD_REF}" != "null" ]; then
           if git fetch --no-tags origin "refs/heads/${HEAD_REF}:refs/remotes/origin/${HEAD_REF}" 2>/dev/null \


### PR DESCRIPTION
Root causes surfaced by PR #1016's CI runs:

1. .github/workflows/test-and-mark-stable.yml — `check_all_steps` used
   `JOBS_JSON=$(gh api … || echo '{"jobs":[]}')`. On error responses gh
   writes the API error body to stdout and exits non-zero, so the
   `|| echo` fallback concatenates with gh's stdout inside the command
   substitution, producing a multi-document JSON blob. Downstream
   `jq '.jobs | length'` then emitted "0\n0" (tripping
   `[: 0 0: integer expression expected`) and `jq '[.jobs[] | …]'`
   errored with "Cannot iterate over null (null)", causing every phase
   to report `no steps found in run` and the Internals gate to fail.
   Moved the fallback outside the command substitution in both retry
   loops and hardened the post-retry shape check to reject anything
   that isn't a single object with a `.jobs` array.

2. scripts/orchestrate_poll_process.sh — two new functional tests for
   the merged-PR follow-up path (added in #1016) could never pass:
   - The ORCH_FOLLOWUP_OWNED=true branch blocked follow-up PR creation
     whenever the orchestrator state had no integration branch context
     at all, even though the safety invariant only applies when an
     integration branch is named but unreachable. Split into three
     cases: exists→retarget, set-but-invalid→block (existing safety
     preserved, same warning text), empty→keep default base.
   - RB_PR_MERGED was only sampled at the top of the iteration and
     never re-checked before the branch-prep decision, so any merge
     that landed during the auto-unstick block sent the flow down the
     open-PR HEAD_REF checkout path and the judge's fixes never
     produced a follow-up PR. Added a targeted re-fetch right before
     the merged-vs-open branch at line 5248.
   - git fetch --no-tags origin refs/heads/BASE_REF:… followed by
     checkout of the remote-tracking ref was the only way to reach
     RB_COMBINED_MODE=true; when fetch failed (test sandboxes with a
     fake origin, transient production network), the follow-up PR was
     silently skipped. Added a three-strategy checkout source chain:
     origin remote-tracking ref → pre-existing local ref → current
     HEAD (best-effort, with warning).

All three fixes preserve the integration-branch safety check and the
exact warning strings the static-string-match tests in
tests/test_orchestrate_poll_process.py:2142-2160 assert against.

Test results: 73 passed, 0 failed (was 71 passed, 2 failed).

https://claude.ai/code/session_01BZU3bw7TUh1q8XdDp3PTwL