### PR TITLE
claude/add-tg-api-limit-alerts-KcUYg

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `REVIEW_BLOCKED_AUTO_UNSTICK` | No | `true` | orchestrate_poll | Before invoking the review-blocked judge, the poller inspects each `ai:review-blocked` PR. If the PR is `mergeable=false` it dispatches `review_autofix.yml` (via `_dispatch_review_for_conflicts`) so the in-workflow Codex resolver gets a fresh shot at the conflict, and skips the judge for this tick. If the PR head commit was authored by an **external** identity (anything other than `codex`, `codex-bot`, `github-actions`, or `github-actions[bot]`), the poller also dispatches the review workflow AND clears `ai:review-blocked`, re-entering the normal phase loop — this bridges the GitHub platform rule that suppresses `pull_request.synchronize` events on commits pushed with the default `GITHUB_TOKEN` (Claude Code on the web, custom wrapper actions) and matches the "push a new commit to re-trigger the review workflow" contract printed in the workflow-failure comment. Set to `false` to disable both paths and force the judge-first flow. Dispatch is always gated by the existing `_dispatch_review_for_conflicts` cycle-local dedup and active-run detection, so repeat calls are cheap no-ops. |
 | `TG_ADMIN_CHAT_ID` | No | — | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, validate | Telegram chat ID for notifications (pair with `TG_BOT_SECRET`) |
 | `ALERT_MSG_LEVEL` | No | `DEBUG` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, orchestrate_clarify_respond, validate, issue_pr_status, update_workflows, test-and-mark-stable | Minimum Telegram alert level to send. Alerts below this threshold are suppressed. Valid values: `DEBUG`, `WARNING`, `ERROR`, `CRITICAL`. Each alert is prefixed with an icon and level (e.g. `🔍 DEBUG:`, `⚠️ WARNING:`, `❌ ERROR:`, `🚨 CRITICAL:`). New alerts default to `CRITICAL` until explicitly recategorised. |
+| `TG_GH_RATELIMIT_ALERT_COOLDOWN_SECS` | No | `3600` | all (any workflow or script that sources `scripts/gh_helpers.sh`) | Minimum seconds between consecutive admin Telegram alerts when a GitHub API rate limit is hit. The alert (`⚠️ WARNING: GitHub API rate limit hit …`) is fired from inside the rate-limit branch of `gh_retry` / `gh_retry_to_file` / `gh_api_json_to_file` / `curl_gh_api`, and is throttled globally via a Telegram pinned message in the admin chat (marker `<!-- gh_rl_ts:EPOCH -->`). This deliberately avoids any GitHub API call for dedup state so the throttle keeps working while the GitHub API itself is the resource being limited. Fail-closed: on Telegram pin failure the sent message is rolled back so the "≤ 1 alert per window" invariant holds. Set to `0` has no suppression effect (any non-numeric or empty value is coerced to `3600`). No-op when `TG_BOT_SECRET` / `TG_ADMIN_CHAT_ID` are unset. |
 | `SERENA_VERSION` | No | `main` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, validate | Version/branch of the Serena MCP server |
 | `SERENA_LANGUAGES` | No | `""` (empty) | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, validate | Languages for Serena symbol analysis |
 | `SERENA_DISABLED` | No | `false` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, validate | Disable the Serena MCP server |
@@ -928,6 +929,26 @@ For non-orchestrator issues, human-intervention alerts are cleaned up automatica
 - No additional configuration is needed — cleanup is enabled automatically when `TG_BOT_SECRET` and `TG_ADMIN_CHAT_ID` are set.
 
 **Note:** Messages older than 48 hours cannot be deleted by the Telegram Bot API. For long-running orchestrated projects, intermediate messages sent more than 48 hours before completion will remain in the chat.
+
+### GitHub API rate-limit admin alert
+
+Any workflow or script that routes GitHub API calls through `scripts/gh_helpers.sh` (`gh_retry`, `gh_retry_to_file`, `gh_api_json_to_file`, `curl_gh_api`) will fire a single admin Telegram alert the first time a rate limit is detected in a cooldown window. The alert body is of the form:
+
+```
+⚠️ WARNING: GitHub API rate limit hit — workflow=<name> repo=<owner/repo> run=<runs-url>
+```
+
+**Throttling:** alerts are globally throttled to at most one per `TG_GH_RATELIMIT_ALERT_COOLDOWN_SECS` (default `3600` s = 1 h) across **all** workflow runs. The cooldown state is kept in a Telegram **pinned message** in the admin chat via an embedded marker `<!-- gh_rl_ts:EPOCH -->`, read with `getChat`. This deliberately avoids any GitHub API call for dedup state so the throttle still works while the GitHub API itself is the resource being limited. Previous pinned alerts are unpinned best-effort after a new alert is pinned.
+
+**Fail-closed semantics:** if `pinChatMessage` fails after the alert was sent, the sent message is rolled back via `deleteMessage` so the "≤ 1 alert per cooldown window" invariant is preserved even under transient Telegram failures.
+
+**Requirements:**
+- `TG_BOT_SECRET` and `TG_ADMIN_CHAT_ID` must be set.
+- The bot must have permission to pin / unpin / delete messages in the target chat.
+- `jq` must be available (already a baseline on all repo runners).
+- The caller script must source `scripts/gh_helpers.sh`. All four `review_*.sh` helpers and `orchestrate_poll_process.sh` route GitHub API calls through `gh_retry` / `curl_gh_api` and therefore participate in the alert.
+
+**Disabling:** unset `TG_BOT_SECRET` or `TG_ADMIN_CHAT_ID` — the helper no-ops silently. There is no way to disable the feature per-caller; if you need to skip alerting for a specific bootstrap probe (e.g. a `gh api /labels/<name>` existence check where 404 is the expected normal case), call `gh` directly instead of via `gh_retry`. See `ensure_label_exists` in `scripts/orchestrate_poll_process.sh` for an example.
 
 ## Runtime Validation Phase
 

--- a/README.md
+++ b/README.md
@@ -948,7 +948,9 @@ Any workflow or script that routes GitHub API calls through `scripts/gh_helpers.
 - `jq` must be available (already a baseline on all repo runners).
 - The caller script must source `scripts/gh_helpers.sh`. All four `review_*.sh` helpers and `orchestrate_poll_process.sh` route GitHub API calls through `gh_retry` / `curl_gh_api` and therefore participate in the alert.
 
-**Disabling:** unset `TG_BOT_SECRET` or `TG_ADMIN_CHAT_ID` — the helper no-ops silently. There is no way to disable the feature per-caller; if you need to skip alerting for a specific bootstrap probe (e.g. a `gh api /labels/<name>` existence check where 404 is the expected normal case), call `gh` directly instead of via `gh_retry`. See `ensure_label_exists` in `scripts/orchestrate_poll_process.sh` for an example.
+**Interaction with `ALERT_MSG_LEVEL`:** the rate-limit alert is emitted at `WARNING` level and honours the global `ALERT_MSG_LEVEL` threshold the same way `scripts/tg_helpers.sh::tg_send_msg` does. If an operator configures `ALERT_MSG_LEVEL=ERROR` or `ALERT_MSG_LEVEL=CRITICAL`, the rate-limit alert is suppressed entirely (no send, no pin update, no cooldown advance). The cooldown state is only touched when the alert would actually fire, so tightening `ALERT_MSG_LEVEL` does not strand a stale pinned marker.
+
+**Disabling:** unset `TG_BOT_SECRET` or `TG_ADMIN_CHAT_ID` — the helper no-ops silently. You can also set `ALERT_MSG_LEVEL=ERROR` (or higher) to suppress the rate-limit alert while keeping other ERROR/CRITICAL Telegram notifications. There is no way to disable the feature per-caller; if you need to skip alerting for a specific bootstrap probe (e.g. a `gh api /labels/<name>` existence check where 404 is the expected normal case), call `gh` directly instead of via `gh_retry`. See `ensure_label_exists` in `scripts/orchestrate_poll_process.sh` for an example.
 
 ## Runtime Validation Phase
 

--- a/agents.md
+++ b/agents.md
@@ -153,6 +153,7 @@ All code is production-bound. Verify: logic correctness, error paths, race condi
 - Preserve all existing env var names.
 - Batch controls in this repo: `BATCH_API_DISABLED` (default `false`), `BATCH_API_PROVIDER` (default `auto`), `BATCH_API_POLL_TIMEOUT_HOURS` (default `24`).
 - Orchestrator clean-wave control: `ENABLE_CLEAN_WAVE_JUDGE_SKIP` (default `true`) skips judge invocation on clean completed waves (no failures, not stuck, project not complete) and advances wave mechanically.
+- GitHub API rate-limit admin alert: `TG_GH_RATELIMIT_ALERT_COOLDOWN_SECS` (default `3600`) throttles the Telegram admin alert fired from `scripts/gh_helpers.sh` when a GH API rate limit is detected. State is kept in a Telegram pinned message (marker `<!-- gh_rl_ts:EPOCH -->`) to avoid spending GH API calls on dedup. Fail-closed on pin failure. See README "GitHub API rate-limit admin alert" section.
 
 ---
 

--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -169,7 +169,7 @@ _gh_ratelimit_tg_alert()
 		| jq -r '.result.pinned_message.message_id // ""' 2>/dev/null) || return 0
 
 	_last_epoch=$(printf '%s' "${_pinned_text}" \
-		| sed -n 's/.*<!-- gh_rl_ts:\([0-9]\{1,\}\) -->.*/\1/p' | head -1)
+		| sed -n 's/.*<!-- gh_rl_ts:\([0-9]\{1,\}\) -->.*/\1/p' | tail -1)
 
 	_now=$(date +%s)
 	if [ -n "${_last_epoch}" ] && [ "${_last_epoch}" -gt 0 ] 2>/dev/null; then
@@ -246,7 +246,7 @@ _gh_ratelimit_tg_alert()
 	# leave it alone — the new rate-limit pin will still be the
 	# most-recent pin returned by `getChat` for cooldown reads,
 	# which is all we need. ---
-	if [ -n "${_last_epoch}" ] \
+	if [ -n "${_last_epoch}" ] && [ "${_last_epoch}" -gt 0 ] 2>/dev/null \
 		&& [ -n "${_prev_pin_id}" ] \
 		&& [ "${_prev_pin_id}" != "${_new_msg_id}" ]; then
 		curl -sS --max-time 10 -X POST \

--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -235,8 +235,20 @@ _gh_ratelimit_tg_alert()
 	fi
 
 	# --- Best-effort unpin the previous stale pin so the admin
-	# chat keeps a single sticky alert. ---
-	if [ -n "${_prev_pin_id}" ] && [ "${_prev_pin_id}" != "${_new_msg_id}" ]; then
+	# chat keeps a single sticky rate-limit alert.
+	#
+	# IMPORTANT: only unpin when the previous pinned message was
+	# itself one of OUR rate-limit alerts. `_last_epoch` is
+	# extracted from the `<!-- gh_rl_ts:EPOCH -->` marker in the
+	# previous pin's text, so a non-empty value proves the previous
+	# pin carried the marker. If an operator has pinned an
+	# unrelated important message (ops notice, runbook, etc.),
+	# leave it alone — the new rate-limit pin will still be the
+	# most-recent pin returned by `getChat` for cooldown reads,
+	# which is all we need. ---
+	if [ -n "${_last_epoch}" ] \
+		&& [ -n "${_prev_pin_id}" ] \
+		&& [ "${_prev_pin_id}" != "${_new_msg_id}" ]; then
 		curl -sS --max-time 10 -X POST \
 			"${_tg_base}/unpinChatMessage" \
 			-d "chat_id=${_chat_id}" \

--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -83,6 +83,154 @@ _gh_rate_limit_wait()
 }
 
 # ---------------------------------------------------------------
+# _gh_ratelimit_tg_alert — Telegram admin alert when a GitHub
+# API rate limit is hit in any workflow or script.
+#
+# Throttled to at most one message per
+# TG_GH_RATELIMIT_ALERT_COOLDOWN_SECS (default 3600 s = 1 h).
+#
+# State persistence: a Telegram pinned message in the admin chat
+# carries an embedded marker `<!-- gh_rl_ts:EPOCH -->`.  The
+# function reads the pinned message via `getChat`, suppresses the
+# alert if the marker is within the cooldown window, otherwise
+# sends a new message and re-pins it (unpinning the stale pin
+# best-effort).  This deliberately avoids any GitHub API call so
+# the throttle still works while the GitHub API itself is the
+# resource being limited.
+#
+# Fail-closed semantics (Q8=B): on any read/pin error the
+# function returns without sending — if pinning fails AFTER the
+# message is sent, the sent message is deleted so the invariant
+# "≤ 1 alert per cooldown window" is preserved even under
+# transient Telegram failures.
+#
+# Env (all optional, function no-ops when creds are missing):
+#   TG_BOT_SECRET, TG_ADMIN_CHAT_ID (fallback TG_CHAT_ID)
+#   TG_GH_RATELIMIT_ALERT_COOLDOWN_SECS (default 3600)
+#   GITHUB_WORKFLOW, GITHUB_SERVER_URL, GITHUB_REPOSITORY,
+#   GITHUB_RUN_ID — used to build a descriptive message.
+#
+# Emits: best-effort ::warning:: log lines on persistence failure.
+# Returns: always 0 — never block a rate-limit retry path.
+# ---------------------------------------------------------------
+_gh_ratelimit_tg_alert()
+{
+	# Resolve chat id; no-op without creds.
+	local _chat_id="${TG_ADMIN_CHAT_ID:-${TG_CHAT_ID:-}}"
+	if [ -z "${TG_BOT_SECRET:-}" ] || [ -z "${_chat_id}" ]; then
+		return 0
+	fi
+
+	# jq is required for the Telegram state dance; skip silently
+	# if not installed (all repo runners already have it).
+	if ! command -v jq >/dev/null 2>&1; then
+		return 0
+	fi
+
+	# Cooldown window (seconds). Reject non-numeric values, fall
+	# back to 3600.
+	local _cooldown="${TG_GH_RATELIMIT_ALERT_COOLDOWN_SECS:-3600}"
+	case "${_cooldown}" in
+		''|*[!0-9]*) _cooldown=3600 ;;
+	esac
+
+	local _tg_base="https://api.telegram.org/bot${TG_BOT_SECRET}"
+
+	# --- Read current pinned message state (fail-closed on error) ---
+	local _get_chat_resp
+	_get_chat_resp=$(curl -sS --max-time 10 -X POST \
+		"${_tg_base}/getChat" \
+		-d "chat_id=${_chat_id}" 2>/dev/null) || return 0
+	[ -n "${_get_chat_resp}" ] || return 0
+	if ! printf '%s' "${_get_chat_resp}" | jq -e '.ok == true' >/dev/null 2>&1; then
+		return 0
+	fi
+
+	local _pinned_text _prev_pin_id _last_epoch _now
+	_pinned_text=$(printf '%s' "${_get_chat_resp}" \
+		| jq -r '.result.pinned_message.text // ""' 2>/dev/null) || return 0
+	_prev_pin_id=$(printf '%s' "${_get_chat_resp}" \
+		| jq -r '.result.pinned_message.message_id // ""' 2>/dev/null) || return 0
+
+	_last_epoch=$(printf '%s' "${_pinned_text}" \
+		| sed -n 's/.*<!-- gh_rl_ts:\([0-9]\{1,\}\) -->.*/\1/p' | head -1)
+
+	_now=$(date +%s)
+	if [ -n "${_last_epoch}" ] && [ "${_last_epoch}" -gt 0 ] 2>/dev/null; then
+		local _age=$(( _now - _last_epoch ))
+		if [ "${_age}" -ge 0 ] && [ "${_age}" -lt "${_cooldown}" ]; then
+			# Within cooldown — suppress.
+			return 0
+		fi
+	fi
+
+	# --- Build message body ---
+	local _workflow="${GITHUB_WORKFLOW:-unknown}"
+	local _repo="${GITHUB_REPOSITORY:-unknown}"
+	local _run_url=""
+	if [ -n "${GITHUB_SERVER_URL:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ] && [ -n "${GITHUB_RUN_ID:-}" ]; then
+		_run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+	fi
+	local _body
+	_body="⚠️ WARNING: GitHub API rate limit hit — workflow=${_workflow} repo=${_repo}"
+	if [ -n "${_run_url}" ]; then
+		_body="${_body} run=${_run_url}"
+	fi
+	# Embed dedup marker on a new line (sticky inside pinned text).
+	_body="${_body}
+<!-- gh_rl_ts:${_now} -->"
+
+	# --- Send the alert message ---
+	local _send_resp _new_msg_id
+	_send_resp=$(curl -sS --max-time 10 -X POST \
+		"${_tg_base}/sendMessage" \
+		-d "chat_id=${_chat_id}" \
+		-d "disable_web_page_preview=true" \
+		--data-urlencode "text=${_body}" 2>/dev/null) || return 0
+	[ -n "${_send_resp}" ] || return 0
+	if ! printf '%s' "${_send_resp}" | jq -e '.ok == true' >/dev/null 2>&1; then
+		return 0
+	fi
+	_new_msg_id=$(printf '%s' "${_send_resp}" \
+		| jq -r '.result.message_id // ""' 2>/dev/null)
+	[ -n "${_new_msg_id}" ] || return 0
+
+	# --- Pin new message (persists state). Fail-closed: on pin
+	# failure, delete the message we just sent so the cooldown
+	# invariant is preserved. ---
+	local _pin_resp _pin_ok=0
+	_pin_resp=$(curl -sS --max-time 10 -X POST \
+		"${_tg_base}/pinChatMessage" \
+		-d "chat_id=${_chat_id}" \
+		-d "message_id=${_new_msg_id}" \
+		-d "disable_notification=true" 2>/dev/null) || _pin_resp=""
+
+	if [ -n "${_pin_resp}" ] && printf '%s' "${_pin_resp}" | jq -e '.ok == true' >/dev/null 2>&1; then
+		_pin_ok=1
+	fi
+
+	if [ "${_pin_ok}" -ne 1 ]; then
+		echo "::warning::_gh_ratelimit_tg_alert: failed to pin new alert message (fail-closed); rolling back sent message" >&2
+		curl -sS --max-time 10 -X POST \
+			"${_tg_base}/deleteMessage" \
+			-d "chat_id=${_chat_id}" \
+			-d "message_id=${_new_msg_id}" >/dev/null 2>&1 || true
+		return 0
+	fi
+
+	# --- Best-effort unpin the previous stale pin so the admin
+	# chat keeps a single sticky alert. ---
+	if [ -n "${_prev_pin_id}" ] && [ "${_prev_pin_id}" != "${_new_msg_id}" ]; then
+		curl -sS --max-time 10 -X POST \
+			"${_tg_base}/unpinChatMessage" \
+			-d "chat_id=${_chat_id}" \
+			-d "message_id=${_prev_pin_id}" >/dev/null 2>&1 || true
+	fi
+
+	return 0
+}
+
+# ---------------------------------------------------------------
 # gh_retry — Execute a gh CLI command with automatic retry.
 #
 # Rate-limit errors  → wait until X-RateLimit-Reset, retry (up to max_attempts).
@@ -113,6 +261,7 @@ gh_retry()
 
 		if _is_gh_rate_limit "${stderr_content}"; then
 			echo "::warning::GitHub API rate limit hit (attempt ${attempt}/${max_attempts}), waiting for reset…" >&2
+			_gh_ratelimit_tg_alert
 			_gh_rate_limit_wait
 		else
 			local wait_secs=$(( 2 ** (attempt - 1) ))
@@ -165,6 +314,7 @@ gh_retry_to_file()
 
 		if _is_gh_rate_limit "${stderr_content}"; then
 			echo "::warning::GitHub API rate limit hit (attempt ${attempt}/${max_attempts}), waiting for reset…" >&2
+			_gh_ratelimit_tg_alert
 			_gh_rate_limit_wait
 		else
 			local wait_secs=$(( 2 ** (attempt - 1) ))
@@ -263,6 +413,7 @@ gh_api_json_to_file()
 
 			if _is_gh_rate_limit "${stderr_content}"; then
 				echo "::warning::GitHub API rate limit hit (attempt ${attempt}/${max_attempts}), waiting for reset…" >&2
+				_gh_ratelimit_tg_alert
 				_gh_rate_limit_wait
 			else
 				local wait_secs=$(( 2 ** (attempt - 1) ))
@@ -331,6 +482,7 @@ curl_gh_api()
 
 		if [ "${http_code}" = "429" ] || { [ "${http_code}" = "403" ] && _is_gh_rate_limit "${body_content}"; }; then
 			echo "::warning::GitHub API rate limit (HTTP ${http_code}, attempt ${attempt}/${max_attempts}), waiting for reset…" >&2
+			_gh_ratelimit_tg_alert
 			local _reset_ts
 			_reset_ts=$(_parse_reset_header "${header_file}")
 			_sleep_until_reset "${_reset_ts}"

--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -98,15 +98,20 @@ _gh_rate_limit_wait()
 # the throttle still works while the GitHub API itself is the
 # resource being limited.
 #
-# Fail-closed semantics (Q8=B): on any read/pin error the
-# function returns without sending — if pinning fails AFTER the
-# message is sent, the sent message is deleted so the invariant
+# Fail-closed semantics: on any read/pin error the function
+# returns without sending — if pinning fails AFTER the message is
+# sent, the sent message is deleted so the invariant
 # "≤ 1 alert per cooldown window" is preserved even under
 # transient Telegram failures.
+#
+# Alert level: WARNING. The function honours `ALERT_MSG_LEVEL`
+# (the same global threshold `tg_helpers.sh::tg_send_msg` uses);
+# when ALERT_MSG_LEVEL is ERROR or CRITICAL the alert is skipped.
 #
 # Env (all optional, function no-ops when creds are missing):
 #   TG_BOT_SECRET, TG_ADMIN_CHAT_ID (fallback TG_CHAT_ID)
 #   TG_GH_RATELIMIT_ALERT_COOLDOWN_SECS (default 3600)
+#   ALERT_MSG_LEVEL (default DEBUG; suppresses when > WARNING)
 #   GITHUB_WORKFLOW, GITHUB_SERVER_URL, GITHUB_REPOSITORY,
 #   GITHUB_RUN_ID — used to build a descriptive message.
 #
@@ -126,6 +131,17 @@ _gh_ratelimit_tg_alert()
 	if ! command -v jq >/dev/null 2>&1; then
 		return 0
 	fi
+
+	# Honour the global ALERT_MSG_LEVEL threshold the same way
+	# tg_helpers.sh::tg_send_msg does. This alert is WARNING level,
+	# so when the operator has configured ALERT_MSG_LEVEL=ERROR or
+	# CRITICAL the rate-limit alert is suppressed (no send, no pin
+	# update, cooldown window is not advanced).
+	case "$(printf '%s' "${ALERT_MSG_LEVEL:-DEBUG}" | tr '[:lower:]' '[:upper:]')" in
+		DEBUG|WARNING) : ;;
+		ERROR|CRITICAL) return 0 ;;
+		*) : ;;  # unknown value → match tg_helpers.sh permissive default
+	esac
 
 	# Cooldown window (seconds). Reject non-numeric values, fall
 	# back to 3600.

--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -180,6 +180,50 @@ _gh_ratelimit_tg_alert()
 		fi
 	fi
 
+	# --- Best-effort de-race across concurrent workflow runs ---
+	#
+	# The getChat→send→pin sequence is not atomic: two runners can
+	# both read an old marker, both decide the cooldown has expired,
+	# and both go on to send+pin alerts, producing duplicate pings.
+	# Add a short randomized jitter (1–3 s) and then re-read the
+	# pinned message before sending. If a concurrent runner already
+	# published a fresh alert in the gap, `_recheck_epoch` will be
+	# within the current cooldown window and we suppress. This does
+	# not eliminate the race (Telegram has no client-side locks),
+	# but shrinks the window by orders of magnitude. The jitter cost
+	# is negligible inside a rate-limit branch that is already about
+	# to sleep up to 600 s waiting for the GH reset window.
+	local _jitter_secs
+	_jitter_secs=$(( (RANDOM % 3) + 1 ))
+	sleep "${_jitter_secs}"
+
+	local _recheck_resp _recheck_text _recheck_epoch
+	_recheck_resp=$(curl -sS --max-time 10 -X POST \
+		"${_tg_base}/getChat" \
+		-d "chat_id=${_chat_id}" 2>/dev/null) || return 0
+	[ -n "${_recheck_resp}" ] || return 0
+	if ! printf '%s' "${_recheck_resp}" | jq -e '.ok == true' >/dev/null 2>&1; then
+		return 0
+	fi
+	_recheck_text=$(printf '%s' "${_recheck_resp}" \
+		| jq -r '.result.pinned_message.text // ""' 2>/dev/null) || return 0
+	_recheck_epoch=$(printf '%s' "${_recheck_text}" \
+		| sed -n 's/.*<!-- gh_rl_ts:\([0-9]\{1,\}\) -->.*/\1/p' | tail -1)
+	_now=$(date +%s)
+	if [ -n "${_recheck_epoch}" ] && [ "${_recheck_epoch}" -gt 0 ] 2>/dev/null; then
+		local _recheck_age=$(( _now - _recheck_epoch ))
+		if [ "${_recheck_age}" -ge 0 ] && [ "${_recheck_age}" -lt "${_cooldown}" ]; then
+			# Another concurrent run already published a fresh
+			# pinned alert during the jitter window — suppress.
+			return 0
+		fi
+	fi
+	# Refresh _prev_pin_id from the rechecked state so the later
+	# unpin guard still targets the right message id if it changed.
+	_prev_pin_id=$(printf '%s' "${_recheck_resp}" \
+		| jq -r '.result.pinned_message.message_id // ""' 2>/dev/null) || _prev_pin_id=""
+	_last_epoch="${_recheck_epoch}"
+
 	# --- Build message body ---
 	local _workflow="${GITHUB_WORKFLOW:-unknown}"
 	local _repo="${GITHUB_REPOSITORY:-unknown}"

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1441,7 +1441,18 @@ invoke_judge_for_integration_conflict() {
 
   local pr_diff
   local pr_files
-  pr_diff="$(gh_retry gh pr diff "${final_pr}" --repo "${GITHUB_REPOSITORY}" 2>/dev/null | head -c 120000 || true)"
+  # Fetch into a temp file before truncating: piping gh pr diff directly
+  # into `head -c` causes SIGPIPE on gh pr diff once head has read enough
+  # bytes, which gh_retry then treats as a transient failure and retries
+  # with exponential backoff. Capture first, truncate second.
+  local _pr_diff_tmp
+  _pr_diff_tmp="$(mktemp)"
+  if gh_retry_to_file "${_pr_diff_tmp}" gh pr diff "${final_pr}" --repo "${GITHUB_REPOSITORY}" 2>/dev/null; then
+    pr_diff="$(head -c 120000 "${_pr_diff_tmp}")"
+  else
+    pr_diff=""
+  fi
+  rm -f "${_pr_diff_tmp}"
   pr_files="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/pulls/${final_pr}/files" --jq '[.[] | {filename, status, additions, deletions}]' 2>/dev/null || echo "[]")"
   local retries
   retries="$(jq -r '.integration_conflict_dispatch_count // 0' "${STATE_FILE}")"
@@ -6486,8 +6497,18 @@ Manual intervention required." >/dev/null
       --jq '[.[] | select(.event == "cross-referenced" and .source.issue.pull_request != null) | .source.issue.number] | last' \
       || echo "")"
     if [[ "${PR_NUM}" =~ ^[0-9]+$ ]]; then
-      PR_DIFF="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUM}" \
-        -H 'Accept: application/vnd.github.diff' 2>/dev/null | head -500 || echo "(diff unavailable)")"
+      # Fetch the diff into a temp file before truncating: piping
+      # gh api directly into `head -500` causes SIGPIPE on gh api once
+      # head has read enough lines, which gh_retry then treats as a
+      # transient failure and retries with exponential backoff.
+      _pr_diff_tmp="$(mktemp)"
+      if gh_retry_to_file "${_pr_diff_tmp}" gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUM}" \
+        -H 'Accept: application/vnd.github.diff' 2>/dev/null; then
+        PR_DIFF="$(head -500 "${_pr_diff_tmp}")"
+      else
+        PR_DIFF="(diff unavailable)"
+      fi
+      rm -f "${_pr_diff_tmp}"
       _issue_status="$(jq -r --arg num "${inum}" --argjson wi "${WAVE_IDX}" \
         '.waves[$wi].issues[] | select((.github_issue | tostring) == $num) | .status // ""' \
         "${STATE_FILE}" 2>/dev/null | head -n1)"

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -2023,7 +2023,11 @@ has_active_validation_run() {
   local wf_name="${VALIDATE_WORKFLOW_NAME:-ai-validate.yml}"
   local active_count
 
-  active_count="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf_name}/runs?per_page=5" \
+  # _safe_gh_jq (via gh_retry) suppresses stdout on failure so the
+  # `|| echo '0'` fallback yields a clean numeric value even when
+  # gh api fails — preventing the error JSON body from being
+  # concatenated with '0' and breaking the `-gt` comparison below.
+  active_count="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf_name}/runs?per_page=5" \
     --jq '[.workflow_runs[] | select(.status == "in_progress" or .status == "queued")] | length' 2>/dev/null || echo '0')"
   if [ "${active_count}" -gt 0 ]; then
     return 0
@@ -2031,7 +2035,7 @@ has_active_validation_run() {
 
   # Fallback: check internal-validate.yml if primary name differs
   if [ "${wf_name}" != "internal-validate.yml" ]; then
-    active_count="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/internal-validate.yml/runs?per_page=5" \
+    active_count="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/actions/workflows/internal-validate.yml/runs?per_page=5" \
       --jq '[.workflow_runs[] | select(.status == "in_progress" or .status == "queued")] | length' 2>/dev/null || echo '0')"
     if [ "${active_count}" -gt 0 ]; then
       return 0
@@ -2050,13 +2054,15 @@ get_last_validation_run_conclusion() {
   local last_dispatch_ts
   last_dispatch_ts="$(jq -r '.validation_last_dispatch_ts // 0' "${STATE_FILE}")"
 
+  # _safe_gh_jq (via gh_retry) guarantees empty stdout on failure so
+  # the `|| echo '[]'` fallback stays valid JSON.
   local runs_json
-  runs_json="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf_name}/runs?status=completed&per_page=5" \
+  runs_json="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf_name}/runs?status=completed&per_page=5" \
     --jq '.workflow_runs' 2>/dev/null || echo '[]')"
 
   # Fallback to internal-validate.yml if no completed runs found
   if [ "$(echo "${runs_json}" | jq 'length')" -eq 0 ] && [ "${wf_name}" != "internal-validate.yml" ]; then
-    runs_json="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/internal-validate.yml/runs?status=completed&per_page=5" \
+    runs_json="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/actions/workflows/internal-validate.yml/runs?status=completed&per_page=5" \
       --jq '.workflow_runs' 2>/dev/null || echo '[]')"
   fi
 
@@ -2275,12 +2281,13 @@ build_active_issue_set() {
   now_epoch="$(date +%s)"
   local stall_secs=$(( STALL_THRESHOLD_MINUTES * 60 ))
 
-  # Fetch in_progress + queued runs (recent, max 50)
+  # Fetch in_progress + queued runs (recent, max 50).
+  # _safe_gh_jq guarantees empty stdout on failure → fallback is valid JSON.
   local runs_json
-  runs_json="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/actions/runs?status=in_progress&per_page=50" \
+  runs_json="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/actions/runs?status=in_progress&per_page=50" \
     --jq '.workflow_runs' 2>/dev/null || echo '[]')"
   local queued_json
-  queued_json="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/actions/runs?status=queued&per_page=50" \
+  queued_json="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/actions/runs?status=queued&per_page=50" \
     --jq '.workflow_runs' 2>/dev/null || echo '[]')"
 
   # Merge both lists
@@ -2350,9 +2357,10 @@ cancel_zombie_runs_for_issue() {
   now_epoch="$(date +%s)"
   local stall_secs=$(( STALL_THRESHOLD_MINUTES * 60 ))
 
-  # Re-fetch in_progress runs and find zombies matching this issue
+  # Re-fetch in_progress runs and find zombies matching this issue.
+  # _safe_gh_jq guarantees empty stdout on failure → fallback stays valid.
   local runs_json
-  runs_json="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/actions/runs?status=in_progress&per_page=50" \
+  runs_json="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/actions/runs?status=in_progress&per_page=50" \
     --jq '.workflow_runs' 2>/dev/null || echo '[]')"
 
   local zombie_run_ids
@@ -2929,7 +2937,9 @@ invoke_stall_judge() {
 
   local workflows_json
   local workflow_outcomes
-  workflows_json="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/actions/runs?per_page=50" 2>/dev/null || echo '{"workflow_runs":[]}')"
+  # _safe_gh_jq → clean empty stdout on failure so the `|| echo '{...}'`
+  # fallback stays valid JSON for downstream jq reads.
+  workflows_json="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/actions/runs?per_page=50" 2>/dev/null || echo '{"workflow_runs":[]}')"
   workflow_outcomes="$(printf '%s' "${workflows_json}" | jq -c --arg head_ref "${head_ref}" --arg head_sha "${head_sha}" '
     [.workflow_runs[]?
       | select((.name // "") == "AI Review"
@@ -4790,7 +4800,9 @@ These issues will enter the AI pipeline (clarify → plan → implement → revi
 
   if [ "${#_gql_issue_nums[@]}" -gt 0 ]; then
     _gql_query="query { repository(owner: \"${_repo_owner}\", name: \"${_repo_name}\") {${_gql_fields} } }"
-    _labels_result="$(gh_retry gh api graphql -f query="${_gql_query}" 2>/dev/null || echo '{}')"
+    # _safe_gh_jq → clean empty stdout on failure so the `|| echo '{}'`
+    # fallback stays valid JSON for the downstream python parser.
+    _labels_result="$(gh_retry _safe_gh_jq graphql -f query="${_gql_query}" 2>/dev/null || echo '{}')"
     LABELS_JSON="$(echo "${_labels_result}" | python3 -c "
 import json, sys
 raw = json.load(sys.stdin)
@@ -6509,6 +6521,7 @@ Manual intervention required." >/dev/null
         PR_DIFF="(diff unavailable)"
       fi
       rm -f "${_pr_diff_tmp}"
+      unset _pr_diff_tmp
       _issue_status="$(jq -r --arg num "${inum}" --argjson wi "${WAVE_IDX}" \
         '.waves[$wi].issues[] | select((.github_issue | tostring) == $num) | .status // ""' \
         "${STATE_FILE}" 2>/dev/null | head -n1)"
@@ -7170,7 +7183,9 @@ for (( sidx=0; sidx<STANDALONE_COUNT; sidx++ )); do
 	fi
 
 	# Check mergeable state via REST API (dirty == merge conflicts)
-	S_PR_JSON="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${S_PR}" 2>/dev/null || echo '{}')"
+	# _safe_gh_jq → clean empty stdout on failure so the `|| echo '{}'`
+	# fallback stays valid JSON for the downstream jq reads.
+	S_PR_JSON="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/pulls/${S_PR}" 2>/dev/null || echo '{}')"
 	S_STATE="$(echo "${S_PR_JSON}" | jq -r '.state // ""')"
 	if [ "${S_STATE}" != "open" ]; then
 		continue

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -520,6 +520,13 @@ ensure_label_exists() {
 
   # Check if label already exists to avoid futile retries (gh label create
   # returns a non-zero exit code for existing labels, which is not transient).
+  #
+  # The two `gh api` probes below are intentionally NOT wrapped with
+  # `gh_retry`: a 404 (label missing) is the expected normal case on the
+  # first probe, and re-running it under exponential backoff would add
+  # ~31 s of latency to every label miss. Rate-limit detection + the
+  # Telegram admin alert still fire on the `gh_retry gh label create`
+  # immediately below, which is the write path that actually matters.
   local encoded_name
   encoded_name="$(printf '%s' "${label_name}" | jq -sRr @uri)"
   if gh api "repos/${GITHUB_REPOSITORY}/labels/${encoded_name}" >/dev/null 2>&1; then
@@ -537,6 +544,7 @@ ensure_label_exists() {
 
   # Creation can fail if another concurrent actor created the label first.
   # Cache only when a follow-up read confirms the label now exists.
+  # (Same rationale as above — not wrapped with gh_retry.)
   if gh api "repos/${GITHUB_REPOSITORY}/labels/${encoded_name}" >/dev/null 2>&1; then
     _ENSURED_LABELS_CACHE[${label_name}]=1
   fi
@@ -1338,7 +1346,7 @@ ensure_eager_final_pr() {
   fi
 
   local discovered
-  discovered="$(gh pr list \
+  discovered="$(gh_retry gh pr list \
     --repo "${GITHUB_REPOSITORY}" \
     --state open \
     --base "${default_branch}" \
@@ -1348,7 +1356,7 @@ ensure_eager_final_pr() {
 
   if [ -z "${discovered}" ]; then
     local pr_url
-    pr_url="$(gh pr create \
+    pr_url="$(gh_retry gh pr create \
       --repo "${GITHUB_REPOSITORY}" \
       --base "${default_branch}" \
       --head "${integration_branch}" \
@@ -1433,7 +1441,7 @@ invoke_judge_for_integration_conflict() {
 
   local pr_diff
   local pr_files
-  pr_diff="$(gh pr diff "${final_pr}" --repo "${GITHUB_REPOSITORY}" 2>/dev/null | head -c 120000 || true)"
+  pr_diff="$(gh_retry gh pr diff "${final_pr}" --repo "${GITHUB_REPOSITORY}" 2>/dev/null | head -c 120000 || true)"
   pr_files="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/pulls/${final_pr}/files" --jq '[.[] | {filename, status, additions, deletions}]' 2>/dev/null || echo "[]")"
   local retries
   retries="$(jq -r '.integration_conflict_dispatch_count // 0' "${STATE_FILE}")"
@@ -1836,7 +1844,7 @@ finalize_integration_merge_if_needed() {
   fi
 
   if [ -z "${final_pr}" ] || [ "${final_pr}" = "null" ]; then
-    final_pr="$(gh pr list \
+    final_pr="$(gh_retry gh pr list \
       --repo "${GITHUB_REPOSITORY}" \
       --state open \
       --base "${default_branch}" \
@@ -1847,7 +1855,7 @@ finalize_integration_merge_if_needed() {
 
   if [ -z "${final_pr}" ]; then
     local final_pr_url
-    final_pr_url="$(gh pr create \
+    final_pr_url="$(gh_retry gh pr create \
       --repo "${GITHUB_REPOSITORY}" \
       --base "${default_branch}" \
       --head "${integration_branch}" \
@@ -1903,7 +1911,7 @@ Unable to create or locate the final integration PR from \`${integration_branch}
     return 1
   fi
 
-  if gh pr merge "${final_pr}" --repo "${GITHUB_REPOSITORY}" --squash --delete-branch >/dev/null 2>&1; then
+  if gh_retry gh pr merge "${final_pr}" --repo "${GITHUB_REPOSITORY}" --squash --delete-branch >/dev/null 2>&1; then
     jq --argjson final_pr "${final_pr}" \
       '.final_merge_pr = $final_pr |
        .final_merge_status = "merged" |
@@ -2004,7 +2012,7 @@ has_active_validation_run() {
   local wf_name="${VALIDATE_WORKFLOW_NAME:-ai-validate.yml}"
   local active_count
 
-  active_count="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf_name}/runs?per_page=5" \
+  active_count="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf_name}/runs?per_page=5" \
     --jq '[.workflow_runs[] | select(.status == "in_progress" or .status == "queued")] | length' 2>/dev/null || echo '0')"
   if [ "${active_count}" -gt 0 ]; then
     return 0
@@ -2012,7 +2020,7 @@ has_active_validation_run() {
 
   # Fallback: check internal-validate.yml if primary name differs
   if [ "${wf_name}" != "internal-validate.yml" ]; then
-    active_count="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/internal-validate.yml/runs?per_page=5" \
+    active_count="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/internal-validate.yml/runs?per_page=5" \
       --jq '[.workflow_runs[] | select(.status == "in_progress" or .status == "queued")] | length' 2>/dev/null || echo '0')"
     if [ "${active_count}" -gt 0 ]; then
       return 0
@@ -2032,12 +2040,12 @@ get_last_validation_run_conclusion() {
   last_dispatch_ts="$(jq -r '.validation_last_dispatch_ts // 0' "${STATE_FILE}")"
 
   local runs_json
-  runs_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf_name}/runs?status=completed&per_page=5" \
+  runs_json="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf_name}/runs?status=completed&per_page=5" \
     --jq '.workflow_runs' 2>/dev/null || echo '[]')"
 
   # Fallback to internal-validate.yml if no completed runs found
   if [ "$(echo "${runs_json}" | jq 'length')" -eq 0 ] && [ "${wf_name}" != "internal-validate.yml" ]; then
-    runs_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/internal-validate.yml/runs?status=completed&per_page=5" \
+    runs_json="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/internal-validate.yml/runs?status=completed&per_page=5" \
       --jq '.workflow_runs' 2>/dev/null || echo '[]')"
   fi
 
@@ -2258,10 +2266,10 @@ build_active_issue_set() {
 
   # Fetch in_progress + queued runs (recent, max 50)
   local runs_json
-  runs_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?status=in_progress&per_page=50" \
+  runs_json="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/actions/runs?status=in_progress&per_page=50" \
     --jq '.workflow_runs' 2>/dev/null || echo '[]')"
   local queued_json
-  queued_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?status=queued&per_page=50" \
+  queued_json="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/actions/runs?status=queued&per_page=50" \
     --jq '.workflow_runs' 2>/dev/null || echo '[]')"
 
   # Merge both lists
@@ -2333,7 +2341,7 @@ cancel_zombie_runs_for_issue() {
 
   # Re-fetch in_progress runs and find zombies matching this issue
   local runs_json
-  runs_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?status=in_progress&per_page=50" \
+  runs_json="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/actions/runs?status=in_progress&per_page=50" \
     --jq '.workflow_runs' 2>/dev/null || echo '[]')"
 
   local zombie_run_ids
@@ -2350,7 +2358,7 @@ cancel_zombie_runs_for_issue() {
   if [ -n "${zombie_run_ids}" ]; then
     for run_id in ${zombie_run_ids}; do
       echo "  Cancelling zombie workflow run ${run_id} for issue #${issue_num}..."
-      gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel" -X POST 2>/dev/null || true
+      gh_retry gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel" -X POST 2>/dev/null || true
     done
   fi
 }
@@ -3591,8 +3599,8 @@ STALL_EOF
           merge_state="$(printf '%s' "${merge_pr_json}" | jq -r 'if (type == "object" and .state?) then .state else empty end' 2>/dev/null | tail -n1)"
           merge_mergeable="$(printf '%s' "${merge_pr_json}" | jq -r 'if (type == "object" and (.mergeable == true or .mergeable == false)) then .mergeable else empty end' 2>/dev/null | tail -n1)"
           if [ "${merge_state}" = "open" ] && [ "${merge_mergeable}" = "true" ] && _pr_checks_completed "${merge_pr}"; then
-            gh pr merge "${merge_pr}" --repo "${GITHUB_REPOSITORY}" --squash --auto >/dev/null 2>&1 \
-              || gh pr merge "${merge_pr}" --repo "${GITHUB_REPOSITORY}" --squash >/dev/null 2>&1 \
+            gh_retry gh pr merge "${merge_pr}" --repo "${GITHUB_REPOSITORY}" --squash --auto >/dev/null 2>&1 \
+              || gh_retry gh pr merge "${merge_pr}" --repo "${GITHUB_REPOSITORY}" --squash >/dev/null 2>&1 \
               || true
           fi
         fi
@@ -3959,7 +3967,7 @@ _has_active_autofix_run()
 
 	for wf_candidate in ai-review.yml internal-review.yml review_autofix.yml; do
 		local active
-		active="$(gh run list --repo "${GITHUB_REPOSITORY}" \
+		active="$(gh_retry gh run list --repo "${GITHUB_REPOSITORY}" \
 			--workflow "${wf_candidate}" \
 			--branch "${head_ref}" \
 			--limit 5 \
@@ -4016,7 +4024,7 @@ _dispatch_review_for_conflicts()
 	echo "  ${log_prefix} Dispatching review workflow for conflict resolution..."
 
 	for wf_candidate in ai-review.yml internal-review.yml review_autofix.yml; do
-		if gh workflow run "${wf_candidate}" \
+		if gh_retry gh workflow run "${wf_candidate}" \
 			--repo "${GITHUB_REPOSITORY}" \
 			--ref "${head_ref}" \
 			-f pr_number="${pr_number}" 2>/dev/null; then
@@ -4128,7 +4136,7 @@ for ((tidx=0; tidx<COUNT; tidx++)); do
     fi
 
     # Search for child issues whose body contains the tracking reference
-    CHILD_ISSUES="$(gh api "search/issues" \
+    CHILD_ISSUES="$(gh_retry gh api "search/issues" \
       -f q="repo:${GITHUB_REPOSITORY} \"Tracking issue: #${TRACKING_NUM}\" in:body" \
       --jq '.items // []' 2>/dev/null || echo '[]')"
 
@@ -4563,10 +4571,10 @@ The poller will resume processing on the next cycle."
             PW_PR_MERGEABLE="$(_jq_field "${_pw_pr_json}" '.mergeable' 'true|false')"
             _pw_head_sha="$(_jq_field "${_pw_pr_json}" '.head.sha')"
 			if [ "${PW_PR_STATE}" = "open" ] && [ "${PW_PR_MERGEABLE}" = "true" ] && _pr_checks_completed "${PW_PR}" "${_pw_head_sha}"; then
-			  gh pr merge "${PW_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto 2>/dev/null \
-			    || gh pr merge "${PW_PR}" --repo "${GITHUB_REPOSITORY}" --squash 2>/dev/null || true
+			  gh_retry gh pr merge "${PW_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto 2>/dev/null \
+			    || gh_retry gh pr merge "${PW_PR}" --repo "${GITHUB_REPOSITORY}" --squash 2>/dev/null || true
             elif [ "${PW_PR_STATE}" = "open" ] && [ "${PW_PR_MERGEABLE}" = "false" ]; then
-              gh api "repos/${GITHUB_REPOSITORY}/pulls/${PW_PR}/update-branch" \
+              gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${PW_PR}/update-branch" \
                 -X PUT -f expected_head_sha="${_pw_head_sha}" \
                 2>/dev/null || true
             fi
@@ -4635,7 +4643,7 @@ The poller will resume processing on the next cycle."
 
       ensure_label_exists "ai:clarification"
       ensure_label_exists "ai:orchestrator-managed"
-      NEW_URL="$(gh issue create \
+      NEW_URL="$(gh_retry gh issue create \
         --repo "${GITHUB_REPOSITORY}" \
         --title "${DEF_TITLE}" \
         --body "${FULL_BODY}" \
@@ -4771,7 +4779,7 @@ These issues will enter the AI pipeline (clarify → plan → implement → revi
 
   if [ "${#_gql_issue_nums[@]}" -gt 0 ]; then
     _gql_query="query { repository(owner: \"${_repo_owner}\", name: \"${_repo_name}\") {${_gql_fields} } }"
-    _labels_result="$(gh api graphql -f query="${_gql_query}" 2>/dev/null || echo '{}')"
+    _labels_result="$(gh_retry gh api graphql -f query="${_gql_query}" 2>/dev/null || echo '{}')"
     LABELS_JSON="$(echo "${_labels_result}" | python3 -c "
 import json, sys
 raw = json.load(sys.stdin)
@@ -4926,9 +4934,9 @@ json.dump(result, sys.stdout)
       if [ "${PR_STATE}" = "open" ] && [ "${PR_MERGEABLE}" = "true" ]; then
 		if _pr_checks_completed "${RTM_PR}" "${_rtm_head_sha}"; then
 		  echo "  Merging PR #${RTM_PR} (squash)..."
-		  if gh pr merge "${RTM_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto; then
+		  if gh_retry gh pr merge "${RTM_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto; then
 		    echo "  PR #${RTM_PR} merge initiated."
-		  elif gh pr merge "${RTM_PR}" --repo "${GITHUB_REPOSITORY}" --squash; then
+		  elif gh_retry gh pr merge "${RTM_PR}" --repo "${GITHUB_REPOSITORY}" --squash; then
 		    echo "  PR #${RTM_PR} merged directly."
 		  else
 		    echo "::warning::Could not merge PR #${RTM_PR} for issue #${rtm_issue}. May need manual merge or branch protection prevents it."
@@ -4936,7 +4944,7 @@ json.dump(result, sys.stdout)
 		fi
       elif [ "${PR_STATE}" = "open" ] && [ "${PR_MERGEABLE}" = "false" ]; then
         echo "  PR #${RTM_PR} is not mergeable (mergeable=${PR_MERGEABLE}). Attempting branch update..."
-        if gh api "repos/${GITHUB_REPOSITORY}/pulls/${RTM_PR}/update-branch" \
+        if gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${RTM_PR}/update-branch" \
           -X PUT -f expected_head_sha="${_rtm_head_sha}" \
           2>/dev/null; then
           echo "  PR #${RTM_PR} branch updated via API. The synchronize event will re-trigger review (including conflict resolution)."
@@ -5009,7 +5017,7 @@ json.dump(result, sys.stdout)
 
     # Try the GitHub API update-branch first (creates a merge commit
     # if the merge is clean; fails when there are real conflicts).
-    if gh api "repos/${GITHUB_REPOSITORY}/pulls/${IP_PR}/update-branch" \
+    if gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${IP_PR}/update-branch" \
       -X PUT -f expected_head_sha="${_ip_head_sha}" \
       2>/dev/null; then
       echo "  PR #${IP_PR} branch updated via API. Synchronize event will re-trigger review."
@@ -5057,7 +5065,7 @@ json.dump(result, sys.stdout)
   # dispatch review workflows; it only attempts update-branch.
   if [ "${FEATURE_SWEEP_DONE}" != "true" ]; then
     echo "  [feature-sweep] Scanning open ai/issue-* PRs for base-branch drift..."
-    _FEATURE_SWEEP_JSON="$(gh pr list \
+    _FEATURE_SWEEP_JSON="$(gh_retry gh pr list \
       --repo "${GITHUB_REPOSITORY}" \
       --state open \
       --json number,headRefName,baseRefName,mergeable,mergeStateStatus \
@@ -5304,11 +5312,11 @@ json.dump(result, sys.stdout)
       fi
 
       # Collect full PR context for the judge
-      PR_DIFF="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${RB_PR}" \
+      PR_DIFF="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${RB_PR}" \
         -H 'Accept: application/vnd.github.diff' 2>/dev/null || echo "(diff unavailable)")"
-      PR_COMMENTS="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${RB_PR}/comments" \
+      PR_COMMENTS="$(gh_retry gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${RB_PR}/comments" \
         | jq -s 'add // [] | [.[] | {author: .user.login, body: .body, created_at: .created_at}]' 2>/dev/null || echo "[]")"
-      PR_REVIEW_COMMENTS="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${RB_PR}/comments" \
+      PR_REVIEW_COMMENTS="$(gh_retry gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${RB_PR}/comments" \
         | jq -s 'add // [] | [.[] | {author: .user.login, path: .path, line: .line, body: .body}]' 2>/dev/null || echo "[]")"
       PR_META="$(echo "${_rb_pr_json}" | jq '{title: .title, body: .body, head_ref: .head.ref, base_ref: .base.ref, head_sha: .head.sha}' 2>/dev/null || echo "{}")"
       ISSUE_BODY="$(_safe_gh_jq "repos/${GITHUB_REPOSITORY}/issues/${rb_issue}" --jq '.body' || echo "")"
@@ -5654,7 +5662,7 @@ sys.exit(1)
 
 **Remaining issues:** ${RB_REMAINING}"
 
-      gh api "repos/${GITHUB_REPOSITORY}/issues/${RB_PR}/comments" \
+      gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${RB_PR}/comments" \
         -f body="${RB_COMMENT}" >/dev/null 2>&1 || true
 
       case "${RB_ACTION}" in
@@ -5677,10 +5685,10 @@ sys.exit(1)
           PR_MERGEABLE="$(_jq_field "${_rb_merge_json}" '.mergeable' 'true|false')"
           _rb_merge_sha="$(_jq_field "${_rb_merge_json}" '.head.sha')"
 		  if [ "${PR_STATE}" = "open" ] && [ "${PR_MERGEABLE}" = "true" ] && _pr_checks_completed "${RB_PR}" "${_rb_merge_sha}"; then
-		    if gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto; then
+		    if gh_retry gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto; then
 		      echo "  PR #${RB_PR} merge initiated (auto)."
 		      RB_MERGED="true"
-		    elif gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash; then
+		    elif gh_retry gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash; then
 		      echo "  PR #${RB_PR} merged directly."
 		      RB_MERGED="true"
 		    else
@@ -5688,7 +5696,7 @@ sys.exit(1)
 		    fi
           elif [ "${PR_STATE}" = "open" ] && [ "${PR_MERGEABLE}" = "false" ]; then
             echo "  PR #${RB_PR} is not mergeable. Attempting branch update..."
-            if gh api "repos/${GITHUB_REPOSITORY}/pulls/${RB_PR}/update-branch" \
+            if gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${RB_PR}/update-branch" \
               -X PUT -f expected_head_sha="${_rb_merge_sha}" \
               2>/dev/null; then
               echo "  PR #${RB_PR} branch updated. Synchronize event will re-trigger review + conflict resolution."
@@ -5723,7 +5731,7 @@ sys.exit(1)
           if [ "${IS_FINAL}" = "true" ]; then
             echo "  Judge returned 'fix' but retries exhausted — treating as merge."
             ensure_label_exists "ai:ready-to-merge"
-            gh issue edit "${rb_issue}" --repo "${GITHUB_REPOSITORY}" \
+            gh_retry gh issue edit "${rb_issue}" --repo "${GITHUB_REPOSITORY}" \
               --remove-label 'ai:review-blocked' --add-label 'ai:ready-to-merge' 2>/dev/null || true
             RB_FORCE_MERGED="false"
             _rb_fm_json="$(_fetch_pr_json "${RB_PR}")"
@@ -5731,15 +5739,15 @@ sys.exit(1)
             PR_MERGEABLE="$(_jq_field "${_rb_fm_json}" '.mergeable' 'true|false')"
             _rb_fm_sha="$(_jq_field "${_rb_fm_json}" '.head.sha')"
 				if [ "${PR_STATE}" = "open" ] && [ "${PR_MERGEABLE}" = "true" ] && _pr_checks_completed "${RB_PR}" "${_rb_fm_sha}"; then
-				  if gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto \
-				    || gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash; then
+				  if gh_retry gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto \
+				    || gh_retry gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash; then
 				    RB_FORCE_MERGED="true"
 				  else
 				    echo "::warning::Could not merge PR #${RB_PR} in force-merge path."
 				  fi
             elif [ "${PR_STATE}" = "open" ] && [ "${PR_MERGEABLE}" = "false" ]; then
               echo "  PR #${RB_PR} is not mergeable (force-merge path). Attempting branch update..."
-              if gh api "repos/${GITHUB_REPOSITORY}/pulls/${RB_PR}/update-branch" \
+              if gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${RB_PR}/update-branch" \
                 -X PUT -f expected_head_sha="${_rb_fm_sha}" \
                 2>/dev/null; then
                 echo "  PR #${RB_PR} branch updated. Will retry force-merge on next poll cycle."
@@ -5775,7 +5783,7 @@ sys.exit(1)
             if [ "${RB_PR_STATE_NOW}" != "open" ] && [ "${RB_PR_MERGED_NOW}" != "true" ]; then
               # PR was closed without merge — skip
               echo "::warning::PR #${RB_PR} is closed (not merged). Skipping fix application."
-              gh issue edit "${rb_issue}" --repo "${GITHUB_REPOSITORY}" \
+              gh_retry gh issue edit "${rb_issue}" --repo "${GITHUB_REPOSITORY}" \
                 --remove-label 'ai:review-blocked' 2>/dev/null || true
               REVIEW_BLOCKED_STATE_CHANGED=true
             else
@@ -5922,7 +5930,7 @@ ${FOLLOWUP_GUARD_REASON}"
                       RB_FOLLOWUP_REFUSED="true"
                       REVIEW_BLOCKED_STATE_CHANGED=true
                     else
-                      FOLLOWUP_PR_URL="$(gh pr create \
+                      FOLLOWUP_PR_URL="$(gh_retry gh pr create \
                       --repo "${GITHUB_REPOSITORY}" \
                       --base "${BASE_REF}" \
                       --head "${FOLLOWUP_BRANCH}" \
@@ -5941,7 +5949,7 @@ ${RB_FIX_DESC}
                     fi
                     if [ -n "${FOLLOWUP_PR_URL}" ]; then
                       echo "  Created follow-up PR: ${FOLLOWUP_PR_URL}"
-                      gh issue edit "${rb_issue}" --repo "${GITHUB_REPOSITORY}" \
+                      gh_retry gh issue edit "${rb_issue}" --repo "${GITHUB_REPOSITORY}" \
                         --remove-label 'ai:review-blocked' 2>/dev/null || true
                       tg_notify "Orchestrator judge created follow-up PR for merged PR #${RB_PR} (issue #${rb_issue}): ${FOLLOWUP_PR_URL}"$'\n'"PR: $(_gh_url "pull/${RB_PR}")"$'\n'"Issue: $(_gh_url "issues/${rb_issue}")" "DEBUG"
                     else
@@ -5956,7 +5964,7 @@ ${RB_FIX_DESC}
                     echo "  Pushed [orchestrator-fix] commit to ${HEAD_REF}."
                     # Remove review-blocked label — the push triggers synchronize
                     # which re-runs review_autofix with a reset autofix counter.
-                    gh issue edit "${rb_issue}" --repo "${GITHUB_REPOSITORY}" \
+                    gh_retry gh issue edit "${rb_issue}" --repo "${GITHUB_REPOSITORY}" \
                       --remove-label 'ai:review-blocked' 2>/dev/null || true
                     tg_notify "Orchestrator judge pushed fix for review-blocked PR #${RB_PR} (issue #${rb_issue}, retry $((RETRY_COUNT + 1))/${MAX_REVIEW_BLOCKED_RETRIES})"$'\n'"PR: $(_gh_url "pull/${RB_PR}")"$'\n'"Issue: $(_gh_url "issues/${rb_issue}")" "DEBUG"
                   else
@@ -5967,21 +5975,21 @@ ${RB_FIX_DESC}
                 echo "  Judge produced no file changes."
                 if [ "${RB_TARGET_MERGED}" = "true" ]; then
                   echo "  No follow-up needed — merged PR has no outstanding fixes."
-                  gh issue edit "${rb_issue}" --repo "${GITHUB_REPOSITORY}" \
+                  gh_retry gh issue edit "${rb_issue}" --repo "${GITHUB_REPOSITORY}" \
                     --remove-label 'ai:review-blocked' 2>/dev/null || true
                   tg_notify "Orchestrator judge found no fixes needed for merged PR #${RB_PR} (issue #${rb_issue})"$'\n'"PR: $(_gh_url "pull/${RB_PR}")"$'\n'"Issue: $(_gh_url "issues/${rb_issue}")" "DEBUG"
                 else
                   echo "  Treating as merge decision."
                   ensure_label_exists "ai:ready-to-merge"
-                  gh issue edit "${rb_issue}" --repo "${GITHUB_REPOSITORY}" \
+                  gh_retry gh issue edit "${rb_issue}" --repo "${GITHUB_REPOSITORY}" \
                     --remove-label 'ai:review-blocked' --add-label 'ai:ready-to-merge' 2>/dev/null || true
                   _rb_nofix_json="$(_fetch_pr_json "${RB_PR}")"
                   PR_STATE="$(_jq_field "${_rb_nofix_json}" '.state' 'open|closed|merged')"
                   PR_MERGEABLE="$(_jq_field "${_rb_nofix_json}" '.mergeable' 'true|false')"
                   _rb_nofix_sha="$(_jq_field "${_rb_nofix_json}" '.head.sha')"
                   if [ "${PR_STATE}" = "open" ] && [ "${PR_MERGEABLE}" = "true" ] && _pr_checks_completed "${RB_PR}" "${_rb_nofix_sha}"; then
-                    if gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto \
-                      || gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash; then
+                    if gh_retry gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto \
+                      || gh_retry gh pr merge "${RB_PR}" --repo "${GITHUB_REPOSITORY}" --squash; then
                       tg_notify "Orchestrator judge merged PR #${RB_PR} (no fix changes needed, issue #${rb_issue})"$'\n'"PR: $(_gh_url "pull/${RB_PR}")"$'\n'"Issue: $(_gh_url "issues/${rb_issue}")" "DEBUG"
                     else
                       echo "::warning::Could not merge PR #${RB_PR} in no-fix merge path."
@@ -6015,7 +6023,7 @@ ${RB_FIX_DESC}
           # judge call; close_and_reissue operates via GitHub API only.
           rb_cleanup_combined_workspace
           # Close the PR
-          gh pr close "${RB_PR}" --repo "${GITHUB_REPOSITORY}" \
+          gh_retry gh pr close "${RB_PR}" --repo "${GITHUB_REPOSITORY}" \
             --comment "Closed by orchestrator judge — the approach needs rework. A new issue will be created with refined guidance." \
             2>/dev/null || true
 
@@ -6042,7 +6050,7 @@ ${RB_FIX_DESC}
 
             ensure_label_exists "ai:clarification"
             ensure_label_exists "ai:orchestrator-managed"
-            NEW_URL="$(gh issue create \
+            NEW_URL="$(gh_retry gh issue create \
               --repo "${GITHUB_REPOSITORY}" \
               --title "${NEW_ISSUE_TITLE}" \
               --body "${FULL_NEW_BODY}" \
@@ -6148,9 +6156,9 @@ ${RB_FIX_DESC}
     if [ "${NOOP_COUNT}" -ge "${MAX_IMPL_NOOP_REISSUES}" ]; then
       echo "  Issue #${if_issue} (${IF_LOCAL_ID}) hit implementation no-op cap (${OBSERVED_NOOP_COUNT}/${MAX_IMPL_NOOP_REISSUES}). Closing as likely already resolved — judge will verify."
       bump_impl_noop_count "${IF_LOCAL_ID}"
-      gh issue edit "${if_issue}" --repo "${GITHUB_REPOSITORY}" \
+      gh_retry gh issue edit "${if_issue}" --repo "${GITHUB_REPOSITORY}" \
         --remove-label 'ai:implementation-failed' --add-label 'ai:closed' 2>/dev/null || true
-      gh issue close "${if_issue}" --repo "${GITHUB_REPOSITORY}" \
+      gh_retry gh issue close "${if_issue}" --repo "${GITHUB_REPOSITORY}" \
         -c "Closing: implementation produced no changes ${OBSERVED_NOOP_COUNT} time(s). The code described in this issue likely already exists on the default branch. The wave-completion judge will verify." 2>/dev/null || true
       tg_notify "Issue #${if_issue} (${IF_LOCAL_ID}) hit impl no-op cap (${OBSERVED_NOOP_COUNT}). Closed as likely already resolved — judge will verify."$'\n'"Issue: $(_gh_url "issues/${if_issue}")" "WARNING"
       IMPL_FAILED_STATE_CHANGED=true
@@ -6191,7 +6199,7 @@ REISSUE_EOF
 
     ensure_label_exists "ai:clarification"
     ensure_label_exists "ai:orchestrator-managed"
-    NEW_ISSUE_URL="$(gh issue create --repo "${GITHUB_REPOSITORY}" \
+    NEW_ISSUE_URL="$(gh_retry gh issue create --repo "${GITHUB_REPOSITORY}" \
       --title "${IF_TITLE}" \
       --body "${NEW_BODY}" \
       --label "ai:clarification" \
@@ -6402,7 +6410,7 @@ with open('${STATE_FILE}', 'w') as f:
     echo "::error::Judge stall cycle limit reached ($((JUDGE_STALL_CYCLES + 1)) > ${MAX_JUDGE}). Marking project as failed."
     jq '.status = "failed"' "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
     post_state_comment
-    gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
+    gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
       -f body="## Project Failed — Judge stall cycle limit exceeded
 
 Judge has used ${JUDGE_STALL_CYCLES} stall cycle(s) (recovery/fix-ups) out of ${MAX_JUDGE} allowed (total judge evaluations: ${JUDGE_CYCLE}).
@@ -6478,7 +6486,7 @@ Manual intervention required." >/dev/null
       --jq '[.[] | select(.event == "cross-referenced" and .source.issue.pull_request != null) | .source.issue.number] | last' \
       || echo "")"
     if [[ "${PR_NUM}" =~ ^[0-9]+$ ]]; then
-      PR_DIFF="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUM}" \
+      PR_DIFF="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUM}" \
         -H 'Accept: application/vnd.github.diff' 2>/dev/null | head -500 || echo "(diff unavailable)")"
       _issue_status="$(jq -r --arg num "${inum}" --argjson wi "${WAVE_IDX}" \
         '.waves[$wi].issues[] | select((.github_issue | tostring) == $num) | .status // ""' \
@@ -6690,7 +6698,7 @@ ${JUDGE_ASSESSMENT}
 New fix-up issues: ${NEW_ISSUES_COUNT}
 PRs to revert: ${REVERT_COUNT}"
 
-  gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
+  gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
     -f body="${JUDGE_COMMENT}" >/dev/null
 
   # ---------------------------------------------------------------
@@ -6699,7 +6707,7 @@ PRs to revert: ${REVERT_COUNT}"
   if [ "${JUDGE_STATUS}" = "complete" ] && [ "${PROJECT_COMPLETE}" != "true" ]; then
     echo "::warning::Judge returned 'complete' but project_complete=${PROJECT_COMPLETE} (wave ${CURRENT_WAVE}/${TOTAL_WAVES}). Overriding to 'in_progress'."
     JUDGE_STATUS="in_progress"
-    gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
+    gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
       -f body="⚠️ Judge verdict overridden: \`complete\` → \`in_progress\` because wave ${CURRENT_WAVE}/${TOTAL_WAVES} is not the final wave. Advancing to next wave." >/dev/null
   fi
 
@@ -6782,7 +6790,7 @@ All waves have merged and the judge is satisfied. Transitioning to runtime valid
 
         post_state_comment
 
-        gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
+        gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
           -f body="## Project Failed
 
 Recovery was attempted ${RECOVERY_COUNT} time(s) (max ${MAX_RECOVERY_ATTEMPTS}) but the judge still reports failure. Manual intervention required.
@@ -6807,7 +6815,7 @@ Recovery was attempted ${RECOVERY_COUNT} time(s) (max ${MAX_RECOVERY_ATTEMPTS}) 
           if [[ "${PR_TO_REVERT}" =~ ^[0-9]+$ ]]; then
             echo "  Reverting PR #${PR_TO_REVERT} (issue #${revert_issue})..."
             # Create revert PR via gh
-            gh api "repos/${GITHUB_REPOSITORY}/pulls" \
+            gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls" \
               -f title="Revert PR #${PR_TO_REVERT} (orchestrator auto-recovery)" \
               -f head="revert-${PR_TO_REVERT}-$(date +%s)" \
               -f base="${DEFAULT_BRANCH}" \
@@ -6822,7 +6830,7 @@ Recovery was attempted ${RECOVERY_COUNT} time(s) (max ${MAX_RECOVERY_ATTEMPTS}) 
                 git checkout -b "${REVERT_BRANCH}" "${DEFAULT_BRANCH}"
                 if git revert --no-edit "${MERGE_SHA}"; then
                   git push -u origin "${REVERT_BRANCH}"
-                  gh pr create \
+                  gh_retry gh pr create \
                     --repo "${GITHUB_REPOSITORY}" \
                     --title "Revert PR #${PR_TO_REVERT} (orchestrator auto-recovery)" \
                     --body "Automated revert of PR #${PR_TO_REVERT} by orchestrator judge.
@@ -6876,7 +6884,7 @@ Recovery was attempted ${RECOVERY_COUNT} time(s) (max ${MAX_RECOVERY_ATTEMPTS}) 
 
           ensure_label_exists "ai:clarification"
           ensure_label_exists "ai:orchestrator-managed"
-          FIX_URL="$(gh issue create \
+          FIX_URL="$(gh_retry gh issue create \
             --repo "${GITHUB_REPOSITORY}" \
             --title "${FIX_TITLE}" \
             --body "${FULL_FIX_BODY}" \
@@ -6946,7 +6954,7 @@ Recovery was attempted ${RECOVERY_COUNT} time(s) (max ${MAX_RECOVERY_ATTEMPTS}) 
 
           ensure_label_exists "ai:clarification"
           ensure_label_exists "ai:orchestrator-managed"
-          NEW_URL="$(gh issue create \
+          NEW_URL="$(gh_retry gh issue create \
             --repo "${GITHUB_REPOSITORY}" \
             --title "${NEW_TITLE}" \
             --body "${FULL_NEW_BODY}" \
@@ -7030,7 +7038,7 @@ Recovery was attempted ${RECOVERY_COUNT} time(s) (max ${MAX_RECOVERY_ATTEMPTS}) 
 
           ensure_label_exists "ai:clarification"
           ensure_label_exists "ai:orchestrator-managed"
-          NEW_URL="$(gh issue create \
+          NEW_URL="$(gh_retry gh issue create \
             --repo "${GITHUB_REPOSITORY}" \
             --title "${DEF_TITLE}" \
             --body "${FULL_BODY}" \
@@ -7067,7 +7075,7 @@ $(for inum in ${CREATED_NUMS}; do echo "- #${inum}"; done)
 
 These issues will enter the AI pipeline (clarify → plan → implement → review)."
 
-        gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
+        gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
           -f body="${WAVE_COMMENT}" >/dev/null
       else
         # All waves dispatched but judge says in_progress with new issues
@@ -7111,7 +7119,7 @@ echo "========================================"
 # Collect open PR candidates with their refs.
 # gh pr list does not expose mergeable, so we fetch the full list and
 # then query each candidate via the REST API.
-STANDALONE_PRS="$(gh pr list \
+STANDALONE_PRS="$(gh_retry gh pr list \
 	--repo "${GITHUB_REPOSITORY}" \
 	--state open \
 	--json number,headRefName,baseRefName \
@@ -7141,7 +7149,7 @@ for (( sidx=0; sidx<STANDALONE_COUNT; sidx++ )); do
 	fi
 
 	# Check mergeable state via REST API (dirty == merge conflicts)
-	S_PR_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${S_PR}" 2>/dev/null || echo '{}')"
+	S_PR_JSON="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${S_PR}" 2>/dev/null || echo '{}')"
 	S_STATE="$(echo "${S_PR_JSON}" | jq -r '.state // ""')"
 	if [ "${S_STATE}" != "open" ]; then
 		continue
@@ -7166,7 +7174,7 @@ for (( sidx=0; sidx<STANDALONE_COUNT; sidx++ )); do
 
 	# Stage 1: Try the GitHub API update-branch endpoint (clean merge)
 	S_HEAD_SHA="$(echo "${S_PR_JSON}" | jq -r '.head.sha // ""')"
-	if [ -n "${S_HEAD_SHA}" ] && gh api "repos/${GITHUB_REPOSITORY}/pulls/${S_PR}/update-branch" \
+	if [ -n "${S_HEAD_SHA}" ] && gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${S_PR}/update-branch" \
 		-X PUT -f expected_head_sha="${S_HEAD_SHA}" 2>/dev/null; then
 		echo "  PR #${S_PR} branch updated via API. Synchronize event will re-trigger review."
 		CONFLICT_SWEEP_FIXED=$(( CONFLICT_SWEEP_FIXED + 1 ))

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # Source rate-limit-aware GH API helpers (provides gh_retry and the
-# Telegram admin alert on GH API rate-limit events). Fail-open if the
-# helper is absent.
-source "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh" 2>/dev/null || true
+# Telegram admin alert on GH API rate-limit events).
+if [ -n "${SUPPORT_SCRIPTS_DIR:-}" ] && [ -f "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh" ]; then
+  # shellcheck source=/dev/null
+  source "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh"
+fi
+# Fallback: if gh_helpers.sh was not sourced (missing file, unset
+# SUPPORT_SCRIPTS_DIR), define a pass-through so subsequent
+# `gh_retry gh ...` calls still execute — without the rate-limit
+# retry/alert behaviour, but without hard-failing under `set -e`.
+if ! command -v gh_retry >/dev/null 2>&1; then
+  gh_retry() { "$@"; }
+fi
 
 if [ ! -s "${LAST_RUN_DIFF_FILE}" ]; then
   echo "LAST_RUN_DIFF_FILE is missing or empty before editor stage; using placeholder context."

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# Source rate-limit-aware GH API helpers (provides gh_retry and the
+# Telegram admin alert on GH API rate-limit events). Fail-open if the
+# helper is absent.
+source "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh" 2>/dev/null || true
 
 if [ ! -s "${LAST_RUN_DIFF_FILE}" ]; then
   echo "LAST_RUN_DIFF_FILE is missing or empty before editor stage; using placeholder context."
@@ -456,7 +460,7 @@ while [ "${attempt}" -le 3 ]; do
       # PR state check — abort if PR was merged/closed (~every 2 min)
       wd_iter=$((wd_iter + 1))
       if [ $((wd_iter % 8)) -eq 0 ]; then
-        pr_state="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.state' 2>/dev/null | grep -xE 'open|closed|merged' || echo "open")"
+        pr_state="$(gh_retry gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.state' 2>/dev/null | grep -xE 'open|closed|merged' || echo "open")"
         if [ "${pr_state}" != "open" ]; then
           echo "Editor aborted — PR #${PR_NUMBER} is ${pr_state} (attempt ${attempt})." >&2
           touch "/tmp/pr_closed_sentinel_${PR_NUMBER}"

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -335,7 +335,11 @@ case "${RB_ACTION}" in
     _mergeable_sleep="${PR_MERGEABLE_POLL_SLEEP:-5}"
     _attempt=0
     while [ "${_attempt}" -lt "${_mergeable_attempts}" ]; do
-      _pr_json="$(gh_retry gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" 2>/dev/null || echo '{}')"
+      # Use _safe_gh_jq (via gh_retry) so a failed `gh api` response
+      # emits no stdout — preventing the error JSON body from being
+      # concatenated with the `|| echo '{}'` fallback, which would
+      # yield invalid JSON and break the downstream `jq` parses below.
+      _pr_json="$(gh_retry _safe_gh_jq "repos/${REPOSITORY}/pulls/${PR_NUMBER}" 2>/dev/null || echo '{}')"
       PR_STATE="$(echo "${_pr_json}" | jq -r '.state // ""' | grep -xE 'open|closed|merged' || echo "")"
       PR_MERGEABLE="$(echo "${_pr_json}" | jq -r '.mergeable // ""' | grep -xE 'true|false' || echo "")"
       # Stop polling as soon as state is terminal or mergeability is known.
@@ -351,8 +355,16 @@ case "${RB_ACTION}" in
 
     if [ "${PR_STATE}" = "open" ] && [ "${PR_MERGEABLE}" = "true" ]; then
       if [ "${ENABLE_AUTO_MERGE}" = "true" ]; then
-        gh_retry gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash --auto 2>/dev/null \
-          || gh_retry gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash 2>/dev/null || true
+        # NOTE: gh pr merge is intentionally NOT wrapped with gh_retry.
+        # These calls are best-effort (trailing `|| true`); non-
+        # transient failures (branch protection, permissions, merge
+        # queue, 422 merge commit conflicts, etc.) would otherwise
+        # incur ~31s of exponential backoff under gh_retry before
+        # reaching the `|| true` fallthrough. Rate-limit alerts still
+        # fire through every other gh_retry-wrapped call in this
+        # script.
+        gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash --auto 2>/dev/null \
+          || gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash 2>/dev/null || true
       fi
     elif [ "${PR_STATE}" = "open" ] && [ "${PR_MERGEABLE}" = "false" ]; then
       echo "::warning::PR #${PR_NUMBER} has merge conflicts (mergeable=false); judge cannot merge as-is."
@@ -381,8 +393,9 @@ case "${RB_ACTION}" in
 
       PR_STATE="$(gh_retry gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.state' 2>/dev/null | grep -xE 'open|closed|merged' || echo "")"
       if [ "${PR_STATE}" = "open" ] && [ "${ENABLE_AUTO_MERGE}" = "true" ]; then
-        gh_retry gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash --auto 2>/dev/null \
-          || gh_retry gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash 2>/dev/null || true
+        # Best-effort merge — see note above re: gh_retry.
+        gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash --auto 2>/dev/null \
+          || gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash 2>/dev/null || true
       fi
 
       echo "judge_handled=true" >> "$GITHUB_OUTPUT"

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+SUPPORT_SCRIPTS_DIR="${SUPPORT_SCRIPTS_DIR:-/tmp/codex-support}"
 source "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh" 2>/dev/null || true
 # Fallback: if gh_helpers.sh was not sourced (missing file), define a
 # pass-through so subsequent `gh_retry gh ...` calls still execute —

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -28,18 +28,27 @@ else
     chmod +x "${SUPPORT_SCRIPTS_DIR}/label_helpers.sh"
   else
     # Last-resort inline fallback if fetch fails.
+    #
+    # NOTE: `gh label create` is intentionally NOT wrapped with
+    # `gh_retry` here — a "label already exists" (422) is a
+    # non-transient error, and `gh_retry` would add ~31 s of
+    # exponential backoff before the trailing `|| true` takes
+    # effect. Same rationale as `ensure_label_exists` in
+    # `scripts/orchestrate_poll_process.sh`. Rate-limit alerts
+    # still fire through every other `gh_retry`-wrapped call
+    # elsewhere in this script.
     ensure_label_exists() {
       local label_name="$1"
       local repo="$2"
       case "${label_name}" in
         ai:ready-to-merge)
-          gh_retry gh label create "${label_name}" --repo "${repo}" --color "0e8a16" --description "PR review complete and ready to merge" 2>/dev/null || true
+          gh label create "${label_name}" --repo "${repo}" --color "0e8a16" --description "PR review complete and ready to merge" 2>/dev/null || true
           ;;
         ai:closed)
-          gh_retry gh label create "${label_name}" --repo "${repo}" --color "6a737d" --description "Linked PR closed without merge" 2>/dev/null || true
+          gh label create "${label_name}" --repo "${repo}" --color "6a737d" --description "Linked PR closed without merge" 2>/dev/null || true
           ;;
         *)
-          gh_retry gh label create "${label_name}" --repo "${repo}" --color "1d76db" --description "AI workflow label" 2>/dev/null || true
+          gh label create "${label_name}" --repo "${repo}" --color "1d76db" --description "AI workflow label" 2>/dev/null || true
           ;;
       esac
     }

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -12,9 +12,9 @@ else
     script_ref="stable"
   fi
   mkdir -p "${SUPPORT_SCRIPTS_DIR}"
-  if { gh api -H 'Accept: application/vnd.github.raw+json' \
+  if { gh_retry gh api -H 'Accept: application/vnd.github.raw+json' \
     "repos/${wf_source}/contents/scripts/label_helpers.sh?ref=${script_ref}" > "${SUPPORT_SCRIPTS_DIR}/label_helpers.sh" 2>/dev/null || \
-     gh api -H 'Accept: application/vnd.github.raw+json' \
+     gh_retry gh api -H 'Accept: application/vnd.github.raw+json' \
       "repos/${wf_source}/contents/scripts/label_helpers.sh?ref=main" > "${SUPPORT_SCRIPTS_DIR}/label_helpers.sh" 2>/dev/null; } && \
     [ -s "${SUPPORT_SCRIPTS_DIR}/label_helpers.sh" ] && source "${SUPPORT_SCRIPTS_DIR}/label_helpers.sh" 2>/dev/null; then
     chmod +x "${SUPPORT_SCRIPTS_DIR}/label_helpers.sh"
@@ -25,13 +25,13 @@ else
       local repo="$2"
       case "${label_name}" in
         ai:ready-to-merge)
-          gh label create "${label_name}" --repo "${repo}" --color "0e8a16" --description "PR review complete and ready to merge" 2>/dev/null || true
+          gh_retry gh label create "${label_name}" --repo "${repo}" --color "0e8a16" --description "PR review complete and ready to merge" 2>/dev/null || true
           ;;
         ai:closed)
-          gh label create "${label_name}" --repo "${repo}" --color "6a737d" --description "Linked PR closed without merge" 2>/dev/null || true
+          gh_retry gh label create "${label_name}" --repo "${repo}" --color "6a737d" --description "Linked PR closed without merge" 2>/dev/null || true
           ;;
         *)
-          gh label create "${label_name}" --repo "${repo}" --color "1d76db" --description "AI workflow label" 2>/dev/null || true
+          gh_retry gh label create "${label_name}" --repo "${repo}" --color "1d76db" --description "AI workflow label" 2>/dev/null || true
           ;;
       esac
     }
@@ -59,7 +59,7 @@ ensure_label_exists "ai:closed" "${REPOSITORY}"
 # -----------------------------------------------------------
 # Find linked issues for judge context
 # -----------------------------------------------------------
-ISSUE_NUMBERS="$(gh api graphql \
+ISSUE_NUMBERS="$(gh_retry gh api graphql \
   -f owner="${REPOSITORY%/*}" \
   -f name="${REPOSITORY#*/}" \
   -F number="${PR_NUMBER}" \
@@ -104,11 +104,11 @@ fi
 # -----------------------------------------------------------
 # Collect PR context for judge
 # -----------------------------------------------------------
-PR_DIFF="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
+PR_DIFF="$(gh_retry gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
   -H 'Accept: application/vnd.github.diff' 2>/dev/null || echo "(diff unavailable)")"
-PR_COMMENTS="$(gh api --paginate "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+PR_COMMENTS="$(gh_retry gh api --paginate "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
   | jq -s 'add // [] | [.[] | {author: .user.login, body: .body, created_at: .created_at}]' 2>/dev/null || echo "[]")"
-PR_REVIEW_COMMENTS="$(gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/comments" \
+PR_REVIEW_COMMENTS="$(gh_retry gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/comments" \
   | jq -s 'add // [] | [.[] | {author: .user.login, path: .path, line: .line, body: .body}]' 2>/dev/null || echo "[]")"
 PR_META_JSON="$(jq '.' "${PR_META_FILE}" 2>/dev/null || echo "{}")"
 
@@ -280,7 +280,7 @@ JUDGE_COMMENT="## Review-Blocked Judge Decision
 
 **Remaining issues:** ${RB_REMAINING}"
 
-gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+gh_retry gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
   -f body="${JUDGE_COMMENT}" >/dev/null 2>&1 || true
 
 # -----------------------------------------------------------
@@ -294,7 +294,7 @@ case "${RB_ACTION}" in
     ensure_label_exists "ai:ready-to-merge" "${REPOSITORY}"
     while IFS= read -r issue_number; do
       [ -n "${issue_number}" ] || continue
-      gh issue edit "${issue_number}" --repo "${REPOSITORY}" \
+      gh_retry gh issue edit "${issue_number}" --repo "${REPOSITORY}" \
         --remove-label 'ai:done' --remove-label 'ai:implementing' --remove-label 'ai:awaiting-approval' \
         --remove-label 'ai:planning' --remove-label 'ai:clarification' --remove-label 'ai:ready-to-merge' \
         --remove-label 'ai:review-blocked' --remove-label 'ai:merged' --remove-label 'ai:closed' \
@@ -318,7 +318,7 @@ case "${RB_ACTION}" in
     _mergeable_sleep="${PR_MERGEABLE_POLL_SLEEP:-5}"
     _attempt=0
     while [ "${_attempt}" -lt "${_mergeable_attempts}" ]; do
-      _pr_json="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" 2>/dev/null || echo '{}')"
+      _pr_json="$(gh_retry gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" 2>/dev/null || echo '{}')"
       PR_STATE="$(echo "${_pr_json}" | jq -r '.state // ""' | grep -xE 'open|closed|merged' || echo "")"
       PR_MERGEABLE="$(echo "${_pr_json}" | jq -r '.mergeable // ""' | grep -xE 'true|false' || echo "")"
       # Stop polling as soon as state is terminal or mergeability is known.
@@ -334,8 +334,8 @@ case "${RB_ACTION}" in
 
     if [ "${PR_STATE}" = "open" ] && [ "${PR_MERGEABLE}" = "true" ]; then
       if [ "${ENABLE_AUTO_MERGE}" = "true" ]; then
-        gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash --auto 2>/dev/null \
-          || gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash 2>/dev/null || true
+        gh_retry gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash --auto 2>/dev/null \
+          || gh_retry gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash 2>/dev/null || true
       fi
     elif [ "${PR_STATE}" = "open" ] && [ "${PR_MERGEABLE}" = "false" ]; then
       echo "::warning::PR #${PR_NUMBER} has merge conflicts (mergeable=false); judge cannot merge as-is."
@@ -355,17 +355,17 @@ case "${RB_ACTION}" in
       ensure_label_exists "ai:ready-to-merge" "${REPOSITORY}"
       while IFS= read -r issue_number; do
         [ -n "${issue_number}" ] || continue
-        gh issue edit "${issue_number}" --repo "${REPOSITORY}" \
+        gh_retry gh issue edit "${issue_number}" --repo "${REPOSITORY}" \
           --remove-label 'ai:done' --remove-label 'ai:implementing' --remove-label 'ai:awaiting-approval' \
           --remove-label 'ai:planning' --remove-label 'ai:clarification' --remove-label 'ai:ready-to-merge' \
           --remove-label 'ai:review-blocked' --remove-label 'ai:merged' --remove-label 'ai:closed' \
           --add-label 'ai:ready-to-merge' || true
       done <<< "${ISSUE_NUMBERS}"
 
-      PR_STATE="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.state' 2>/dev/null | grep -xE 'open|closed|merged' || echo "")"
+      PR_STATE="$(gh_retry gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.state' 2>/dev/null | grep -xE 'open|closed|merged' || echo "")"
       if [ "${PR_STATE}" = "open" ] && [ "${ENABLE_AUTO_MERGE}" = "true" ]; then
-        gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash --auto 2>/dev/null \
-          || gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash 2>/dev/null || true
+        gh_retry gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash --auto 2>/dev/null \
+          || gh_retry gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash 2>/dev/null || true
       fi
 
       echo "judge_handled=true" >> "$GITHUB_OUTPUT"
@@ -473,7 +473,7 @@ ${RB_FIX_DESC}"
           ensure_label_exists "ai:ready-to-merge" "${REPOSITORY}"
           while IFS= read -r issue_number; do
             [ -n "${issue_number}" ] || continue
-            gh issue edit "${issue_number}" --repo "${REPOSITORY}" \
+            gh_retry gh issue edit "${issue_number}" --repo "${REPOSITORY}" \
               --remove-label 'ai:review-blocked' --add-label 'ai:ready-to-merge' 2>/dev/null || true
           done <<< "${ISSUE_NUMBERS}"
           echo "judge_handled=true" >> "$GITHUB_OUTPUT"
@@ -484,7 +484,7 @@ ${RB_FIX_DESC}"
         ensure_label_exists "ai:ready-to-merge" "${REPOSITORY}"
         while IFS= read -r issue_number; do
           [ -n "${issue_number}" ] || continue
-          gh issue edit "${issue_number}" --repo "${REPOSITORY}" \
+          gh_retry gh issue edit "${issue_number}" --repo "${REPOSITORY}" \
             --remove-label 'ai:review-blocked' --add-label 'ai:ready-to-merge' 2>/dev/null || true
         done <<< "${ISSUE_NUMBERS}"
         echo "judge_handled=true" >> "$GITHUB_OUTPUT"
@@ -497,7 +497,7 @@ ${RB_FIX_DESC}"
     echo "Judge says close PR #${PR_NUMBER} and reissue."
 
     # Close the PR
-    gh pr close "${PR_NUMBER}" --repo "${REPOSITORY}" \
+    gh_retry gh pr close "${PR_NUMBER}" --repo "${REPOSITORY}" \
       --comment "Closed by review-blocked judge — the approach needs rework. A new issue will be created with refined guidance." \
       2>/dev/null || true
 
@@ -505,7 +505,7 @@ ${RB_FIX_DESC}"
     ensure_label_exists "ai:closed" "${REPOSITORY}"
     while IFS= read -r issue_number; do
       [ -n "${issue_number}" ] || continue
-      gh issue edit "${issue_number}" --repo "${REPOSITORY}" \
+      gh_retry gh issue edit "${issue_number}" --repo "${REPOSITORY}" \
         --remove-label 'ai:review-blocked' --remove-label 'ai:done' \
         --add-label 'ai:closed' 2>/dev/null || true
     done <<< "${ISSUE_NUMBERS}"

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 source "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh" 2>/dev/null || true
+# Fallback: if gh_helpers.sh was not sourced (missing file), define a
+# pass-through so subsequent `gh_retry gh ...` calls still execute —
+# without the rate-limit retry/alert behaviour, but without hard-failing
+# under `set -e`.
+if ! command -v gh_retry >/dev/null 2>&1; then
+  gh_retry() { "$@"; }
+fi
 if [ -f "${SUPPORT_SCRIPTS_DIR}/label_helpers.sh" ] && source "${SUPPORT_SCRIPTS_DIR}/label_helpers.sh" 2>/dev/null; then
   :
 else

--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# Source rate-limit-aware GH API helpers (provides gh_retry and the
+# Telegram admin alert on GH API rate-limit events). Fail-open if the
+# helper is absent.
+source "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh" 2>/dev/null || true
 
 if [ ! -s "${LAST_RUN_DIFF_FILE}" ]; then
   echo "LAST_RUN_DIFF_FILE is missing or empty; using placeholder context for this run."
@@ -24,7 +28,7 @@ fi
 # Safe to skip on local/manual invocation where PR_NUMBER or REPOSITORY are
 # unset — downstream watchdog polling remains the fallback.
 if [ -n "${PR_NUMBER:-}" ] && [ -n "${REPOSITORY:-}" ] && command -v gh >/dev/null 2>&1; then
-  preflight_state="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.state' 2>/dev/null | grep -xE 'open|closed|merged' || echo "open")"
+  preflight_state="$(gh_retry gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.state' 2>/dev/null | grep -xE 'open|closed|merged' || echo "open")"
   if [ "${preflight_state}" != "open" ]; then
     echo "Pre-flight: PR #${PR_NUMBER} is ${preflight_state} — skipping reviewer fan-out."
     mkdir -p "${PREVIOUS_REVIEWS_DIR}"
@@ -701,7 +705,7 @@ run_reviewer() {
           # stdout on 403/429 rate-limit responses (--jq is not applied
           # to error bodies, so raw JSON leaks into the variable and
           # defeats the || echo "open" fallback).
-          pr_state="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.state' 2>/dev/null | grep -xE 'open|closed|merged' || echo "open")"
+          pr_state="$(gh_retry gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.state' 2>/dev/null | grep -xE 'open|closed|merged' || echo "open")"
           if [ "${pr_state}" != "open" ]; then
             echo "Reviewer ${model} aborted — PR #${PR_NUMBER} is ${pr_state}." | tee -a "${log_file}" >&2
             printf 'pr_closed_api' > "${wd_reason_file}"

--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # Source rate-limit-aware GH API helpers (provides gh_retry and the
-# Telegram admin alert on GH API rate-limit events). Fail-open if the
-# helper is absent.
-source "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh" 2>/dev/null || true
+# Telegram admin alert on GH API rate-limit events).
+if [ -n "${SUPPORT_SCRIPTS_DIR:-}" ] && [ -f "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh" ]; then
+  # shellcheck source=/dev/null
+  source "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh"
+fi
+# Fallback: if gh_helpers.sh was not sourced (missing file, unset
+# SUPPORT_SCRIPTS_DIR), define a pass-through so subsequent
+# `gh_retry gh ...` calls still execute — without the rate-limit
+# retry/alert behaviour, but without hard-failing under `set -e`.
+if ! command -v gh_retry >/dev/null 2>&1; then
+  gh_retry() { "$@"; }
+fi
 
 if [ ! -s "${LAST_RUN_DIFF_FILE}" ]; then
   echo "LAST_RUN_DIFF_FILE is missing or empty; using placeholder context for this run."


### PR DESCRIPTION
Adds `_gh_ratelimit_tg_alert` to `scripts/gh_helpers.sh` and wires it
into the rate-limit branch of all four GH API helpers (`gh_retry`,
`gh_retry_to_file`, `gh_api_json_to_file`, `curl_gh_api`). Every
workflow or script that routes through these helpers now emits a
single admin Telegram alert when GitHub rate limits kick in.

Throttling state is kept in a Telegram pinned message in the admin
chat via an embedded `<!-- gh_rl_ts:EPOCH -->` marker, read with
`getChat`. This deliberately avoids any GitHub API call so the
throttle keeps working while the GitHub API itself is the resource
being limited.

Semantics:
- Cooldown: `TG_GH_RATELIMIT_ALERT_COOLDOWN_SECS` (default 3600 s).
- Level: WARNING.
- Fail-closed: on `pinChatMessage` failure the just-sent message is
  `deleteMessage`'d to preserve the "<= 1 alert per cooldown" invariant.
- No-op when `TG_BOT_SECRET`/`TG_ADMIN_CHAT_ID` are unset.

Migration of direct `gh api` / `curl api.github.com` callers that
bypass `gh_helpers.sh` is pending a scope decision and will land in
a follow-up commit on the same branch.

https://claude.ai/code/session_01NGwxGuGuncsxMf7EAg5Fdr