### PR TITLE
claude/analyze-job-logs-0172b

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1512,13 +1512,21 @@ jobs:
           git config user.name "codex-bot"
           git config user.email "codex@users.noreply.github.com"
           git rm -r --cached node_modules 2>/dev/null || true
-          # Template-owned paths (scripts/, prompts/, .github/prompts/,
+          # Template-owned paths (prompts/, .github/prompts/,
           # .github/scripts/) are fetched from coding-workflows at runtime in
           # consumer repos, and must NOT be committed there — any edit to them
           # in a consumer wrapper would either be a no-op (overwritten next run)
           # or leak a stale copy back into the caller's tree.  In the canonical
           # `*/coding-workflows` repository these paths ARE the source of truth
           # and must be editable, so the excludes are dropped.
+          #
+          # NOTE: scripts/ is NOT blanket-excluded here.  The bootstrap step
+          # writes a scripts/.gitignore that ignores only the runtime-fetched
+          # helpers (gh_helpers.sh, tg_helpers.sh, etc.).  A blanket ':!scripts'
+          # would also block legitimate consumer-repo scripts such as
+          # scripts/security/*.js — which was the root cause of
+          # ai:implementation-failed false-positives on repos that keep their
+          # own scripts under scripts/.
           is_self_repo="false"
           if [[ "${{ github.repository }}" == *"/coding-workflows" ]]; then
             is_self_repo="true"
@@ -1526,8 +1534,8 @@ jobs:
           add_u_excludes=(':!node_modules' ':!.codex-workflow-src' ':!.codex-workflow-src-main')
           add_o_excludes=(':!node_modules' ':!.serena' ':!.github/ai' ':!.codex-workflow-src' ':!.codex-workflow-src-main')
           if [ "${is_self_repo}" = "false" ]; then
-            add_u_excludes+=(':!scripts' ':!.github/prompts' ':!.github/scripts')
-            add_o_excludes+=(':!scripts' ':!prompts' ':!.github/prompts' ':!.github/scripts')
+            add_u_excludes+=(':!.github/prompts' ':!.github/scripts')
+            add_o_excludes+=(':!prompts' ':!.github/prompts' ':!.github/scripts')
           fi
           git add -u -- "${add_u_excludes[@]}"
           git ls-files --others --exclude-standard -z -- "${add_o_excludes[@]}" | xargs -0 -r git add --
@@ -1612,7 +1620,7 @@ jobs:
           # re-label the issue and post an explanatory comment.
           if [ -z "$(git diff --cached --name-only)" ]; then
             if [ "${is_self_repo}" = "false" ]; then
-              echo "All Codex changes were filtered out (scripts/, .github/prompts/, .github/scripts/, or fetched-manifest cleanup); nothing to commit."
+              echo "All Codex changes were filtered out (.github/prompts/, .github/scripts/, prompts/, or fetched-manifest cleanup); nothing to commit."
             else
               echo "No staged changes after fetched-manifest cleanup; nothing to commit."
             fi

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1539,6 +1539,12 @@ jobs:
           fi
           git add -u -- "${add_u_excludes[@]}"
           git ls-files --others --exclude-standard -z -- "${add_o_excludes[@]}" | xargs -0 -r git add --
+          if [ "${is_self_repo}" = "false" ] && [ -f scripts/.gitignore ]; then
+            while IFS= read -r fetched_script; do
+              case "${fetched_script}" in ''|'#'*|'.gitignore') continue ;; esac
+              git reset -q HEAD -- "scripts/${fetched_script}" 2>/dev/null || true
+            done < scripts/.gitignore
+          fi
           echo "Staged files before commit:"
           git diff --cached --name-only | sed 's/^/ - /' || true
           if [ "${is_self_repo}" = "false" ] && git diff --cached --name-only | grep -E '^\.github/(prompts|scripts)/'; then

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -921,9 +921,11 @@ jobs:
 
       - name: "Preflight: Warn if protected paths are tracked in consumer repo"
         # Defensive check: in consumer repos, the workflow's runtime helpers
-        # (scripts/, prompts/, .serena/, .github/scripts/, .github/prompts/,
-        # ai-memory/) should never be tracked — they are fetched at runtime
-        # from coding-workflows.  If a prior buggy run leaked them into the
+        # (known scripts/<helper> files, prompts/, .serena/, .github/scripts/,
+        # .github/prompts/, ai-memory/) should never be tracked — they are
+        # fetched at runtime from coding-workflows. Consumer-owned scripts/**
+        # are allowed and intentionally excluded from this warning.
+        # If a prior buggy run leaked runtime helpers into the
         # consumer's history, every merge with the base branch will re-stage
         # them in the conflict-resolver step and trip the downstream guard.
         # We can't fix the leak from here, but we surface it immediately so
@@ -934,10 +936,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          leaked_paths="$(git ls-files -- 'scripts/' 'prompts/' '.serena/' '.github/scripts/' '.github/prompts/' 'ai-memory/' 2>/dev/null || true)"
+          leaked_paths="$(git ls-files -- \
+            'scripts/gh_helpers.sh' 'scripts/setup_serena.sh' 'scripts/git_ref_health_check.sh' \
+            'scripts/render_prompt.sh' 'scripts/validate_changed_files_syntax.sh' 'scripts/serena_efficiency_report.py' \
+            'scripts/tg_helpers.sh' 'scripts/label_helpers.sh' 'scripts/memory_helpers.sh' \
+            'scripts/ai_memory.py' 'scripts/ai_memory_lib.py' 'scripts/openrouter_prompt_cache.py' \
+            'scripts/codex_model_catalog.json' \
+            'prompts/' '.serena/' '.github/scripts/' '.github/prompts/' 'ai-memory/' 2>/dev/null || true)"
           if [ -n "${leaked_paths}" ]; then
             leaked_count="$(printf '%s\n' "${leaked_paths}" | sed '/^$/d' | wc -l | tr -d ' ')"
-            echo "::warning::Consumer repo tracks ${leaked_count} workflow runtime/helper artifact(s) under scripts/, prompts/, .serena/, .github/scripts/, .github/prompts/, or ai-memory/. These will be auto-unstaged before commit, but please remove them from the repo (git rm -r --cached + commit) to prevent repeated friction on every merge with the base branch."
+            echo "::warning::Consumer repo tracks ${leaked_count} workflow runtime/helper artifact(s) (scripts/<known helper>, prompts/, .serena/, .github/scripts/, .github/prompts/, or ai-memory/). Consumer-owned scripts under scripts/ are allowed; remove only leaked workflow artifacts (git rm -r --cached + commit) to prevent repeated merge friction on every merge with the base branch."
             echo "Tracked protected paths found on ${TARGET_BRANCH:-HEAD}:"
             printf '%s\n' "${leaked_paths}" | sed '/^$/d; s/^/ - /'
           else
@@ -2260,7 +2268,7 @@ jobs:
           # Skipped on the workflow source repo, where these paths are
           # tracked source files — removing them here would leave them
           # missing for the rest of this step because the consumer-repo
-          # restore block below (git reset/checkout on 'scripts' etc.) is
+          # restore block below (git reset/checkout on protected paths) is
           # intentionally skipped when IS_WORKFLOW_SOURCE_REPO=true, and
           # `git merge --no-commit` does not rewrite paths whose content
           # is identical between HEAD and BASE.  Downstream

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1508,8 +1508,10 @@ jobs:
           # "canonical helpers" like review_apply_fixes.sh — be legitimately
           # modified, while still blocking files the editor never touched from
           # riding along in the commit.
-          # Consumer repos are unchanged: they continue to use the ':!scripts'
-          # full-directory exclusion, which already blocks script leaks there.
+          # Consumer repos no longer blanket-exclude ':!scripts' — the
+          # bootstrap-generated scripts/.gitignore handles fetched helpers.
+          # This lets consumer-repo-owned scripts (e.g. scripts/security/)
+          # be committed normally.
           if [ "${IS_WORKFLOW_SOURCE_REPO:-false}" = "true" ]; then
             PRE_EDITOR_STATE_FILE="${RUNTIME_DIR}/pre_editor_state.tsv"
             : > "${PRE_EDITOR_STATE_FILE}"
@@ -1726,8 +1728,8 @@ jobs:
             done < "${CODEX_TOUCHED_FILE}"
             rm -f "${CODEX_TOUCHED_FILE}"
           else
-            git add -u -- ':!node_modules' ':!scripts' ':!prompts' ':!.serena' ':!ai-memory' ':!.codex-workflow-src' ':!.codex-workflow-src-main' ':!.github/prompts' ':!.github/scripts'
-            git ls-files --others --exclude-standard -z -- ':!node_modules' ':!scripts' ':!prompts' ':!.serena' ':!ai-memory' ':!.codex-workflow-src' ':!.codex-workflow-src-main' ':!.github/ai' ':!.github/prompts' ':!.github/scripts' | xargs -0 -r git add --
+            git add -u -- ':!node_modules' ':!prompts' ':!.serena' ':!ai-memory' ':!.codex-workflow-src' ':!.codex-workflow-src-main' ':!.github/prompts' ':!.github/scripts'
+            git ls-files --others --exclude-standard -z -- ':!node_modules' ':!prompts' ':!.serena' ':!ai-memory' ':!.codex-workflow-src' ':!.codex-workflow-src-main' ':!.github/ai' ':!.github/prompts' ':!.github/scripts' | xargs -0 -r git add --
           fi
 
           echo "Staged files before commit:"
@@ -2374,10 +2376,10 @@ jobs:
 
           # Defensive: `git merge --no-commit` auto-stages merged hunks (and
           # conflict-marked hunks) into the index for every path both sides
-          # touched, including protected paths (scripts/, prompts/, .serena/,
+          # touched, including protected paths (prompts/, .serena/,
           # .github/scripts/, .github/prompts/, ai-memory/) when the consumer
           # repo has leaked tracked copies of workflow runtime helpers from an
-          # older buggy run.  The downstream `git add -u -- ':!scripts' …`
+          # older buggy run.  The downstream `git add -u -- ':!prompts' …`
           # exclusion does NOT unstage already-indexed paths, so without this
           # reset the merge commit would carry protected-path changes and
           # trip the commit-gate guard, wasting the whole review run.
@@ -2625,11 +2627,12 @@ jobs:
           # Remove root-level workflow-generated artifacts so they are never
           # committed to caller repos.  Skip when running on coding-workflows
           # itself — these files are actual source code there, not artifacts.
-          # NOTE: scripts/, .serena/, and prompts/ are cleaned up in the final
+          # NOTE: .serena/ and prompts/ are cleaned up in the final
           # "Cleanup temporary artifacts" step because later notification steps
           # (Telegram, labeling) still need scripts/tg_helpers.sh and
-          # scripts/label_helpers.sh.  These directories are already excluded
-          # from git add via ':!scripts', ':!.serena', ':!prompts' patterns.
+          # scripts/label_helpers.sh.  prompts/ and .serena/ are excluded
+          # from git add via ':!.serena', ':!prompts' patterns; fetched
+          # scripts are excluded via the bootstrap-generated scripts/.gitignore.
           if [[ "${{ github.repository }}" != *"/coding-workflows" ]]; then
             rm -f ./pre_assembled_static.txt
             rm -f codex_system_instructions.md ai_pipeline.md unattended_llm_system_instructions.md agents.md
@@ -2834,8 +2837,8 @@ jobs:
               done < "${RESOLVER_TOUCHED_FILE}"
               rm -f "${RESOLVER_TOUCHED_FILE}"
             else
-              git add -u -- ':!node_modules' ':!scripts' ':!prompts' ':!.serena' ':!ai-memory' ':!.codex-workflow-src' ':!.codex-workflow-src-main' ':!.github/prompts' ':!.github/scripts'
-              git ls-files --others --exclude-standard -z -- ':!node_modules' ':!scripts' ':!prompts' ':!.serena' ':!ai-memory' ':!.codex-workflow-src' ':!.codex-workflow-src-main' ':!.github/ai' ':!.github/prompts' ':!.github/scripts' | xargs -0 -r git add --
+              git add -u -- ':!node_modules' ':!prompts' ':!.serena' ':!ai-memory' ':!.codex-workflow-src' ':!.codex-workflow-src-main' ':!.github/prompts' ':!.github/scripts'
+              git ls-files --others --exclude-standard -z -- ':!node_modules' ':!prompts' ':!.serena' ':!ai-memory' ':!.codex-workflow-src' ':!.codex-workflow-src-main' ':!.github/ai' ':!.github/prompts' ':!.github/scripts' | xargs -0 -r git add --
             fi
             echo "Staged files before commit:"
             STAGED_FILES="$(git diff --cached --name-only || true)"

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1747,9 +1747,9 @@ jobs:
             git reset -q HEAD -- '.github/prompts' '.github/scripts' 2>/dev/null || true
             PROTECTED_LEAKED=true
           fi
-          if [ "${IS_WORKFLOW_SOURCE_REPO:-false}" != "true" ] && printf '%s\n' "${STAGED_FILES}" | grep -Eq '^(scripts/|prompts/|\.serena/|\.github/scripts/|\.github/prompts/|ai-memory/|\.codex-workflow-src/|\.codex-workflow-src-main/)'; then
+          if [ "${IS_WORKFLOW_SOURCE_REPO:-false}" != "true" ] && printf '%s\n' "${STAGED_FILES}" | grep -Eq '^(prompts/|\.serena/|\.github/scripts/|\.github/prompts/|ai-memory/|\.codex-workflow-src/|\.codex-workflow-src-main/)'; then
             echo "::warning::workflow runtime/helper artifacts were staged in consumer repo; unstaging protected paths and continuing."
-            git reset -q HEAD -- 'scripts' 'prompts' '.serena' '.github/scripts' '.github/prompts' 'ai-memory' '.codex-workflow-src' '.codex-workflow-src-main' 2>/dev/null || true
+            git reset -q HEAD -- 'prompts' '.serena' '.github/scripts' '.github/prompts' 'ai-memory' '.codex-workflow-src' '.codex-workflow-src-main' 2>/dev/null || true
             PROTECTED_LEAKED=true
           fi
           if [ "${PROTECTED_LEAKED}" = "true" ]; then
@@ -2386,8 +2386,8 @@ jobs:
           # Skipped on the workflow source repo itself, where these paths are
           # real source code.
           if [ "${IS_WORKFLOW_SOURCE_REPO:-false}" != "true" ]; then
-            git reset -q HEAD -- 'scripts' 'prompts' '.serena' '.github/scripts' '.github/prompts' 'ai-memory' '.codex-workflow-src' '.codex-workflow-src-main' 2>/dev/null || true
-            git checkout -- 'scripts' 'prompts' '.serena' '.github/scripts' '.github/prompts' 'ai-memory' '.codex-workflow-src' 2>/dev/null || true
+            git reset -q HEAD -- 'prompts' '.serena' '.github/scripts' '.github/prompts' 'ai-memory' '.codex-workflow-src' '.codex-workflow-src-main' 2>/dev/null || true
+            git checkout -- 'prompts' '.serena' '.github/scripts' '.github/prompts' 'ai-memory' '.codex-workflow-src' 2>/dev/null || true
           fi
 
           # Restore stashed dirs so Codex has its full environment.
@@ -2855,9 +2855,9 @@ jobs:
               git reset -q HEAD -- '.github/prompts' '.github/scripts' 2>/dev/null || true
               PROTECTED_LEAKED=true
             fi
-            if [ "${IS_WORKFLOW_SOURCE_REPO:-false}" != "true" ] && printf '%s\n' "${STAGED_FILES}" | grep -Eq '^(scripts/|prompts/|\.serena/|\.github/scripts/|\.github/prompts/|ai-memory/|\.codex-workflow-src/|\.codex-workflow-src-main/)'; then
+            if [ "${IS_WORKFLOW_SOURCE_REPO:-false}" != "true" ] && printf '%s\n' "${STAGED_FILES}" | grep -Eq '^(prompts/|\.serena/|\.github/scripts/|\.github/prompts/|ai-memory/|\.codex-workflow-src/|\.codex-workflow-src-main/)'; then
               echo "::warning::workflow runtime/helper artifacts were staged in consumer repo; unstaging protected paths and continuing."
-              git reset -q HEAD -- 'scripts' 'prompts' '.serena' '.github/scripts' '.github/prompts' 'ai-memory' '.codex-workflow-src' '.codex-workflow-src-main' 2>/dev/null || true
+              git reset -q HEAD -- 'prompts' '.serena' '.github/scripts' '.github/prompts' 'ai-memory' '.codex-workflow-src' '.codex-workflow-src-main' 2>/dev/null || true
               PROTECTED_LEAKED=true
             fi
             if [ "${PROTECTED_LEAKED}" = "true" ]; then


### PR DESCRIPTION
The implement.yml and review_autofix.yml commit steps used a blanket
':!scripts' pathspec exclusion for consumer repos, which was intended
to prevent runtime-fetched helper scripts from being committed. However,
this also blocked legitimate consumer-repo-owned scripts (e.g.
scripts/security/check-npm-audit.js), causing false ai:implementation-failed
labels when Codex successfully created files under scripts/.

The runtime-fetched helpers are already excluded by the bootstrap-generated
scripts/.gitignore, making the blanket exclusion both redundant and harmful.

Remove ':!scripts' from git-add pathspecs in both workflows while keeping
all other exclusions (prompts/, .github/prompts/, .github/scripts/) intact.

https://claude.ai/code/session_01XaHQn21FdznwTfFBoeQH8Y