### PR TITLE
claude/ecstatic-mendel-JlqM5

### DIFF
--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -503,7 +503,7 @@ jobs:
             marker_sample = match.group(0).rstrip() if match else ""
             print(f"MARKER_FOUND={shlex.quote(marker_found)}")
             print(f"MARKER_SAMPLE={shlex.quote(marker_sample)}")
-            PY
+          PY
           )"
           MARKER_SAMPLE="${MARKER_SAMPLE//$'\r'/ }"
           MARKER_SAMPLE="${MARKER_SAMPLE//$'\n'/ }"


### PR DESCRIPTION
The closing `PY` heredoc delimiter was indented at 12 spaces (2 spaces
in the bash script after YAML stripping), but `<<'PY'` requires the
terminator at column 0. Reduced to 10 spaces (the YAML base indentation)
so it resolves to column 0 in the generated bash script.

This caused: "unexpected EOF while looking for matching `)'"
and exit code 2 in the "Evaluate pre-LLM short-circuit" step.

https://claude.ai/code/session_01FFqAHWSHEbX38Bo5TozkDF