### PR TITLE
claude/add-circuit-breaker-gh-api-GIyFm

### DIFF
--- a/.github/workflows/internal-orchestrate-poll.yml
+++ b/.github/workflows/internal-orchestrate-poll.yml
@@ -2,7 +2,7 @@ name: "Internal: AI Orchestrate Poller"
 
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/30 * * * *'
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -72,12 +72,14 @@ jobs:
             echo "::warning::  Rate limit resets in ${_wait_secs}s (X-RateLimit-Reset: ${_reset_ts:-unknown})" >&2
             sleep "${_wait_secs}"
           }
+          _GH_RATE_LIMIT_BREAKER_FILE="${GH_RATE_LIMIT_BREAKER_FILE:-/tmp/.gh_rate_limit_circuit_breaker}"
           _gh_retry() {
             local attempt=1
             while [ "${attempt}" -le 5 ]; do
               if "$@" 2>/tmp/_gh_retry_err; then return 0; fi
               if grep -qiE 'rate limit|abuse detection|secondary rate|HTTP 429' /tmp/_gh_retry_err 2>/dev/null; then
                 echo "::warning::Rate limit hit (attempt ${attempt}/5), waiting for reset…" >&2
+                touch "${_GH_RATE_LIMIT_BREAKER_FILE}" 2>/dev/null || true
                 _rl_wait
               else
                 local wait_secs=$(( 2 ** (attempt - 1) ))
@@ -454,11 +456,25 @@ jobs:
             --actor "${GITHUB_ACTOR}" \
             --metadata-json "{\"run_attempt\":\"${GITHUB_RUN_ATTEMPT}\",\"repository\":\"${GITHUB_REPOSITORY}\",\"job_status\":\"${{ job.status }}\",\"has_work\":\"${{ steps.find_tracking.outputs.has_work || 'false' }}\"}" || true
 
+      - name: Check rate-limit circuit breaker
+        id: circuit_breaker
+        if: always()
+        run: |
+          set -euo pipefail
+          _BREAKER_FILE="${GH_RATE_LIMIT_BREAKER_FILE:-/tmp/.gh_rate_limit_circuit_breaker}"
+          if [ -f "${_BREAKER_FILE}" ]; then
+            echo "::warning::Rate-limit circuit breaker tripped — skipping self-retrigger; cron will start next cycle"
+            echo "tripped=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tripped=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Rate-limit cooldown before retrigger
         if: >-
           !cancelled()
           && steps.find_tracking.outputs.has_tracking == 'true'
           && inputs.caller_workflow != ''
+          && steps.circuit_breaker.outputs.tripped != 'true'
         run: |
           set -euo pipefail
           NOW="$(date +%s)"
@@ -477,6 +493,7 @@ jobs:
           !cancelled()
           && steps.find_tracking.outputs.has_tracking == 'true'
           && inputs.caller_workflow != ''
+          && steps.circuit_breaker.outputs.tripped != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `GIT_MCP_DISABLED` | No | `false` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, orchestrate_clarify_respond, validate | Disable the optional Git MCP server setup (preloaded diff artifacts remain the fallback). |
 | `OPENROUTER_PROMPT_CACHE_DISABLED` | No | `false` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, orchestrate_clarify_respond, validate, workflow-log-analysis | Kill switch for OpenRouter prompt-cache instrumentation. `false` enables cache-friendly prompt ordering and cache telemetry logging; `true` disables explicit cache breakpoints and related instrumentation. |
 | `WORKFLOW_ORCHESTRATE_MODEL` | No | (falls back to `WORKFLOW_EDITOR_MODEL`) | orchestrate, orchestrate_poll | Model override for orchestrator decomposer and judge |
-| `ORCHESTRATE_POLL_INTERVAL` | No | `5` | orchestrate | Reserved poll interval setting (current poll cadence is controlled by the poller wrapper cron schedule) |
+| `ORCHESTRATE_POLL_INTERVAL` | No | `30` | orchestrate | Reserved poll interval setting (current poll cadence is controlled by the poller wrapper cron schedule) |
 | `ORCHESTRATE_SHORTCIRCUIT_MAX_CHARS` | No | `1200` | orchestrate | Pre-LLM short-circuit threshold for creating a single plain issue. If `project_description` length is `<=` this value and no multi-step markers match (`step\s*\d|phase\s*\d|wave\s*\d|\bthen\b|\bafter\b|\band\s+then\b|multi[- ]?step`), orchestrate skips decomposer/tracking/wave dispatch and opens one unlabeled plain issue from the description. |
-| `ORCHESTRATE_POLL_CALLER_WORKFLOW` | No | `ai-orchestrate-poll.yml` | orchestrate_poll | Filename of the caller wrapper workflow to retrigger for continuous polling. The poller dispatches this workflow via `workflow_dispatch` at the end of each run when active tracking issues exist, so the next cycle starts immediately instead of waiting for the cron schedule. Set to empty string to disable self-retrigger. |
+| `ORCHESTRATE_POLL_CALLER_WORKFLOW` | No | `ai-orchestrate-poll.yml` | orchestrate_poll | Filename of the caller wrapper workflow to retrigger for continuous polling. The poller dispatches this workflow via `workflow_dispatch` at the end of each run when active tracking issues exist, so the next cycle starts immediately instead of waiting for the cron schedule. Self-retrigger is suppressed when a GitHub API rate limit was hit during the run (circuit breaker). Set to empty string to disable self-retrigger entirely. |
 | `EDITOR_IDLE_TIMEOUT` | No | `1200` | review_autofix, implement | Editor watchdog idle timeout in seconds. The editor is killed if it produces no output for this long and has no active network connections. |
 | `EDITOR_MAX_WALL` | No | `3300` | review_autofix, implement | Maximum wall-clock seconds per editor attempt. Budget-aware: auto-capped to remaining job time minus a 2-min buffer. |
 | `EDITOR_MIN_ATTEMPT_SECS` | No | `300` | review_autofix | Minimum remaining job budget (seconds) required to start an editor attempt. Prevents futile retries near the job deadline. |
@@ -590,7 +590,7 @@ See [`workflow-templates/`](workflow-templates/) in this repository for ready-to
 | `memory_maintenance.yml` | `schedule` (monthly) | Memory compaction/archival |
 | `orchestrate.yml` | `workflow_dispatch` | Project decomposition + multi-issue orchestration |
 | `orchestrate_clarify_respond.yml` | `issue_comment.created` | Auto-answers clarification questions on orchestrator issues |
-| `orchestrate_poll.yml` | `schedule` (every ~5 min) + self-retrigger | Orchestrator progress poller + judge + auto-recovery. Self-retriggers via `workflow_dispatch` when active tracking issues exist for near-immediate next cycles; cron acts as fallback. |
+| `orchestrate_poll.yml` | `schedule` (every ~30 min) + self-retrigger | Orchestrator progress poller + judge + auto-recovery. Self-retriggers via `workflow_dispatch` when active tracking issues exist for near-immediate next cycles; cron acts as fallback. A rate-limit circuit breaker suppresses self-retrigger when a GitHub API rate limit was hit during the run. |
 | `update_workflows.yml` | `schedule` (daily), `repository_dispatch`, `workflow_dispatch` | Auto-updates existing and creates new workflow wrappers from upstream templates |
 
 ## Workflow Log Analysis
@@ -764,7 +764,7 @@ Analyzer script: [`scripts/analyze_workflow_logs.py`](scripts/analyze_workflow_l
 | `WORKFLOW_ORCHESTRATE_MODEL` | (falls back to `WORKFLOW_EDITOR_MODEL`) | Model override for orchestrator/judge |
 | `THINKING_LEVEL_ORCHESTRATE` | `medium` | Reasoning effort for project decomposition |
 | `THINKING_LEVEL_JUDGE` | `xhigh` | Reasoning effort for judge evaluation (`xhigh` for cycles 1-3, automatically `high` from cycle 4 onward) |
-| `ORCHESTRATE_POLL_INTERVAL` | `5` | Reserved poll interval setting (current poll cadence is controlled by the poller wrapper cron schedule) |
+| `ORCHESTRATE_POLL_INTERVAL` | `30` | Reserved poll interval setting (current poll cadence is controlled by the poller wrapper cron schedule) |
 | `ORCHESTRATE_SHORTCIRCUIT_MAX_CHARS` | `1200` | Pre-LLM short-circuit threshold for creating a single plain issue when no multi-step markers are detected |
 | `ORCHESTRATE_POLL_CALLER_WORKFLOW` | `ai-orchestrate-poll.yml` | Caller workflow filename for self-retrigger; empty string disables |
 | `EDITOR_IDLE_TIMEOUT` | `1200` | Editor watchdog idle timeout (seconds); killed if no output and no active network connections |
@@ -933,7 +933,7 @@ Or create them manually — see the inline examples in the [Quickstart](#quickst
 3. **Wave dispatch:** Wave 1 issues (no dependencies) are created immediately and enter the existing clarify → plan → implement → review pipeline automatically. If clarification questions are raised, the `orchestrate_clarify_respond` workflow answers them automatically using an LLM. When `plan.yml` emits structured `Q<ID>` clarification blocks with single-letter `(RECOMMENDED)` options for every question, `plan.yml` now posts a synthesized `/answer Q1: A, ... [auto-answered-by-orchestrator]`; if parsing fails or any recommendation is non-single-letter (for example `A+C`), it does not auto-answer and keeps the human `/answer` loop.
 4. **Auto-merge:** The poller automatically merges PRs via squash merge when they reach `ai:ready-to-merge`. If a PR has merge conflicts (e.g. `main` advanced since the PR was created), the poller automatically updates the PR branch via the GitHub API before retrying the merge. This requires either (a) no branch protection rules, or (b) branch protection with "Require status checks" that have already passed. See [Enabling auto-merge](#enabling-auto-merge) below.
 5. **In-progress conflict resolution:** When the base branch advances and creates merge conflicts on open PRs whose tracking issue is in the `in_progress` or `done` wave status (still going through the review/autofix cycle, or sitting in `ai:done` awaiting promotion to `ai:ready-to-merge`), the poller detects the conflict (`mergeable == false`). It first tries a GitHub API branch update; if that fails (real conflicts), it dispatches the review workflow via `workflow_dispatch`. The review workflow's built-in Codex conflict resolver then handles the resolution on a dedicated runner with a clean environment.
-6. **Polling:** Every 5 minutes, the poller checks if the current wave's issues have reached `ai:merged`. When all are merged, it runs the judge.
+6. **Polling:** Every 30 minutes (cron fallback), the poller checks if the current wave's issues have reached `ai:merged`. When all are merged, it runs the judge. Between cron ticks the poller self-retriggers for near-immediate cycles, unless a GitHub API rate limit was hit during the run (circuit breaker).
 7. **Judge:** Full repo checkout + tool access (Serena, shell, file reads) with adaptive thinking (`xhigh` for cycles 1-3, then `high`). Compares merged code against the project spec. Decides: complete, in_progress (next wave or fix-ups), or failed.
 7a. **Clean-wave skip (flagged):** When `ENABLE_CLEAN_WAVE_JUDGE_SKIP=true`, and the completed wave has no failed issues, project is not complete, and it is not a stuck-wave invocation, the poller advances `current_wave` and increments `judge_cycle` without calling Codex judge. `judge_stall_cycles` is unchanged.
 7b. **Clean project-completion skip (flagged):** When `ENABLE_CLEAN_WAVE_JUDGE_SKIP=true`, the final wave is complete with all issues merged, no failures, no review-blocked issues, and no stuck-wave invocation, the poller emits a synthetic `complete` verdict without calling the Codex judge. The outcome is deterministic in this case — the LLM judge cannot add value and risks empty-output failures.
@@ -1044,6 +1044,16 @@ Any workflow or script that routes GitHub API calls through `scripts/gh_helpers.
 **Interaction with `ALERT_MSG_LEVEL`:** the rate-limit alert is emitted at `WARNING` level and honours the global `ALERT_MSG_LEVEL` threshold the same way `scripts/tg_helpers.sh::tg_send_msg` does. If an operator configures `ALERT_MSG_LEVEL=ERROR` or `ALERT_MSG_LEVEL=CRITICAL`, the rate-limit alert is suppressed entirely (no send, no pin update, no cooldown advance). The cooldown state is only touched when the alert would actually fire, so tightening `ALERT_MSG_LEVEL` does not strand a stale pinned marker.
 
 **Disabling:** unset `TG_BOT_SECRET` or `TG_ADMIN_CHAT_ID` — the helper no-ops silently. You can also set `ALERT_MSG_LEVEL=ERROR` (or higher) to suppress the rate-limit alert while keeping other ERROR/CRITICAL Telegram notifications. There is no way to disable the feature per-caller; if you need to skip alerting for a specific bootstrap probe (e.g. a `gh api /labels/<name>` existence check where 404 is the expected normal case), call `gh` directly instead of via `gh_retry`. See `ensure_label_exists` in `scripts/orchestrate_poll_process.sh` for an example.
+
+### GitHub API rate-limit circuit breaker
+
+When any `gh_retry`, `gh_retry_to_file`, `gh_api_json_to_file`, or `curl_gh_api` call in `scripts/gh_helpers.sh` detects a GitHub API rate limit (403/429), it touches a flag file (`/tmp/.gh_rate_limit_circuit_breaker`, overridable via `GH_RATE_LIMIT_BREAKER_FILE`). The poller's inline retry helper in the "Find active tracking issues" step also writes this flag on rate-limit detection.
+
+At the end of each `orchestrate_poll.yml` run, a "Check rate-limit circuit breaker" step reads this flag. If tripped, both the cooldown sleep and the self-retrigger dispatch are skipped — the poller exits immediately and waits for the next cron-scheduled run (every 30 minutes) instead of chaining another immediate cycle.
+
+This prevents a rate-limited poller from burning Actions minutes and GH API quota on back-to-back runs that will hit the same limit. The current run always completes normally; only the _next_ self-triggered cycle is suppressed.
+
+The `gh_rate_limit_breaker_tripped` shell function is exported by `gh_helpers.sh` for use by other scripts that may want to query the flag.
 
 ### H3 Timeline GraphQL Shim
 

--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -83,6 +83,32 @@ _gh_rate_limit_wait()
 }
 
 # ---------------------------------------------------------------
+# Circuit breaker: rate-limit flag file.
+#
+# When any gh_retry / curl_gh_api helper detects a GitHub API
+# rate limit, it touches this file.  Callers (e.g.
+# orchestrate_poll.yml) can check gh_rate_limit_breaker_tripped
+# to suppress self-retrigger and let the cron schedule handle the
+# next cycle instead.
+#
+# The file path defaults to /tmp/.gh_rate_limit_circuit_breaker
+# and can be overridden via GH_RATE_LIMIT_BREAKER_FILE env var.
+# ---------------------------------------------------------------
+_GH_RATE_LIMIT_BREAKER_FILE="${GH_RATE_LIMIT_BREAKER_FILE:-/tmp/.gh_rate_limit_circuit_breaker}"
+
+_gh_rate_limit_trip_breaker()
+{
+	touch "${_GH_RATE_LIMIT_BREAKER_FILE}" 2>/dev/null || true
+}
+
+# gh_rate_limit_breaker_tripped — returns 0 (true) if a rate
+# limit was encountered at any point during this run.
+gh_rate_limit_breaker_tripped()
+{
+	[ -f "${_GH_RATE_LIMIT_BREAKER_FILE}" ]
+}
+
+# ---------------------------------------------------------------
 # _gh_ratelimit_tg_alert — Telegram admin alert when a GitHub
 # API rate limit is hit in any workflow or script.
 #
@@ -334,6 +360,7 @@ gh_retry()
 		if _is_gh_rate_limit "${stderr_content}"; then
 			echo "::warning::GitHub API rate limit hit (attempt ${attempt}/${max_attempts}), waiting for reset…" >&2
 			_gh_ratelimit_tg_alert
+			_gh_rate_limit_trip_breaker
 			_gh_rate_limit_wait
 		else
 			local wait_secs=$(( 2 ** (attempt - 1) ))
@@ -387,6 +414,7 @@ gh_retry_to_file()
 		if _is_gh_rate_limit "${stderr_content}"; then
 			echo "::warning::GitHub API rate limit hit (attempt ${attempt}/${max_attempts}), waiting for reset…" >&2
 			_gh_ratelimit_tg_alert
+			_gh_rate_limit_trip_breaker
 			_gh_rate_limit_wait
 		else
 			local wait_secs=$(( 2 ** (attempt - 1) ))
@@ -486,6 +514,7 @@ gh_api_json_to_file()
 			if _is_gh_rate_limit "${stderr_content}"; then
 				echo "::warning::GitHub API rate limit hit (attempt ${attempt}/${max_attempts}), waiting for reset…" >&2
 				_gh_ratelimit_tg_alert
+				_gh_rate_limit_trip_breaker
 				_gh_rate_limit_wait
 			else
 				local wait_secs=$(( 2 ** (attempt - 1) ))
@@ -555,6 +584,7 @@ curl_gh_api()
 		if [ "${http_code}" = "429" ] || { [ "${http_code}" = "403" ] && _is_gh_rate_limit "${body_content}"; }; then
 			echo "::warning::GitHub API rate limit (HTTP ${http_code}, attempt ${attempt}/${max_attempts}), waiting for reset…" >&2
 			_gh_ratelimit_tg_alert
+			_gh_rate_limit_trip_breaker
 			local _reset_ts
 			_reset_ts=$(_parse_reset_header "${header_file}")
 			_sleep_until_reset "${_reset_ts}"

--- a/workflow-templates/ai-orchestrate-poll.yml
+++ b/workflow-templates/ai-orchestrate-poll.yml
@@ -4,7 +4,7 @@
 name: AI Orchestrate Poller
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/30 * * * *'
   workflow_dispatch: {}
 permissions:
   contents: write


### PR DESCRIPTION
When a GitHub API rate limit is detected during a poll run, the circuit
breaker flag file is set. After the run completes, the poller skips
self-retrigger and waits for the next cron-scheduled cycle instead of
chaining another immediate run into the same rate-limit window.

Also changes the cron schedule from every 5 minutes to every 30 minutes
in both internal-orchestrate-poll.yml and the consumer template.

https://claude.ai/code/session_018W3THL34ztzdGXbfnYcEVD