### PR TITLE
claude/analyze-job-logs-AsgWT

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2912,7 +2912,12 @@ jobs:
           trap 'rm -f "${push_stderr_file}"' EXIT
           while :; do
             push_exit=0
-            git push origin "HEAD:${TARGET_BRANCH}" 2>"${push_stderr_file}" || push_exit=$?
+            # Capture BOTH stdout and stderr: `git push` normally emits
+            # rejection details on stderr, but remote helpers and some
+            # git versions can surface `! [rejected]` / `non-fast-forward`
+            # on stdout, which would cause stderr-only classification to
+            # mis-route a retryable failure to the hard-fail branch.
+            git push origin "HEAD:${TARGET_BRANCH}" >"${push_stderr_file}" 2>&1 || push_exit=$?
             cat "${push_stderr_file}" >&2
             if [ "${push_exit}" -eq 0 ]; then
               echo "Push complete."

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2875,8 +2875,54 @@ jobs:
 
           git remote set-url origin "https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}"
           echo "Pushing pending commits to ${TARGET_BRANCH}..."
-          git push origin "HEAD:${TARGET_BRANCH}"
-          echo "Push complete."
+
+          # Retry non-fast-forward rejections with fetch+rebase.  A concurrent
+          # push to ${TARGET_BRANCH} (another workflow run, a human push, a
+          # sibling autofix job) during this ~30-minute job would otherwise
+          # cause an unrecoverable `! [rejected] (fetch first)` failure and
+          # lose the deferred autofix / [ai-merge-resolve] commit.  We rebase
+          # our local commits on top of the advanced remote tip and retry up
+          # to 3 times with exponential backoff.  If the rebase itself would
+          # introduce new conflicts, we abort the rebase and fail loudly —
+          # we must never silently resurrect conflict markers that the
+          # resolver just cleared, and we must never clobber someone else's
+          # commits (no --force / --force-with-lease on this path).
+          max_push_attempts=3
+          push_attempt=1
+          push_backoff=2
+          push_stderr_file="$(mktemp)"
+          trap 'rm -f "${push_stderr_file}"' EXIT
+          while :; do
+            push_exit=0
+            git push origin "HEAD:${TARGET_BRANCH}" 2>"${push_stderr_file}" || push_exit=$?
+            cat "${push_stderr_file}" >&2
+            if [ "${push_exit}" -eq 0 ]; then
+              echo "Push complete."
+              break
+            fi
+            if ! grep -qE '\[rejected\].*\(fetch first\)|non-fast-forward' "${push_stderr_file}"; then
+              echo "::error::git push failed (exit ${push_exit}) for a reason other than non-fast-forward; not retrying."
+              exit "${push_exit}"
+            fi
+            if [ "${push_attempt}" -ge "${max_push_attempts}" ]; then
+              echo "::error::git push still rejected as non-fast-forward after ${max_push_attempts} attempts; giving up."
+              exit 1
+            fi
+            echo "::warning::git push rejected as non-fast-forward (attempt ${push_attempt}/${max_push_attempts}); fetching ${TARGET_BRANCH} and rebasing before retry in ${push_backoff}s."
+            sleep "${push_backoff}"
+            push_backoff=$((push_backoff * 2))
+            push_attempt=$((push_attempt + 1))
+            if ! git fetch origin "${TARGET_BRANCH}"; then
+              echo "::error::git fetch origin ${TARGET_BRANCH} failed during push-retry; giving up to avoid pushing a stale tree."
+              exit 1
+            fi
+            if ! git rebase "origin/${TARGET_BRANCH}"; then
+              echo "::error::git rebase onto origin/${TARGET_BRANCH} failed — rebase would introduce new conflicts. Aborting rebase and failing the job; refusing to silently resurrect conflict markers."
+              git rebase --abort || true
+              exit 1
+            fi
+            : > "${push_stderr_file}"
+          done
 
       - name: Re-trigger review via workflow_dispatch
         # The push above fires a pull_request synchronize event, but GitHub

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2877,17 +2877,34 @@ jobs:
           git remote set-url origin "https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}"
           echo "Pushing pending commits to ${TARGET_BRANCH}..."
 
-          # Retry non-fast-forward rejections with fetch+rebase.  A concurrent
+          # Retry non-fast-forward rejections with fetch+merge.  A concurrent
           # push to ${TARGET_BRANCH} (another workflow run, a human push, a
           # sibling autofix job) during this ~30-minute job would otherwise
           # cause an unrecoverable `! [rejected] (fetch first)` failure and
-          # lose the deferred autofix / [ai-merge-resolve] commit.  We rebase
-          # our local commits on top of the advanced remote tip and retry up
-          # to 3 times with exponential backoff.  If the rebase itself would
-          # introduce new conflicts, we abort the rebase and fail loudly —
+          # lose the deferred autofix / [ai-merge-resolve] commit.  We merge
+          # the advanced remote tip into our local HEAD and retry up to 3
+          # times with exponential backoff.
+          #
+          # Why `git merge` and NOT `git rebase` here: the conflict-resolver
+          # step above (see the "NOTE: git is intentionally left in merge
+          # state" block around the `git commit -m "[ai-merge-resolve]…"`
+          # call) deliberately creates the ai-merge-resolve commit as a
+          # real two-parent merge commit.  That second parent is load-
+          # bearing — without it, git's merge-base walker rewinds to the
+          # original merge base on every subsequent `git merge` attempt
+          # and re-raises the identical conflict (observed on PR #908,
+          # which left the PR in mergeable_state=dirty).  A plain
+          # `git rebase` would flatten that merge commit into a single-
+          # parent commit and resurrect the exact bug PR #908 was designed
+          # to fix.  `git rebase --rebase-merges` would rewrite the merge
+          # commit SHA too.  `git merge` preserves the existing commit
+          # exactly and simply adds another merge commit on top when
+          # origin has genuinely advanced — never rewriting history and
+          # never clobbering other pushers' commits (no --force / no
+          # --force-with-lease on this path).  If the merge itself would
+          # introduce new conflicts we abort the merge and fail loudly —
           # we must never silently resurrect conflict markers that the
-          # resolver just cleared, and we must never clobber someone else's
-          # commits (no --force / --force-with-lease on this path).
+          # resolver just cleared.
           max_push_attempts=3
           push_attempt=1
           push_backoff=2
@@ -2909,7 +2926,7 @@ jobs:
               echo "::error::git push still rejected as non-fast-forward after ${max_push_attempts} attempts; giving up."
               exit 1
             fi
-            echo "::warning::git push rejected as non-fast-forward (attempt ${push_attempt}/${max_push_attempts}); fetching ${TARGET_BRANCH} and rebasing before retry in ${push_backoff}s."
+            echo "::warning::git push rejected as non-fast-forward (attempt ${push_attempt}/${max_push_attempts}); fetching ${TARGET_BRANCH} and merging before retry in ${push_backoff}s."
             sleep "${push_backoff}"
             push_backoff=$((push_backoff * 2))
             push_attempt=$((push_attempt + 1))
@@ -2923,9 +2940,9 @@ jobs:
               fetch_attempt=$((fetch_attempt + 1))
               sleep 2
             done
-            if ! git rebase "origin/${TARGET_BRANCH}"; then
-              echo "::error::git rebase onto origin/${TARGET_BRANCH} failed — rebase would introduce new conflicts. Aborting rebase and failing the job; refusing to silently resurrect conflict markers."
-              git rebase --abort || true
+            if ! git merge --no-edit --no-ff "origin/${TARGET_BRANCH}"; then
+              echo "::error::git merge origin/${TARGET_BRANCH} failed — merge would introduce new conflicts. Aborting merge and failing the job; refusing to silently resurrect conflict markers."
+              git merge --abort || true
               exit 1
             fi
             : > "${push_stderr_file}"

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2872,6 +2872,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           set -euo pipefail
+          export LANG=C
 
           git remote set-url origin "https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}"
           echo "Pushing pending commits to ${TARGET_BRANCH}..."
@@ -2912,10 +2913,16 @@ jobs:
             sleep "${push_backoff}"
             push_backoff=$((push_backoff * 2))
             push_attempt=$((push_attempt + 1))
-            if ! git fetch origin "${TARGET_BRANCH}"; then
-              echo "::error::git fetch origin ${TARGET_BRANCH} failed during push-retry; giving up to avoid pushing a stale tree."
-              exit 1
-            fi
+            fetch_attempt=1
+            while ! git fetch origin "${TARGET_BRANCH}"; do
+              if [ "${fetch_attempt}" -ge 2 ]; then
+                echo "::error::git fetch origin ${TARGET_BRANCH} failed twice during push-retry; giving up to avoid pushing a stale tree."
+                exit 1
+              fi
+              echo "::warning::git fetch origin ${TARGET_BRANCH} failed during push-retry (attempt ${fetch_attempt}/2); retrying in 2s."
+              fetch_attempt=$((fetch_attempt + 1))
+              sleep 2
+            done
             if ! git rebase "origin/${TARGET_BRANCH}"; then
               echo "::error::git rebase onto origin/${TARGET_BRANCH} failed — rebase would introduce new conflicts. Aborting rebase and failing the job; refusing to silently resurrect conflict markers."
               git rebase --abort || true

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2923,8 +2923,8 @@ jobs:
               echo "Push complete."
               break
             fi
-            if ! grep -qE '\[rejected\].*\(fetch first\)|non-fast-forward' "${push_stderr_file}"; then
-              echo "::error::git push failed (exit ${push_exit}) for a reason other than non-fast-forward; not retrying."
+            if ! grep -qE '\[rejected\].*\((fetch first|non-fast-forward)\)' "${push_stderr_file}"; then
+              echo "::error::git push failed (exit ${push_exit}) for a reason other than [rejected] (fetch first/non-fast-forward); not retrying."
               exit "${push_exit}"
             fi
             if [ "${push_attempt}" -ge "${max_push_attempts}" ]; then


### PR DESCRIPTION
The `Push all pending commits` step did a bare `git push origin HEAD:${TARGET_BRANCH}` with no retry. On PR #1076 a concurrent push to `orchestrator/project-866` advanced the remote during the ~27-minute job, so the deferred `[ai-merge-resolve]` commit was rejected as non-fast-forward and the job failed at the very last step, losing the conflict resolution work.

Add a retry loop (up to 3 attempts, 2s/4s backoff) that, on a `[rejected] (fetch first)` / `non-fast-forward` push failure, runs `git fetch origin $TARGET_BRANCH` followed by `git merge --no-edit --no-ff origin/$TARGET_BRANCH` and retries the push. Any other push failure mode exits immediately (no blind retries). If the merge itself would introduce new conflicts, we `git merge --abort` and fail loudly — we must never silently resurrect conflict markers the resolver just cleared, and we must never clobber other pushers (no force / no force-with-lease on this path).

**Why `git merge` and not `git rebase`:** the conflict-resolver step earlier in the same workflow (around `review_autofix.yml:2550-2580`) deliberately creates the `[ai-merge-resolve]` commit as a real two-parent merge commit (the `MERGE_HEAD` is intentionally preserved through the resolver's `git add`/`git rm` loop so `git commit` produces a true merge). That second parent is load-bearing — without it, git's merge-base walker rewinds to the original merge base on every subsequent `git merge` attempt and re-raises the identical conflict (observed on PR #908, which left the PR in `mergeable_state=dirty`). A plain `git rebase` would flatten the merge commit into a single-parent commit and resurrect the exact bug PR #908 was designed to fix. `git rebase --rebase-merges` would still rewrite the merge commit SHA. `git merge` preserves the existing commit exactly and simply adds another merge commit on top when origin has genuinely advanced.

**Classification hardening** (follow-up commit): the push output is captured via `>"${push_stderr_file}" 2>&1` (combined stdout+stderr) rather than stderr-only, because `git push` rejection details can surface on stdout depending on the git version / remote helper. Stderr-only capture risked mis-classifying a retryable failure as non-retryable.

**Adjacent hardening** (from the autofix editor's commit `6b4406a`): `export LANG=C` for deterministic stderr-locale regex matching, and a 2-attempt inner retry loop around `git fetch origin "${TARGET_BRANCH}"`.

https://claude.ai/code/session_01L5cfuySuozYph3X4mhjVwy