### PR TITLE
claude/monitor-ai-memory-usage-v6jqI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Key behaviors:
 
 Memory operations are implemented in `scripts/memory_helpers.sh` (shared helper wrappers) and `scripts/ai_memory.py` (CLI). The `ai-memory` branch is created automatically on the first write.
 
-**Telemetry:** Every memory operation emits a structured `AI_MEMORY_TELEMETRY: {...}` line to workflow logs (stderr from Python, stdout from shell wrappers). These lines are picked up by the workflow log analysis pipeline and surfaced in the **AI Memory Health** section of optimization reports. Key fields: `op` (operation name), `ok`, `records_selected`, `estimated_tokens`, `keyword_method` (`llm`/`plain`/`none`), `fail_open`, `did_push`.
+**Telemetry:** Every memory operation emits a structured `AI_MEMORY_TELEMETRY: {...}` line to workflow logs (stderr from Python; shell wrappers use stdout unless stdout is reserved for machine-readable JSON, in which case telemetry is sent to stderr). These lines are picked up by the workflow log analysis pipeline and surfaced in the **AI Memory Health** section of optimization reports. Key fields: `op` (operation name), `ok`, `records_selected`, `estimated_tokens`, `keyword_method` (`llm`/`plain`/`none`), `fail_open`, `did_push`.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Key behaviors:
 
 Memory operations are implemented in `scripts/memory_helpers.sh` (shared helper wrappers) and `scripts/ai_memory.py` (CLI). The `ai-memory` branch is created automatically on the first write.
 
+**Telemetry:** Every memory operation emits a structured `AI_MEMORY_TELEMETRY: {...}` line to workflow logs (stderr from Python, stdout from shell wrappers). These lines are picked up by the workflow log analysis pipeline and surfaced in the **AI Memory Health** section of optimization reports. Key fields: `op` (operation name), `ok`, `records_selected`, `estimated_tokens`, `keyword_method` (`llm`/`plain`/`none`), `fail_open`, `did_push`.
+
 ## Quickstart
 
 Get AI-powered issue-to-PR automation running in your repository in a few minutes.
@@ -635,16 +637,18 @@ Collector script: [`scripts/collect_workflow_logs.py`](scripts/collect_workflow_
   - window selector (exactly one): `--lookback-days` or `--since`
   - `--output` (default `workflow_log_report.json`)
   - `--per-page`, `--max-pages`, `--max-runs`, `--max-log-runs` (default `15`)
+  - `--success-sample-rate` (default `0.07` = ~7%) — fraction of successful runs randomly sampled for log analysis
 - Token handling in `main`: uses `GH_TOKEN` with `GITHUB_TOKEN` fallback.
-- For notable runs (failed, retries > 0, and top 10 slowest per repository), the collector also downloads raw run logs from `repos/{repo}/actions/runs/{run_id}/logs`, extracts ZIP contents in memory, and stores truncated per-step excerpts.
+- All workflow families are collected (no family filter). The `workflow_families` field in the report is derived from observed runs rather than a static list.
+- For notable runs (failed, retries > 0, top 10 slowest per repository, and ~7% randomly sampled successful runs), the collector also downloads raw run logs from `repos/{repo}/actions/runs/{run_id}/logs`, extracts ZIP contents in memory, and stores truncated per-step excerpts. Random sampling uses a deterministic seed derived from the collection window for reproducibility.
 
 Generated JSON report (`workflow_log_report.json`) includes:
 
-- `schema_version`
+- `schema_version` (`workflow_log_collector.v2`)
 - `generated_at`
-- `scope` (`repositories`, `workflow_families`, `source`)
-- `runs` (per-run metrics including `workflow_family`, `duration_seconds`, `retries`, `failure_point`, and optional `log_excerpts` as `{step_name, excerpt}` entries for notable runs)
-- `summary` (`total_runs`, success/failure/cancelled/other counts, `avg_duration_seconds`, `p50_duration_seconds`, `p95_duration_seconds`)
+- `scope` (`repositories`, `workflow_families` (observed, not static), `source`, `success_sample_rate`)
+- `runs` (per-run metrics including `workflow_family`, `duration_seconds`, `retries`, `failure_point`, optional `log_excerpts` as `{step_name, excerpt}` entries for notable runs, optional `_success_sampled: true` flag for randomly sampled successful runs)
+- `summary` (`total_runs`, success/failure/cancelled/other counts, `avg_duration_seconds`, `p50_duration_seconds`, `p95_duration_seconds`, `sampled_success_runs`)
 - `errors` (includes `scope: "logs"` entries when run log download/extraction fails; collection continues)
 
 ### Analyzer input/output contract

--- a/agents.md
+++ b/agents.md
@@ -296,6 +296,9 @@ After changes: original intent preserved, behavior unchanged unless approved, ba
 - Pending batch analyzer exits with code `3` to signal deferred completion; workflow must treat this as non-failure.
 - On unsupported provider/model, capability probe errors, poll timeout, or batch terminal errors, analyzer must emit structured `batch_fallback` warnings and run synchronous analysis.
 - `memory_maintenance.yml` currently has no LLM path; keep compaction behavior unchanged and emit `batch_noop` compatibility logging only.
+- The collector (`scripts/collect_workflow_logs.py`) collects **all** workflow families (no static filter). `workflow_families` in the report is derived from observed runs.
+- The collector randomly samples ~7% of successful runs for log analysis (`--success-sample-rate`, default `0.07`) using a deterministic seed. Sampled runs are tagged with `_success_sampled: true`.
+- AI memory operations emit `AI_MEMORY_TELEMETRY: {JSON}` lines (stderr from `ai_memory.py`, stdout from `memory_helpers.sh`). The analysis prompt instructs the LLM to produce an **AI Memory Health** section from these lines.
 
 ---
 

--- a/agents.md
+++ b/agents.md
@@ -298,7 +298,7 @@ After changes: original intent preserved, behavior unchanged unless approved, ba
 - `memory_maintenance.yml` currently has no LLM path; keep compaction behavior unchanged and emit `batch_noop` compatibility logging only.
 - The collector (`scripts/collect_workflow_logs.py`) collects **all** workflow families (no static filter). `workflow_families` in the report is derived from observed runs.
 - The collector randomly samples ~7% of successful runs for log analysis (`--success-sample-rate`, default `0.07`) using a deterministic seed. Sampled runs are tagged with `_success_sampled: true`.
-- AI memory operations emit `AI_MEMORY_TELEMETRY: {JSON}` lines (stderr from `ai_memory.py`, stdout from `memory_helpers.sh`). The analysis prompt instructs the LLM to produce an **AI Memory Health** section from these lines.
+- AI memory operations emit `AI_MEMORY_TELEMETRY: {JSON}` lines (stderr from `ai_memory.py`; `memory_helpers.sh` uses stdout unless stdout must remain machine-readable, then telemetry is sent to stderr). The analysis prompt instructs the LLM to produce an **AI Memory Health** section from these lines.
 
 ---
 

--- a/prompts/mode-workflow-analysis.txt
+++ b/prompts/mode-workflow-analysis.txt
@@ -21,6 +21,7 @@ Output requirements:
   - ## Speed Optimizations
   - ## Cost Optimizations
   - ## Reliability Improvements
+  - ## AI Memory Health
   - ## Per-Repo Breakdown
   - ## Metrics Appendix
 
@@ -39,6 +40,12 @@ Section requirements:
 - ## Reliability Improvements
   - Rank recommendations by expected failure-rate reduction.
   - For each recommendation include: evidence (failure pattern), root cause, exact change, and expected reliability impact.
+- ## AI Memory Health
+  - Look for `AI_MEMORY_TELEMETRY:` lines in deep-dive log excerpts. Each line is a JSON object with `op` (operation name) and operation-specific fields.
+  - Key telemetry operations: `retrieve` (memory context fetch), `record-candidate` (learning), `record-run-event` (ledger), `finalize-task` (lineage), `promote` (candidate elevation), `compact` (archival), `processed-command-claim`/`processed-command-complete` (idempotency).
+  - For `retrieve` operations, report: hit rate (% with `records_selected > 0`), average `estimated_tokens` vs budget, `keyword_method` distribution (`llm` vs `plain` vs `none`).
+  - Flag: retrieves returning 0 records, `fail_open: true` entries (silent failures), `enabled: false` entries (memory disabled), high push retry counts.
+  - If no `AI_MEMORY_TELEMETRY` lines are found in the log excerpts, state that memory telemetry was not observed and recommend verifying telemetry emission in the sampled runs.
 - ## Per-Repo Breakdown
   - Add a subsection per repository with repo-specific findings and targeted actions.
 - ## Metrics Appendix

--- a/scripts/ai_memory.py
+++ b/scripts/ai_memory.py
@@ -39,6 +39,13 @@ def _print_json(payload: dict[str, Any]) -> None:
     print(json.dumps(payload, ensure_ascii=True, sort_keys=True))
 
 
+def _emit_telemetry(op: str, **fields: Any) -> None:
+    """Emit a structured telemetry line to stderr for log analysis visibility."""
+    entry: dict[str, Any] = {"op": op}
+    entry.update(fields)
+    print(f"AI_MEMORY_TELEMETRY: {json.dumps(entry, ensure_ascii=True, sort_keys=True)}", file=sys.stderr)
+
+
 def _require_nonempty(value: str, field_name: str) -> str:
     text = (value or "").strip()
     if not text:
@@ -106,6 +113,7 @@ def cmd_retrieve(args: argparse.Namespace) -> int:
         else:
             print(context, end="")
         _print_json({"ok": True, "enabled": False, "records_selected": 0, "estimated_tokens": 0})
+        _emit_telemetry("retrieve", ok=True, enabled=False, records_selected=0)
         return 0
 
     repo_root = _resolve_repo_root(args.repo_root)
@@ -125,6 +133,7 @@ def cmd_retrieve(args: argparse.Namespace) -> int:
             else:
                 print(context, end="")
             _print_json({"ok": True, "enabled": False, "records_selected": 0, "estimated_tokens": 0, "warning": str(exc)})
+            _emit_telemetry("retrieve", ok=True, enabled=False, records_selected=0, warning="branch_unavailable")
             return 0
         memory_root = _resolve_memory_root(branch_dir, args.memory_root)
         profiles_path = branch_dir / args.retrieval_profiles
@@ -165,7 +174,17 @@ def cmd_retrieve(args: argparse.Namespace) -> int:
                 "records_selected": len(result.selected_record_ids),
                 "record_ids": result.selected_record_ids,
                 "estimated_tokens": result.estimated_tokens,
+                "keyword_method": result.keyword_method,
             }
+        )
+        _emit_telemetry(
+            "retrieve",
+            ok=True,
+            enabled=True,
+            role=result.role,
+            records_selected=len(result.selected_record_ids),
+            estimated_tokens=result.estimated_tokens,
+            keyword_method=result.keyword_method,
         )
         return 0
     finally:
@@ -206,6 +225,14 @@ def cmd_record_run_event(args: argparse.Namespace) -> int:
         operation=_op,
     )
     _print_json({"ok": True, **result})
+    _emit_telemetry(
+        "record-run-event",
+        ok=True,
+        workflow=args.workflow,
+        event_type=args.event_type,
+        did_push=result.get("did_push", False),
+        push_attempts=result.get("push_attempts", 0),
+    )
     return 0
 
 
@@ -267,7 +294,18 @@ def cmd_record_candidate(args: argparse.Namespace) -> int:
         commit_message=f"ai-memory: record candidate [{args.category}]",
         operation=_op,
     )
+    op_result = result.get("operation_result") or {}
+    record = op_result.get("record") or {}
     _print_json({"ok": True, **result})
+    _emit_telemetry(
+        "record-candidate",
+        ok=True,
+        category=args.category,
+        record_id=record.get("record_id"),
+        issue_number=_safe_int(args.issue_number),
+        did_push=result.get("did_push", False),
+        push_attempts=result.get("push_attempts", 0),
+    )
     return 0
 
 
@@ -333,7 +371,16 @@ def cmd_promote(args: argparse.Namespace) -> int:
         commit_message="ai-memory: promote candidates",
         operation=_op,
     )
+    op_result = result.get("operation_result") or {}
     _print_json({"ok": True, **result})
+    _emit_telemetry(
+        "promote",
+        ok=True,
+        promoted=len(op_result.get("promoted") or []),
+        rejected=len(op_result.get("rejected") or []),
+        superseded=len(op_result.get("superseded") or []),
+        did_push=result.get("did_push", False),
+    )
     return 0
 
 
@@ -384,7 +431,16 @@ def cmd_finalize_task(args: argparse.Namespace) -> int:
         commit_message=f"ai-memory: finalize issue-{args.issue_number}",
         operation=_op,
     )
+    op_result = result.get("operation_result") or {}
+    lineage = op_result.get("lineage") or {}
     _print_json({"ok": True, **result})
+    _emit_telemetry(
+        "finalize-task",
+        ok=True,
+        issue_number=_safe_int(args.issue_number),
+        final_state=lineage.get("state"),
+        did_push=result.get("did_push", False),
+    )
     return 0
 
 
@@ -414,7 +470,19 @@ def cmd_compact(args: argparse.Namespace) -> int:
         commit_message=f"ai-memory: compact {month}",
         operation=_op,
     )
+    op_result = result.get("operation_result") or {}
+    summary = op_result.get("summary") or {}
     _print_json({"ok": True, **result})
+    _emit_telemetry(
+        "compact",
+        ok=True,
+        month=month,
+        archived_candidates=summary.get("archived_candidates", 0),
+        archived_ledgers=summary.get("archived_ledgers", 0),
+        removed_candidates=summary.get("removed_candidates", 0),
+        removed_ledgers=summary.get("removed_ledgers", 0),
+        did_push=result.get("did_push", False),
+    )
     return 0
 
 
@@ -657,7 +725,15 @@ def cmd_processed_command_claim(args: argparse.Namespace) -> int:
             commit_message=f"ai-memory: claim processed command [{args.command}]",
             operation=_op,
         )
+        op_result = result.get("operation_result") or {}
         _print_json({"ok": True, **result})
+        _emit_telemetry(
+            "processed-command-claim",
+            ok=True,
+            command=args.command,
+            claimed=op_result.get("claimed", False),
+            did_push=result.get("did_push", False),
+        )
         return 0
     except MemoryGitError as exc:
         # Concurrent claims on different runners can race on the same entry file.
@@ -730,6 +806,13 @@ def cmd_processed_command_complete(args: argparse.Namespace) -> int:
         operation=_op,
     )
     _print_json({"ok": True, **result})
+    _emit_telemetry(
+        "processed-command-complete",
+        ok=True,
+        command=args.command,
+        status=args.status,
+        did_push=result.get("did_push", False),
+    )
     return 0
 
 

--- a/scripts/ai_memory.py
+++ b/scripts/ai_memory.py
@@ -515,6 +515,7 @@ def cmd_processed_command_check(args: argparse.Namespace) -> int:
                 "entry": entry,
             }
         )
+        _emit_telemetry("processed-command-check", ok=True, enabled=True, exists=bool(entry))
         return 0
     except MemoryGitError as exc:
         error_text = str(exc)
@@ -566,6 +567,7 @@ def cmd_processed_command_list(args: argparse.Namespace) -> int:
                 "count": len(entries),
             }
         )
+        _emit_telemetry("processed-command-list", ok=True, enabled=True, count=len(entries))
         return 0
     except MemoryGitError as exc:
         error_text = str(exc)
@@ -638,6 +640,14 @@ def cmd_clarify_loop_guard(args: argparse.Namespace) -> int:
                 "result": result,
                 "entries_considered": len(entries),
             }
+        )
+        _emit_telemetry(
+            "clarify-loop-guard",
+            ok=True,
+            enabled=True,
+            blocked=bool(result.get("blocked")),
+            cycle=_safe_int(result.get("cycle")),
+            entries_considered=len(entries),
         )
         return 0
     except MemoryGitError as exc:

--- a/scripts/ai_memory_lib.py
+++ b/scripts/ai_memory_lib.py
@@ -85,6 +85,7 @@ class RetrievalResult:
     selected_record_ids: list[str]
     estimated_tokens: int
     role: str
+    keyword_method: str  # "llm", "plain", or "none"
 
 
 def parse_bool(value: Any, default: bool = False) -> bool:
@@ -1065,21 +1066,24 @@ def _extract_keywords(
     body: str | None,
     *,
     api_key: str | None = None,
-) -> set[str]:
-    """Extract keywords using LLM when available, falling back to plain tokenisation."""
+) -> tuple[set[str], str]:
+    """Extract keywords using LLM when available, falling back to plain tokenisation.
+
+    Returns (keywords, method) where method is "llm", "plain", or "none".
+    """
     safe_title = title or ""
     safe_body = body or ""
     if not safe_title and not safe_body:
-        return set()
+        return set(), "none"
 
     if api_key:
         llm_keywords = _extract_keywords_llm(safe_title, safe_body, api_key=api_key)
         if llm_keywords is not None:
             # Combine LLM concepts with plain tokens for broader coverage
             plain = _extract_keywords_plain(safe_title, safe_body)
-            return plain | {kw.lower() for kw in llm_keywords}
+            return plain | {kw.lower() for kw in llm_keywords}, "llm"
 
-    return _extract_keywords_plain(safe_title, safe_body)
+    return _extract_keywords_plain(safe_title, safe_body), "plain"
 
 
 def _keyword_overlap_ratio(keywords: set[str], text: str) -> float:
@@ -1182,7 +1186,7 @@ def retrieve_memory_context(
     token_budget = _resolve_token_budget(profile, resolved_role)
 
     # Extract keywords for content-aware scoring
-    keywords = _extract_keywords(issue_title, issue_body, api_key=api_key)
+    keywords, keyword_method = _extract_keywords(issue_title, issue_body, api_key=api_key)
 
     records: list[dict[str, Any]] = []
     for record in _load_canonical_records(memory_root):
@@ -1254,6 +1258,7 @@ def retrieve_memory_context(
         selected_record_ids=[str(item.get("record_id")) for item in selected],
         estimated_tokens=used_tokens,
         role=resolved_role,
+        keyword_method=keyword_method,
     )
 
 

--- a/scripts/collect_workflow_logs.py
+++ b/scripts/collect_workflow_logs.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import io
 import json
 import math
 import os
+import random
 import re
 import subprocess
 import sys
@@ -18,10 +20,10 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlencode
 
-SCHEMA_VERSION = "workflow_log_collector.v1"
-CORE_WORKFLOW_FAMILIES = ("clarify", "plan", "implement", "review_autofix")
+SCHEMA_VERSION = "workflow_log_collector.v2"
 LOG_EXCERPT_MAX_CHARS = 4000
 SLOW_RUNS_PER_REPO = 10
+DEFAULT_SUCCESS_SAMPLE_RATE = 0.07
 RETRY_MARKERS = (
     "rate limit",
     "secondary",
@@ -109,6 +111,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=15,
         help="Optional cap on notable runs to fetch raw logs for (0 = disabled).",
+    )
+    parser.add_argument(
+        "--success-sample-rate",
+        type=float,
+        default=DEFAULT_SUCCESS_SAMPLE_RATE,
+        help="Fraction of successful runs to randomly sample for log analysis (default 0.07 = ~7%%).",
     )
     return parser
 
@@ -219,11 +227,8 @@ def normalize_workflow_family(workflow_name: str | None, workflow_path: str | No
     path = (workflow_path or "").lower()
     combined = f"{name} {path}"
 
-    if "orchestrate" in combined or "validate" in combined:
-        return None
-    if "clarify_respond" in combined:
-        return None
-
+    if any(tag in combined for tag in ("clarify_respond", "orchestrate_clarify_respond")):
+        return "orchestrate_clarify_respond"
     if any(tag in combined for tag in ("clarify", "ai-clarify", "internal-clarify")):
         return "clarify"
     if any(tag in combined for tag in ("plan", "ai-plan", "internal-plan")):
@@ -240,7 +245,30 @@ def normalize_workflow_family(workflow_name: str | None, workflow_path: str | No
         )
     ):
         return "review_autofix"
-    return None
+    if any(tag in combined for tag in ("orchestrate_poll", "orchestrate-poll")):
+        return "orchestrate_poll"
+    if any(tag in combined for tag in ("orchestrate", "ai-orchestrate", "internal-orchestrate")):
+        return "orchestrate"
+    if any(tag in combined for tag in ("validate", "ai-validate", "internal-validate")):
+        return "validate"
+    if any(tag in combined for tag in ("issue_pr_status", "issue-pr-status")):
+        return "issue_pr_status"
+    if any(tag in combined for tag in ("memory_maintenance", "memory-maintenance")):
+        return "memory_maintenance"
+    if "ci" in combined:
+        return "ci"
+    if "workflow-log-analysis" in combined or "workflow_log_analysis" in combined:
+        return "workflow_log_analysis"
+
+    # Derive family from workflow path filename as fallback
+    if path:
+        stem = Path(path).stem.lower()
+        stem = re.sub(r"^(ai-|internal-)", "", stem)
+        stem = stem.replace("-", "_")
+        if stem:
+            return stem
+
+    return "other"
 
 
 def _build_runs_endpoint(repo: str, since_utc: datetime, per_page: int, page: int) -> str:
@@ -436,6 +464,8 @@ def build_report(
     repositories: list[str],
     runs: list[dict[str, Any]],
     errors: list[dict[str, str]],
+    *,
+    success_sample_rate: float = DEFAULT_SUCCESS_SAMPLE_RATE,
 ) -> dict[str, Any]:
     durations = [int(item.get("duration_seconds", 0)) for item in runs]
     success_count = sum(1 for item in runs if (item.get("conclusion") or "").lower() == "success")
@@ -447,15 +477,18 @@ def build_report(
         if (item.get("conclusion") or "").lower() not in {"success", "failure", "cancelled"}
     )
 
+    observed_families = sorted({str(item.get("workflow_family") or "other") for item in runs})
     avg_duration = float(sum(durations) / len(durations)) if durations else 0.0
+    sampled_success_count = sum(1 for item in runs if item.get("_success_sampled"))
 
     return {
         "schema_version": SCHEMA_VERSION,
         "generated_at": _format_iso8601(datetime.now(timezone.utc)),
         "scope": {
             "repositories": repositories,
-            "workflow_families": list(CORE_WORKFLOW_FAMILIES),
+            "workflow_families": observed_families,
             "source": "github_actions_api",
+            "success_sample_rate": success_sample_rate,
         },
         "runs": runs,
         "summary": {
@@ -467,6 +500,7 @@ def build_report(
             "avg_duration_seconds": avg_duration,
             "p50_duration_seconds": _percentile(durations, 50),
             "p95_duration_seconds": _percentile(durations, 95),
+            "sampled_success_runs": sampled_success_count,
         },
         "errors": errors,
     }
@@ -488,7 +522,18 @@ def _run_identity(run: dict[str, Any]) -> tuple[str, int]:
     return str(run.get("repository") or ""), _to_int(run.get("run_id"), 0)
 
 
-def select_notable_runs_for_logs(runs: list[dict[str, Any]], max_log_runs: int) -> list[dict[str, Any]]:
+def _deterministic_seed(runs: list[dict[str, Any]]) -> str:
+    """Build a deterministic seed from the collection window for reproducible sampling."""
+    timestamps = sorted(run.get("created_at") or "" for run in runs if run.get("created_at"))
+    seed_input = f"{timestamps[0]}:{timestamps[-1]}:{len(runs)}" if timestamps else f"empty:{len(runs)}"
+    return hashlib.sha256(seed_input.encode("utf-8")).hexdigest()
+
+
+def select_notable_runs_for_logs(
+    runs: list[dict[str, Any]],
+    max_log_runs: int,
+    success_sample_rate: float = DEFAULT_SUCCESS_SAMPLE_RATE,
+) -> list[dict[str, Any]]:
     if max_log_runs <= 0:
         return []
 
@@ -536,6 +581,31 @@ def select_notable_runs_for_logs(runs: list[dict[str, Any]], max_log_runs: int) 
             ordered.append(run)
             if len(ordered) >= max_log_runs:
                 return ordered
+
+    # Random sampling of successful runs for baseline visibility
+    if success_sample_rate > 0 and len(ordered) < max_log_runs:
+        success_runs = [
+            run for run in eligible
+            if (run.get("conclusion") or "").lower() == "success" and _run_identity(run) not in seen
+        ]
+        if success_runs:
+            sample_count = max(1, math.ceil(len(success_runs) * success_sample_rate))
+            remaining_slots = max_log_runs - len(ordered)
+            sample_count = min(sample_count, remaining_slots)
+            seed = _deterministic_seed(eligible)
+            rng = random.Random(seed)
+            sampled = rng.sample(success_runs, min(sample_count, len(success_runs)))
+            sampled = _sort_runs_by_created_desc(sampled)
+            for run in sampled:
+                identity = _run_identity(run)
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                run["_success_sampled"] = True
+                ordered.append(run)
+                if len(ordered) >= max_log_runs:
+                    break
+
     return ordered
 
 
@@ -573,6 +643,8 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 2
+
+    success_sample_rate = max(0.0, min(1.0, args.success_sample_rate))
 
     try:
         since_utc = _resolve_since_utc(args)
@@ -639,7 +711,7 @@ def main(argv: list[str] | None = None) -> int:
 
             run_rows.append(compute_run_metrics(repo, run, jobs))
 
-    for run in select_notable_runs_for_logs(run_rows, args.max_log_runs):
+    for run in select_notable_runs_for_logs(run_rows, args.max_log_runs, success_sample_rate=success_sample_rate):
         repository = str(run.get("repository") or "")
         run_id = _to_int(run.get("run_id"), 0)
         if not repository or run_id <= 0:
@@ -657,7 +729,7 @@ def main(argv: list[str] | None = None) -> int:
             )
 
     run_rows.sort(key=lambda item: (item.get("created_at") or ""), reverse=True)
-    report = build_report(repositories, run_rows, errors)
+    report = build_report(repositories, run_rows, errors, success_sample_rate=success_sample_rate)
 
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/collect_workflow_logs.py
+++ b/scripts/collect_workflow_logs.py
@@ -222,7 +222,7 @@ def gh_api_bytes(
     raise RuntimeError(f"gh api failed for {endpoint} after retries")
 
 
-def normalize_workflow_family(workflow_name: str | None, workflow_path: str | None) -> str | None:
+def normalize_workflow_family(workflow_name: str | None, workflow_path: str | None) -> str:
     name = (workflow_name or "").lower()
     path = (workflow_path or "").lower()
     combined = f"{name} {path}"

--- a/scripts/collect_workflow_logs.py
+++ b/scripts/collect_workflow_logs.py
@@ -227,7 +227,7 @@ def normalize_workflow_family(workflow_name: str | None, workflow_path: str | No
     path = (workflow_path or "").lower()
     combined = f"{name} {path}"
 
-    if any(tag in combined for tag in ("clarify_respond", "orchestrate_clarify_respond")):
+    if any(tag in combined for tag in ("clarify_respond", "orchestrate_clarify_respond", "clarify respond", "orchestrate clarify respond")):
         return "orchestrate_clarify_respond"
     if any(tag in combined for tag in ("clarify", "ai-clarify", "internal-clarify")):
         return "clarify"

--- a/scripts/memory_helpers.sh
+++ b/scripts/memory_helpers.sh
@@ -151,7 +151,7 @@ memory_processed_command_check()
 {
 	if ! _memory_enabled; then
 		echo '{"exists": false}'
-		_memory_telemetry '{"op":"processed-command-check","ok":true,"enabled":false,"source":"shell"}' >&2
+		_memory_telemetry '{"op":"processed-command-check","ok":true,"enabled":false,"source":"shell"}'
 		return 0
 	fi
 
@@ -163,7 +163,7 @@ memory_processed_command_check()
 
 	{
 		_memory_warn "processed-command-check failed (fail-open)"
-		_memory_telemetry '{"op":"processed-command-check","ok":false,"fail_open":true,"source":"shell"}' >&2
+		_memory_telemetry '{"op":"processed-command-check","ok":false,"fail_open":true,"source":"shell"}'
 		echo '{"exists": false}'
 		return 0
 	}
@@ -173,7 +173,7 @@ memory_processed_command_list()
 {
 	if ! _memory_enabled; then
 		echo '{"entries": [], "count": 0}'
-		_memory_telemetry '{"op":"processed-command-list","ok":true,"enabled":false,"source":"shell"}' >&2
+		_memory_telemetry '{"op":"processed-command-list","ok":true,"enabled":false,"source":"shell"}'
 		return 0
 	fi
 
@@ -185,7 +185,7 @@ memory_processed_command_list()
 
 	{
 		_memory_warn "processed-command-list failed (fail-open)"
-		_memory_telemetry '{"op":"processed-command-list","ok":false,"fail_open":true,"source":"shell"}' >&2
+		_memory_telemetry '{"op":"processed-command-list","ok":false,"fail_open":true,"source":"shell"}'
 		echo '{"entries": [], "count": 0}'
 		return 0
 	}
@@ -195,7 +195,7 @@ memory_clarify_loop_guard()
 {
 	if ! _memory_enabled; then
 		echo '{"result": {"blocked": false, "reason": "none", "cycle": 1, "max_cycles": null}}'
-		_memory_telemetry '{"op":"clarify-loop-guard","ok":true,"enabled":false,"source":"shell"}' >&2
+		_memory_telemetry '{"op":"clarify-loop-guard","ok":true,"enabled":false,"source":"shell"}'
 		return 0
 	fi
 
@@ -207,7 +207,7 @@ memory_clarify_loop_guard()
 
 	{
 		_memory_warn "clarify-loop-guard failed (fail-open)"
-		_memory_telemetry '{"op":"clarify-loop-guard","ok":false,"fail_open":true,"source":"shell"}' >&2
+		_memory_telemetry '{"op":"clarify-loop-guard","ok":false,"fail_open":true,"source":"shell"}'
 		echo '{"result": {"blocked": false, "reason": "none", "cycle": 1, "max_cycles": null}}'
 		return 0
 	}

--- a/scripts/memory_helpers.sh
+++ b/scripts/memory_helpers.sh
@@ -151,7 +151,7 @@ memory_processed_command_check()
 {
 	if ! _memory_enabled; then
 		echo '{"exists": false}'
-		_memory_telemetry '{"op":"processed-command-check","ok":true,"enabled":false,"source":"shell"}'
+		_memory_telemetry '{"op":"processed-command-check","ok":true,"enabled":false,"source":"shell"}' >&2
 		return 0
 	fi
 
@@ -163,7 +163,7 @@ memory_processed_command_check()
 
 	{
 		_memory_warn "processed-command-check failed (fail-open)"
-		_memory_telemetry '{"op":"processed-command-check","ok":false,"fail_open":true,"source":"shell"}'
+		_memory_telemetry '{"op":"processed-command-check","ok":false,"fail_open":true,"source":"shell"}' >&2
 		echo '{"exists": false}'
 		return 0
 	}
@@ -173,7 +173,7 @@ memory_processed_command_list()
 {
 	if ! _memory_enabled; then
 		echo '{"entries": [], "count": 0}'
-		_memory_telemetry '{"op":"processed-command-list","ok":true,"enabled":false,"source":"shell"}'
+		_memory_telemetry '{"op":"processed-command-list","ok":true,"enabled":false,"source":"shell"}' >&2
 		return 0
 	fi
 
@@ -185,7 +185,7 @@ memory_processed_command_list()
 
 	{
 		_memory_warn "processed-command-list failed (fail-open)"
-		_memory_telemetry '{"op":"processed-command-list","ok":false,"fail_open":true,"source":"shell"}'
+		_memory_telemetry '{"op":"processed-command-list","ok":false,"fail_open":true,"source":"shell"}' >&2
 		echo '{"entries": [], "count": 0}'
 		return 0
 	}
@@ -195,7 +195,7 @@ memory_clarify_loop_guard()
 {
 	if ! _memory_enabled; then
 		echo '{"result": {"blocked": false, "reason": "none", "cycle": 1, "max_cycles": null}}'
-		_memory_telemetry '{"op":"clarify-loop-guard","ok":true,"enabled":false,"source":"shell"}'
+		_memory_telemetry '{"op":"clarify-loop-guard","ok":true,"enabled":false,"source":"shell"}' >&2
 		return 0
 	fi
 
@@ -207,7 +207,7 @@ memory_clarify_loop_guard()
 
 	{
 		_memory_warn "clarify-loop-guard failed (fail-open)"
-		_memory_telemetry '{"op":"clarify-loop-guard","ok":false,"fail_open":true,"source":"shell"}'
+		_memory_telemetry '{"op":"clarify-loop-guard","ok":false,"fail_open":true,"source":"shell"}' >&2
 		echo '{"result": {"blocked": false, "reason": "none", "cycle": 1, "max_cycles": null}}'
 		return 0
 	}
@@ -236,7 +236,8 @@ memory_promote()
 memory_processed_command_claim()
 {
 	if ! _memory_enabled; then
-		_memory_telemetry '{"op":"processed-command-claim","ok":true,"enabled":false,"source":"shell"}'
+		echo '{"ok": true, "enabled": false, "operation_result": {"claimed": true, "entry": null}}'
+		_memory_telemetry '{"op":"processed-command-claim","ok":true,"enabled":false,"source":"shell"}' >&2
 		return 0
 	fi
 
@@ -246,7 +247,8 @@ memory_processed_command_claim()
 memory_processed_command_complete()
 {
 	if ! _memory_enabled; then
-		_memory_telemetry '{"op":"processed-command-complete","ok":true,"enabled":false,"source":"shell"}'
+		echo '{"ok": true, "enabled": false, "entry": null}'
+		_memory_telemetry '{"op":"processed-command-complete","ok":true,"enabled":false,"source":"shell"}' >&2
 		return 0
 	fi
 

--- a/scripts/memory_helpers.sh
+++ b/scripts/memory_helpers.sh
@@ -22,6 +22,13 @@ _memory_warn()
 	echo "::warning::memory $*" >&2
 }
 
+_memory_telemetry()
+{
+	# Emit a structured telemetry line to stdout for log-analysis visibility.
+	# Usage: _memory_telemetry '{"op":"retrieve","ok":true,...}'
+	echo "AI_MEMORY_TELEMETRY: $1"
+}
+
 _memory_retrieve_fallback()
 {
 	local output_file="${1:-}"
@@ -93,11 +100,13 @@ memory_ensure_branch()
 memory_record_run_event()
 {
 	if ! _memory_enabled; then
+		_memory_telemetry '{"op":"record-run-event","ok":true,"enabled":false,"source":"shell"}'
 		return 0
 	fi
 
 	python3 "${MEMORY_SCRIPTS_DIR}/ai_memory.py" record-run-event "$@" 2>&1 || {
 		_memory_warn "record-run-event failed (fail-open)"
+		_memory_telemetry '{"op":"record-run-event","ok":false,"fail_open":true,"source":"shell"}'
 		return 0
 	}
 }
@@ -105,11 +114,13 @@ memory_record_run_event()
 memory_record_candidate()
 {
 	if ! _memory_enabled; then
+		_memory_telemetry '{"op":"record-candidate","ok":true,"enabled":false,"source":"shell"}'
 		return 0
 	fi
 
 	python3 "${MEMORY_SCRIPTS_DIR}/ai_memory.py" record-candidate "$@" 2>&1 || {
 		_memory_warn "record-candidate failed (fail-open)"
+		_memory_telemetry '{"op":"record-candidate","ok":false,"fail_open":true,"source":"shell"}'
 		return 0
 	}
 }
@@ -120,6 +131,7 @@ memory_retrieve()
 
 	if ! _memory_enabled; then
 		_memory_retrieve_fallback "${output_file}" "disabled"
+		_memory_telemetry '{"op":"retrieve","ok":true,"enabled":false,"source":"shell"}'
 		return 0
 	fi
 
@@ -130,6 +142,7 @@ memory_retrieve()
 	python3 "${MEMORY_SCRIPTS_DIR}/ai_memory.py" retrieve --output-file "${output_file}" "$@" 2>&1 || {
 		_memory_warn "retrieve failed (fail-open)"
 		_memory_retrieve_fallback "${output_file}" "unavailable"
+		_memory_telemetry '{"op":"retrieve","ok":false,"fail_open":true,"source":"shell"}'
 		return 0
 	}
 }
@@ -138,6 +151,7 @@ memory_processed_command_check()
 {
 	if ! _memory_enabled; then
 		echo '{"exists": false}'
+		_memory_telemetry '{"op":"processed-command-check","ok":true,"enabled":false,"source":"shell"}' >&2
 		return 0
 	fi
 
@@ -149,6 +163,7 @@ memory_processed_command_check()
 
 	{
 		_memory_warn "processed-command-check failed (fail-open)"
+		_memory_telemetry '{"op":"processed-command-check","ok":false,"fail_open":true,"source":"shell"}' >&2
 		echo '{"exists": false}'
 		return 0
 	}
@@ -158,6 +173,7 @@ memory_processed_command_list()
 {
 	if ! _memory_enabled; then
 		echo '{"entries": [], "count": 0}'
+		_memory_telemetry '{"op":"processed-command-list","ok":true,"enabled":false,"source":"shell"}' >&2
 		return 0
 	fi
 
@@ -169,6 +185,7 @@ memory_processed_command_list()
 
 	{
 		_memory_warn "processed-command-list failed (fail-open)"
+		_memory_telemetry '{"op":"processed-command-list","ok":false,"fail_open":true,"source":"shell"}' >&2
 		echo '{"entries": [], "count": 0}'
 		return 0
 	}
@@ -178,6 +195,7 @@ memory_clarify_loop_guard()
 {
 	if ! _memory_enabled; then
 		echo '{"result": {"blocked": false, "reason": "none", "cycle": 1, "max_cycles": null}}'
+		_memory_telemetry '{"op":"clarify-loop-guard","ok":true,"enabled":false,"source":"shell"}' >&2
 		return 0
 	fi
 
@@ -189,6 +207,7 @@ memory_clarify_loop_guard()
 
 	{
 		_memory_warn "clarify-loop-guard failed (fail-open)"
+		_memory_telemetry '{"op":"clarify-loop-guard","ok":false,"fail_open":true,"source":"shell"}' >&2
 		echo '{"result": {"blocked": false, "reason": "none", "cycle": 1, "max_cycles": null}}'
 		return 0
 	}
@@ -197,6 +216,7 @@ memory_clarify_loop_guard()
 memory_finalize_task()
 {
 	if ! _memory_enabled; then
+		_memory_telemetry '{"op":"finalize-task","ok":true,"enabled":false,"source":"shell"}'
 		return 0
 	fi
 
@@ -206,6 +226,7 @@ memory_finalize_task()
 memory_promote()
 {
 	if ! _memory_enabled; then
+		_memory_telemetry '{"op":"promote","ok":true,"enabled":false,"source":"shell"}'
 		return 0
 	fi
 
@@ -215,6 +236,7 @@ memory_promote()
 memory_processed_command_claim()
 {
 	if ! _memory_enabled; then
+		_memory_telemetry '{"op":"processed-command-claim","ok":true,"enabled":false,"source":"shell"}'
 		return 0
 	fi
 
@@ -224,11 +246,13 @@ memory_processed_command_claim()
 memory_processed_command_complete()
 {
 	if ! _memory_enabled; then
+		_memory_telemetry '{"op":"processed-command-complete","ok":true,"enabled":false,"source":"shell"}'
 		return 0
 	fi
 
 	python3 "${MEMORY_SCRIPTS_DIR}/ai_memory.py" processed-command-complete "$@" || {
 		_memory_warn "processed-command-complete failed (fail-open)"
+		_memory_telemetry '{"op":"processed-command-complete","ok":false,"fail_open":true,"source":"shell"}'
 		return 0
 	}
 }

--- a/tests/test_collect_workflow_logs.py
+++ b/tests/test_collect_workflow_logs.py
@@ -30,13 +30,18 @@ def _write_exec(path: Path, body: str) -> None:
 	path.chmod(0o755)
 
 
-def test_normalize_workflow_family_core_and_exclusion():
+def test_normalize_workflow_family_core_and_formerly_excluded():
 	assert collector.normalize_workflow_family("AI Clarify", ".github/workflows/clarify.yml") == "clarify"
 	assert collector.normalize_workflow_family("AI Plan", ".github/workflows/plan.yml") == "plan"
 	assert collector.normalize_workflow_family("AI Implement", ".github/workflows/implement.yml") == "implement"
 	assert collector.normalize_workflow_family("AI Review", ".github/workflows/review_autofix.yml") == "review_autofix"
-	assert collector.normalize_workflow_family("AI Validate", ".github/workflows/validate.yml") is None
-	assert collector.normalize_workflow_family("AI Orchestrate", ".github/workflows/orchestrate.yml") is None
+	assert collector.normalize_workflow_family("AI Validate", ".github/workflows/validate.yml") == "validate"
+	assert collector.normalize_workflow_family("AI Orchestrate", ".github/workflows/orchestrate.yml") == "orchestrate"
+	assert collector.normalize_workflow_family("AI Orchestrate Poll", ".github/workflows/orchestrate_poll.yml") == "orchestrate_poll"
+	assert collector.normalize_workflow_family("Clarify Respond", ".github/workflows/orchestrate_clarify_respond.yml") == "orchestrate_clarify_respond"
+	assert collector.normalize_workflow_family("CI", ".github/workflows/ci.yml") == "ci"
+	assert collector.normalize_workflow_family("Unknown", ".github/workflows/foo-bar.yml") == "foo_bar"
+	assert collector.normalize_workflow_family("", "") == "other"
 
 
 def test_compute_run_metrics_retries_and_duration_with_missing_timestamps():
@@ -88,7 +93,7 @@ def test_extract_failure_point_step_precedence_then_job_fallback():
 	assert point_job == {"job_name": "build", "step_name": None}
 
 
-def test_list_runs_for_repo_paginates_and_filters_core_scope():
+def test_list_runs_for_repo_paginates_and_includes_all_families():
 	orig = collector.gh_api_json
 	calls = []
 
@@ -124,8 +129,8 @@ def test_list_runs_for_repo_paginates_and_filters_core_scope():
 		collector.gh_api_json = orig
 
 	assert capped is False
-	assert [r["id"] for r in runs] == [1, 3]
-	assert [r["_workflow_family"] for r in runs] == ["plan", "implement"]
+	assert [r["id"] for r in runs] == [1, 2, 3]
+	assert [r["_workflow_family"] for r in runs] == ["plan", "validate", "implement"]
 	assert len(calls) == 3
 
 
@@ -213,6 +218,38 @@ def test_select_notable_runs_for_logs_prioritizes_failed_then_retried_then_slow_
 		("owner/repo-a", 202),
 		("owner/repo-b", 301),
 	]
+
+
+def test_select_notable_runs_success_sampling():
+	# Build 30 successful runs — the slow bucket picks the top SLOW_RUNS_PER_REPO (10)
+	# by duration; remaining successful runs are candidates for random sampling.
+	runs = [
+		{
+			"repository": "owner/repo",
+			"run_id": i,
+			"conclusion": "success",
+			"retries": 0,
+			"duration_seconds": 60,
+			"created_at": f"2026-04-10T{10 + (i % 12):02d}:00:00Z",
+		}
+		for i in range(1, 31)
+	]
+	selected = collector.select_notable_runs_for_logs(runs, max_log_runs=20, success_sample_rate=0.07)
+	sampled = [item for item in selected if item.get("_success_sampled")]
+	non_sampled = [item for item in selected if not item.get("_success_sampled")]
+	# Slow bucket picks 10 (SLOW_RUNS_PER_REPO); sampling picks from the remaining 20
+	assert len(non_sampled) == collector.SLOW_RUNS_PER_REPO
+	# ceil(20 * 0.07) = 2
+	assert len(sampled) >= 1
+
+	# Deterministic: same input produces same selection
+	selected2 = collector.select_notable_runs_for_logs(runs, max_log_runs=20, success_sample_rate=0.07)
+	assert [item["run_id"] for item in selected] == [item["run_id"] for item in selected2]
+
+	# Rate 0 disables sampling — only slow runs remain
+	selected_zero = collector.select_notable_runs_for_logs(runs, max_log_runs=20, success_sample_rate=0.0)
+	assert all(not item.get("_success_sampled") for item in selected_zero)
+	assert len(selected_zero) == collector.SLOW_RUNS_PER_REPO
 
 
 def test_main_partial_jobs_failure_still_emits_report_with_errors():
@@ -387,22 +424,24 @@ print(json.dumps({}))
 		assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
 
 		report = json.loads(report_file.read_text(encoding="utf-8"))
-		assert report["schema_version"] == "workflow_log_collector.v1"
-		assert report["scope"]["workflow_families"] == ["clarify", "plan", "implement", "review_autofix"]
-		assert report["summary"]["total_runs"] == 3
-		assert report["summary"]["success_count"] == 2
+		assert report["schema_version"] == "workflow_log_collector.v2"
+		# All families are now collected — validate is included
+		assert isinstance(report["scope"]["workflow_families"], list)
+		assert report["summary"]["total_runs"] == 4
+		assert report["summary"]["success_count"] == 3
 		assert report["summary"]["failure_count"] == 1
 		assert report["summary"]["cancelled_count"] == 0
 		assert report["summary"]["other_count"] == 0
 		assert isinstance(report["summary"]["p50_duration_seconds"], float)
 		assert isinstance(report["summary"]["p95_duration_seconds"], float)
+		assert "sampled_success_runs" in report["summary"]
+		assert "success_sample_rate" in report["scope"]
 		assert len(report["errors"]) == 2
 		assert sorted(item["scope"] for item in report["errors"]) == ["jobs", "logs"]
 
 		by_run_id = {item["run_id"]: item for item in report["runs"]}
 		assert by_run_id[101]["log_excerpts"] == [{"step_name": "plan", "excerpt": "plan ok\n"}]
 		assert by_run_id[102]["log_excerpts"] == [{"step_name": "failure", "excerpt": "failure details\n"}]
-		assert "log_excerpts" not in by_run_id[104]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_collect_workflow_logs.py
+++ b/tests/test_collect_workflow_logs.py
@@ -240,7 +240,9 @@ def test_select_notable_runs_success_sampling():
 	# Slow bucket picks 10 (SLOW_RUNS_PER_REPO); sampling picks from the remaining 20
 	assert len(non_sampled) == collector.SLOW_RUNS_PER_REPO
 	# ceil(20 * 0.07) = 2
-	assert len(sampled) >= 1
+	assert len(sampled) == 2
+	assert all(item.get("_success_sampled") for item in sampled)
+	assert all(not item.get("_success_sampled") for item in non_sampled)
 
 	# Deterministic: same input produces same selection
 	selected2 = collector.select_notable_runs_for_logs(runs, max_log_runs=20, success_sample_rate=0.07)


### PR DESCRIPTION
- Remove workflow family filter from log collector — all workflow families
  are now collected (schema_version bumped to v2, workflow_families derived
  from observed runs instead of a static list)
- Add random success sampling (~7% default) to select_notable_runs_for_logs
  so the analyzer sees baseline successful run logs, not only failures/slow
  runs; deterministic seed from collection window for reproducibility
- Emit AI_MEMORY_TELEMETRY structured JSON lines from both ai_memory.py
  (stderr) and memory_helpers.sh wrappers (stdout) for every memory
  operation including retrieve, record-candidate, record-run-event,
  finalize-task, promote, compact, and processed-command operations
- Track keyword_method (llm/plain/none) in RetrievalResult so retrieve
  telemetry reports whether LLM or plain tokenisation was used
- Add AI Memory Health section to the workflow analysis prompt so the
  LLM analyzer surfaces memory hit rates, token budget utilisation,
  keyword method distribution, and fail-open events

https://claude.ai/code/session_01VZV9ZxYfJvBSEGiyeMUHP6