### PR TITLE
claude/analyze-job-logs-mc0TS

### DIFF
--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -646,6 +646,46 @@ CRITICAL — sibling imports when dynamically loading modules from subdirectorie
   directory (e.g. `/workspace/backend`) when the entry point uses bare
   sibling imports.
 
+CRITICAL — dependency_auditing binary audit MUST be a sidecar file (NOT inline Python):
+- The `dependency_auditing` category typically has two checks: (1) an import
+  audit (already uses sidecar `validation/tests/_lib/import_audit.py`) and
+  (2) a custom binary audit that AST-walks test files for subprocess calls
+  to detect unexpected external binaries. The binary audit Python snippet is
+  complex (imports `ast`, `pathlib`, `sys`; defines helper functions; uses
+  f-strings) and MUST be placed in a sidecar file, never inlined via a
+  heredoc or `python3 -c` inside `docker compose exec -T ... /bin/sh -c`.
+- Failure mode being prevented: when the binary audit is inlined, the outer
+  shell quoting layer strips single quotes from f-string expressions like
+  `f"UNEXPECTED_BINARIES {','.join(unexpected)}"`, producing the mangled
+  `f"UNEXPECTED_BINARIES {,.join(unexpected)}"` at runtime, which crashes
+  with `SyntaxError: f-string: expecting a valid expression after '{'`.
+  This is a harness defect, not an application defect.
+- Hard rule: write the binary audit as `validation/tests/_lib/binary_audit.py`
+  and invoke it from `08_dependency_auditing.sh` via:
+    if docker compose -f "$COMPOSE_FILE" exec -T "$APP_SERVICE" \
+        python3 /workspace/validation/tests/_lib/binary_audit.py \
+        >"$TMP_OUT" 2>"$TMP_ERR"; then
+      if grep -q '^BINARY_AUDIT_OK$' "$TMP_OUT"; then
+        echo "ok $ASSERTION - custom test binary audit passed (no missing external tools detected)"
+      else
+        echo "not ok $ASSERTION - custom test binary audit unexpected output"
+        exit 1
+      fi
+    else
+      echo "not ok $ASSERTION - custom test binary audit failed (exit=$?)"
+      exit 1
+    fi
+- The sidecar file MUST follow the named-variable-then-interpolate pattern
+  for any f-string output:
+    # WRONG (will break under shell re-quoting)
+    print(f"UNEXPECTED_BINARIES {','.join(unexpected)}")
+    # RIGHT
+    joined = ",".join(unexpected)
+    print(f"UNEXPECTED_BINARIES {joined}")
+- This rule applies even when the Python source would parse correctly in
+  isolation. The shell quoting hazard is latent and only manifests at
+  runtime inside the container.
+
 Validation coverage (implement only when concretely applicable):
 1. Build verification
 2. Startup and health checks


### PR DESCRIPTION
The validation harness generation model inlined the binary audit Python
snippet inside a docker compose exec /bin/sh -c wrapper, which stripped
single quotes from f-string expressions like {','.join(unexpected)},
producing {,.join(unexpected)} at runtime — a SyntaxError that caused
08_dependency_auditing.sh to fail (29/30 tests passed, 1 failed).

Add explicit CRITICAL rule in mode-validate-generate.txt requiring the
binary audit to use a sidecar file (validation/tests/_lib/binary_audit.py)
with the named-variable-then-interpolate pattern for f-string output.

https://claude.ai/code/session_01TijH5zo8Czmy2SA61ERJ6s