### PR TITLE
claude/upgrade-clarify-respond-autonomous-NQMaa

### DIFF
--- a/.github/workflows/orchestrate_clarify_respond.yml
+++ b/.github/workflows/orchestrate_clarify_respond.yml
@@ -47,7 +47,7 @@ jobs:
       ISSUE_URL: ${{ github.event.issue.html_url }}
       ISSUE_TITLE: ${{ github.event.issue.title }}
       MODEL_EDITOR: ${{ vars.WORKFLOW_EDITOR_MODEL || 'openai/gpt-5.3-codex' }}
-      MODEL_REASONING_EFFORT: ${{ vars.THINKING_LEVEL_CLARIFY_RESPOND || 'low' }}
+      MODEL_REASONING_EFFORT: ${{ vars.THINKING_LEVEL_CLARIFY_RESPOND || 'medium' }}
       ORCHESTRATOR_MAX_CLARIFY_CYCLES: ${{ vars.ORCHESTRATOR_MAX_CLARIFY_CYCLES || '3' }}
       OPENROUTER_PROMPT_CACHE_DISABLED: ${{ vars.OPENROUTER_PROMPT_CACHE_DISABLED || 'false' }}
 
@@ -577,7 +577,7 @@ jobs:
         if: steps.check_orchestrator.outputs.is_orchestrator == 'true' && steps.semantic_cache_lookup.outputs.cache_hit != 'true'
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          TOOL_CALL_BUDGET: ${{ vars.TOOL_CALL_BUDGET_CLARIFY_RESPOND || '15' }}
+          TOOL_CALL_BUDGET: ${{ vars.TOOL_CALL_BUDGET_CLARIFY_RESPOND || '25' }}
         run: |
           set -euo pipefail
 
@@ -604,6 +604,24 @@ jobs:
             cat "${RUNTIME_DIR}/clarification_comment.txt"
           } > "${CODEX_PROMPT_FILE}"
 
+          # Inject prior clarify-cycle context if available.
+          # NOTE: memory_clarify_cycle_history should be implemented in
+          # scripts/memory_helpers.sh as a follow-up.
+          if [ -f scripts/memory_helpers.sh ]; then
+            source scripts/memory_helpers.sh
+            PRIOR_CYCLES="$(memory_clarify_cycle_history \
+              --issue-number "${ISSUE_NUMBER}" \
+              --max-cycles 5 2>/dev/null || true)"
+            if [ -n "${PRIOR_CYCLES}" ] && [ "${PRIOR_CYCLES}" != "null" ] && [ "${PRIOR_CYCLES}" != "[]" ]; then
+              {
+                echo "=== PRIOR CLARIFY CYCLES ==="
+                echo "The following auto-answer cycles have already occurred on this issue."
+                echo "Do NOT repeat a prior answer that failed to unblock planning."
+                echo "${PRIOR_CYCLES}"
+              } >> "${CODEX_PROMPT_FILE}"
+            fi
+          fi
+
           max_attempts=3
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "Codex clarify-respond attempt ${attempt}/${max_attempts}..."
@@ -626,6 +644,73 @@ jobs:
               exit 1
             fi
           done
+
+      - name: Self-critique pass for non-letter decisions
+        if: steps.check_orchestrator.outputs.is_orchestrator == 'true' && steps.semantic_cache_lookup.outputs.cache_hit != 'true' && steps.run_codex.outcome == 'success'
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          # Self-critique pass for non-letter decisions
+          HAS_NON_LETTER="false"
+          if grep -qE '^Q[0-9]+:\s*(DERIVE_FROM_REPO|SYNTHESIZE|REFRAME|ESCALATE)' "${CODEX_OUTPUT_FILE}"; then
+            HAS_NON_LETTER="true"
+          fi
+
+          if [ "${HAS_NON_LETTER}" = "true" ]; then
+            echo "Non-letter decisions detected; running self-critique pass..."
+
+            {
+              echo "You are reviewing an autonomous clarify-resolve decision."
+              echo "The original clarification questions and the responder's decisions follow."
+              echo
+              echo "=== CLARIFICATION QUESTIONS ==="
+              cat "${RUNTIME_DIR}/clarification_comment.txt"
+              echo
+              echo "=== RESPONDER DECISIONS ==="
+              cat "${CODEX_OUTPUT_FILE}"
+              echo
+              echo "Review checklist:"
+              echo "1. Did the responder avoid fabricating data? Every derivation must trace to a specific repo file."
+              echo "2. Is each equivalence argument sound? Does the substitute genuinely satisfy the original intent?"
+              echo "3. Is the execution plan actually executable by the planner/implementer with repo access only?"
+              echo "4. Are synthetic fixtures deterministic and well-specified?"
+              echo "5. If ESCALATE was used, are rungs 1-3 genuinely infeasible?"
+              echo
+              echo "Output exactly one of:"
+              echo "VERDICT: APPROVE"
+              echo "VERDICT: REJECT"
+              echo "REASON: <1-2 sentences if REJECT>"
+            } > "${RUNTIME_DIR}/critic_prompt.txt"
+
+            CRITIC_MODEL="${MODEL_EDITOR}"
+            if cat "${RUNTIME_DIR}/critic_prompt.txt" | codex exec \
+              --model "${CRITIC_MODEL}" --full-auto > "${RUNTIME_DIR}/critic_output.txt" 2>/dev/null; then
+              if grep -q 'VERDICT: REJECT' "${RUNTIME_DIR}/critic_output.txt"; then
+                echo "::warning::Self-critique rejected the decision. Appending critique and re-running."
+                CRITIC_REASON="$(grep -A5 'REASON:' "${RUNTIME_DIR}/critic_output.txt" || echo "No reason provided")"
+                {
+                  cat "${CODEX_PROMPT_FILE}"
+                  echo
+                  echo "=== SELF-CRITIQUE FEEDBACK (your previous output was rejected) ==="
+                  echo "${CRITIC_REASON}"
+                  echo "Revise your decisions to address this feedback."
+                } > "${CODEX_PROMPT_FILE}.v2"
+
+                if cat "${CODEX_PROMPT_FILE}.v2" | codex exec \
+                  --model "${MODEL_EDITOR}" --full-auto > "${CODEX_OUTPUT_FILE}" 2>/dev/null; then
+                  echo "Revised decision produced after self-critique."
+                else
+                  echo "::warning::Revised Codex call failed; using original output."
+                fi
+              else
+                echo "Self-critique approved the decision."
+              fi
+            else
+              echo "::warning::Critic call failed; proceeding with original output."
+            fi
+          fi
 
       - name: Semantic cache store
         if: always() && steps.check_orchestrator.outputs.is_orchestrator == 'true' && steps.semantic_cache_lookup.outputs.cache_hit != 'true' && steps.run_codex.outcome == 'success'
@@ -703,6 +788,12 @@ jobs:
           if [ -z "${ANSWERS_BODY}" ]; then
             echo "::error::Codex output is empty; cannot post answer."
             exit 1
+          fi
+
+          # Detect ESCALATE decisions — treat same as loop-guard block
+          HAS_ESCALATE="false"
+          if printf '%s' "${ANSWERS_BODY}" | grep -qE '^Q[0-9]+:\s*ESCALATE'; then
+            HAS_ESCALATE="true"
           fi
 
           if [ -f scripts/memory_helpers.sh ]; then
@@ -785,7 +876,7 @@ jobs:
             fi
           fi
 
-          if [ "${LOOP_BLOCKED}" = "true" ]; then
+          if [ "${LOOP_BLOCKED}" = "true" ] || [ "${HAS_ESCALATE}" = "true" ]; then
             if [ -f scripts/label_helpers.sh ]; then
               source scripts/label_helpers.sh
               ensure_label_exists "ai:blocked" "${{ github.repository }}"
@@ -794,17 +885,32 @@ jobs:
             gh_retry gh issue edit "${ISSUE_NUMBER}" --repo "${{ github.repository }}" \
               --add-label 'ai:blocked' --remove-label 'ai:planning' --remove-label 'ai:clarification' >/dev/null 2>&1 || true
 
-            {
-              echo "Clarification loop guard escalation for issue #${ISSUE_NUMBER}."
-              echo
-              echo "Auto-answer has been paused to prevent repeated clarification loops."
-              echo
-              echo "- Current clarify comment ID: ${CLARIFICATION_COMMENT_ID}"
-              echo "- Previous clarify comment ID: ${PREVIOUS_CLARIFY_COMMENT_ID}"
-              echo "- Previous auto-answer comment ID: ${PREVIOUS_ANSWER_COMMENT_ID}"
-              echo "- Loop reason: ${LOOP_REASON}"
-              echo "- Cycle: ${CYCLE}/${MAX_CYCLES}"
-            } > "${RUNTIME_DIR}/loop_break_comment.md"
+            # Build escalation comment — ESCALATE-triggered vs loop-guard-triggered
+            if [ "${HAS_ESCALATE}" = "true" ] && [ "${LOOP_BLOCKED}" != "true" ]; then
+              ESCALATION_SECTION="$(printf '%s' "${ANSWERS_BODY}" | sed -n '/^ESCALATION/,$ p')"
+              {
+                echo "Autonomous resolution not possible for issue #${ISSUE_NUMBER}."
+                echo
+                echo "The clarify-resolve phase determined that one or more questions require data that cannot be derived from the repository."
+                echo
+                echo "${ESCALATION_SECTION}"
+                echo
+                echo "- Clarify comment ID: ${CLARIFICATION_COMMENT_ID}"
+                echo "- Cycle: ${CYCLE}/${MAX_CYCLES}"
+              } > "${RUNTIME_DIR}/loop_break_comment.md"
+            else
+              {
+                echo "Clarification loop guard escalation for issue #${ISSUE_NUMBER}."
+                echo
+                echo "Auto-answer has been paused to prevent repeated clarification loops."
+                echo
+                echo "- Current clarify comment ID: ${CLARIFICATION_COMMENT_ID}"
+                echo "- Previous clarify comment ID: ${PREVIOUS_CLARIFY_COMMENT_ID}"
+                echo "- Previous auto-answer comment ID: ${PREVIOUS_ANSWER_COMMENT_ID}"
+                echo "- Loop reason: ${LOOP_REASON}"
+                echo "- Cycle: ${CYCLE}/${MAX_CYCLES}"
+              } > "${RUNTIME_DIR}/loop_break_comment.md"
+            fi
 
             LOOP_BREAK_RESPONSE="$(gh_retry gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
               -f body="$(cat "${RUNTIME_DIR}/loop_break_comment.md")" || true)"

--- a/prompts/mode-clarify-respond.txt
+++ b/prompts/mode-clarify-respond.txt
@@ -1,25 +1,62 @@
-You are an AI assistant answering clarification questions on behalf of the
+You are an AI assistant resolving clarification questions on behalf of the
 project orchestrator. The orchestrator decomposed a project into multiple
 GitHub issues and the clarification phase has asked questions about one of them.
 
-Your job is to answer each clarification question using the available context:
-the original issue description (which contains the full task spec written by the
-orchestrator), the project tracking issue (which contains the overall project
-plan), and the codebase itself.
+Your job is to decide how the task will proceed — not just pick a letter.
+You have full authority to reinterpret questions, pick an option, combine
+options, propose a new strategy, or replace the question with a concrete
+execution plan. Your output is a decision record the planner will treat as
+binding.
 
-Rules:
-- Answer every Q<N> question using its lettered choices (A, B, C, ...).
-- Pick the option marked (RECOMMENDED) unless codebase evidence or project
-  context clearly favours a different choice.
-- If multiple selections are allowed and more than one option is appropriate,
-  combine them (e.g. "A+C").
-- Keep answers concise: one line per question in the format "Q1: A".
-- After the answer lines, add a brief rationale section explaining each choice
-  in 1-2 sentences.
-- Do NOT propose code changes or implementation details.
-- Do NOT invent information that is not in the issue, tracking issue, or codebase.
-- If a question cannot be answered from available context, pick the
-  (RECOMMENDED) option and note the assumption in the rationale.
+Context sources:
+- Original issue description (which contains the full task spec written by
+  the orchestrator)
+- Project tracking issue (which contains the overall project plan)
+- Codebase (via tool calls)
+
+Decision rules:
+- For straightforward questions where a lettered choice is clearly correct:
+  pick the letter as before.
+- For questions requiring data not in the issue, tracking issue, or codebase:
+  walk the derivation ladder.
+
+Derivation ladder:
+
+When a question requires data not present in the issue, tracking issue, or
+codebase, work through this ladder and commit to the first feasible rung:
+
+  DERIVE_FROM_REPO: Can the answer be found or computed from code,
+    configs, tests, fixtures, or constants already in the repository?
+    Specify exact file paths and the derivation logic.
+
+  SYNTHESIZE: Can the validation intent be satisfied with synthetic
+    inputs constructed from the repo's own definitions (formulas,
+    thresholds, schemas, type contracts)? Build deterministic fixtures
+    that exercise the relevant code paths. Specify the construction
+    recipe with exact values.
+
+  REFRAME: Can the acceptance criterion be replaced with an equally
+    or more rigorous check that doesn't need the missing data? State
+    the replacement criterion and the equivalence argument.
+
+You may only stop at a rung if all rungs above it are genuinely infeasible —
+state why in the rationale. One of rungs 1-3 is almost always feasible for
+code-level tasks.
+
+Hard prohibitions:
+- Do NOT query databases, external APIs, or runtime systems.
+- Do NOT fabricate real-looking identifiers, user IDs, or production data.
+- Do NOT propose code changes or implementation details beyond the decision
+  strategy.
+- Do NOT invent information. Derivation must trace back to specific repo files.
+- If PRIOR CLARIFY CYCLES context is present and your proposed answer would
+  repeat a prior cycle's answer for the same question, you must choose a
+  different rung or ESCALATE. Do not repeat a losing answer.
+
+ESCALATE rule:
+- Use ESCALATE only when all 3 rungs are genuinely infeasible AND you can
+  articulate exactly what is missing and why the repo cannot provide it.
+- ESCALATE is a last resort, not a convenience exit.
 
 Use Serena MCP tools or targeted file reads only to inspect specific code
 symbols referenced in the questions. Keep tool usage minimal.
@@ -30,12 +67,27 @@ symbols referenced in the questions. Keep tool usage minimal.
 
 Output format (exact):
 
-ANSWERS:
-Q1: <letter(s)>
-Q2: <letter(s)>
-...
+DECISIONS:
+Q1: <A | B | C | A+C | DERIVE_FROM_REPO | SYNTHESIZE | REFRAME | ESCALATE>
+Q2: ...
 
 RATIONALE:
-Q1: <1-2 sentence explanation>
-Q2: <1-2 sentence explanation>
-...
+Q1: <1-3 sentences>
+Q2: ...
+
+EXECUTION PLAN (required for any non-letter decision):
+Q<N>:
+  strategy: derive_from_repo | synthesize | reframe
+  inputs:
+    - <file paths, constants, fixture specs>
+  steps:
+    - <concrete, executable step the planner/implementer can follow>
+  replaces_acceptance_criterion: <if applicable, the exact criterion being replaced>
+  equivalence_argument: <why this satisfies the original intent>
+  reversibility: <what happens if a human later disagrees>
+
+ESCALATION (required for any ESCALATE decision):
+Q<N>:
+  missing: <what data is needed>
+  why_not_derivable: <why rungs 1-3 all fail>
+  suggested_scope_change: <what acceptance criterion to relax>

--- a/prompts/mode-clarify.txt
+++ b/prompts/mode-clarify.txt
@@ -20,6 +20,19 @@ Rules:
 - Use repo documentation only; no external web searches.
 - If external APIs are needed, use provided docs/artifacts; if unavailable, ask rather than guess.
 - Do not write code or propose solutions.
+- The responder is an autonomous LLM with repo access only — no database,
+  no external APIs, no production systems. Do NOT ask questions whose only
+  valid answer is data from outside the repo (production user IDs, runtime
+  metrics, operator credentials, external service responses). The responder
+  can derive and synthesize from code.
+- If a task requires external data that cannot be derived from the repo,
+  do not frame it as a multiple-choice clarification. Instead, state it as
+  a blocking prerequisite in your RATIONALE and set STATUS: CLEAR so the
+  pipeline can proceed with the responder's derivation ladder handling it.
+- When listing choices for data-sourcing questions, include derivation-friendly
+  options such as "derive from repo heuristics", "use synthetic fixtures
+  based on scoring formula", or "reframe acceptance criterion" alongside
+  traditional options.
 
 Question format (MANDATORY):
 - Use Q1, Q2, Q3... identifiers with lettered choices.


### PR DESCRIPTION
Promote the orchestrator clarify-respond phase from a closed-form classifier
(picks A/B/C) to an autonomous sub-planner that can derive answers from
the repo, synthesize fixtures, or reframe acceptance criteria — breaking
the repeated-loop pattern when questions require data outside the issue.

Key changes:
- Rewrite mode-clarify-respond.txt with derivation ladder (DERIVE_FROM_REPO,
  SYNTHESIZE, REFRAME), hard prohibitions, ESCALATE rule, and new output
  contract (DECISIONS/RATIONALE/EXECUTION PLAN/ESCALATION)
- Add 3 rules to mode-clarify.txt so the clarifier avoids asking questions
  whose only valid answer is external data
- Bump default thinking level from low to medium, tool budget from 15 to 25
- Wire prior-cycle context injection (memory_clarify_cycle_history) into
  prompt assembly (fail-silent if helper not yet implemented)
- Add self-critique pass for non-letter decisions: critic LLM reviews
  derivations for fabrication, soundness, and executability; rejects
  trigger a single revision pass
- ESCALATE decisions now trigger the existing loop-guard/blocked escalation
  path on first occurrence, with a specific comment explaining what data
  is missing and why repo derivation failed

https://claude.ai/code/session_0112MCgNKpVTTvutavshD5Ta