### PR TITLE
claude/analyze-job-logs-tooSt

### DIFF
--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -615,6 +615,17 @@ CRITICAL — importlib dynamic module loading for dependency_auditing import che
   `importlib.import_module` handles `sys.modules` registration automatically
   and is the correct API for "does this module load?" audits.
 
+CRITICAL — dependency_auditing sidecar scripts MUST set sys.path to repo root:
+- Any Python sidecar file generated under `validation/tests/_lib/` for
+  dependency_auditing MUST contain BOTH of the following lines before any
+  `importlib.import_module()` call:
+    os.chdir("/workspace")
+    sys.path.insert(0, "/workspace")
+  Without these lines, `scripts.*` modules are not importable because
+  `/workspace` is not on `sys.path` by default inside the container.
+  This is the single most common cause of false `No module named 'scripts'`
+  harness failures. Omitting these lines is a harness defect.
+
 Validation coverage (implement only when concretely applicable):
 1. Build verification
 2. Startup and health checks


### PR DESCRIPTION
The validation harness generate prompt already documents the preferred
pattern (os.chdir + sys.path.insert) for dependency_auditing sidecar
scripts, but the instruction was buried inside the importlib CRITICAL
block. The Codex model used the correct API (importlib.import_module)
but omitted the sys.path setup, causing 'No module named scripts'
failures in 08_dependency_auditing.sh (28/29 tests passed, only
dependency auditing failed).

Add a separate, clearly labeled CRITICAL block specifically stating
that dependency_auditing sidecar scripts MUST set sys.path to
/workspace before any import_module call.

https://claude.ai/code/session_012wQfRn8aD99HV812tBHV5X