### PR TITLE
claude/analyze-job-logs-5xB5D

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1577,12 +1577,33 @@ prepare_tracking_judge_checkout() {
 
   if target_ref="$(resolve_branch_analysis_ref "${target_branch}")"; then
     if ! git checkout -q "${target_branch}" >/dev/null 2>&1 && ! git checkout -q "${target_ref}" >/dev/null 2>&1; then
-      if [ -n "${integration_branch}" ]; then
-        echo "::error::Integration branch '${integration_branch}' exists but could not be checked out for judge context (resolved ref '${target_ref}')." >&2
-        return 1
+      # Workflow support files (scripts/, prompts/, .github/ai/) installed
+      # from coding-workflows are untracked and can block checkout when the
+      # target branch has overlapping paths.  Back them up, force-checkout,
+      # then restore so render_prompt.sh et al. remain available.
+      local _wf_backup
+      _wf_backup="$(mktemp -d)"
+      for _d in scripts prompts; do
+        [ -d "${_d}" ] && cp -a "${_d}" "${_wf_backup}/${_d}" 2>/dev/null || true
+      done
+      [ -d ".github/ai" ] && { mkdir -p "${_wf_backup}/github_ai"; cp -a ".github/ai/." "${_wf_backup}/github_ai/" 2>/dev/null || true; }
+
+      if git checkout -f -q "${target_ref}" >/dev/null 2>&1; then
+        # Force checkout succeeded — restore workflow support files
+        for _d in scripts prompts; do
+          [ -d "${_wf_backup}/${_d}" ] && { mkdir -p "${_d}"; cp -a "${_wf_backup}/${_d}/." "${_d}/" 2>/dev/null || true; }
+        done
+        [ -d "${_wf_backup}/github_ai" ] && { mkdir -p ".github/ai"; cp -a "${_wf_backup}/github_ai/." ".github/ai/" 2>/dev/null || true; }
+        rm -rf "${_wf_backup}"
+      else
+        rm -rf "${_wf_backup}"
+        if [ -n "${integration_branch}" ]; then
+          echo "::error::Integration branch '${integration_branch}' exists but could not be checked out for judge context (resolved ref '${target_ref}')." >&2
+          return 1
+        fi
+        JUDGE_EXECUTION_SOURCE="current_ref"
+        echo "::warning::Could not check out '${target_branch}' for judge context; continuing on current ref." >&2
       fi
-      JUDGE_EXECUTION_SOURCE="current_ref"
-      echo "::warning::Could not check out '${target_branch}' for judge context; continuing on current ref." >&2
     fi
   else
     if [ -n "${integration_branch}" ]; then


### PR DESCRIPTION
The "Fetch workflow support scripts" step installs files from
coding-workflows into scripts/, prompts/, and .github/ai/ as untracked
files.  When prepare_tracking_judge_checkout() later tries to switch to
the orchestrator/project-* integration branch, git checkout refuses
because the untracked files would be overwritten by the target tree.

This caused the judge evaluation to be entirely skipped (the function
returned 1, triggering `continue` at L8005), so the orchestrator could
not make progress decisions.

Fix: when both normal checkout attempts fail, back up the workflow
support directories, force-checkout the resolved ref, then restore the
backups so render_prompt.sh and other support files remain available for
the judge evaluation.

Fixes orchestrate_poll run 24518806332 (binance-blessings tracking #105).

https://claude.ai/code/session_01Um98D655PXfcxbVYd4SWbc