### PR TITLE
claude/stable-workflow-versions-2mpT2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,18 +31,35 @@ jobs:
       - name: YAML lint
         run: |
           set -euo pipefail
-          yamllint -s .github/workflows/*.yml .github/actions/*/action.yml workflow-templates/*.yml
+          # Expand globs via `nullglob` + array so an empty directory does
+          # not pass a literal pattern to yamllint (which would fail).
+          shopt -s nullglob
+          files=(.github/workflows/*.yml .github/actions/*/action.yml workflow-templates/*.yml)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::warning::No YAML files matched — skipping yamllint"
+            exit 0
+          fi
+          yamllint -s "${files[@]}"
 
       - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
         run: |
           set -euo pipefail
           # Dogfood gate: actionlint catches GitHub Actions schema errors that
           # yamllint cannot (bad action refs, invalid contexts, unresolved
-          # `uses:` targets, etc.). Pinned via the upstream download script
-          # which picks the latest stable release at install time.
+          # `uses:` targets, etc.). Pinned to a specific upstream release
+          # with sha256 verification for supply-chain safety and reproducible
+          # CI (no `bash <(curl ...)` or moving-target `latest` refs).
           cd /tmp
-          bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          sudo mv /tmp/actionlint /usr/local/bin/actionlint
+          tarball="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -sSLf -o "${tarball}" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${tarball}"
+          echo "${ACTIONLINT_SHA256}  ${tarball}" | sha256sum -c -
+          tar -xzf "${tarball}" actionlint
+          sudo mv actionlint /usr/local/bin/actionlint
+          rm -f "${tarball}"
           actionlint -version
 
       - name: Actionlint — reusable workflows and consumer templates
@@ -53,9 +70,21 @@ jobs:
           # breaks a reusable workflow body or a template schema will fail
           # this gate before it lands and starts breaking in-flight
           # orchestrator runs on feature branches.
-          actionlint \
-            .github/workflows/*.yml \
-            workflow-templates/*.yml
+          #
+          # `-shellcheck=` disables actionlint's shellcheck integration over
+          # inline `run:` blocks. Shell script static analysis is already
+          # covered by the standalone `ShellCheck static analysis` step
+          # further down in this job, which runs shellcheck on every
+          # `scripts/*.sh` file. Enabling it here would surface ~30
+          # pre-existing style/info/warning findings in unrelated reusable
+          # workflow `run:` blocks that are out of scope for this gate.
+          shopt -s nullglob
+          files=(.github/workflows/*.yml workflow-templates/*.yml)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::warning::No workflow files matched — skipping actionlint"
+            exit 0
+          fi
+          actionlint -shellcheck= "${files[@]}"
 
       - name: Python syntax check
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,31 @@ jobs:
       - name: YAML lint
         run: |
           set -euo pipefail
-          yamllint -s .github/workflows/*.yml .github/actions/*/action.yml
+          yamllint -s .github/workflows/*.yml .github/actions/*/action.yml workflow-templates/*.yml
+
+      - name: Install actionlint
+        run: |
+          set -euo pipefail
+          # Dogfood gate: actionlint catches GitHub Actions schema errors that
+          # yamllint cannot (bad action refs, invalid contexts, unresolved
+          # `uses:` targets, etc.). Pinned via the upstream download script
+          # which picks the latest stable release at install time.
+          cd /tmp
+          bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          sudo mv /tmp/actionlint /usr/local/bin/actionlint
+          actionlint -version
+
+      - name: Actionlint — reusable workflows and consumer templates
+        run: |
+          set -euo pipefail
+          # Lint every workflow file in this repo and every consumer template.
+          # The internal-*.yml wrappers pin `uses:` to @main, so a PR that
+          # breaks a reusable workflow body or a template schema will fail
+          # this gate before it lands and starts breaking in-flight
+          # orchestrator runs on feature branches.
+          actionlint \
+            .github/workflows/*.yml \
+            workflow-templates/*.yml
 
       - name: Python syntax check
         run: |

--- a/.github/workflows/internal-cancel-on-pr-close.yml
+++ b/.github/workflows/internal-cancel-on-pr-close.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   cancel:
-    uses: ./.github/workflows/cancel_on_pr_close.yml
+    uses: shubhodeep1/coding-workflows/.github/workflows/cancel_on_pr_close.yml@main
     secrets: inherit

--- a/.github/workflows/internal-clarify.yml
+++ b/.github/workflows/internal-clarify.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   clarify:
-    uses: ./.github/workflows/clarify.yml
+    uses: shubhodeep1/coding-workflows/.github/workflows/clarify.yml@main
     secrets: inherit

--- a/.github/workflows/internal-implement.yml
+++ b/.github/workflows/internal-implement.yml
@@ -14,5 +14,5 @@ jobs:
     if: >-
       github.event.issue.pull_request == null &&
       startsWith(github.event.comment.body, '/approved')
-    uses: ./.github/workflows/implement.yml
+    uses: shubhodeep1/coding-workflows/.github/workflows/implement.yml@main
     secrets: inherit

--- a/.github/workflows/internal-issue-pr-status.yml
+++ b/.github/workflows/internal-issue-pr-status.yml
@@ -9,5 +9,5 @@ permissions:
 
 jobs:
   sync-status:
-    uses: ./.github/workflows/issue_pr_status.yml
+    uses: shubhodeep1/coding-workflows/.github/workflows/issue_pr_status.yml@main
     secrets: inherit

--- a/.github/workflows/internal-memory-maintenance.yml
+++ b/.github/workflows/internal-memory-maintenance.yml
@@ -9,5 +9,5 @@ permissions:
 
 jobs:
   maintenance:
-    uses: ./.github/workflows/memory_maintenance.yml
+    uses: shubhodeep1/coding-workflows/.github/workflows/memory_maintenance.yml@main
     secrets: inherit

--- a/.github/workflows/internal-orchestrate-clarify-respond.yml
+++ b/.github/workflows/internal-orchestrate-clarify-respond.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   respond:
-    uses: ./.github/workflows/orchestrate_clarify_respond.yml
+    uses: shubhodeep1/coding-workflows/.github/workflows/orchestrate_clarify_respond.yml@main
     secrets: inherit

--- a/.github/workflows/internal-orchestrate-poll.yml
+++ b/.github/workflows/internal-orchestrate-poll.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   poll:
-    uses: ./.github/workflows/orchestrate_poll.yml
+    uses: shubhodeep1/coding-workflows/.github/workflows/orchestrate_poll.yml@main
     with:
       caller_workflow: internal-orchestrate-poll.yml
     secrets: inherit

--- a/.github/workflows/internal-orchestrate.yml
+++ b/.github/workflows/internal-orchestrate.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   orchestrate:
-    uses: ./.github/workflows/orchestrate.yml
+    uses: shubhodeep1/coding-workflows/.github/workflows/orchestrate.yml@main
     with:
       project_description: ${{ inputs.project_description }}
     secrets: inherit

--- a/.github/workflows/internal-plan.yml
+++ b/.github/workflows/internal-plan.yml
@@ -13,5 +13,5 @@ jobs:
     if: >-
       github.event.issue.pull_request == null &&
       startsWith(github.event.comment.body, '/answer')
-    uses: ./.github/workflows/plan.yml
+    uses: shubhodeep1/coding-workflows/.github/workflows/plan.yml@main
     secrets: inherit

--- a/.github/workflows/internal-review.yml
+++ b/.github/workflows/internal-review.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   review:
-    uses: ./.github/workflows/review_autofix.yml
+    uses: shubhodeep1/coding-workflows/.github/workflows/review_autofix.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
       pr_is_draft: >-

--- a/.github/workflows/internal-validate.yml
+++ b/.github/workflows/internal-validate.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   validate:
-    uses: ./.github/workflows/validate.yml
+    uses: shubhodeep1/coding-workflows/.github/workflows/validate.yml@main
     with:
       tracking_issue: ${{ inputs.tracking_issue || '0' }}
       compose_file: ${{ inputs.compose_file || 'docker-compose.yml' }}

--- a/README.md
+++ b/README.md
@@ -484,6 +484,51 @@ jobs:
 > each update.
 
 > All internal wrapper reference implementations can be found in [`.github/workflows/internal-*.yml`](.github/workflows/).
+>
+> **Note on `@main` vs `@stable` inside this repo.** The `internal-*.yml`
+> wrappers here pin `uses:` to
+> `shubhodeep1/coding-workflows/.github/workflows/<wf>.yml@main` rather than
+> `@stable` (consumer templates in [`workflow-templates/`](workflow-templates/)
+> keep `@stable`). This split is intentional:
+>
+> 1. **Branch-drift immunity.** When the orchestrator opens a feature PR, any
+>    `pull_request`-triggered wrapper (`internal-review.yml`,
+>    `internal-cancel-on-pr-close.yml`, `internal-issue-pr-status.yml`) runs
+>    from the PR branch's copy of the wrapper file. Pinning to `@main` makes
+>    GitHub fetch the reusable workflow body from `main` on this repo,
+>    bypassing whatever potentially stale copy the feature branch carries.
+>    This is the fix for orchestrator runs that used to stall because the
+>    feature branch carried an outdated reusable workflow and was hard to
+>    update mid-run.
+> 2. **Fast recovery.** If a bad reusable workflow lands on `main`, pushing a
+>    fix to `main` takes effect on the next wrapper invocation immediately —
+>    no need to re-run the full `test-and-mark-stable.yml` gate first. The
+>    trade-off is that a broken merge to `main` immediately breaks in-flight
+>    orchestrator runs, which is accepted as the cost of fast recovery in
+>    the source-of-truth repo.
+> 3. **`test-and-mark-stable.yml` still validates main HEAD.** The E2E smoke
+>    test job in [`test-and-mark-stable.yml`](.github/workflows/test-and-mark-stable.yml)
+>    creates a real issue on this repo, and the `issues:[opened]` event fires
+>    the default-branch wrapper (`internal-clarify.yml@main`), which then
+>    fetches `clarify.yml@main` — i.e. the candidate code about to be tagged
+>    stable. So the release gate continues to exercise main HEAD rather than
+>    the already-stable tag.
+> 4. **Consumer repos are unaffected.** Consumer repos install the
+>    `workflow-templates/ai-*.yml` copies pinned `@stable` and get the
+>    conservative, release-gated channel.
+>
+> **Dogfood lint gate.** Because `@main` wrappers run whatever is on `main`,
+> a bad merge can cascade. To catch YAML/schema regressions on PRs before
+> they land on `main`, [`ci.yml`](.github/workflows/ci.yml) runs `yamllint`
+> and `actionlint` over every file in `.github/workflows/` **and**
+> `workflow-templates/` on `pull_request` against `main`. Broken reusable
+> workflow bodies or template schemas fail CI before merge.
+>
+> **Recovery procedure for a broken `main` reusable.** Push a fix directly
+> to `main` (or merge a hotfix PR). The next triggered wrapper run picks
+> up the fix immediately — no `test-and-mark-stable.yml` re-run required.
+> Run `test-and-mark-stable.yml` separately when you are ready to promote
+> the fix to the `@stable` channel for consumer repos.
 
 ### 3. Open an issue
 
@@ -1132,8 +1177,12 @@ coding-workflows/
 - **Immutable tags**: `v1.0.0`, `v1.0.1`, etc.
 - **Stable channel**: `@stable` — moving tag, updated after canary validation
 - **Canary channel**: `@canary` — pre-stable testing
+- **Source-of-truth channel**: `@main` — used by this repo's own
+  `internal-*.yml` wrappers. See the wrapper-pinning note in
+  "Create wrapper workflows" above for why internal wrappers track `@main`
+  rather than `@stable`.
 
-Consumer repos pin to `@stable` for automatic updates or exact tags for reproducibility.
+Consumer repos pin to `@stable` for automatic updates or exact tags for reproducibility. This repo's own `internal-*.yml` wrappers pin `@main`.
 
 ## Contributing
 

--- a/agents.md
+++ b/agents.md
@@ -303,6 +303,41 @@ After changes: original intent preserved, behavior unchanged unless approved, ba
 
 ---
 
+## 17. Internal Wrapper Pin Policy
+
+- The `.github/workflows/internal-*.yml` wrappers in this repo MUST pin
+  `uses:` to `shubhodeep1/coding-workflows/.github/workflows/<wf>.yml@main`.
+  Do NOT revert them to local refs (`./.github/workflows/<wf>.yml`) and do
+  NOT flip them to `@stable`. The `@main` pin is required for two reasons:
+  (a) it makes orchestrator runs immune to stale reusable-workflow copies
+  on feature branches (which previously caused hangs that were hard to
+  fix mid-run), and (b) it still lets `test-and-mark-stable.yml`'s E2E
+  smoke test validate main HEAD — because `issues:[opened]` events fire
+  the default-branch wrapper, which then fetches the reusable body from
+  `@main` (= main HEAD = the candidate about to be tagged).
+- Consumer templates under `workflow-templates/ai-*.yml` MUST stay pinned
+  to `@stable`. Do not unify the two pin targets.
+- `ai-update-workflows.yml` must NOT be installed into `.github/workflows/`
+  in this repo. If installed, its daily self-update loop would overwrite
+  `internal-*.yml` files keyed by filename — but it only touches files
+  whose names match `workflow-templates/*.yml`, so keeping the
+  `internal-*.yml` filenames (rather than renaming to `ai-*.yml`) insulates
+  them. Do not rename `internal-*.yml` to `ai-*.yml` without first removing
+  the self-updater exposure.
+- PR-time dogfood gate: `ci.yml` runs `yamllint` and `actionlint` across
+  `.github/workflows/*.yml` and `workflow-templates/*.yml` on
+  `pull_request` against `main`. Any change that breaks YAML or GitHub
+  Actions schema must be caught here before landing on `main`, because a
+  broken merge to `main` immediately breaks all in-flight orchestrator
+  runs (accepted trade-off for fast recovery).
+- Recovery procedure for a broken `main` reusable: push the fix directly
+  to `main` (or merge a hotfix PR). The next wrapper invocation picks it
+  up immediately. Only run `test-and-mark-stable.yml` when promoting the
+  fix to the `@stable` channel for consumer repos — it is not on the
+  critical path for recovering this repo's own runtime.
+
+---
+
 ## FINAL REMINDER
 
 If uncertainty exists: **ASK (multiple-choice). DO NOT EXECUTE.**

--- a/agents.md
+++ b/agents.md
@@ -318,12 +318,16 @@ After changes: original intent preserved, behavior unchanged unless approved, ba
 - Consumer templates under `workflow-templates/ai-*.yml` MUST stay pinned
   to `@stable`. Do not unify the two pin targets.
 - `ai-update-workflows.yml` must NOT be installed into `.github/workflows/`
-  in this repo. If installed, its daily self-update loop would overwrite
-  `internal-*.yml` files keyed by filename — but it only touches files
-  whose names match `workflow-templates/*.yml`, so keeping the
-  `internal-*.yml` filenames (rather than renaming to `ai-*.yml`) insulates
-  them. Do not rename `internal-*.yml` to `ai-*.yml` without first removing
-  the self-updater exposure.
+  in this repo. The self-updater in `update_workflows.yml` copies files
+  from `workflow-templates/*.yml` into `.github/workflows/` keyed by exact
+  filename, so the current `internal-*.yml` filenames are not directly
+  overwritten. The hazard is different: on first run the self-updater
+  would **create** new `ai-*.yml` wrappers pinned `@stable` (because
+  those filenames are absent today), which would then auto-fire on the
+  same issue/PR events as the `internal-*.yml` wrappers and cause
+  duplicate runs and racing state writes. Keeping the self-updater
+  uninstalled prevents that creation path entirely. Do not rename
+  `internal-*.yml` to `ai-*.yml` without first removing this risk.
 - PR-time dogfood gate: `ci.yml` runs `yamllint` and `actionlint` across
   `.github/workflows/*.yml` and `workflow-templates/*.yml` on
   `pull_request` against `main`. Any change that breaks YAML or GitHub


### PR DESCRIPTION
Internal wrapper files in this repo previously called reusable workflows
via local refs (./.github/workflows/<wf>.yml), which resolve to whichever
branch the workflow runs on. For pull_request-triggered wrappers on
feature branches, GitHub used the PR branch's (potentially stale) copy
of the reusable body, causing orchestrator runs to stall on outdated
workflow YAML that was hard to fix mid-run.

Pin all 11 internal-*.yml wrappers to
shubhodeep1/coding-workflows/.github/workflows/<wf>.yml@main so that
GitHub fetches the reusable body from main regardless of which branch
the wrapper runs on. This eliminates branch drift for every trigger
class (issues, issue_comment, pull_request, workflow_dispatch, schedule)
while keeping test-and-mark-stable.yml's E2E smoke test valid — the
issues:[opened] path still fires the default-branch wrapper, which now
delegates to clarify.yml@main (= main HEAD = the candidate about to be
tagged).

Consumer templates under workflow-templates/ai-*.yml remain pinned to
@stable — they are unaffected. internal-*.yml filenames are preserved
(rather than renamed to ai-*.yml) so the filename-keyed self-updater in
update_workflows.yml cannot accidentally overwrite the @main pin back
to @stable.

Dogfood gate: extend ci.yml to run yamllint over workflow-templates/*.yml
in addition to .github/workflows/ and .github/actions/, and add an
actionlint step that validates both directories. Because @main wrappers
run whatever lands on main, we need a PR-time schema gate to catch bad
reusable workflow bodies or template schemas before merge.

Recovery procedure for a broken main reusable: push the fix directly to
main. The next wrapper invocation picks it up immediately — no need to
re-run test-and-mark-stable.yml first. Full rationale documented in
README.md and agents.md #17.

https://claude.ai/code/session_01Rtp4EwaaGvaZYWdoRNYcEf