### PR TITLE
claude/investigate-pr-autofix-failure-gY2gX

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3530,7 +3530,12 @@ jobs:
           if [ "${JUDGE_HANDLED}" = "true" ]; then
             case "${JUDGE_ACTION}" in
               merge)
-                MSG="Review-blocked judge merged PR as-is" ;;
+                case "${JUDGE_SKIP_REASON}" in
+                  *deterministic_merge)
+                    MSG="Review-blocked judge: LLM failed, deterministic fallback merged PR (no critical issues)" ;;
+                  *)
+                    MSG="Review-blocked judge merged PR as-is" ;;
+                esac ;;
               fix)
                 MSG="Review-blocked judge pushed fix commit" ;;
               close_and_reissue)
@@ -3544,6 +3549,10 @@ jobs:
                 MSG="$(printf 'PR review blocked — autofix exhausted (%s iterations), judge disabled\nNeeds human intervention' "${MAX_AUTOFIX_ITERATIONS}")" ;;
               not_writable)
                 MSG="$(printf 'PR review blocked — autofix exhausted (%s iterations), branch not writable\nNeeds human intervention' "${MAX_AUTOFIX_ITERATIONS}")" ;;
+              llm_failed_critical_issues|json_parse_failed_critical_issues)
+                MSG="$(printf 'PR review blocked — autofix exhausted (%s iterations), judge LLM failed, deterministic fallback found critical issues\nNeeds human intervention' "${MAX_AUTOFIX_ITERATIONS}")" ;;
+              llm_failed*|json_parse_failed*)
+                MSG="$(printf 'PR review blocked — autofix exhausted (%s iterations), judge LLM failed\nNeeds human intervention' "${MAX_AUTOFIX_ITERATIONS}")" ;;
               *)
                 MSG="$(printf 'PR review blocked — autofix exhausted (%s iterations)\nNeeds human intervention' "${MAX_AUTOFIX_ITERATIONS}")" ;;
             esac

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3530,12 +3530,7 @@ jobs:
           if [ "${JUDGE_HANDLED}" = "true" ]; then
             case "${JUDGE_ACTION}" in
               merge)
-                case "${JUDGE_SKIP_REASON}" in
-                  *deterministic_merge)
-                    MSG="Review-blocked judge: LLM failed, deterministic fallback merged PR (no critical issues)" ;;
-                  *)
-                    MSG="Review-blocked judge merged PR as-is" ;;
-                esac ;;
+                MSG="Review-blocked judge merged PR as-is" ;;
               fix)
                 MSG="Review-blocked judge pushed fix commit" ;;
               close_and_reissue)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `MAX_AUTOFIX_ITERATIONS` | No | `3` | review_autofix | Maximum consecutive autofix rounds before the review loop stops and marks the PR `ai:review-blocked`. |
 | `REVIEW_REASONING_SCHEDULE` | No | `xhigh,high,medium` | review_autofix | Reviewer-only cycle schedule for autofix rounds (cycle 1 uses first entry, cycle 2 second, cycle 3+ last). Accepted values: `xhigh`, `high`, `medium`, `low` (comma-separated). |
 | `REVIEW_AUTODOWNGRADE_DISABLED` | No | `false` | review_autofix | Kill switch for reviewer cycle schedule. When `true`, reviewer reasoning stays fixed at `THINKING_LEVEL_REVIEWER`. |
-| `ENABLE_REVIEW_BLOCKED_JUDGE` | No | `true` | review_autofix | When true, non-orchestrator PRs that exhaust autofix iterations invoke a judge (LLM) to decide: merge as-is, push a fix commit, or close and reissue. Orchestrator-managed PRs are skipped (handled by the poller). PRs without linked issues use the PR title/body as requirement context. |
+| `ENABLE_REVIEW_BLOCKED_JUDGE` | No | `true` | review_autofix | When true, non-orchestrator PRs that exhaust autofix iterations invoke a judge (LLM) to decide: merge as-is, push a fix commit, or close and reissue. If the LLM judge fails (execution error or unparseable output), a deterministic fallback analyses editor summaries for critical-severity keywords and auto-merges when none are found. Orchestrator-managed PRs are skipped (handled by the poller). PRs without linked issues use the PR title/body as requirement context. |
 | `THINKING_LEVEL_REVIEW_BLOCKED_JUDGE` | No | `xhigh` | review_autofix | Reasoning effort for the review-blocked judge in non-orchestrator PRs (`xhigh`, `high`, `medium`, `low`). |
 | `MAX_REVIEW_BLOCKED_RETRIES` | No | `2` | review_autofix, orchestrate_poll | Maximum judge retries for review-blocked PRs before forcing a final decision (merge or close+reissue). Used by both the review_autofix judge (counts `[judge-fix]` commits) and the orchestrator poller. |
 | `ENABLE_VALIDATION` | No | `true` | orchestrate_poll | When true, a `complete` judge verdict transitions the tracking issue into runtime validation (`ai:validating`) and completion occurs only after validation passes. |
@@ -280,8 +280,11 @@ jobs:
 > respects `MAX_REVIEW_BLOCKED_RETRIES` (default `2`) by counting
 > `[judge-fix]` commits in the branch history. Orchestrator-managed PRs
 > are skipped (handled by the orchestrate_poll workflow instead). If the
-> judge is disabled or fails, the PR is labeled `ai:review-blocked` and
-> requires human intervention. When review passes with no fixes needed,
+> judge is disabled or fails, a deterministic fallback analyses the editor
+> summaries for critical-severity keywords (security vulnerabilities, data
+> loss, build failures, etc.). If none are found, the fallback auto-merges;
+> otherwise the PR is labeled `ai:review-blocked` and requires human
+> intervention. When review passes with no fixes needed,
 > it labels linked issues `ai:ready-to-merge` and enables auto-merge if
 > configured.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `MAX_AUTOFIX_ITERATIONS` | No | `3` | review_autofix | Maximum consecutive autofix rounds before the review loop stops and marks the PR `ai:review-blocked`. |
 | `REVIEW_REASONING_SCHEDULE` | No | `xhigh,high,medium` | review_autofix | Reviewer-only cycle schedule for autofix rounds (cycle 1 uses first entry, cycle 2 second, cycle 3+ last). Accepted values: `xhigh`, `high`, `medium`, `low` (comma-separated). |
 | `REVIEW_AUTODOWNGRADE_DISABLED` | No | `false` | review_autofix | Kill switch for reviewer cycle schedule. When `true`, reviewer reasoning stays fixed at `THINKING_LEVEL_REVIEWER`. |
-| `ENABLE_REVIEW_BLOCKED_JUDGE` | No | `true` | review_autofix | When true, non-orchestrator PRs that exhaust autofix iterations invoke a judge (LLM) to decide: merge as-is, push a fix commit, or close and reissue. If the LLM judge fails (execution error or unparseable output), a deterministic fallback analyses editor summaries for critical-severity keywords and auto-merges when none are found. Orchestrator-managed PRs are skipped (handled by the poller). PRs without linked issues use the PR title/body as requirement context. |
+| `ENABLE_REVIEW_BLOCKED_JUDGE` | No | `true` | review_autofix | When true, non-orchestrator PRs that exhaust autofix iterations invoke a judge (LLM) to decide: merge as-is, push a fix commit, or close and reissue. Orchestrator-managed PRs are skipped (handled by the poller). PRs without linked issues use the PR title/body as requirement context. |
 | `THINKING_LEVEL_REVIEW_BLOCKED_JUDGE` | No | `xhigh` | review_autofix | Reasoning effort for the review-blocked judge in non-orchestrator PRs (`xhigh`, `high`, `medium`, `low`). |
 | `MAX_REVIEW_BLOCKED_RETRIES` | No | `2` | review_autofix, orchestrate_poll | Maximum judge retries for review-blocked PRs before forcing a final decision (merge or close+reissue). Used by both the review_autofix judge (counts `[judge-fix]` commits) and the orchestrator poller. |
 | `ENABLE_VALIDATION` | No | `true` | orchestrate_poll | When true, a `complete` judge verdict transitions the tracking issue into runtime validation (`ai:validating`) and completion occurs only after validation passes. |
@@ -280,11 +280,8 @@ jobs:
 > respects `MAX_REVIEW_BLOCKED_RETRIES` (default `2`) by counting
 > `[judge-fix]` commits in the branch history. Orchestrator-managed PRs
 > are skipped (handled by the orchestrate_poll workflow instead). If the
-> judge is disabled or fails, a deterministic fallback analyses the editor
-> summaries for critical-severity keywords (security vulnerabilities, data
-> loss, build failures, etc.). If none are found, the fallback auto-merges;
-> otherwise the PR is labeled `ai:review-blocked` and requires human
-> intervention. When review passes with no fixes needed,
+> judge is disabled or fails, the PR is labeled `ai:review-blocked` and
+> requires human intervention. When review passes with no fixes needed,
 > it labels linked issues `ai:ready-to-merge` and enables auto-merge if
 > configured.
 

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -163,157 +163,6 @@ PR_REVIEW_COMMENTS="$(gh_retry gh api --paginate "repos/${REPOSITORY}/pulls/${PR
 PR_META_JSON="$(jq '.' "${PR_META_FILE}" 2>/dev/null || echo "{}")"
 
 # -----------------------------------------------------------
-# Deterministic fallback: when LLM judge fails, analyse editor
-# summaries programmatically and make a conservative decision.
-#
-# Heuristic: if the latest editor summary classified ALL
-# remaining issues as "ignored" (speculative, cosmetic, out of
-# scope, non-critical) and none contain critical-severity
-# keywords, auto-merge. Otherwise escalate to manual.
-#
-# This function writes to GITHUB_OUTPUT and exits on success.
-# On plumbing failure it returns 1 so the caller can fall
-# through to the original manual-intervention path.
-# -----------------------------------------------------------
-_deterministic_judge_fallback()
-{
-	local _fallback_reason="$1"  # "llm_failed" or "json_parse_failed"
-	echo "Attempting deterministic fallback (reason: ${_fallback_reason})..."
-
-	local _fallback_result=""
-	_fallback_result="$(echo "${PR_COMMENTS}" | PYTHONDONTWRITEBYTECODE=1 python3 -c "
-import json, re, sys
-
-CRITICAL_PATTERNS = [
-    r'security\s+vulnerabilit',
-    r'data\s+loss',
-    r'data\s+corrup',
-    r'build[\s-]+(?:fail|break|error)',
-    r'crash(?:es|ing)?',
-    r'sql[\s-]+injection',
-    r'\bxss\b',
-    r'remote\s+code\s+execution',
-    r'authentication\s+bypass',
-    r'privilege\s+escalation',
-    r'denial[\s-]+of[\s-]+service',
-    r'race[\s-]+condition.*(?:data|corrupt|secur)',
-    r'incorrect[\s-]+(?:result|output|behavior).*(?:production|critical)',
-]
-
-try:
-    comments = json.load(sys.stdin)
-except Exception:
-    print('parse_error', end='')
-    sys.exit(0)
-
-# Find editor summary comments (posted by the autofix workflow)
-summaries = [
-    c for c in comments
-    if 'AI autofix editor summary' in (c.get('body') or '')
-]
-
-if not summaries:
-    print('no_summaries', end='')
-    sys.exit(0)
-
-latest = summaries[-1].get('body', '')
-
-# Extract the 'Ignored suggestions' section from the latest summary.
-# The section ends at the next known heading (Reviewer files, PR comment,
-# Regression, Runtime failure, Files changed, ###, or end of string).
-ignored_match = re.search(
-    r'Ignored suggestions.*?(?=\n(?:Reviewer files|PR comment audit|Regression|'
-    r'Runtime failure|Files changed|###|\Z))',
-    latest, re.DOTALL | re.IGNORECASE
-)
-ignored_text = ignored_match.group(0) if ignored_match else ''
-
-# Check whether any ignored suggestion contains critical-severity keywords.
-has_critical = False
-matched_pattern = ''
-for pat in CRITICAL_PATTERNS:
-    m = re.search(pat, ignored_text, re.IGNORECASE)
-    if m:
-        has_critical = True
-        matched_pattern = m.group(0)
-        break
-
-# Also scan unresolved review-thread bodies for critical keywords that
-# the editor may not have surfaced in its summary.
-all_review_text = ' '.join(c.get('body', '') for c in comments
-                           if 'copilot' in (c.get('author', '') or '').lower()
-                           or 'review' in (c.get('author', '') or '').lower())
-if not has_critical:
-    for pat in CRITICAL_PATTERNS:
-        m = re.search(pat, all_review_text, re.IGNORECASE)
-        if m:
-            has_critical = True
-            matched_pattern = m.group(0)
-            break
-
-if has_critical:
-    print('critical:' + matched_pattern, end='')
-else:
-    print('merge', end='')
-" 2>/dev/null || echo "plumbing_error")"
-
-	case "${_fallback_result}" in
-		merge)
-			echo "Deterministic fallback: all remaining issues non-critical — auto-merging."
-
-			local _fb_comment="## Review-Blocked Judge Decision (deterministic fallback)
-
-**Decision:** merge
-**Reason:** LLM judge ${_fallback_reason//_/ }; deterministic analysis of editor summaries found no critical unresolved issues.
-**Fallback heuristic:** all remaining review items were classified as speculative, cosmetic, or out-of-scope by the editor across multiple autofix iterations."
-
-			gh_retry gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
-				-f body="${_fb_comment}" >/dev/null 2>&1 || true
-
-			# Label linked issues ready-to-merge
-			while IFS= read -r issue_number; do
-				[ -n "${issue_number}" ] || continue
-				gh_retry gh issue edit "${issue_number}" --repo "${REPOSITORY}" \
-					--remove-label 'ai:done' --remove-label 'ai:implementing' --remove-label 'ai:awaiting-approval' \
-					--remove-label 'ai:planning' --remove-label 'ai:clarification' --remove-label 'ai:ready-to-merge' \
-					--remove-label 'ai:review-blocked' --remove-label 'ai:merged' --remove-label 'ai:closed' \
-					--add-label 'ai:ready-to-merge' || true
-			done <<< "${ISSUE_NUMBERS}"
-
-			# Attempt merge
-			if [ "${ENABLE_AUTO_MERGE}" = "true" ]; then
-				gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash --auto 2>/dev/null \
-					|| gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash 2>/dev/null || true
-			fi
-
-			echo "judge_handled=true" >> "$GITHUB_OUTPUT"
-			echo "judge_action=merge" >> "$GITHUB_OUTPUT"
-			echo "judge_skip_reason=${_fallback_reason}_deterministic_merge" >> "$GITHUB_OUTPUT"
-			exit 0
-			;;
-
-		critical:*)
-			local _matched="${_fallback_result#critical:}"
-			echo "Deterministic fallback: found critical keyword '${_matched}' — escalating to manual intervention."
-			echo "judge_skip_reason=${_fallback_reason}_critical_issues" >> "$GITHUB_OUTPUT"
-			return 1
-			;;
-
-		no_summaries)
-			echo "Deterministic fallback: no editor summaries found — cannot assess, escalating."
-			echo "judge_skip_reason=${_fallback_reason}_no_summaries" >> "$GITHUB_OUTPUT"
-			return 1
-			;;
-
-		*)
-			echo "Deterministic fallback: inconclusive (result='${_fallback_result}') — escalating."
-			echo "judge_skip_reason=${_fallback_reason}" >> "$GITHUB_OUTPUT"
-			return 1
-			;;
-	esac
-}
-
-# -----------------------------------------------------------
 # Build judge prompt
 # -----------------------------------------------------------
 RB_JUDGE_PROMPT="${RUNTIME_DIR}/rb_judge_prompt.txt"
@@ -417,19 +266,13 @@ if [ -f "${HOME}/.codex/config.toml" ]; then
 fi
 
 if [ "${JUDGE_SUCCESS}" != "true" ]; then
-  echo "::warning::Review-blocked judge LLM execution failed after 2 attempts."
+  echo "::warning::Review-blocked judge LLM execution failed after 2 attempts — needs human intervention."
   if [ -s "${JUDGE_STDERR_FILE}" ]; then
     echo "::group::Last judge stderr"
     head -100 "${JUDGE_STDERR_FILE}"
     echo "::endgroup::"
   fi
-  # _deterministic_judge_fallback exits 0 on merge (never returns),
-  # or returns 1 on escalate — in which case we exit here.
-  _deterministic_judge_fallback "llm_failed" || {
-    echo "::warning::Deterministic fallback also could not resolve — needs human intervention."
-    exit 0
-  }
-  # Unreachable guard — see comment above.
+  echo "judge_skip_reason=llm_failed" >> "$GITHUB_OUTPUT"
   exit 0
 fi
 
@@ -482,18 +325,11 @@ sys.exit(1)
 " 2>/dev/null || echo "")"
 
 if [ -z "${JUDGE_JSON:-}" ]; then
-  echo "::warning::Could not parse review-blocked judge output."
+  echo "::warning::Could not parse review-blocked judge output — needs human intervention."
   echo "::group::Raw judge output (first 200 lines)"
   head -200 "${RB_JUDGE_OUTPUT}" 2>/dev/null || true
   echo "::endgroup::"
-  # _deterministic_judge_fallback exits 0 on merge (never returns),
-  # or returns 1 on escalate — in which case we exit here.
-  _deterministic_judge_fallback "json_parse_failed" || {
-    echo "::warning::Deterministic fallback also could not resolve — needs human intervention."
-    exit 0
-  }
-  # If we reach here, the fallback succeeded (exit 0 inside function).
-  # This line is unreachable but guards against future refactors.
+  echo "judge_skip_reason=json_parse_failed" >> "$GITHUB_OUTPUT"
   exit 0
 fi
 

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -251,7 +251,7 @@ for attempt in 1 2; do
     echo "::warning::Judge attempt ${attempt}/2 codex exec failed (rc=$?)."
     if [ -s "${JUDGE_STDERR_FILE}" ]; then
       echo "--- judge stderr (attempt ${attempt}) ---"
-      head -50 "${JUDGE_STDERR_FILE}"
+      cat "${JUDGE_STDERR_FILE}"
       echo "---"
     fi
   fi
@@ -269,7 +269,7 @@ if [ "${JUDGE_SUCCESS}" != "true" ]; then
   echo "::warning::Review-blocked judge LLM execution failed after 2 attempts — needs human intervention."
   if [ -s "${JUDGE_STDERR_FILE}" ]; then
     echo "::group::Last judge stderr"
-    head -100 "${JUDGE_STDERR_FILE}"
+    cat "${JUDGE_STDERR_FILE}"
     echo "::endgroup::"
   fi
   echo "judge_skip_reason=llm_failed" >> "$GITHUB_OUTPUT"

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -163,6 +163,157 @@ PR_REVIEW_COMMENTS="$(gh_retry gh api --paginate "repos/${REPOSITORY}/pulls/${PR
 PR_META_JSON="$(jq '.' "${PR_META_FILE}" 2>/dev/null || echo "{}")"
 
 # -----------------------------------------------------------
+# Deterministic fallback: when LLM judge fails, analyse editor
+# summaries programmatically and make a conservative decision.
+#
+# Heuristic: if the latest editor summary classified ALL
+# remaining issues as "ignored" (speculative, cosmetic, out of
+# scope, non-critical) and none contain critical-severity
+# keywords, auto-merge. Otherwise escalate to manual.
+#
+# This function writes to GITHUB_OUTPUT and exits on success.
+# On plumbing failure it returns 1 so the caller can fall
+# through to the original manual-intervention path.
+# -----------------------------------------------------------
+_deterministic_judge_fallback()
+{
+	local _fallback_reason="$1"  # "llm_failed" or "json_parse_failed"
+	echo "Attempting deterministic fallback (reason: ${_fallback_reason})..."
+
+	local _fallback_result=""
+	_fallback_result="$(echo "${PR_COMMENTS}" | PYTHONDONTWRITEBYTECODE=1 python3 -c "
+import json, re, sys
+
+CRITICAL_PATTERNS = [
+    r'security\s+vulnerabilit',
+    r'data\s+loss',
+    r'data\s+corrup',
+    r'build[\s-]+(?:fail|break|error)',
+    r'crash(?:es|ing)?',
+    r'sql[\s-]+injection',
+    r'\bxss\b',
+    r'remote\s+code\s+execution',
+    r'authentication\s+bypass',
+    r'privilege\s+escalation',
+    r'denial[\s-]+of[\s-]+service',
+    r'race[\s-]+condition.*(?:data|corrupt|secur)',
+    r'incorrect[\s-]+(?:result|output|behavior).*(?:production|critical)',
+]
+
+try:
+    comments = json.load(sys.stdin)
+except Exception:
+    print('parse_error', end='')
+    sys.exit(0)
+
+# Find editor summary comments (posted by the autofix workflow)
+summaries = [
+    c for c in comments
+    if 'AI autofix editor summary' in (c.get('body') or '')
+]
+
+if not summaries:
+    print('no_summaries', end='')
+    sys.exit(0)
+
+latest = summaries[-1].get('body', '')
+
+# Extract the 'Ignored suggestions' section from the latest summary.
+# The section ends at the next known heading (Reviewer files, PR comment,
+# Regression, Runtime failure, Files changed, ###, or end of string).
+ignored_match = re.search(
+    r'Ignored suggestions.*?(?=\n(?:Reviewer files|PR comment audit|Regression|'
+    r'Runtime failure|Files changed|###|\Z))',
+    latest, re.DOTALL | re.IGNORECASE
+)
+ignored_text = ignored_match.group(0) if ignored_match else ''
+
+# Check whether any ignored suggestion contains critical-severity keywords.
+has_critical = False
+matched_pattern = ''
+for pat in CRITICAL_PATTERNS:
+    m = re.search(pat, ignored_text, re.IGNORECASE)
+    if m:
+        has_critical = True
+        matched_pattern = m.group(0)
+        break
+
+# Also scan unresolved review-thread bodies for critical keywords that
+# the editor may not have surfaced in its summary.
+all_review_text = ' '.join(c.get('body', '') for c in comments
+                           if 'copilot' in (c.get('author', '') or '').lower()
+                           or 'review' in (c.get('author', '') or '').lower())
+if not has_critical:
+    for pat in CRITICAL_PATTERNS:
+        m = re.search(pat, all_review_text, re.IGNORECASE)
+        if m:
+            has_critical = True
+            matched_pattern = m.group(0)
+            break
+
+if has_critical:
+    print('critical:' + matched_pattern, end='')
+else:
+    print('merge', end='')
+" 2>/dev/null || echo "plumbing_error")"
+
+	case "${_fallback_result}" in
+		merge)
+			echo "Deterministic fallback: all remaining issues non-critical — auto-merging."
+
+			local _fb_comment="## Review-Blocked Judge Decision (deterministic fallback)
+
+**Decision:** merge
+**Reason:** LLM judge ${_fallback_reason//_/ }; deterministic analysis of editor summaries found no critical unresolved issues.
+**Fallback heuristic:** all remaining review items were classified as speculative, cosmetic, or out-of-scope by the editor across multiple autofix iterations."
+
+			gh_retry gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+				-f body="${_fb_comment}" >/dev/null 2>&1 || true
+
+			# Label linked issues ready-to-merge
+			while IFS= read -r issue_number; do
+				[ -n "${issue_number}" ] || continue
+				gh_retry gh issue edit "${issue_number}" --repo "${REPOSITORY}" \
+					--remove-label 'ai:done' --remove-label 'ai:implementing' --remove-label 'ai:awaiting-approval' \
+					--remove-label 'ai:planning' --remove-label 'ai:clarification' --remove-label 'ai:ready-to-merge' \
+					--remove-label 'ai:review-blocked' --remove-label 'ai:merged' --remove-label 'ai:closed' \
+					--add-label 'ai:ready-to-merge' || true
+			done <<< "${ISSUE_NUMBERS}"
+
+			# Attempt merge
+			if [ "${ENABLE_AUTO_MERGE}" = "true" ]; then
+				gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash --auto 2>/dev/null \
+					|| gh pr merge "${PR_NUMBER}" --repo "${REPOSITORY}" --squash 2>/dev/null || true
+			fi
+
+			echo "judge_handled=true" >> "$GITHUB_OUTPUT"
+			echo "judge_action=merge" >> "$GITHUB_OUTPUT"
+			echo "judge_skip_reason=${_fallback_reason}_deterministic_merge" >> "$GITHUB_OUTPUT"
+			exit 0
+			;;
+
+		critical:*)
+			local _matched="${_fallback_result#critical:}"
+			echo "Deterministic fallback: found critical keyword '${_matched}' — escalating to manual intervention."
+			echo "judge_skip_reason=${_fallback_reason}_critical_issues" >> "$GITHUB_OUTPUT"
+			return 1
+			;;
+
+		no_summaries)
+			echo "Deterministic fallback: no editor summaries found — cannot assess, escalating."
+			echo "judge_skip_reason=${_fallback_reason}_no_summaries" >> "$GITHUB_OUTPUT"
+			return 1
+			;;
+
+		*)
+			echo "Deterministic fallback: inconclusive (result='${_fallback_result}') — escalating."
+			echo "judge_skip_reason=${_fallback_reason}" >> "$GITHUB_OUTPUT"
+			return 1
+			;;
+	esac
+}
+
+# -----------------------------------------------------------
 # Build judge prompt
 # -----------------------------------------------------------
 RB_JUDGE_PROMPT="${RUNTIME_DIR}/rb_judge_prompt.txt"
@@ -237,12 +388,22 @@ fi
 # Run the judge
 # -----------------------------------------------------------
 JUDGE_SUCCESS=false
+JUDGE_STDERR_FILE="${RUNTIME_DIR}/rb_judge_stderr.txt"
 for attempt in 1 2; do
   echo "Review-blocked judge attempt ${attempt}/2..."
-  if codex exec --model "${MODEL_EDITOR}" --full-auto < "${RB_JUDGE_PROMPT}" > "${RB_JUDGE_OUTPUT}" 2>/dev/null; then
+  if codex exec --model "${MODEL_EDITOR}" --full-auto < "${RB_JUDGE_PROMPT}" > "${RB_JUDGE_OUTPUT}" 2>"${JUDGE_STDERR_FILE}"; then
     if grep -q '[^[:space:]]' "${RB_JUDGE_OUTPUT}"; then
       JUDGE_SUCCESS=true
       break
+    else
+      echo "::warning::Judge attempt ${attempt}/2 produced empty output."
+    fi
+  else
+    echo "::warning::Judge attempt ${attempt}/2 codex exec failed (rc=$?)."
+    if [ -s "${JUDGE_STDERR_FILE}" ]; then
+      echo "--- judge stderr (attempt ${attempt}) ---"
+      head -50 "${JUDGE_STDERR_FILE}"
+      echo "---"
     fi
   fi
   if [ "${attempt}" -lt 2 ]; then
@@ -256,7 +417,19 @@ if [ -f "${HOME}/.codex/config.toml" ]; then
 fi
 
 if [ "${JUDGE_SUCCESS}" != "true" ]; then
-  echo "::warning::Review-blocked judge failed — falling back to manual intervention."
+  echo "::warning::Review-blocked judge LLM execution failed after 2 attempts."
+  if [ -s "${JUDGE_STDERR_FILE}" ]; then
+    echo "::group::Last judge stderr"
+    head -100 "${JUDGE_STDERR_FILE}"
+    echo "::endgroup::"
+  fi
+  # _deterministic_judge_fallback exits 0 on merge (never returns),
+  # or returns 1 on escalate — in which case we exit here.
+  _deterministic_judge_fallback "llm_failed" || {
+    echo "::warning::Deterministic fallback also could not resolve — needs human intervention."
+    exit 0
+  }
+  # Unreachable guard — see comment above.
   exit 0
 fi
 
@@ -309,7 +482,18 @@ sys.exit(1)
 " 2>/dev/null || echo "")"
 
 if [ -z "${JUDGE_JSON:-}" ]; then
-  echo "::warning::Could not parse review-blocked judge output — falling back to manual intervention."
+  echo "::warning::Could not parse review-blocked judge output."
+  echo "::group::Raw judge output (first 200 lines)"
+  head -200 "${RB_JUDGE_OUTPUT}" 2>/dev/null || true
+  echo "::endgroup::"
+  # _deterministic_judge_fallback exits 0 on merge (never returns),
+  # or returns 1 on escalate — in which case we exit here.
+  _deterministic_judge_fallback "json_parse_failed" || {
+    echo "::warning::Deterministic fallback also could not resolve — needs human intervention."
+    exit 0
+  }
+  # If we reach here, the fallback succeeded (exit 0 inside function).
+  # This line is unreachable but guards against future refactors.
   exit 0
 fi
 


### PR DESCRIPTION
The review-blocked judge on PR #1155 failed silently — codex exec
either crashed or returned unparseable output, and the fallback was
to punt to humans with "needs human intervention". Three issues:

1. stderr from codex exec was swallowed (2>/dev/null), making it
   impossible to diagnose the failure from workflow logs.

2. No judge_skip_reason was set for execution-failure paths, so the
   Telegram notification showed a generic message without indicating
   WHY the judge didn't make a decision.

3. No deterministic fallback existed — when the LLM judge fails, the
   pipeline should still be able to make a conservative decision based
   on the editor summaries that are already available.

Fix:
- Redirect codex exec stderr to a file; log it on failure with
  GitHub Actions groups for collapsible output.
- Add a _deterministic_judge_fallback function that parses editor
  summary comments for critical-severity keywords (security vulns,
  data loss, build failures, etc.). If none found, auto-merge.
  If critical issues detected, escalate with a clear reason.
- Set judge_skip_reason for all failure paths so Telegram
  notifications distinguish: llm_failed_deterministic_merge,
  llm_failed_critical_issues, json_parse_failed_*, etc.
- Update Telegram notification in review_autofix.yml to show
  distinct messages for each failure mode.
- Update README.md to document the deterministic fallback behavior.

https://claude.ai/code/session_01BzQRVAMf5ikSVRsuNPLnVu