### PR TITLE
claude/analyze-job-logs-JH1Fd

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2004,11 +2004,11 @@ jobs:
               # file-change claims; without this guard those bullets trigger
               # a false-positive EDITOR_CHANGES_LOST error.
               first_line="$(printf '%s\n' "${changes_section}" | grep -vE '^[[:space:]]*$' | head -1 || true)"
-              if printf '%s\n' "${first_line}" | grep -qiE '^[[:space:]]*-[[:space:]]*none'; then
+              if printf '%s\n' "${first_line}" | grep -qiE '^[[:space:]]*-[[:space:]]*none([[:space:]]|$)'; then
                 has_real_changes="false"
               else
                 # Strip lines that are blank or match "- none*"
-                substantive="$(printf '%s\n' "${changes_section}" | grep -vE '^[[:space:]]*$' | grep -vE '^[[:space:]]*-[[:space:]]*none' || true)"
+                substantive="$(printf '%s\n' "${changes_section}" | grep -vE '^[[:space:]]*$' | grep -viE '^[[:space:]]*-[[:space:]]*none([[:space:]]|$)' || true)"
                 if [ -n "${substantive}" ]; then
                   has_real_changes="true"
                 fi

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1997,10 +1997,21 @@ jobs:
             # "- none" variants).
             has_real_changes="false"
             if [ -n "${changes_section}" ]; then
-              # Strip lines that are blank or match "- none*"
-              substantive="$(printf '%s\n' "${changes_section}" | grep -vE '^[[:space:]]*$' | grep -vE '^[[:space:]]*-[[:space:]]*none' || true)"
-              if [ -n "${substantive}" ]; then
-                has_real_changes="true"
+              # If the first non-blank line is a "- none" variant (with any
+              # trailing description), treat the entire section as "no changes".
+              # Editors may append informational bullets (validation runs,
+              # missing-context notes) below "- none" that are not real
+              # file-change claims; without this guard those bullets trigger
+              # a false-positive EDITOR_CHANGES_LOST error.
+              first_line="$(printf '%s\n' "${changes_section}" | grep -vE '^[[:space:]]*$' | head -1 || true)"
+              if printf '%s\n' "${first_line}" | grep -qiE '^[[:space:]]*-[[:space:]]*none'; then
+                has_real_changes="false"
+              else
+                # Strip lines that are blank or match "- none*"
+                substantive="$(printf '%s\n' "${changes_section}" | grep -vE '^[[:space:]]*$' | grep -vE '^[[:space:]]*-[[:space:]]*none' || true)"
+                if [ -n "${substantive}" ]; then
+                  has_real_changes="true"
+                fi
               fi
             fi
 


### PR DESCRIPTION
When the editor summary's "Changes made:" section starts with "- none"
but also includes informational bullets (validation runs, missing-context
notes), the has_real_changes filter incorrectly treated those non-change
bullets as substantive entries. This triggered a spurious
EDITOR_CHANGES_LOST=true, causing the workflow to re-dispatch itself and
skip auto-merge — even though no changes were actually lost.

Fix: when the first non-blank line in the section is a "- none" variant,
short-circuit has_real_changes to false regardless of subsequent bullets.

https://claude.ai/code/session_01QRyHJZzxEb2aeDkJHpav4K