### PR TITLE
claude/investigate-pr-1167-judge-8h1lY

### DIFF
--- a/.github/workflows/issue_pr_status.yml
+++ b/.github/workflows/issue_pr_status.yml
@@ -234,11 +234,28 @@ jobs:
               --silent 2>/dev/null || echo "::warning::Could not create label '${FINAL_LABEL}' (may already exist or lack permissions)."
           fi
 
+          # Phase labels that are mutually exclusive — at most one should
+          # be present.  Defined as a jq-parseable array for the PUT swap.
+          _AI_PHASE_LABELS='["ai:done","ai:implementing","ai:awaiting-approval","ai:planning","ai:clarification","ai:ready-to-merge","ai:review-blocked","ai:implementation-failed","ai:merged","ai:closed"]'
           while IFS= read -r issue_number; do
             [ -n "${issue_number}" ] || continue
             echo "Updating issue #${issue_number} with label ${FINAL_LABEL}"
-            if ! gh_retry gh issue edit "${issue_number}" -R "${REPOSITORY}" --remove-label 'ai:done' --remove-label 'ai:implementing' --remove-label 'ai:awaiting-approval' --remove-label 'ai:planning' --remove-label 'ai:clarification' --remove-label 'ai:ready-to-merge' --remove-label 'ai:review-blocked' --remove-label 'ai:implementation-failed' --remove-label 'ai:merged' --remove-label 'ai:closed' --add-label "${FINAL_LABEL}"; then
-              echo "::warning::Failed to update labels on issue #${issue_number}."
+            # Fetch current labels (1 call) then atomically replace via PUT
+            # (1 call).  This avoids the `gh issue edit --remove-label`
+            # failure mode where a label that does not exist as a repo
+            # label definition aborts the entire edit command, leaving the
+            # issue with stale phase labels and no target label applied.
+            _cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+              --jq '[.[].name]' 2>/dev/null || echo '[]')"
+            _new="$(echo "${_cur}" | jq -c --argjson p "${_AI_PHASE_LABELS}" --arg t "${FINAL_LABEL}" \
+              '(. - $p) + [$t] | unique')"
+            if ! printf '{"labels":%s}' "${_new}" | \
+              gh_retry gh api -X PUT "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+                --input - >/dev/null 2>&1; then
+              echo "::warning::PUT labels failed for #${issue_number} — falling back to POST add."
+              gh_retry gh api -X POST "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+                -f "labels[]=${FINAL_LABEL}" >/dev/null 2>&1 \
+                || echo "::warning::POST fallback also failed for #${issue_number}."
             fi
 
             if [ "${PR_MERGED}" != "true" ] || [ "${PR_BASE_REF}" = "main" ]; then

--- a/.github/workflows/issue_pr_status.yml
+++ b/.github/workflows/issue_pr_status.yml
@@ -245,8 +245,8 @@ jobs:
             # failure mode where a label that does not exist as a repo
             # label definition aborts the entire edit command, leaving the
             # issue with stale phase labels and no target label applied.
-            if ! _cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${issue_number}/labels" \
-              --jq '[.[].name]' 2>/dev/null)"; then
+            if ! _cur="$(gh_retry gh api --paginate "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+              --jq '[.[].name]' 2>/dev/null | jq -cs 'add // []')"; then
               echo "::warning::GET labels failed for #${issue_number} — falling back to POST add."
               gh_retry gh api -X POST "repos/${REPOSITORY}/issues/${issue_number}/labels" \
                 -f "labels[]=${FINAL_LABEL}" >/dev/null 2>&1 \

--- a/.github/workflows/issue_pr_status.yml
+++ b/.github/workflows/issue_pr_status.yml
@@ -245,8 +245,15 @@ jobs:
             # failure mode where a label that does not exist as a repo
             # label definition aborts the entire edit command, leaving the
             # issue with stale phase labels and no target label applied.
-            _cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${issue_number}/labels" \
-              --jq '[.[].name]' 2>/dev/null || echo '[]')"
+            if ! _cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+              --jq '[.[].name]' 2>/dev/null)"; then
+              echo "::warning::GET labels failed for #${issue_number} — falling back to POST add."
+              gh_retry gh api -X POST "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+                -f "labels[]=${FINAL_LABEL}" >/dev/null 2>&1 \
+                || echo "::warning::POST fallback also failed for #${issue_number}."
+              continue
+            fi
+            _cur="${_cur:-[]}"
             _new="$(echo "${_cur}" | jq -c --argjson p "${_AI_PHASE_LABELS}" --arg t "${FINAL_LABEL}" \
               '(. - $p) + [$t] | unique')"
             if ! printf '{"labels":%s}' "${_new}" | \

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2998,10 +2998,29 @@ jobs:
           fi
 
           ensure_label_exists "ai:ready-to-merge" "${REPOSITORY}"
+          # Phase labels that are mutually exclusive — at most one should
+          # be present.  Defined as a jq-parseable array for the PUT swap.
+          _AI_PHASE_LABELS='["ai:done","ai:implementing","ai:awaiting-approval","ai:planning","ai:clarification","ai:ready-to-merge","ai:review-blocked","ai:merged","ai:closed"]'
           while IFS= read -r issue_number; do
             [ -n "${issue_number}" ] || continue
             echo "Setting ai:ready-to-merge on issue #${issue_number}"
-            gh_retry gh issue edit "${issue_number}" --repo "${REPOSITORY}" --remove-label 'ai:done' --remove-label 'ai:implementing' --remove-label 'ai:awaiting-approval' --remove-label 'ai:planning' --remove-label 'ai:clarification' --remove-label 'ai:ready-to-merge' --remove-label 'ai:review-blocked' --remove-label 'ai:merged' --remove-label 'ai:closed' --add-label 'ai:ready-to-merge' || true
+            # Fetch current labels (1 call) then atomically replace via PUT
+            # (1 call).  This avoids the `gh issue edit --remove-label`
+            # failure mode where a label that does not exist as a repo
+            # label definition aborts the entire edit command, leaving the
+            # issue with stale phase labels and no target label applied.
+            _cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+              --jq '[.[].name]' 2>/dev/null || echo '[]')"
+            _new="$(echo "${_cur}" | jq -c --argjson p "${_AI_PHASE_LABELS}" \
+              '(. - $p) + ["ai:ready-to-merge"] | unique')"
+            if ! printf '{"labels":%s}' "${_new}" | \
+              gh_retry gh api -X PUT "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+                --input - >/dev/null 2>&1; then
+              echo "::warning::PUT labels failed for #${issue_number} — falling back to POST add."
+              gh_retry gh api -X POST "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+                -f 'labels[]=ai:ready-to-merge' >/dev/null 2>&1 \
+                || echo "::warning::POST fallback also failed for #${issue_number}."
+            fi
           done <<< "${ISSUE_NUMBERS}"
 
       - name: Review-blocked judge decision
@@ -3083,14 +3102,34 @@ jobs:
           fi
 
           ensure_label_exists "ai:review-blocked" "${REPOSITORY}"
+          # Phase labels that are mutually exclusive — at most one should
+          # be present.  Defined as a jq-parseable array for the PUT swap.
+          _AI_PHASE_LABELS='["ai:done","ai:implementing","ai:awaiting-approval","ai:planning","ai:clarification","ai:ready-to-merge","ai:review-blocked","ai:merged","ai:closed"]'
           while IFS= read -r issue_number; do
             [ -n "${issue_number}" ] || continue
             echo "Setting ai:review-blocked on issue #${issue_number}"
-            if ! gh issue edit "${issue_number}" --repo "${REPOSITORY}" --remove-label 'ai:done' --remove-label 'ai:implementing' --remove-label 'ai:awaiting-approval' --remove-label 'ai:planning' --remove-label 'ai:clarification' --remove-label 'ai:ready-to-merge' --remove-label 'ai:review-blocked' --remove-label 'ai:merged' --remove-label 'ai:closed' --add-label 'ai:review-blocked'; then
-              echo "::warning::Failed to update labels on issue #${issue_number} — retrying in 2s..."
-              sleep 2
-              gh issue edit "${issue_number}" --repo "${REPOSITORY}" --add-label 'ai:review-blocked' \
-                || echo "::warning::Retry also failed for issue #${issue_number}. Label may need manual application."
+            # Fetch current labels (1 call) then atomically replace via PUT
+            # (1 call).  This avoids the `gh issue edit --remove-label`
+            # failure mode where a label that does not exist as a repo
+            # label definition aborts the entire edit command, leaving the
+            # issue with stale phase labels and no target label applied.
+            _cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+              --jq '[.[].name]' 2>/dev/null || echo '[]')"
+            _new="$(echo "${_cur}" | jq -c --argjson p "${_AI_PHASE_LABELS}" \
+              '(. - $p) + ["ai:review-blocked"] | unique')"
+            if ! printf '{"labels":%s}' "${_new}" | \
+              gh_retry gh api -X PUT "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+                --input - >/dev/null 2>&1; then
+              # Fallback: just ensure ai:review-blocked is present (1 call).
+              # This alone is sufficient for the orchestrator poller to detect
+              # the review-blocked state; stale phase labels are cosmetic.
+              echo "::warning::PUT labels failed for #${issue_number} — falling back to POST add."
+              if gh_retry gh api -X POST "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+                -f 'labels[]=ai:review-blocked' >/dev/null 2>&1; then
+                echo "  ai:review-blocked added via POST fallback on #${issue_number}."
+              else
+                echo "::warning::POST fallback also failed for #${issue_number}. Label may need manual application."
+              fi
             fi
           done <<< "${ISSUE_NUMBERS}"
 
@@ -3535,10 +3574,29 @@ jobs:
             echo "Found linked issues via PR body/title fallback: ${ISSUE_NUMBERS}"
           fi
 
+          # Phase labels that are mutually exclusive — at most one should
+          # be present.  Defined as a jq-parseable array for the PUT swap.
+          _AI_PHASE_LABELS='["ai:done","ai:implementing","ai:awaiting-approval","ai:planning","ai:clarification","ai:ready-to-merge","ai:review-blocked","ai:merged","ai:closed"]'
           while IFS= read -r issue_number; do
             [ -n "${issue_number}" ] || continue
             echo "Setting ai:review-blocked on issue #${issue_number} (workflow failure)"
-            gh_retry gh issue edit "${issue_number}" --repo "${REPOSITORY}" --remove-label 'ai:done' --remove-label 'ai:implementing' --remove-label 'ai:awaiting-approval' --remove-label 'ai:planning' --remove-label 'ai:clarification' --remove-label 'ai:ready-to-merge' --remove-label 'ai:review-blocked' --remove-label 'ai:merged' --remove-label 'ai:closed' --add-label 'ai:review-blocked' || true
+            # Fetch current labels (1 call) then atomically replace via PUT
+            # (1 call).  This avoids the `gh issue edit --remove-label`
+            # failure mode where a label that does not exist as a repo
+            # label definition aborts the entire edit command, leaving the
+            # issue with stale phase labels and no target label applied.
+            _cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+              --jq '[.[].name]' 2>/dev/null || echo '[]')"
+            _new="$(echo "${_cur}" | jq -c --argjson p "${_AI_PHASE_LABELS}" \
+              '(. - $p) + ["ai:review-blocked"] | unique')"
+            if ! printf '{"labels":%s}' "${_new}" | \
+              gh_retry gh api -X PUT "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+                --input - >/dev/null 2>&1; then
+              echo "::warning::PUT labels failed for #${issue_number} — falling back to POST add."
+              gh_retry gh api -X POST "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+                -f 'labels[]=ai:review-blocked' >/dev/null 2>&1 \
+                || echo "::warning::POST fallback also failed for #${issue_number}."
+            fi
           done <<< "${ISSUE_NUMBERS}"
 
       - name: Post review-blocked comment on PR (workflow failure)

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3000,7 +3000,7 @@ jobs:
           ensure_label_exists "ai:ready-to-merge" "${REPOSITORY}"
           # Phase labels that are mutually exclusive — at most one should
           # be present.  Defined as a jq-parseable array for the PUT swap.
-          _AI_PHASE_LABELS='["ai:done","ai:implementing","ai:awaiting-approval","ai:planning","ai:clarification","ai:ready-to-merge","ai:review-blocked","ai:merged","ai:closed"]'
+          _AI_PHASE_LABELS='["ai:done","ai:implementing","ai:awaiting-approval","ai:planning","ai:clarification","ai:ready-to-merge","ai:review-blocked","ai:implementation-failed","ai:merged","ai:closed"]'
           while IFS= read -r issue_number; do
             [ -n "${issue_number}" ] || continue
             echo "Setting ai:ready-to-merge on issue #${issue_number}"
@@ -3009,8 +3009,15 @@ jobs:
             # failure mode where a label that does not exist as a repo
             # label definition aborts the entire edit command, leaving the
             # issue with stale phase labels and no target label applied.
-            _cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${issue_number}/labels" \
-              --jq '[.[].name]' 2>/dev/null || echo '[]')"
+            if ! _cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+              --jq '[.[].name]' 2>/dev/null)"; then
+              echo "::warning::GET labels failed for #${issue_number} — falling back to POST add."
+              gh_retry gh api -X POST "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+                -f 'labels[]=ai:ready-to-merge' >/dev/null 2>&1 \
+                || echo "::warning::POST fallback also failed for #${issue_number}."
+              continue
+            fi
+            _cur="${_cur:-[]}"
             _new="$(echo "${_cur}" | jq -c --argjson p "${_AI_PHASE_LABELS}" \
               '(. - $p) + ["ai:ready-to-merge"] | unique')"
             if ! printf '{"labels":%s}' "${_new}" | \
@@ -3104,7 +3111,7 @@ jobs:
           ensure_label_exists "ai:review-blocked" "${REPOSITORY}"
           # Phase labels that are mutually exclusive — at most one should
           # be present.  Defined as a jq-parseable array for the PUT swap.
-          _AI_PHASE_LABELS='["ai:done","ai:implementing","ai:awaiting-approval","ai:planning","ai:clarification","ai:ready-to-merge","ai:review-blocked","ai:merged","ai:closed"]'
+          _AI_PHASE_LABELS='["ai:done","ai:implementing","ai:awaiting-approval","ai:planning","ai:clarification","ai:ready-to-merge","ai:review-blocked","ai:implementation-failed","ai:merged","ai:closed"]'
           while IFS= read -r issue_number; do
             [ -n "${issue_number}" ] || continue
             echo "Setting ai:review-blocked on issue #${issue_number}"
@@ -3113,8 +3120,18 @@ jobs:
             # failure mode where a label that does not exist as a repo
             # label definition aborts the entire edit command, leaving the
             # issue with stale phase labels and no target label applied.
-            _cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${issue_number}/labels" \
-              --jq '[.[].name]' 2>/dev/null || echo '[]')"
+            if ! _cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+              --jq '[.[].name]' 2>/dev/null)"; then
+              echo "::warning::GET labels failed for #${issue_number} — falling back to POST add."
+              if gh_retry gh api -X POST "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+                -f 'labels[]=ai:review-blocked' >/dev/null 2>&1; then
+                echo "  ai:review-blocked added via POST fallback on #${issue_number}."
+              else
+                echo "::warning::POST fallback also failed for #${issue_number}. Label may need manual application."
+              fi
+              continue
+            fi
+            _cur="${_cur:-[]}"
             _new="$(echo "${_cur}" | jq -c --argjson p "${_AI_PHASE_LABELS}" \
               '(. - $p) + ["ai:review-blocked"] | unique')"
             if ! printf '{"labels":%s}' "${_new}" | \
@@ -3576,7 +3593,7 @@ jobs:
 
           # Phase labels that are mutually exclusive — at most one should
           # be present.  Defined as a jq-parseable array for the PUT swap.
-          _AI_PHASE_LABELS='["ai:done","ai:implementing","ai:awaiting-approval","ai:planning","ai:clarification","ai:ready-to-merge","ai:review-blocked","ai:merged","ai:closed"]'
+          _AI_PHASE_LABELS='["ai:done","ai:implementing","ai:awaiting-approval","ai:planning","ai:clarification","ai:ready-to-merge","ai:review-blocked","ai:implementation-failed","ai:merged","ai:closed"]'
           while IFS= read -r issue_number; do
             [ -n "${issue_number}" ] || continue
             echo "Setting ai:review-blocked on issue #${issue_number} (workflow failure)"
@@ -3585,8 +3602,15 @@ jobs:
             # failure mode where a label that does not exist as a repo
             # label definition aborts the entire edit command, leaving the
             # issue with stale phase labels and no target label applied.
-            _cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${issue_number}/labels" \
-              --jq '[.[].name]' 2>/dev/null || echo '[]')"
+            if ! _cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+              --jq '[.[].name]' 2>/dev/null)"; then
+              echo "::warning::GET labels failed for #${issue_number} — falling back to POST add."
+              gh_retry gh api -X POST "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+                -f 'labels[]=ai:review-blocked' >/dev/null 2>&1 \
+                || echo "::warning::POST fallback also failed for #${issue_number}."
+              continue
+            fi
+            _cur="${_cur:-[]}"
             _new="$(echo "${_cur}" | jq -c --argjson p "${_AI_PHASE_LABELS}" \
               '(. - $p) + ["ai:review-blocked"] | unique')"
             if ! printf '{"labels":%s}' "${_new}" | \

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3009,8 +3009,8 @@ jobs:
             # failure mode where a label that does not exist as a repo
             # label definition aborts the entire edit command, leaving the
             # issue with stale phase labels and no target label applied.
-            if ! _cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${issue_number}/labels" \
-              --jq '[.[].name]' 2>/dev/null)"; then
+            if ! _cur="$(gh_retry gh api --paginate "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+              --jq '[.[].name]' 2>/dev/null | jq -cs 'add // []')"; then
               echo "::warning::GET labels failed for #${issue_number} — falling back to POST add."
               gh_retry gh api -X POST "repos/${REPOSITORY}/issues/${issue_number}/labels" \
                 -f 'labels[]=ai:ready-to-merge' >/dev/null 2>&1 \
@@ -3120,8 +3120,8 @@ jobs:
             # failure mode where a label that does not exist as a repo
             # label definition aborts the entire edit command, leaving the
             # issue with stale phase labels and no target label applied.
-            if ! _cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${issue_number}/labels" \
-              --jq '[.[].name]' 2>/dev/null)"; then
+            if ! _cur="$(gh_retry gh api --paginate "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+              --jq '[.[].name]' 2>/dev/null | jq -cs 'add // []')"; then
               echo "::warning::GET labels failed for #${issue_number} — falling back to POST add."
               if gh_retry gh api -X POST "repos/${REPOSITORY}/issues/${issue_number}/labels" \
                 -f 'labels[]=ai:review-blocked' >/dev/null 2>&1; then
@@ -3602,8 +3602,8 @@ jobs:
             # failure mode where a label that does not exist as a repo
             # label definition aborts the entire edit command, leaving the
             # issue with stale phase labels and no target label applied.
-            if ! _cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${issue_number}/labels" \
-              --jq '[.[].name]' 2>/dev/null)"; then
+            if ! _cur="$(gh_retry gh api --paginate "repos/${REPOSITORY}/issues/${issue_number}/labels" \
+              --jq '[.[].name]' 2>/dev/null | jq -cs 'add // []')"; then
               echo "::warning::GET labels failed for #${issue_number} — falling back to POST add."
               gh_retry gh api -X POST "repos/${REPOSITORY}/issues/${issue_number}/labels" \
                 -f 'labels[]=ai:review-blocked' >/dev/null 2>&1 \

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -87,8 +87,8 @@ _resilient_phase_swap()
 	local _rps_issue="$1" _rps_target="$2"
 	local _rps_phases='["ai:done","ai:implementing","ai:awaiting-approval","ai:planning","ai:clarification","ai:ready-to-merge","ai:review-blocked","ai:implementation-failed","ai:merged","ai:closed"]'
 	local _rps_cur _rps_new
-	if ! _rps_cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${_rps_issue}/labels" \
-		--jq '[.[].name]' 2>/dev/null)"; then
+	if ! _rps_cur="$(gh_retry gh api --paginate "repos/${REPOSITORY}/issues/${_rps_issue}/labels" \
+		--jq '[.[].name]' 2>/dev/null | jq -cs 'add // []')"; then
 		echo "::warning::_resilient_phase_swap: GET labels failed for #${_rps_issue} — falling back to POST add." >&2
 		gh_retry gh api -X POST "repos/${REPOSITORY}/issues/${_rps_issue}/labels" \
 			-f "labels[]=${_rps_target}" >/dev/null 2>&1 \

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -87,8 +87,15 @@ _resilient_phase_swap()
 	local _rps_issue="$1" _rps_target="$2"
 	local _rps_phases='["ai:done","ai:implementing","ai:awaiting-approval","ai:planning","ai:clarification","ai:ready-to-merge","ai:review-blocked","ai:implementation-failed","ai:merged","ai:closed"]'
 	local _rps_cur _rps_new
-	_rps_cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${_rps_issue}/labels" \
-		--jq '[.[].name]' 2>/dev/null || echo '[]')"
+	if ! _rps_cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${_rps_issue}/labels" \
+		--jq '[.[].name]' 2>/dev/null)"; then
+		echo "::warning::_resilient_phase_swap: GET labels failed for #${_rps_issue} — falling back to POST add." >&2
+		gh_retry gh api -X POST "repos/${REPOSITORY}/issues/${_rps_issue}/labels" \
+			-f "labels[]=${_rps_target}" >/dev/null 2>&1 \
+			|| echo "::warning::_resilient_phase_swap: POST fallback also failed for #${_rps_issue}." >&2
+		return 1
+	fi
+	_rps_cur="${_rps_cur:-[]}"
 	_rps_new="$(echo "${_rps_cur}" | jq -c --argjson p "${_rps_phases}" --arg t "${_rps_target}" \
 		'(. - $p) + [$t] | unique')"
 	if printf '{"labels":%s}' "${_rps_new}" | \

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -75,6 +75,33 @@ fi
 echo "judge_handled=false" >> "$GITHUB_OUTPUT"
 echo "judge_skip_reason=" >> "$GITHUB_OUTPUT"
 
+# _resilient_phase_swap <issue_number> <target_label>
+#
+# Atomically swap AI phase labels on an issue via REST API GET+PUT,
+# avoiding the `gh issue edit --remove-label` failure mode where a
+# label that does not exist as a repo label definition aborts the
+# entire command.  Falls back to POST (add-only) on PUT failure.
+# API calls: 2 (GET + PUT) happy path, 3 on fallback.
+_resilient_phase_swap()
+{
+	local _rps_issue="$1" _rps_target="$2"
+	local _rps_phases='["ai:done","ai:implementing","ai:awaiting-approval","ai:planning","ai:clarification","ai:ready-to-merge","ai:review-blocked","ai:implementation-failed","ai:merged","ai:closed"]'
+	local _rps_cur _rps_new
+	_rps_cur="$(gh_retry gh api "repos/${REPOSITORY}/issues/${_rps_issue}/labels" \
+		--jq '[.[].name]' 2>/dev/null || echo '[]')"
+	_rps_new="$(echo "${_rps_cur}" | jq -c --argjson p "${_rps_phases}" --arg t "${_rps_target}" \
+		'(. - $p) + [$t] | unique')"
+	if printf '{"labels":%s}' "${_rps_new}" | \
+		gh_retry gh api -X PUT "repos/${REPOSITORY}/issues/${_rps_issue}/labels" \
+			--input - >/dev/null 2>&1; then
+		return 0
+	fi
+	echo "::warning::_resilient_phase_swap: PUT failed for #${_rps_issue} — falling back to POST add." >&2
+	gh_retry gh api -X POST "repos/${REPOSITORY}/issues/${_rps_issue}/labels" \
+		-f "labels[]=${_rps_target}" >/dev/null 2>&1 \
+		|| echo "::warning::_resilient_phase_swap: POST fallback also failed for #${_rps_issue}." >&2
+}
+
 if [ "${ENABLE_REVIEW_BLOCKED_JUDGE}" != "true" ]; then
   echo "Review-blocked judge disabled (set ENABLE_REVIEW_BLOCKED_JUDGE=true to enable)."
   echo "judge_skip_reason=disabled" >> "$GITHUB_OUTPUT"
@@ -364,11 +391,7 @@ case "${RB_ACTION}" in
     ensure_label_exists "ai:ready-to-merge" "${REPOSITORY}"
     while IFS= read -r issue_number; do
       [ -n "${issue_number}" ] || continue
-      gh_retry gh issue edit "${issue_number}" --repo "${REPOSITORY}" \
-        --remove-label 'ai:done' --remove-label 'ai:implementing' --remove-label 'ai:awaiting-approval' \
-        --remove-label 'ai:planning' --remove-label 'ai:clarification' --remove-label 'ai:ready-to-merge' \
-        --remove-label 'ai:review-blocked' --remove-label 'ai:merged' --remove-label 'ai:closed' \
-        --add-label 'ai:ready-to-merge' || true
+      _resilient_phase_swap "${issue_number}" "ai:ready-to-merge" || true
     done <<< "${ISSUE_NUMBERS}"
 
     # Attempt merge.
@@ -437,11 +460,7 @@ case "${RB_ACTION}" in
       ensure_label_exists "ai:ready-to-merge" "${REPOSITORY}"
       while IFS= read -r issue_number; do
         [ -n "${issue_number}" ] || continue
-        gh_retry gh issue edit "${issue_number}" --repo "${REPOSITORY}" \
-          --remove-label 'ai:done' --remove-label 'ai:implementing' --remove-label 'ai:awaiting-approval' \
-          --remove-label 'ai:planning' --remove-label 'ai:clarification' --remove-label 'ai:ready-to-merge' \
-          --remove-label 'ai:review-blocked' --remove-label 'ai:merged' --remove-label 'ai:closed' \
-          --add-label 'ai:ready-to-merge' || true
+        _resilient_phase_swap "${issue_number}" "ai:ready-to-merge" || true
       done <<< "${ISSUE_NUMBERS}"
 
       PR_STATE="$(gh_retry gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.state' 2>/dev/null | grep -xE 'open|closed|merged' || echo "")"
@@ -588,9 +607,7 @@ ${RB_FIX_DESC}"
     ensure_label_exists "ai:closed" "${REPOSITORY}"
     while IFS= read -r issue_number; do
       [ -n "${issue_number}" ] || continue
-      gh_retry gh issue edit "${issue_number}" --repo "${REPOSITORY}" \
-        --remove-label 'ai:review-blocked' --remove-label 'ai:done' \
-        --add-label 'ai:closed' 2>/dev/null || true
+      _resilient_phase_swap "${issue_number}" "ai:closed" || true
     done <<< "${ISSUE_NUMBERS}"
 
     # Create replacement issue


### PR DESCRIPTION
The `gh issue edit --remove-label` command fails atomically when any
label in the removal list does not exist as a repo label definition,
even if that label isn't on the issue.  This caused the review-blocked
label to never be applied (PR #1167 / issue #1156), creating a dead-end
where neither the in-workflow judge nor the orchestrator poller judge
could fire.

Replace all three fragile sites in review_autofix.yml with a two-step
REST API pattern:
1. GET current labels on the issue (1 API call)
2. PUT the computed replacement set: (current - phase_labels) + target
   (1 API call, atomic)
3. POST fallback if PUT fails — just adds the target label so the
   orchestrator poller can still detect the review-blocked state

Affected steps:
- "Mark linked issues ready to merge" (line ~3000)
- "Mark linked issues review-blocked (autofix exhaustion)" (line ~3104)
- "Mark linked issues review-blocked (workflow failure)" (line ~3577)

https://claude.ai/code/session_013bz4APFEmhzc4FodgraWDP