### PR TITLE
fix: block auto-merge when editor claims changes but nothing committed

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1975,8 +1975,8 @@ jobs:
             # top-level section header (line starting with a non-dash
             # alphabetic word followed by a colon).
             changes_section="$(awk '
-              /^Changes made:/ { in_section=1; next }
-              in_section && /^[A-Za-z].*:/ { exit }
+              /^[[:space:]]*Changes made:/ { in_section=1; next }
+              in_section && /^[[:space:]]*[A-Za-z].*:/ { exit }
               in_section { print }
             ' "${EDITOR_SUMMARY_FILE}")"
 
@@ -3091,6 +3091,7 @@ jobs:
               install -m 0755 .codex-workflow-src-main/scripts/label_helpers.sh "${SUPPORT_SCRIPTS_DIR}/label_helpers.sh"
               source "${SUPPORT_SCRIPTS_DIR}/label_helpers.sh" 2>/dev/null || true
             else
+              type gh_retry >/dev/null 2>&1 || gh_retry() { "$@"; }
               ensure_label_exists() {
                 local label_name="$1"
                 local repo="$2"
@@ -3402,9 +3403,13 @@ jobs:
           if [ "${dispatched}" = "false" ]; then
             caller_workflow=""
             if [ -n "${{ github.workflow_ref }}" ]; then
-              caller_workflow="$(printf '%s' "${{ github.workflow_ref }}" | sed -n 's|^[^/]*/[^/]*/\(\.github/workflows/[^@]*\)@.*$|\1|p')"
+              caller_ref="${{ github.workflow_ref }}"
+              caller_workflow="$(basename "${caller_ref%%@*}")"
             fi
-            if [ -n "${caller_workflow}" ] && [ "${caller_workflow}" != ".github/workflows/review_autofix.yml" ]; then
+            if [ -z "${caller_workflow}" ]; then
+              caller_workflow="internal-review.yml"
+            fi
+            if [ "${caller_workflow}" != "review_autofix.yml" ]; then
               if gh workflow run "${caller_workflow}" \
                 --ref "${TARGET_BRANCH}" \
                 -f pr_number="${PR_NUMBER}"; then

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3378,11 +3378,12 @@ jobs:
       - name: Re-dispatch review on editor-changes-lost
         # When the editor claims changes but nothing persisted on disk after
         # all retry attempts, automatically re-dispatch the review workflow
-        # so the next iteration gets a fresh Serena MCP instance.  Bounded
-        # by the retrigger guard (MAX_AUTOFIX_ITERATIONS) — if the guard is
-        # already exhausted this step is a no-op and the Telegram warning
-        # below escalates to manual review.
-        if: "success() && env.EDITOR_CHANGES_LOST == 'true' && env.PR_CLOSED != 'true' && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && env.CAN_PUSH == 'true'"
+        # so the next iteration gets a fresh Serena MCP instance.
+        # Guard against an endless workflow_dispatch loop when no commit is
+        # produced by allowing this auto-redispatch only from workflow_call
+        # runs; the follow-up dispatched run escalates if changes are still
+        # lost.
+        if: "success() && env.EDITOR_CHANGES_LOST == 'true' && env.PR_CLOSED != 'true' && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && env.CAN_PUSH == 'true' && github.event_name == 'workflow_call'"
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3379,11 +3379,12 @@ jobs:
         # When the editor claims changes but nothing persisted on disk after
         # all retry attempts, automatically re-dispatch the review workflow
         # so the next iteration gets a fresh Serena MCP instance.
-        # Guard against an endless workflow_dispatch loop when no commit is
+        # Guard against an endless re-dispatch loop when no commit is
         # produced by allowing this auto-redispatch only from workflow_call
-        # runs; the follow-up dispatched run escalates if changes are still
-        # lost.
-        if: "success() && env.EDITOR_CHANGES_LOST == 'true' && env.PR_CLOSED != 'true' && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && env.CAN_PUSH == 'true' && github.event_name == 'workflow_call'"
+        # runs that still carry the original pull_request event payload.
+        # Re-dispatched wrapper workflow_dispatch runs do not include
+        # github.event.pull_request and therefore cannot re-enter this path.
+        if: "success() && env.EDITOR_CHANGES_LOST == 'true' && env.PR_CLOSED != 'true' && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && env.CAN_PUSH == 'true' && github.event_name == 'workflow_call' && github.event.pull_request.number"
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1993,7 +1993,7 @@ jobs:
 
             if [ "${has_real_changes}" = "true" ]; then
               if [ "${CAN_PUSH:-}" = "true" ]; then
-                echo "::error::Editor claimed changes but no commit was produced. Serena MCP tool calls likely failed to persist changes on disk."
+                echo "::error::Editor claimed changes but no commit was produced. This indicates a mismatch between the editor summary and final git state (changes may have failed to persist, or may have been discarded during commit validation)."
               else
                 echo "::error::Editor claimed changes but no commit was produced. Push is disabled (CAN_PUSH=${CAN_PUSH:-false}), so this does not necessarily indicate a Serena persistence failure."
               fi

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1955,6 +1955,51 @@ jobs:
             echo "::warning::Unable to post editor summary comment after retries."
           fi
 
+      - name: Detect editor-claimed-but-uncommitted changes
+        # The editor LLM reports what it believes it changed in the
+        # EDITOR_SUMMARY_FILE ("Changes made:" section).  The commit step
+        # independently checks `git diff --cached` to determine what actually
+        # changed on disk.  When the editor claims changes but git has no
+        # diff, the Serena MCP tool calls likely failed to persist — this is
+        # NOT a "clean review" signal and must block auto-merge.
+        # See: PR #1136, #1137 where this mismatch caused premature
+        # auto-merge of un-fixed PRs.
+        if: "!cancelled() && steps.commit_changes.outputs.did_commit != 'true' && env.PR_CLOSED != 'true'"
+        run: |
+          set -euo pipefail
+
+          EDITOR_CHANGES_LOST="false"
+
+          if [ -s "${EDITOR_SUMMARY_FILE:-}" ]; then
+            # Extract the "Changes made:" section, stopping at the next
+            # top-level section header (line starting with a non-dash
+            # alphabetic word followed by a colon).
+            changes_section="$(awk '
+              /^Changes made:/ { in_section=1; next }
+              in_section && /^[A-Za-z].*:/ { exit }
+              in_section { print }
+            ' "${EDITOR_SUMMARY_FILE}")"
+
+            # Check if the section contains substantive entries (not just
+            # "- none" variants).
+            has_real_changes="false"
+            if [ -n "${changes_section}" ]; then
+              # Strip lines that are blank or match "- none*"
+              substantive="$(printf '%s\n' "${changes_section}" | grep -vE '^\s*$' | grep -vE '^\s*-\s*none' || true)"
+              if [ -n "${substantive}" ]; then
+                has_real_changes="true"
+              fi
+            fi
+
+            if [ "${has_real_changes}" = "true" ]; then
+              echo "::error::Editor claimed changes but no files were committed. Serena MCP tool calls likely failed to persist changes on disk."
+              echo "Editor-claimed changes:"
+              printf '%s\n' "${changes_section}" | head -20
+              EDITOR_CHANGES_LOST="true"
+            fi
+          fi
+
+          echo "EDITOR_CHANGES_LOST=${EDITOR_CHANGES_LOST}" >> "$GITHUB_ENV"
 
       - name: Detect merge conflicts
         # Run conflict detection regardless of max_iterations_reached or
@@ -2955,7 +3000,7 @@ jobs:
           tg_send_tracked "${PR_NUMBER}" "${MSG}" "DEBUG"
 
       - name: Mark linked issues ready to merge
-        if: "success() && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && steps.commit_changes.outputs.did_commit != 'true' && env.MERGE_CONFLICT != 'true' && env.PR_CLOSED != 'true'"
+        if: "success() && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && steps.commit_changes.outputs.did_commit != 'true' && env.MERGE_CONFLICT != 'true' && env.PR_CLOSED != 'true' && env.EDITOR_CHANGES_LOST != 'true'"
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           REPOSITORY: ${{ github.repository }}
@@ -3111,7 +3156,7 @@ jobs:
           fi
 
       - name: Enable auto-merge on PR
-        if: "success() && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && steps.commit_changes.outputs.did_commit != 'true' && env.MERGE_CONFLICT != 'true' && env.PR_CLOSED != 'true'"
+        if: "success() && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && steps.commit_changes.outputs.did_commit != 'true' && env.MERGE_CONFLICT != 'true' && env.PR_CLOSED != 'true' && env.EDITOR_CHANGES_LOST != 'true'"
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           ENABLE_AUTO_MERGE: ${{ vars.ENABLE_AUTO_MERGE || 'true' }}
@@ -3301,7 +3346,7 @@ jobs:
           fi
 
       - name: Telegram success
-        if: "success() && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && steps.commit_changes.outputs.did_commit != 'true' && env.MERGE_CONFLICT != 'true' && env.PR_CLOSED != 'true'"
+        if: "success() && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && steps.commit_changes.outputs.did_commit != 'true' && env.MERGE_CONFLICT != 'true' && env.PR_CLOSED != 'true' && env.EDITOR_CHANGES_LOST != 'true'"
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
@@ -3324,6 +3369,44 @@ jobs:
           MSG+=$'\n'
           MSG+="Run: ${RUN_URL}"
           tg_send_tracked "${PR_NUMBER}" "${MSG}" "DEBUG"
+
+      - name: Telegram editor-changes-lost warning
+        if: "success() && env.EDITOR_CHANGES_LOST == 'true' && env.PR_CLOSED != 'true'"
+        env:
+          TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
+          TG_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          source "${SUPPORT_SCRIPTS_DIR}/tg_helpers.sh"
+          source "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh" 2>/dev/null || true
+          type gh_retry >/dev/null 2>&1 || gh_retry() { "$@"; }
+          PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUMBER}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          MSG="⚠️ Editor changes lost: #${PR_NUMBER}"
+          MSG+=$'\n'
+          MSG+="Editor claimed changes but nothing was committed."
+          MSG+=$'\n'
+          MSG+="Serena MCP tool calls likely failed to persist."
+          MSG+=$'\n'
+          MSG+="Auto-merge blocked. Manual review required."
+          MSG+=$'\n'
+          MSG+="PR: ${PR_URL}"
+          MSG+=$'\n'
+          MSG+="Run: ${RUN_URL}"
+          tg_send_tracked "${PR_NUMBER}" "${MSG}" "CRITICAL"
+
+          # Also post a warning comment on the PR so the issue is visible
+          BODY="⚠️ **Editor changes lost** — the editor reported making changes but no files were modified on disk."
+          BODY+=$'\n\n'
+          BODY+="Auto-merge has been **blocked** to prevent merging without the intended fixes."
+          BODY+=$'\n'
+          BODY+="The Serena MCP tool calls likely failed to persist the edits."
+          BODY+=$'\n\n'
+          BODY+="**Next steps:** re-run the review workflow or apply the changes manually."
+          BODY+=$'\n'
+          BODY+="See the editor summary comment above for the intended changes."
+          gh_retry gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -f body="${BODY}" >/dev/null 2>&1 || true
 
       - name: Telegram review-blocked judge decision
         if: success() && steps.retrigger_guard.outputs.max_iterations_reached == 'true' && env.PR_CLOSED != 'true'

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3414,7 +3414,8 @@ jobs:
             if [ "${caller_workflow}" != "review_autofix.yml" ]; then
               if gh workflow run "${caller_workflow}" \
                 --ref "${TARGET_BRANCH}" \
-                -f pr_number="${PR_NUMBER}"; then
+                -f pr_number="${PR_NUMBER}" \
+                -f allow_workflow_edits="${ALLOW_WORKFLOW_EDITS}"; then
                 echo "Dispatched ${caller_workflow} on ${TARGET_BRANCH} for PR #${PR_NUMBER}."
                 dispatched=true
               fi

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3370,6 +3370,52 @@ jobs:
           MSG+="Run: ${RUN_URL}"
           tg_send_tracked "${PR_NUMBER}" "${MSG}" "DEBUG"
 
+      - name: Re-dispatch review on editor-changes-lost
+        # When the editor claims changes but nothing persisted on disk after
+        # all retry attempts, automatically re-dispatch the review workflow
+        # so the next iteration gets a fresh Serena MCP instance.  Bounded
+        # by the retrigger guard (MAX_AUTOFIX_ITERATIONS) — if the guard is
+        # already exhausted this step is a no-op and the Telegram warning
+        # below escalates to manual review.
+        if: "success() && env.EDITOR_CHANGES_LOST == 'true' && env.PR_CLOSED != 'true' && steps.retrigger_guard.outputs.max_iterations_reached != 'true'"
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          source "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh" 2>/dev/null || true
+
+          echo "Editor changes lost — dispatching fresh review iteration for PR #${PR_NUMBER}."
+          dispatched=false
+
+          if gh workflow run "review_autofix.yml" \
+            --ref "${TARGET_BRANCH}" \
+            -f pr_number="${PR_NUMBER}" \
+            -f allow_workflow_edits="${ALLOW_WORKFLOW_EDITS}"; then
+            echo "Dispatched review_autofix.yml on ${TARGET_BRANCH} for PR #${PR_NUMBER}."
+            dispatched=true
+          fi
+
+          if [ "${dispatched}" = "false" ]; then
+            caller_workflow=""
+            if [ -n "${{ github.workflow_ref }}" ]; then
+              caller_workflow="$(printf '%s' "${{ github.workflow_ref }}" | sed -n 's|^[^/]*/[^/]*/\(\.github/workflows/[^@]*\)@.*$|\1|p')"
+            fi
+            if [ -n "${caller_workflow}" ] && [ "${caller_workflow}" != ".github/workflows/review_autofix.yml" ]; then
+              if gh workflow run "${caller_workflow}" \
+                --ref "${TARGET_BRANCH}" \
+                -f pr_number="${PR_NUMBER}"; then
+                echo "Dispatched ${caller_workflow} on ${TARGET_BRANCH} for PR #${PR_NUMBER}."
+                dispatched=true
+              fi
+            fi
+          fi
+
+          if [ "${dispatched}" = "false" ]; then
+            echo "::warning::Could not dispatch review workflow for editor-changes-lost recovery. The next synchronize event or manual re-run is needed."
+          fi
+
+          echo "CHANGES_LOST_REDISPATCHED=${dispatched}" >> "$GITHUB_ENV"
+
       - name: Telegram editor-changes-lost warning
         if: "success() && env.EDITOR_CHANGES_LOST == 'true' && env.PR_CLOSED != 'true'"
         env:
@@ -3383,30 +3429,33 @@ jobs:
           PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUMBER}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          MSG="⚠️ Editor changes lost: #${PR_NUMBER}"
-          MSG+=$'\n'
-          MSG+="Editor claimed changes but nothing was committed."
-          MSG+=$'\n'
-          MSG+="Serena MCP tool calls likely failed to persist."
-          MSG+=$'\n'
-          MSG+="Auto-merge blocked. Manual review required."
-          MSG+=$'\n'
-          MSG+="PR: ${PR_URL}"
-          MSG+=$'\n'
-          MSG+="Run: ${RUN_URL}"
-          tg_send_tracked "${PR_NUMBER}" "${MSG}" "CRITICAL"
+          if [ "${CHANGES_LOST_REDISPATCHED:-false}" = "true" ]; then
+            MSG="⚠️ Editor changes lost (retrying): #${PR_NUMBER}"
+            MSG+=$'\n'
+            MSG+="Serena MCP tool calls failed to persist. Fresh review dispatched."
+            MSG+=$'\n'
+            MSG+="PR: ${PR_URL}"
+            MSG+=$'\n'
+            MSG+="Run: ${RUN_URL}"
+            tg_send_tracked "${PR_NUMBER}" "${MSG}" "WARN"
+          else
+            MSG="⚠️ Editor changes lost (exhausted): #${PR_NUMBER}"
+            MSG+=$'\n'
+            MSG+="All retries exhausted. Auto-merge blocked."
+            MSG+=$'\n'
+            MSG+="PR: ${PR_URL}"
+            MSG+=$'\n'
+            MSG+="Run: ${RUN_URL}"
+            tg_send_tracked "${PR_NUMBER}" "${MSG}" "CRITICAL"
 
-          # Also post a warning comment on the PR so the issue is visible
-          BODY="⚠️ **Editor changes lost** — the editor reported making changes but no files were modified on disk."
-          BODY+=$'\n\n'
-          BODY+="Auto-merge has been **blocked** to prevent merging without the intended fixes."
-          BODY+=$'\n'
-          BODY+="The Serena MCP tool calls likely failed to persist the edits."
-          BODY+=$'\n\n'
-          BODY+="**Next steps:** re-run the review workflow or apply the changes manually."
-          BODY+=$'\n'
-          BODY+="See the editor summary comment above for the intended changes."
-          gh_retry gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -f body="${BODY}" >/dev/null 2>&1 || true
+            # Post a PR comment only when re-dispatch failed (human attention needed)
+            BODY="⚠️ **Editor changes lost** — the editor reported making changes but no files were modified on disk."
+            BODY+=$'\n\n'
+            BODY+="Auto-merge has been **blocked**. All automated retry attempts have been exhausted."
+            BODY+=$'\n'
+            BODY+="**Next steps:** re-run the review workflow manually or apply the changes from the editor summary above."
+            gh_retry gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -f body="${BODY}" >/dev/null 2>&1 || true
+          fi
 
       - name: Telegram review-blocked judge decision
         if: success() && steps.retrigger_guard.outputs.max_iterations_reached == 'true' && env.PR_CLOSED != 'true'

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1985,14 +1985,18 @@ jobs:
             has_real_changes="false"
             if [ -n "${changes_section}" ]; then
               # Strip lines that are blank or match "- none*"
-              substantive="$(printf '%s\n' "${changes_section}" | grep -vE '^\s*$' | grep -vE '^\s*-\s*none' || true)"
+              substantive="$(printf '%s\n' "${changes_section}" | grep -vE '^[[:space:]]*$' | grep -vE '^[[:space:]]*-[[:space:]]*none' || true)"
               if [ -n "${substantive}" ]; then
                 has_real_changes="true"
               fi
             fi
 
             if [ "${has_real_changes}" = "true" ]; then
-              echo "::error::Editor claimed changes but no files were committed. Serena MCP tool calls likely failed to persist changes on disk."
+              if [ "${CAN_PUSH:-}" = "true" ]; then
+                echo "::error::Editor claimed changes but no commit was produced. Serena MCP tool calls likely failed to persist changes on disk."
+              else
+                echo "::error::Editor claimed changes but no commit was produced. Push is disabled (CAN_PUSH=${CAN_PUSH:-false}), so this does not necessarily indicate a Serena persistence failure."
+              fi
               echo "Editor-claimed changes:"
               printf '%s\n' "${changes_section}" | head -20
               EDITOR_CHANGES_LOST="true"
@@ -3092,10 +3096,10 @@ jobs:
                 local repo="$2"
                 case "${label_name}" in
                   ai:review-blocked)
-                    gh label create "${label_name}" --repo "${repo}" --color "e11d48" --description "PR review/autofix could not resolve all issues — needs human intervention" 2>/dev/null || true
+                    gh_retry gh label create "${label_name}" --repo "${repo}" --color "e11d48" --description "PR review/autofix could not resolve all issues — needs human intervention" 2>/dev/null || true
                     ;;
                   *)
-                    gh label create "${label_name}" --repo "${repo}" --color "1d76db" --description "AI workflow label" 2>/dev/null || true
+                    gh_retry gh label create "${label_name}" --repo "${repo}" --color "1d76db" --description "AI workflow label" 2>/dev/null || true
                     ;;
                 esac
               }
@@ -3377,7 +3381,7 @@ jobs:
         # by the retrigger guard (MAX_AUTOFIX_ITERATIONS) — if the guard is
         # already exhausted this step is a no-op and the Telegram warning
         # below escalates to manual review.
-        if: "success() && env.EDITOR_CHANGES_LOST == 'true' && env.PR_CLOSED != 'true' && steps.retrigger_guard.outputs.max_iterations_reached != 'true'"
+        if: "success() && env.EDITOR_CHANGES_LOST == 'true' && env.PR_CLOSED != 'true' && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && env.CAN_PUSH == 'true'"
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
@@ -3439,22 +3443,33 @@ jobs:
             MSG+="Run: ${RUN_URL}"
             tg_send_tracked "${PR_NUMBER}" "${MSG}" "WARN"
           else
-            MSG="⚠️ Editor changes lost (exhausted): #${PR_NUMBER}"
-            MSG+=$'\n'
-            MSG+="All retries exhausted. Auto-merge blocked."
-            MSG+=$'\n'
-            MSG+="PR: ${PR_URL}"
-            MSG+=$'\n'
-            MSG+="Run: ${RUN_URL}"
-            tg_send_tracked "${PR_NUMBER}" "${MSG}" "CRITICAL"
+            if [ "${CAN_PUSH:-}" = "true" ]; then
+              MSG="⚠️ Editor changes lost (exhausted): #${PR_NUMBER}"
+              MSG+=$'\n'
+              MSG+="All retries exhausted. Auto-merge blocked."
+              MSG+=$'\n'
+              MSG+="PR: ${PR_URL}"
+              MSG+=$'\n'
+              MSG+="Run: ${RUN_URL}"
+              tg_send_tracked "${PR_NUMBER}" "${MSG}" "CRITICAL"
 
-            # Post a PR comment only when re-dispatch failed (human attention needed)
-            BODY="⚠️ **Editor changes lost** — the editor reported making changes but no files were modified on disk."
-            BODY+=$'\n\n'
-            BODY+="Auto-merge has been **blocked**. All automated retry attempts have been exhausted."
-            BODY+=$'\n'
-            BODY+="**Next steps:** re-run the review workflow manually or apply the changes from the editor summary above."
-            gh_retry gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -f body="${BODY}" >/dev/null 2>&1 || true
+              # Post a PR comment only when re-dispatch failed (human attention needed)
+              BODY="⚠️ **Editor changes lost** — the editor reported making changes but no commit was produced."
+              BODY+=$'\n\n'
+              BODY+="Auto-merge has been **blocked**. All automated retry attempts have been exhausted."
+              BODY+=$'\n'
+              BODY+="**Next steps:** re-run the review workflow manually or apply the changes from the editor summary above."
+              gh_retry gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -f body="${BODY}" >/dev/null 2>&1 || true
+            else
+              MSG="⚠️ Editor changes lost (push disabled): #${PR_NUMBER}"
+              MSG+=$'\n'
+              MSG+="Editor claimed changes but push is disabled (CAN_PUSH=${CAN_PUSH:-false}); changes cannot be committed to the PR."
+              MSG+=$'\n'
+              MSG+="PR: ${PR_URL}"
+              MSG+=$'\n'
+              MSG+="Run: ${RUN_URL}"
+              tg_send_tracked "${PR_NUMBER}" "${MSG}" "WARN"
+            fi
           fi
 
       - name: Telegram review-blocked judge decision

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -560,10 +560,45 @@ while [ "${attempt}" -le 3 ]; do
       done < "${REVIEWER_MANIFEST_FILE}"
 
       if [ "${reviewer_validation_ok}" = true ]; then
-        mv "${tmp_output}" "${EDITOR_SUMMARY_FILE}"
-        rm -f "${tmp_err}"
-        echo "Editor succeeded on attempt ${attempt}."
-        exit 0
+        # ── Verify claimed changes actually persisted on disk ──
+        # The editor LLM may report "Changes made: [X]" in its text output
+        # while Serena MCP tool calls silently fail to write.  When the
+        # editor claims substantive changes but git sees no diff from HEAD,
+        # treat this attempt as failed so the retry loop can try again.
+        # See: PR #1136, #1137 where this mismatch caused premature
+        # auto-merge of un-fixed PRs.
+        _claimed_changes="$(awk '
+          /^Changes made:/ { in_s=1; next }
+          in_s && /^[A-Za-z].*:/ { exit }
+          in_s { print }
+        ' "${tmp_output}" | grep -vE '^\s*$' | grep -vE '^\s*-\s*none' || true)"
+
+        if [ -n "${_claimed_changes}" ]; then
+          # Editor claims it made changes — verify git agrees.
+          _git_has_diff=false
+          if ! git diff --quiet HEAD 2>/dev/null; then
+            _git_has_diff=true
+          elif [ -n "$(git ls-files --others --exclude-standard 2>/dev/null)" ]; then
+            _git_has_diff=true
+          fi
+
+          if [ "${_git_has_diff}" = false ]; then
+            echo "::warning::Editor claimed changes but git shows no diff from HEAD on attempt ${attempt}. Serena tool calls likely failed to persist."
+            echo "Claimed changes (attempt ${attempt}):"
+            printf '%s\n' "${_claimed_changes}" | head -10
+            cp "${tmp_output}" "${PREVIOUS_REVIEWS_DIR}/editor_attempt_${attempt}_changes_lost.txt" || true
+            # Fall through to retry instead of exiting
+            reviewer_validation_ok=false
+          fi
+        fi
+
+        if [ "${reviewer_validation_ok}" = true ]; then
+          mv "${tmp_output}" "${EDITOR_SUMMARY_FILE}"
+          rm -f "${tmp_err}"
+          echo "Editor succeeded on attempt ${attempt}."
+          exit 0
+        fi
+        echo "Editor output passed format/manifest validation but claimed changes did not persist on attempt ${attempt}; retrying."
       fi
       echo "Editor output failed reviewer manifest validation on attempt ${attempt}."
     fi
@@ -598,7 +633,17 @@ if [ -f "/tmp/pr_closed_sentinel_${PR_NUMBER}" ]; then
   exit 0
 fi
 
-cat > "${EDITOR_SUMMARY_FILE}" <<'__EDITOR_SUMMARY__'
+# If any attempt had changes-lost (editor claimed changes but nothing
+# persisted), prefer that output over the generic fallback so the
+# workflow-level EDITOR_CHANGES_LOST detection can fire and trigger
+# a re-dispatch.  The _changes_lost.txt files are saved by the
+# changes-lost check in the retry loop above.
+_last_changes_lost_file="$(ls -1 "${PREVIOUS_REVIEWS_DIR}"/editor_attempt_*_changes_lost.txt 2>/dev/null | sort -V | tail -n 1 || true)"
+if [ -n "${_last_changes_lost_file}" ] && [ -s "${_last_changes_lost_file}" ]; then
+  cp "${_last_changes_lost_file}" "${EDITOR_SUMMARY_FILE}"
+  echo "Editor failed after retries; using last changes-lost output as summary to trigger workflow-level recovery."
+else
+  cat > "${EDITOR_SUMMARY_FILE}" <<'__EDITOR_SUMMARY__'
 Changes made:
 - none (editor failed before producing a validated summary)
 
@@ -620,8 +665,8 @@ Regression fingerprint:
 Runtime failure path:
 - unavailable (editor fallback)
 __EDITOR_SUMMARY__
-
-echo "Editor failed after retries; continuing with fallback summary."
+  echo "Editor failed after retries; continuing with fallback summary."
+fi
 final_editor_err="$(ls -1 "${PREVIOUS_REVIEWS_DIR}"/editor_attempt_*.err 2>/dev/null | sort -V | tail -n 1 || true)"
 if [ -n "${final_editor_err}" ] && [ -s "${final_editor_err}" ]; then
   echo "Editor stderr from final attempt:"

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -504,6 +504,7 @@ while [ "${attempt}" -le 3 ]; do
     cp "${tmp_err}" "${PREVIOUS_REVIEWS_DIR}/editor_attempt_${attempt}.err" 2>/dev/null || true
     if [ -s "${tmp_output}" ] && grep -q '^Changes made:' "${tmp_output}"                 && grep -q '^Already satisfied (suggested but already present):' "${tmp_output}"                 && grep -q '^Ignored suggestions (with short reason):' "${tmp_output}"                 && grep -q '^Reviewer files processed:' "${tmp_output}"                 && grep -q '^Review file issue audit:' "${tmp_output}"                 && ! grep -qiE "I can.?t execute this|need to read|allow read/write shell commands|cannot proceed under the current constraints" "${tmp_output}"; then
       reviewer_validation_ok=true
+      changes_lost_detected=false
       while IFS= read -r manifest_path; do
         manifest_sha="$(sha256sum "${manifest_path}" | awk '{print $1}')"
         if ! awk -v file_path="${manifest_path}" '
@@ -589,6 +590,7 @@ while [ "${attempt}" -le 3 ]; do
             cp "${tmp_output}" "${PREVIOUS_REVIEWS_DIR}/editor_attempt_${attempt}_changes_lost.txt" || true
             # Fall through to retry instead of exiting
             reviewer_validation_ok=false
+            changes_lost_detected=true
           fi
         fi
 
@@ -600,7 +602,9 @@ while [ "${attempt}" -le 3 ]; do
         fi
         echo "Editor output passed format/manifest validation but claimed changes did not persist on attempt ${attempt}; retrying."
       fi
-      echo "Editor output failed reviewer manifest validation on attempt ${attempt}."
+      if [ "${changes_lost_detected}" = false ]; then
+        echo "Editor output failed reviewer manifest validation on attempt ${attempt}."
+      fi
     fi
     if [ -s "${tmp_output}" ]; then
       echo "Editor output on attempt ${attempt} failed structured-format and/or reviewer-manifest validation; retrying."

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -571,7 +571,7 @@ while [ "${attempt}" -le 3 ]; do
           /^Changes made:/ { in_s=1; next }
           in_s && /^[A-Za-z].*:/ { exit }
           in_s { print }
-        ' "${tmp_output}" | grep -vE '^\s*$' | grep -vE '^\s*-\s*none' || true)"
+        ' "${tmp_output}" | grep -vE '^[[:space:]]*$' | grep -vE '^[[:space:]]*-[[:space:]]*none' || true)"
 
         if [ -n "${_claimed_changes}" ]; then
           # Editor claims it made changes — verify git agrees.

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -568,8 +568,8 @@ while [ "${attempt}" -le 3 ]; do
         # See: PR #1136, #1137 where this mismatch caused premature
         # auto-merge of un-fixed PRs.
         _claimed_changes="$(awk '
-          /^Changes made:/ { in_s=1; next }
-          in_s && /^[A-Za-z].*:/ { exit }
+          /^[[:space:]]*Changes made:/ { in_s=1; next }
+          in_s && /^[[:space:]]*[A-Za-z].*:/ { exit }
           in_s { print }
         ' "${tmp_output}" | grep -vE '^[[:space:]]*$' | grep -vE '^[[:space:]]*-[[:space:]]*none' || true)"
 


### PR DESCRIPTION
The review autofix workflow treated did_commit=false as "review is clean"
and enabled auto-merge. But did_commit=false also occurs when the editor
LLM (Codex + Serena MCP) reports making changes that don't persist on
disk — Serena tool calls can fail silently while the LLM's text output
still describes the intended edits.

This caused PRs #1136, #1137 to be auto-merged without their review
fixes: the editor posted "Changes made: [specific fixes]" + "Files
changed: - none", the workflow interpreted no-commit as clean, enabled
gh pr merge --squash --auto, and GitHub merged immediately.

Fix:
- Add "Detect editor-claimed-but-uncommitted changes" step that parses
  the EDITOR_SUMMARY_FILE "Changes made:" section and compares against
  the actual commit status. Sets EDITOR_CHANGES_LOST=true on mismatch.
- Gate "Mark linked issues ready to merge", "Enable auto-merge on PR",
  and "Telegram success" on EDITOR_CHANGES_LOST != 'true'.
- Add "Telegram editor-changes-lost warning" step that sends a CRITICAL
  alert and posts a PR comment when changes are lost, explaining that
  auto-merge was blocked and manual review is needed.

https://claude.ai/code/session_01Jhd2aqfnnpFnaETaZaPRm6