### PR TITLE
claude/analyze-job-logs-jVkBs

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2158,7 +2158,19 @@ jobs:
           # "Untracked working tree file … would be overwritten by merge."
           git clean -ffdx 2>/dev/null || true
 
-          git merge --no-commit --no-ff "origin/${BASE_BRANCH}" || true
+          # Capture the merge exit code explicitly rather than swallowing
+          # it with `|| true`.  We must distinguish:
+          #   exit 0   — merge succeeded (base advanced, no conflicts left)
+          #              or already-up-to-date
+          #   exit 1   — merge produced content conflicts (expected path)
+          #   exit 128 — merge aborted before entering merge state (dirty
+          #              tree, missing ref, corrupt index, etc.) — SHOULD
+          #              be impossible because we reset the tracked-file
+          #              state at the top of this step, but if it ever
+          #              happens we must surface it instead of silently
+          #              running Codex against an empty conflict set.
+          _merge_exit=0
+          git merge --no-commit --no-ff "origin/${BASE_BRANCH}" || _merge_exit=$?
 
           # Capture the set of actually-unmerged paths produced by this
           # merge replay.  This is the authoritative allowlist the Codex
@@ -2172,37 +2184,57 @@ jobs:
           RESOLVER_ALLOWLIST_FILE="${RUNTIME_DIR}/resolver_unmerged_allowlist.txt"
           git diff --name-only --diff-filter=U | sort -u > "${RESOLVER_ALLOWLIST_FILE}" || true
           _resolver_allowlist_count="$(wc -l < "${RESOLVER_ALLOWLIST_FILE}" | tr -d '[:space:]')"
-          echo "Resolver allowlist (unmerged paths at merge replay): ${_resolver_allowlist_count} entries"
+          echo "Resolver allowlist (unmerged paths at merge replay): ${_resolver_allowlist_count} entries (git merge exit=${_merge_exit})"
           if [ "${_resolver_allowlist_count}" -gt 0 ]; then
             sed 's/^/ - /' "${RESOLVER_ALLOWLIST_FILE}" || true
           fi
 
-          # If the merge replay produced no unmerged paths AND left no
-          # merge in progress, there is nothing for Codex to resolve.
-          # This happens when the base branch advanced and the conflict
-          # was resolved upstream between the detect step and this step,
-          # or when git merge failed before entering merge state (e.g.
-          # exit 128 from an untracked/dirty working tree that the reset
-          # above could not fully clean).  Running Codex against an empty
-          # conflict set is how past runs have produced hallucinated
-          # edits to placeholder markers inside prompts/conflict-resolver.txt
-          # — the only file in the tree whose content resembles conflict
-          # markers.  Short-circuit instead: restore the stashed workflow
-          # dirs so later steps keep their environment, reset any partial
-          # merge artefacts, clear MERGE_CONFLICT so the second half of
-          # this split step (and downstream gates that key off it) treat
-          # the conflict as no longer present, and exit 0.
-          if [ "${_resolver_allowlist_count}" -eq 0 ] && [ ! -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
-            echo "::warning::Merge replay produced no unmerged paths and no merge is in progress — skipping Codex resolver (nothing to resolve)."
-            for d in scripts .serena prompts ai-memory; do
-              if [ -d "${RESOLVE_STASH}/${d}" ]; then
-                cp -a "${RESOLVE_STASH}/${d}/." "${d}/" 2>/dev/null || cp -a "${RESOLVE_STASH}/${d}" "${d}"
+          # When the allowlist is empty there is nothing for Codex to
+          # resolve.  Running Codex against an empty conflict set is how
+          # past runs have produced hallucinated edits to placeholder
+          # markers inside prompts/conflict-resolver.txt — the only file
+          # in the tree whose content resembles conflict markers.  Two
+          # sub-cases, distinguished by the merge exit code:
+          #
+          #   1. _merge_exit == 0: the merge either succeeded cleanly
+          #      (base advanced and the conflict was resolved upstream
+          #      between the detect step and this step, or the merge
+          #      auto-resolved the textual conflict) or reported
+          #      "Already up-to-date".  In both cases there is nothing
+          #      real to resolve, even if MERGE_HEAD is still present
+          #      because --no-commit left the merge state around.  Abort
+          #      the in-progress merge to clear MERGE_HEAD, restore the
+          #      stashed workflow dirs so later steps still have their
+          #      environment, clear MERGE_CONFLICT so the second half of
+          #      this split step (and downstream gates keyed off it)
+          #      treat the conflict as no longer present, and exit 0.
+          #
+          #   2. _merge_exit != 0: the merge failed for a non-conflict
+          #      reason — dirty tree, missing ref, corrupt index, etc.
+          #      We must NOT clear MERGE_CONFLICT here: that would let
+          #      the workflow silently continue as if the conflict were
+          #      resolved.  Fail loudly with an error annotation and
+          #      dump diagnostics so the root cause is visible.
+          if [ "${_resolver_allowlist_count}" -eq 0 ]; then
+            if [ "${_merge_exit}" -eq 0 ]; then
+              echo "::warning::Merge replay produced no unmerged paths (git merge exit=0) — skipping Codex resolver (nothing to resolve)."
+              if [ -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
+                git merge --abort 2>/dev/null || true
               fi
-            done
-            rm -rf "${RESOLVE_STASH}"
-            git reset --hard HEAD 2>/dev/null || true
-            echo "MERGE_CONFLICT=false" >> "$GITHUB_ENV"
-            exit 0
+              for d in scripts .serena prompts ai-memory; do
+                if [ -d "${RESOLVE_STASH}/${d}" ]; then
+                  cp -a "${RESOLVE_STASH}/${d}/." "${d}/" 2>/dev/null || cp -a "${RESOLVE_STASH}/${d}" "${d}"
+                fi
+              done
+              rm -rf "${RESOLVE_STASH}"
+              git reset --hard HEAD 2>/dev/null || true
+              echo "MERGE_CONFLICT=false" >> "$GITHUB_ENV"
+              exit 0
+            fi
+            echo "::error::Merge replay failed with exit ${_merge_exit} before producing any unmerged paths. The clean-tree reset at the top of this step did not yield a tree git could merge — investigate. Diagnostics:"
+            git status --porcelain 2>/dev/null || true
+            git ls-files --others --exclude-standard 2>/dev/null | head -20 || true
+            exit 1
           fi
 
           # Defensive: `git merge --no-commit` auto-stages merged hunks (and

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2096,6 +2096,26 @@ jobs:
           git config user.name  "codex-bot"        2>/dev/null || true
           git config user.email "codex@users.noreply.github.com" 2>/dev/null || true
 
+          # Start this step from a clean tracked-file state.  The "Detect
+          # merge conflicts" step's conflict branch only runs `git merge
+          # --abort`; it does NOT `git reset --hard HEAD`, so stale
+          # working-tree modifications from an earlier autofix iteration
+          # (e.g. to scripts/label_helpers.sh) can linger into this step.
+          # When they do, the `git merge --no-commit --no-ff` replay below
+          # fails before entering merge state with "Your local changes to
+          # the following files would be overwritten by merge", the `|| true`
+          # swallows the failure, and `git diff --name-only --diff-filter=U`
+          # returns zero paths — fooling the downstream resolver into
+          # running Codex against an empty conflict set and producing
+          # hallucinated edits.  Reset symmetrically with the no-conflict
+          # cleanup in the detect step.  Only tracked files are affected;
+          # the untracked workflow-fetched dirs handled by RESOLVE_STASH
+          # below are untouched by reset.
+          if [ -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
+            git merge --abort 2>/dev/null || true
+          fi
+          git reset --hard HEAD 2>/dev/null || true
+
           # Move workflow-fetched untracked dirs out of the way so they don't
           # collide with files from origin/BASE_BRANCH during the merge.
           # First, explicitly remove known CI-generated files that may be
@@ -2155,6 +2175,34 @@ jobs:
           echo "Resolver allowlist (unmerged paths at merge replay): ${_resolver_allowlist_count} entries"
           if [ "${_resolver_allowlist_count}" -gt 0 ]; then
             sed 's/^/ - /' "${RESOLVER_ALLOWLIST_FILE}" || true
+          fi
+
+          # If the merge replay produced no unmerged paths AND left no
+          # merge in progress, there is nothing for Codex to resolve.
+          # This happens when the base branch advanced and the conflict
+          # was resolved upstream between the detect step and this step,
+          # or when git merge failed before entering merge state (e.g.
+          # exit 128 from an untracked/dirty working tree that the reset
+          # above could not fully clean).  Running Codex against an empty
+          # conflict set is how past runs have produced hallucinated
+          # edits to placeholder markers inside prompts/conflict-resolver.txt
+          # — the only file in the tree whose content resembles conflict
+          # markers.  Short-circuit instead: restore the stashed workflow
+          # dirs so later steps keep their environment, reset any partial
+          # merge artefacts, clear MERGE_CONFLICT so the second half of
+          # this split step (and downstream gates that key off it) treat
+          # the conflict as no longer present, and exit 0.
+          if [ "${_resolver_allowlist_count}" -eq 0 ] && [ ! -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
+            echo "::warning::Merge replay produced no unmerged paths and no merge is in progress — skipping Codex resolver (nothing to resolve)."
+            for d in scripts .serena prompts ai-memory; do
+              if [ -d "${RESOLVE_STASH}/${d}" ]; then
+                cp -a "${RESOLVE_STASH}/${d}/." "${d}/" 2>/dev/null || cp -a "${RESOLVE_STASH}/${d}" "${d}"
+              fi
+            done
+            rm -rf "${RESOLVE_STASH}"
+            git reset --hard HEAD 2>/dev/null || true
+            echo "MERGE_CONFLICT=false" >> "$GITHUB_ENV"
+            exit 0
           fi
 
           # Defensive: `git merge --no-commit` auto-stages merged hunks (and


### PR DESCRIPTION
The "Detect merge conflicts" step only runs `git merge --abort` on its
conflict branch; it does not `git reset --hard HEAD`, so tracked-file
modifications from earlier autofix iterations leak into the "Run Codex
resolver" step.  When they do, the resolver's own `git merge --no-commit
--no-ff` replay aborts with "local changes would be overwritten by merge"
before entering merge state, the `|| true` swallows the failure, the
allowlist ends up empty, and Codex still gets invoked against a
no-conflict tree.  With no real `<<<<<<<` markers to find, Codex
hallucinates edits against the placeholder markers inside
`prompts/conflict-resolver.txt` — the only file whose content looks
like conflict markers — and `check_resolver_diff.sh` correctly fails
the run with "edited files outside the conflicted set" (touched=1
conflicted=0).

Two mitigations, both in `review_autofix.yml`:

1. Reset to a clean tracked-file state at the top of the resolver
   prepare step (after setting committer identity, before stashing
   untracked workflow dirs).  Mirrors the no-conflict cleanup in the
   detect step.
2. If the merge replay produces zero unmerged paths AND no merge is
   in progress, short-circuit: restore the stashed workflow dirs,
   reset, clear `MERGE_CONFLICT`, and `exit 0`.  There is genuinely
   nothing to resolve, so skipping Codex eliminates the hallucination
   surface.  The second half of the split resolver step (and any
   downstream gate keyed off `MERGE_CONFLICT`) follows suit via the
   unset.

Root cause trace in job 3b6db7f0-cbad-5199-b984-b3c06eeb7f45 (PR #1051).