### PR TITLE
claude/analyze-job-logs-Clxrx

### DIFF
--- a/scripts/validate_driver.sh
+++ b/scripts/validate_driver.sh
@@ -513,6 +513,8 @@ wait_for_health()
 			app_log_tail="$(tail -n "${TAIL_LINES}" "${app_service_log}" 2>/dev/null || echo "(no service log)")"
 			{
 				echo "=== ${APP_SERVICE} timeout diagnostics ==="
+				echo "--- ${APP_SERVICE} log tail ---"
+				echo "${app_log_tail}"
 				echo "--- docker compose ps ---"
 				docker compose -f "${COMPOSE_FILE}" ps 2>&1 || true
 				if [ -n "${container_id}" ]; then
@@ -523,8 +525,6 @@ wait_for_health()
 						docker inspect -f '{{if .State.Health}}{{range .State.Health.Log}}exit={{.ExitCode}} start={{.Start}} output={{.Output}}{{"\n"}}{{end}}{{else}}no healthcheck configured{{end}}' \
 							"${container_id}" 2>&1 || true
 				fi
-				echo "--- ${APP_SERVICE} log tail ---"
-				echo "${app_log_tail}"
 				echo "=== end diagnostics ==="
 			} >> "${app_service_log}" 2>&1 || true
 			capture_compose_logs

--- a/scripts/validate_driver.sh
+++ b/scripts/validate_driver.sh
@@ -462,7 +462,10 @@ wait_for_health()
 		service_ready=0
 		url_ready=1
 
-		container_id="$(docker compose -f "${COMPOSE_FILE}" ps -q --all -- "${APP_SERVICE}" | head -n1 || true)"
+		container_id="$(docker compose -f "${COMPOSE_FILE}" ps -q --all -- "${APP_SERVICE}" 2>/dev/null | head -n1 || true)"
+		if [ -z "${container_id}" ]; then
+			container_id="$(docker compose -f "${COMPOSE_FILE}" ps -q -- "${APP_SERVICE}" 2>/dev/null | head -n1 || true)"
+		fi
 		if [ -n "${container_id}" ]; then
 			running="$(docker inspect -f '{{.State.Running}}' "${container_id}" 2>/dev/null || echo false)"
 			health="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "${container_id}" 2>/dev/null || echo unknown)"

--- a/scripts/validate_driver.sh
+++ b/scripts/validate_driver.sh
@@ -514,6 +514,10 @@ wait_for_health()
 			app_log_tail="$(tail -n "${TAIL_LINES}" "${app_service_log}" 2>/dev/null || echo "(no service log)")"
 			{
 				echo "=== ${APP_SERVICE} timeout diagnostics ==="
+				# Write app log tail first so the final tailed failure payload
+				# still retains infra diagnostics at the end.
+				echo "--- ${APP_SERVICE} log tail ---"
+				echo "${app_log_tail}"
 				echo "--- docker compose ps ---"
 				docker compose -f "${COMPOSE_FILE}" ps 2>&1 || true
 				if [ -n "${container_id}" ]; then
@@ -521,11 +525,9 @@ wait_for_health()
 					docker inspect -f 'Status={{.State.Status}} Running={{.State.Running}} ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} RestartCount={{.RestartCount}} Health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' \
 						"${container_id}" 2>&1 || true
 					echo "--- docker inspect health log (${APP_SERVICE}) ---"
-						docker inspect -f '{{if .State.Health}}{{range .State.Health.Log}}exit={{.ExitCode}} start={{.Start}} output={{.Output}}{{"\n"}}{{end}}{{else}}no healthcheck configured{{end}}' \
-							"${container_id}" 2>&1 | tail -n 5 || true
+					docker inspect -f '{{if .State.Health}}{{range .State.Health.Log}}exit={{.ExitCode}} start={{.Start}} output={{.Output}}{{"\n"}}{{end}}{{else}}no healthcheck configured{{end}}' \
+						"${container_id}" 2>&1 | tail -n 5 || true
 				fi
-				echo "--- ${APP_SERVICE} log tail ---"
-				echo "${app_log_tail}"
 				echo "=== end diagnostics ==="
 			} >> "${app_service_log}" 2>&1 || true
 			capture_compose_logs

--- a/scripts/validate_driver.sh
+++ b/scripts/validate_driver.sh
@@ -188,7 +188,15 @@ capture_service_logs()
 	local dest="${LOG_DIR}/${safe_service}.log"
 	if [ -f "${COMPOSE_FILE}" ]; then
 		mkdir -p "$(dirname -- "${dest}")" >/dev/null 2>&1 || true
-		docker compose -f "${COMPOSE_FILE}" logs --no-color -- "${service}" > "${dest}" 2>&1 || true
+		local service_log_tmp
+		service_log_tmp="$(mktemp "${TMPDIR:-/tmp}/service_capture.XXXXXX" 2>/dev/null || true)"
+		if [ -n "${service_log_tmp}" ]; then
+			docker compose -f "${COMPOSE_FILE}" logs --no-color -- "${service}" > "${service_log_tmp}" 2>&1 || true
+			if [ -s "${service_log_tmp}" ]; then
+				mv "${service_log_tmp}" "${dest}"
+			fi
+			rm -f "${service_log_tmp}" >/dev/null 2>&1 || true
+		fi
 	fi
 }
 
@@ -453,7 +461,7 @@ wait_for_health()
 		service_ready=0
 		url_ready=1
 
-		container_id="$(docker compose -f "${COMPOSE_FILE}" ps -q -- "${APP_SERVICE}" | head -n1 || true)"
+		container_id="$(docker compose -f "${COMPOSE_FILE}" ps -q --all -- "${APP_SERVICE}" | head -n1 || true)"
 		if [ -n "${container_id}" ]; then
 			running="$(docker inspect -f '{{.State.Running}}' "${container_id}" 2>/dev/null || echo false)"
 			health="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "${container_id}" 2>/dev/null || echo unknown)"
@@ -509,10 +517,10 @@ wait_for_health()
 				docker compose -f "${COMPOSE_FILE}" ps 2>&1 || true
 				if [ -n "${container_id}" ]; then
 					echo "--- docker inspect state (${APP_SERVICE}) ---"
-					docker inspect -f 'Status={{.State.Status}} Running={{.State.Running}} ExitCode={{.State.ExitCode}} RestartCount={{.RestartCount}} Health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' \
+					docker inspect -f 'Status={{.State.Status}} Running={{.State.Running}} ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} RestartCount={{.RestartCount}} Health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' \
 						"${container_id}" 2>&1 || true
 					echo "--- docker inspect health log (${APP_SERVICE}) ---"
-						docker inspect -f '{{if .State.Health}}{{range .State.Health.Log}}{{.Output}}{{end}}{{else}}no healthcheck configured{{end}}' \
+						docker inspect -f '{{if .State.Health}}{{range .State.Health.Log}}exit={{.ExitCode}} start={{.Start}} output={{.Output}}{{"\n"}}{{end}}{{else}}no healthcheck configured{{end}}' \
 							"${container_id}" 2>&1 || true
 				fi
 				echo "--- ${APP_SERVICE} log tail ---"

--- a/scripts/validate_driver.sh
+++ b/scripts/validate_driver.sh
@@ -179,7 +179,15 @@ capture_service_log()
 	local dest="$2"
 	if [ -f "${COMPOSE_FILE}" ]; then
 		mkdir -p "$(dirname -- "${dest}")" >/dev/null 2>&1 || true
-		docker compose -f "${COMPOSE_FILE}" logs --no-color "${service}" > "${dest}" 2>&1 || true
+		local service_log_tmp
+		service_log_tmp="$(mktemp "${TMPDIR:-/tmp}/service_capture.XXXXXX" 2>/dev/null || true)"
+		if [ -n "${service_log_tmp}" ]; then
+			docker compose -f "${COMPOSE_FILE}" logs --no-color "${service}" > "${service_log_tmp}" 2>&1 || true
+			if [ -s "${service_log_tmp}" ]; then
+				mv "${service_log_tmp}" "${dest}"
+			fi
+			rm -f "${service_log_tmp}" >/dev/null 2>&1 || true
+		fi
 	fi
 }
 
@@ -208,7 +216,7 @@ collect_container_diagnostics()
 				docker inspect -f 'Status={{.State.Status}} Running={{.State.Running}} ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}}' "${cid}" 2>/dev/null || true
 			echo ""
 			echo "=== healthcheck log (last 5 probes) ==="
-			docker inspect --format '{{if .State.Health}}{{range .State.Health.Log}}exit={{.ExitCode}} start={{.Start}} output={{.Output}}{{end}}{{else}}no healthcheck configured{{end}}' "${cid}" 2>/dev/null | tail -n 5 || true
+			docker inspect --format '{{if .State.Health}}{{range .State.Health.Log}}exit={{.ExitCode}} start={{.Start}} output={{.Output}}{{"\n"}}{{end}}{{else}}no healthcheck configured{{end}}' "${cid}" 2>/dev/null | tail -n 5 || true
 		else
 			echo "=== no container found for service ${service} ==="
 		fi
@@ -489,26 +497,23 @@ wait_for_health()
 			collect_container_diagnostics "${APP_SERVICE}" "${diag_log}"
 			capture_compose_logs
 
-			local merged_timeout_log
-			merged_timeout_log="$(mktemp "${TMPDIR:-/tmp}/health_timeout.XXXXXX" 2>/dev/null || true)"
-			if [ -n "${merged_timeout_log}" ]; then
-				{
-					if [ -s "${diag_log}" ]; then
-						echo "=== container diagnostics (${APP_SERVICE}) ==="
-						cat "${diag_log}"
-						echo ""
-					fi
-					if [ -s "${app_log}" ]; then
-						echo "=== ${APP_SERVICE} logs (last 80 lines) ==="
-						tail -n 80 "${app_log}"
-						echo ""
-					fi
-				} > "${merged_timeout_log}"
-				if [ -s "${merged_timeout_log}" ]; then
-					fail_fast "startup_health_timeout" "service did not become healthy within HEALTH_TIMEOUT seconds" "${merged_timeout_log}" "health" 1
+			local merged_timeout_log="${LOG_DIR}/${APP_SERVICE}.health_timeout.log"
+			{
+				if [ -s "${diag_log}" ]; then
+					echo "=== container diagnostics (${APP_SERVICE}) ==="
+					cat "${diag_log}"
+					echo ""
 				fi
-				rm -f "${merged_timeout_log}" >/dev/null 2>&1 || true
+				if [ -s "${app_log}" ]; then
+					echo "=== ${APP_SERVICE} logs (last 80 lines) ==="
+					tail -n 80 "${app_log}"
+					echo ""
+				fi
+			} > "${merged_timeout_log}"
+			if [ -s "${merged_timeout_log}" ]; then
+				fail_fast "startup_health_timeout" "service did not become healthy within HEALTH_TIMEOUT seconds" "${merged_timeout_log}" "health" 1
 			fi
+			rm -f "${merged_timeout_log}" >/dev/null 2>&1 || true
 			fail_fast "startup_health_timeout" "service did not become healthy within HEALTH_TIMEOUT seconds" "${COMPOSE_LOG}" "health"
 		fi
 

--- a/scripts/validate_driver.sh
+++ b/scripts/validate_driver.sh
@@ -173,6 +173,48 @@ capture_compose_logs()
 	fi
 }
 
+capture_service_log()
+{
+	local service="$1"
+	local dest="$2"
+	if [ -f "${COMPOSE_FILE}" ]; then
+		mkdir -p "$(dirname -- "${dest}")" >/dev/null 2>&1 || true
+		docker compose -f "${COMPOSE_FILE}" logs --no-color "${service}" > "${dest}" 2>&1 || true
+	fi
+}
+
+collect_container_diagnostics()
+{
+	local service="$1"
+	local dest="$2"
+	if [ ! -f "${COMPOSE_FILE}" ]; then
+		return 0
+	fi
+	mkdir -p "$(dirname -- "${dest}")" >/dev/null 2>&1 || true
+	{
+		echo "=== docker compose ps ==="
+		docker compose -f "${COMPOSE_FILE}" ps 2>&1 || true
+		echo ""
+
+		local cid
+		cid="$(docker compose -f "${COMPOSE_FILE}" ps -q "${service}" 2>/dev/null | head -n1 || true)"
+		if [ -z "${cid}" ]; then
+			cid="$(docker compose -f "${COMPOSE_FILE}" ps -q --status exited "${service}" 2>/dev/null | head -n1 || true)"
+		fi
+
+		if [ -n "${cid}" ]; then
+			echo "=== docker inspect ${service} (state) ==="
+			docker inspect -f '{{json .State}}' "${cid}" 2>/dev/null | python3 -m json.tool 2>/dev/null || \
+				docker inspect -f 'Status={{.State.Status}} Running={{.State.Running}} ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}}' "${cid}" 2>/dev/null || true
+			echo ""
+			echo "=== healthcheck log (last 5 probes) ==="
+			docker inspect --format '{{if .State.Health}}{{range .State.Health.Log}}exit={{.ExitCode}} start={{.Start}} output={{.Output}}{{end}}{{else}}no healthcheck configured{{end}}' "${cid}" 2>/dev/null | tail -n 5 || true
+		else
+			echo "=== no container found for service ${service} ==="
+		fi
+	} > "${dest}" 2>&1 || true
+}
+
 append_failure()
 {
 	local test_name="$1"
@@ -261,18 +303,18 @@ print(
 
 teardown()
 {
-	local preserve_startup_failure_log=0
+	local preserve_failure_log=0
 
 	if [ "${TEARDOWN_DONE}" = "1" ]; then
 		return 0
 	fi
 
 	TEARDOWN_DONE=1
-	if [ "${RESULT}" = "fail" ] && [ "${PHASE}" = "startup" ]; then
-		preserve_startup_failure_log=1
+	if [ "${RESULT}" = "fail" ] && { [ "${PHASE}" = "startup" ] || [ "${PHASE}" = "health" ]; }; then
+		preserve_failure_log=1
 	fi
 
-	if [ "${preserve_startup_failure_log}" != "1" ]; then
+	if [ "${preserve_failure_log}" != "1" ]; then
 		capture_compose_logs
 	fi
 
@@ -280,7 +322,7 @@ teardown()
 		docker compose -f "${COMPOSE_FILE}" down -v --remove-orphans >/dev/null 2>&1 || true
 	fi
 
-	if [ "${preserve_startup_failure_log}" != "1" ]; then
+	if [ "${preserve_failure_log}" != "1" ]; then
 		capture_compose_logs
 	fi
 }
@@ -441,7 +483,32 @@ wait_for_health()
 		fi
 
 		if [ "$(date +%s)" -ge "${deadline}" ]; then
+			local app_log="${LOG_DIR}/${APP_SERVICE}.log"
+			local diag_log="${LOG_DIR}/${APP_SERVICE}.diagnostics"
+			capture_service_log "${APP_SERVICE}" "${app_log}"
+			collect_container_diagnostics "${APP_SERVICE}" "${diag_log}"
 			capture_compose_logs
+
+			local merged_timeout_log
+			merged_timeout_log="$(mktemp "${TMPDIR:-/tmp}/health_timeout.XXXXXX" 2>/dev/null || true)"
+			if [ -n "${merged_timeout_log}" ]; then
+				{
+					if [ -s "${diag_log}" ]; then
+						echo "=== container diagnostics (${APP_SERVICE}) ==="
+						cat "${diag_log}"
+						echo ""
+					fi
+					if [ -s "${app_log}" ]; then
+						echo "=== ${APP_SERVICE} logs (last 80 lines) ==="
+						tail -n 80 "${app_log}"
+						echo ""
+					fi
+				} > "${merged_timeout_log}"
+				if [ -s "${merged_timeout_log}" ]; then
+					fail_fast "startup_health_timeout" "service did not become healthy within HEALTH_TIMEOUT seconds" "${merged_timeout_log}" "health" 1
+				fi
+				rm -f "${merged_timeout_log}" >/dev/null 2>&1 || true
+			fi
 			fail_fast "startup_health_timeout" "service did not become healthy within HEALTH_TIMEOUT seconds" "${COMPOSE_LOG}" "health"
 		fi
 

--- a/scripts/validate_driver.sh
+++ b/scripts/validate_driver.sh
@@ -171,7 +171,7 @@ capture_compose_logs()
 		if [ -n "${compose_log_tmp}" ]; then
 			docker compose -f "${COMPOSE_FILE}" logs --no-color > "${compose_log_tmp}" 2>&1 || true
 			if [ -s "${compose_log_tmp}" ]; then
-				mv "${compose_log_tmp}" "${COMPOSE_LOG}"
+				mv "${compose_log_tmp}" "${COMPOSE_LOG}" 2>/dev/null || true
 			fi
 			rm -f "${compose_log_tmp}" >/dev/null 2>&1 || true
 		fi
@@ -194,7 +194,7 @@ capture_service_logs()
 		if [ -n "${service_log_tmp}" ]; then
 			docker compose -f "${COMPOSE_FILE}" logs --no-color -- "${service}" > "${service_log_tmp}" 2>&1 || true
 			if [ -s "${service_log_tmp}" ]; then
-				mv "${service_log_tmp}" "${dest}"
+				mv "${service_log_tmp}" "${dest}" 2>/dev/null || true
 			fi
 			rm -f "${service_log_tmp}" >/dev/null 2>&1 || true
 		fi
@@ -431,7 +431,7 @@ start_compose()
 				fi
 			} > "${merged_log}"
 			mkdir -p "$(dirname -- "${COMPOSE_LOG}")" >/dev/null 2>&1 || true
-			mv "${merged_log}" "${COMPOSE_LOG}"
+			mv "${merged_log}" "${COMPOSE_LOG}" 2>/dev/null || true
 		fi
 		rm -f "${build_log}" >/dev/null 2>&1 || true
 		fail_fast "preflight_compose_up" "failed to build/start compose services" "${COMPOSE_LOG}" "startup" 1

--- a/scripts/validate_driver.sh
+++ b/scripts/validate_driver.sh
@@ -188,6 +188,7 @@ capture_service_logs()
 	local dest="${LOG_DIR}/${safe_service}.log"
 	if [ -f "${COMPOSE_FILE}" ]; then
 		mkdir -p "$(dirname -- "${dest}")" >/dev/null 2>&1 || true
+		: > "${dest}" 2>/dev/null || true
 		local service_log_tmp
 		service_log_tmp="$(mktemp "${TMPDIR:-/tmp}/service_capture.XXXXXX" 2>/dev/null || true)"
 		if [ -n "${service_log_tmp}" ]; then
@@ -513,8 +514,6 @@ wait_for_health()
 			app_log_tail="$(tail -n "${TAIL_LINES}" "${app_service_log}" 2>/dev/null || echo "(no service log)")"
 			{
 				echo "=== ${APP_SERVICE} timeout diagnostics ==="
-				echo "--- ${APP_SERVICE} log tail ---"
-				echo "${app_log_tail}"
 				echo "--- docker compose ps ---"
 				docker compose -f "${COMPOSE_FILE}" ps 2>&1 || true
 				if [ -n "${container_id}" ]; then
@@ -523,8 +522,10 @@ wait_for_health()
 						"${container_id}" 2>&1 || true
 					echo "--- docker inspect health log (${APP_SERVICE}) ---"
 						docker inspect -f '{{if .State.Health}}{{range .State.Health.Log}}exit={{.ExitCode}} start={{.Start}} output={{.Output}}{{"\n"}}{{end}}{{else}}no healthcheck configured{{end}}' \
-							"${container_id}" 2>&1 || true
+							"${container_id}" 2>&1 | tail -n 5 || true
 				fi
+				echo "--- ${APP_SERVICE} log tail ---"
+				echo "${app_log_tail}"
 				echo "=== end diagnostics ==="
 			} >> "${app_service_log}" 2>&1 || true
 			capture_compose_logs

--- a/scripts/validate_driver.sh
+++ b/scripts/validate_driver.sh
@@ -171,7 +171,9 @@ capture_compose_logs()
 		if [ -n "${compose_log_tmp}" ]; then
 			docker compose -f "${COMPOSE_FILE}" logs --no-color > "${compose_log_tmp}" 2>&1 || true
 			if [ -s "${compose_log_tmp}" ]; then
-				mv "${compose_log_tmp}" "${COMPOSE_LOG}" 2>/dev/null || true
+				if ! mv "${compose_log_tmp}" "${COMPOSE_LOG}" 2>/dev/null; then
+					cp "${compose_log_tmp}" "${COMPOSE_LOG}" 2>/dev/null || true
+				fi
 			fi
 			rm -f "${compose_log_tmp}" >/dev/null 2>&1 || true
 		fi
@@ -194,7 +196,9 @@ capture_service_logs()
 		if [ -n "${service_log_tmp}" ]; then
 			docker compose -f "${COMPOSE_FILE}" logs --no-color -- "${service}" > "${service_log_tmp}" 2>&1 || true
 			if [ -s "${service_log_tmp}" ]; then
-				mv "${service_log_tmp}" "${dest}" 2>/dev/null || true
+				if ! mv "${service_log_tmp}" "${dest}" 2>/dev/null; then
+					cp "${service_log_tmp}" "${dest}" 2>/dev/null || true
+				fi
 			fi
 			rm -f "${service_log_tmp}" >/dev/null 2>&1 || true
 		fi
@@ -431,7 +435,10 @@ start_compose()
 				fi
 			} > "${merged_log}"
 			mkdir -p "$(dirname -- "${COMPOSE_LOG}")" >/dev/null 2>&1 || true
-			mv "${merged_log}" "${COMPOSE_LOG}" 2>/dev/null || true
+			if ! mv "${merged_log}" "${COMPOSE_LOG}" 2>/dev/null; then
+				cp "${merged_log}" "${COMPOSE_LOG}" 2>/dev/null || true
+				rm -f "${merged_log}" >/dev/null 2>&1 || true
+			fi
 		fi
 		rm -f "${build_log}" >/dev/null 2>&1 || true
 		fail_fast "preflight_compose_up" "failed to build/start compose services" "${COMPOSE_LOG}" "startup" 1


### PR DESCRIPTION
The validate_driver.sh health timeout path was capturing only
interleaved compose logs (all services), causing the failure log_tail
to be dominated by MongoDB connection chatter with zero app-specific
output. This made diagnosing app startup failures impossible.

Changes:
- Add capture_service_log() for per-service log capture
- Add collect_container_diagnostics() to gather container state,
  exit code, OOM status, and healthcheck probe output on timeout
- On health timeout, prefer app-specific logs + diagnostics over
  the interleaved compose log for the failure log_tail
- Preserve compose logs for health-phase failures in teardown()
  (previously only startup-phase failures were preserved)

https://claude.ai/code/session_012HmJkoZM1EpfTJrgEnKv1o