### PR TITLE
claude/analyze-job-logs-GAXKO

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3020,7 +3020,19 @@ jobs:
           ENABLE_AUTO_MERGE: ${{ vars.ENABLE_AUTO_MERGE || 'true' }}
         run: |
           set -euo pipefail
-          bash "${SUPPORT_SCRIPTS_DIR}/review_rb_judge.sh"
+          # Retry wrapper: transient CI runner issues (filesystem
+          # corruption, IO races after git reset) can cause spurious
+          # bash syntax errors in the judge script.  Retry once with
+          # a short pause to let the runner stabilise.
+          _judge_exit=0
+          bash "${SUPPORT_SCRIPTS_DIR}/review_rb_judge.sh" || _judge_exit=$?
+          if [ "${_judge_exit}" -eq 2 ]; then
+            echo "::warning::review_rb_judge.sh exited 2 (syntax error) — retrying once after 5 s"
+            sleep 5
+            bash "${SUPPORT_SCRIPTS_DIR}/review_rb_judge.sh"
+          elif [ "${_judge_exit}" -ne 0 ]; then
+            exit "${_judge_exit}"
+          fi
       - name: Mark linked issues review-blocked (autofix exhaustion)
         if: success() && steps.retrigger_guard.outputs.max_iterations_reached == 'true' && steps.rb_judge.outputs.judge_handled != 'true' && env.PR_CLOSED != 'true'
         env:

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -1,4 +1,21 @@
 #!/usr/bin/env bash
+# Pre-flight syntax check: detect transient file corruption (e.g. CI
+# runner filesystem issues) before executing.  On failure, print the
+# exact parse error, dump an md5 fingerprint for post-mortem, and exit
+# with a clear diagnostic instead of a cryptic "unexpected token" deep
+# in the script.
+if ! bash -n "${BASH_SOURCE[0]}" 2>/tmp/_rb_judge_syntax_err; then
+	echo "::error::review_rb_judge.sh failed pre-flight syntax check — file may be corrupt on this runner."
+	echo "--- syntax error detail ---"
+	cat /tmp/_rb_judge_syntax_err
+	echo "--- file fingerprint ---"
+	md5sum "${BASH_SOURCE[0]}" 2>/dev/null || wc -c < "${BASH_SOURCE[0]}"
+	echo "---"
+	rm -f /tmp/_rb_judge_syntax_err
+	exit 2
+fi
+rm -f /tmp/_rb_judge_syntax_err
+
 set -euo pipefail
 SUPPORT_SCRIPTS_DIR="${SUPPORT_SCRIPTS_DIR:-/tmp/codex-support}"
 source "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh" 2>/dev/null || true


### PR DESCRIPTION
Transient CI runner filesystem corruption can produce spurious bash
syntax errors (e.g. "line 236: syntax error near unexpected token ';'")
that are not reproducible from any committed version of the file.

Two hardening layers:

1. Pre-flight `bash -n` guard at the top of review_rb_judge.sh —
   detects file corruption before execution and emits a clear
   ::error:: with the parse detail and file fingerprint for
   post-mortem analysis.

2. Retry wrapper in review_autofix.yml — when the script exits 2
   (bash syntax error), waits 5 s for the runner to stabilise and
   retries once.  Non-syntax failures propagate immediately.

https://claude.ai/code/session_01TQ2VyvFadQ9L8xk3QF4pHH