### PR TITLE
claude/analyze-job-logs-NozSf

### DIFF
--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -581,13 +581,15 @@ CRITICAL — importlib dynamic module loading for dependency_auditing import che
   `AttributeError: 'NoneType' object has no attribute '__dict__'`. This is a
   harness defect, not an application defect.
 - WRONG:
-    spec = importlib.util.spec_from_file_location("semantic_cache", p)
+    mod_name = "scripts.semantic_cache"  # use the real module path dynamically
+    spec = importlib.util.spec_from_file_location(mod_name, p)
     m = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(m)          # crashes on @dataclass in Python 3.12
 - RIGHT (register before exec):
-    spec = importlib.util.spec_from_file_location("semantic_cache", p)
+    mod_name = "scripts.semantic_cache"  # use the real module path dynamically
+    spec = importlib.util.spec_from_file_location(mod_name, p)
     m = importlib.util.module_from_spec(spec)
-    sys.modules["semantic_cache"] = m   # must precede exec_module
+    sys.modules[mod_name] = m            # must precede exec_module
     spec.loader.exec_module(m)
 - Preferred: avoid `importlib` entirely for import auditing. Use the sidecar
   pattern from "Preferred pattern A" above with a simple `PYTHONPATH`-based

--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -592,7 +592,11 @@ CRITICAL — importlib dynamic module loading for dependency_auditing import che
     assert spec is not None and spec.loader is not None
     m = importlib.util.module_from_spec(spec)
     sys.modules[mod_name] = m            # must precede exec_module
-    spec.loader.exec_module(m)
+    try:
+        spec.loader.exec_module(m)
+    except Exception:
+        sys.modules.pop(mod_name, None)
+        raise
 - Preferred: avoid low-level `importlib.util.spec_from_file_location` +
   `exec_module` import auditing. Use the sidecar
   pattern from "Preferred pattern A" above with a simple `PYTHONPATH`-based

--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -572,6 +572,40 @@ PY
   bug even when the Python parses in isolation, because the outer shell
   eats the single quotes inside the heredoc body at runtime.
 
+CRITICAL — importlib dynamic module loading for dependency_auditing import checks:
+- When verifying that a Python module is importable (e.g. for `dependency_auditing`),
+  do NOT use raw `importlib.util.spec_from_file_location` + `exec_module` without
+  registering the module in `sys.modules` first. Python 3.12's `dataclasses`
+  decorator calls `sys.modules.get(cls.__module__).__dict__` during class
+  processing; if the module is not registered the call returns `None` and raises
+  `AttributeError: 'NoneType' object has no attribute '__dict__'`. This is a
+  harness defect, not an application defect.
+- WRONG:
+    spec = importlib.util.spec_from_file_location("semantic_cache", p)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)          # crashes on @dataclass in Python 3.12
+- RIGHT (register before exec):
+    spec = importlib.util.spec_from_file_location("semantic_cache", p)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["semantic_cache"] = m   # must precede exec_module
+    spec.loader.exec_module(m)
+- Preferred: avoid `importlib` entirely for import auditing. Use the sidecar
+  pattern from "Preferred pattern A" above with a simple `PYTHONPATH`-based
+  import check:
+    # validation/tests/_lib/import_audit.py
+    import importlib, sys, os
+    os.chdir("/workspace")
+    sys.path.insert(0, "/workspace")
+    mod_name = "scripts.semantic_cache"   # dotted module path
+    try:
+        importlib.import_module(mod_name)
+        print(f"ok - {mod_name} imports cleanly")
+    except Exception as exc:
+        print(f"not ok - {mod_name} import failed: {exc}")
+        sys.exit(1)
+  `importlib.import_module` handles `sys.modules` registration automatically
+  and is the correct API for "does this module load?" audits.
+
 Validation coverage (implement only when concretely applicable):
 1. Build verification
 2. Startup and health checks

--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -583,15 +583,18 @@ CRITICAL — importlib dynamic module loading for dependency_auditing import che
 - WRONG:
     mod_name = "scripts.semantic_cache"  # use the real module path dynamically
     spec = importlib.util.spec_from_file_location(mod_name, p)
+    assert spec is not None and spec.loader is not None
     m = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(m)          # crashes on @dataclass in Python 3.12
 - RIGHT (register before exec):
     mod_name = "scripts.semantic_cache"  # use the real module path dynamically
     spec = importlib.util.spec_from_file_location(mod_name, p)
+    assert spec is not None and spec.loader is not None
     m = importlib.util.module_from_spec(spec)
     sys.modules[mod_name] = m            # must precede exec_module
     spec.loader.exec_module(m)
-- Preferred: avoid `importlib` entirely for import auditing. Use the sidecar
+- Preferred: avoid low-level `importlib.util.spec_from_file_location` +
+  `exec_module` import auditing. Use the sidecar
   pattern from "Preferred pattern A" above with a simple `PYTHONPATH`-based
   import check:
     # validation/tests/_lib/import_audit.py


### PR DESCRIPTION
The dependency_auditing harness generated for issue #1145 used raw
importlib.util.spec_from_file_location + exec_module without registering
the module in sys.modules first. Python 3.12's @dataclass decorator
internally calls sys.modules.get(cls.__module__).__dict__, which returns
None and raises AttributeError when the module is unregistered — a
harness defect, not an application defect (30/31 tests passed, including
the standalone test_semantic_cache.py).

Add a CRITICAL rule to mode-validate-generate.txt that:
1. Explains the Python 3.12 dataclass/importlib interaction
2. Shows the WRONG vs RIGHT pattern for spec_from_file_location usage
3. Recommends importlib.import_module as the preferred sidecar approach

https://claude.ai/code/session_013avUddedAvt8C1eSPQpYph