### PR TITLE
claude/analyze-job-logs-GNlnP

### DIFF
--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -40,7 +40,7 @@ normalize_openrouter_usage() {
   local log_file="$1"
   local call_label="$2"
   local model_name="$3"
-  PYTHONDONTWRITEBYTECODE=1 python3 - "$log_file" "$call_label" "$model_name" <<'PY'
+  PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="${SUPPORT_SCRIPTS_DIR:-scripts}${PYTHONPATH:+:$PYTHONPATH}" python3 - "$log_file" "$call_label" "$model_name" <<'PY'
 import json
 import os
 import sys


### PR DESCRIPTION
The normalize_openrouter_usage() Python heredoc in review_run_reviewers.sh
uses `python3 -` (stdin), which puts sys.path[0] = '' (cwd = repo root),
not the directory containing openrouter_prompt_cache.py. In consumer repos
that file lives at ${SUPPORT_SCRIPTS_DIR}/openrouter_prompt_cache.py, so
both import branches fail and every run prints two ModuleNotFoundError
tracebacks. The failures are caught by `|| true`, but the cache-probe
INFO usage line is silently never emitted.

Add SUPPORT_SCRIPTS_DIR to PYTHONPATH (defaulting to "scripts" for source-
repo runs) so the primary import resolves. The scripts.* fallback stays
intact as a safety net.

https://claude.ai/code/session_012SQz4ZpAbeaScVnrRbk2hz