### PR TITLE
claude/analyze-job-logs-ZJtBY

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1997,8 +1997,10 @@ jobs:
             # "- none" variants).
             has_real_changes="false"
             if [ -n "${changes_section}" ]; then
-              # Strip lines that are blank or match "- none*"
-              substantive="$(printf '%s\n' "${changes_section}" | grep -vE '^[[:space:]]*$' | grep -vE '^[[:space:]]*-[[:space:]]*none' || true)"
+              # Strip lines that are blank, match "- none*", or are
+              # informational metadata (e.g. "- Validation executed: ...")
+              # that the editor emits alongside "- none" when no files changed.
+              substantive="$(printf '%s\n' "${changes_section}" | grep -vE '^[[:space:]]*$' | grep -vE '^[[:space:]]*-[[:space:]]*none' | grep -viE '^[[:space:]]*-[[:space:]]*(Validation executed|No .* modified|No changes)' || true)"
               if [ -n "${substantive}" ]; then
                 has_real_changes="true"
               fi

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2000,7 +2000,7 @@ jobs:
               # Strip lines that are blank, match "- none*", or are
               # informational metadata (e.g. "- Validation executed: ...")
               # that the editor emits alongside "- none" when no files changed.
-              substantive="$(printf '%s\n' "${changes_section}" | grep -vE '^[[:space:]]*$' | grep -vE '^[[:space:]]*-[[:space:]]*none' | grep -viE '^[[:space:]]*-[[:space:]]*(Validation executed|No .* modified|No changes)' || true)"
+              substantive="$(printf '%s\n' "${changes_section}" | grep -viE '^[[:space:]]*$|^[[:space:]]*-[[:space:]]*none|^[[:space:]]*-[[:space:]]*(Validation executed|No .* modified|No changes)' || true)"
               if [ -n "${substantive}" ]; then
                 has_real_changes="true"
               fi

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -572,7 +572,7 @@ while [ "${attempt}" -le 3 ]; do
           /^[[:space:]]*Changes made:/ { in_s=1; next }
           in_s && /^[[:space:]]*[A-Za-z].*:/ { exit }
           in_s { print }
-        ' "${tmp_output}" | grep -viE '^[[:space:]]*$|^[[:space:]]*-[[:space:]]*none|^[[:space:]]*-[[:space:]]*(Validation executed|No .* modified|No changes)' || true)"
+        ' "${tmp_output}" | grep -viE '^[[:space:]]*$|^[[:space:]]*-[[:space:]]*none([[:space:]]|$)|^[[:space:]]*-[[:space:]]*(Validation executed|No .* modified|No changes)' || true)"
 
         if [ -n "${_claimed_changes}" ]; then
           # Editor claims it made changes — verify git agrees.

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -572,7 +572,7 @@ while [ "${attempt}" -le 3 ]; do
           /^[[:space:]]*Changes made:/ { in_s=1; next }
           in_s && /^[[:space:]]*[A-Za-z].*:/ { exit }
           in_s { print }
-        ' "${tmp_output}" | grep -vE '^[[:space:]]*$' | grep -vE '^[[:space:]]*-[[:space:]]*none' || true)"
+        ' "${tmp_output}" | grep -viE '^[[:space:]]*$|^[[:space:]]*-[[:space:]]*none|^[[:space:]]*-[[:space:]]*(Validation executed|No .* modified|No changes)' || true)"
 
         if [ -n "${_claimed_changes}" ]; then
           # Editor claims it made changes — verify git agrees.


### PR DESCRIPTION
The changes-lost detection in review_autofix.yml incorrectly treated
informational metadata lines (e.g. "- Validation executed: ...") in the
editor summary as substantive changes, triggering false-positive
EDITOR_CHANGES_LOST errors and unnecessary re-dispatches when the editor
correctly determined no file changes were needed.

https://claude.ai/code/session_01PJxo2RtHM6ze36i43nwKND