### PR TITLE
fix: gate editor-noop-suspicious alert on max_iterations_reached

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3538,7 +3538,7 @@ jobs:
           fi
 
       - name: Telegram editor-noop-suspicious warning
-        if: "success() && env.EDITOR_NOOP_SUSPICIOUS == 'true' && env.PR_CLOSED != 'true'"
+        if: "success() && env.EDITOR_NOOP_SUSPICIOUS == 'true' && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && env.PR_CLOSED != 'true'"
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}


### PR DESCRIPTION
## Summary

Fixes a false-positive "Editor no-op suspicious" alert that fires alongside the "Review-blocked judge pushed fix commit" alert when autofix iterations are exhausted.

**Root cause** (observed on PR #1184 / [run 24520352013](https://github.com/shubhodeep1/coding-workflows/actions/runs/24520352013)):

- When `max_iterations_reached=true`, editor/reviewer steps are intentionally skipped and the review-blocked judge takes over.
- The "Validate editor no-op disposition" step lacks the `max_iterations_reached` guard, so it still runs, finds no editor summary on disk, and sets `EDITOR_NOOP_SUSPICIOUS=true`.
- The downstream "Telegram editor-noop-suspicious warning" step also lacks the guard, so it fires a WARNING Telegram alert and posts a PR comment claiming the editor silently failed — on top of the expected CRITICAL judge alert.

**Fix:** add `steps.retrigger_guard.outputs.max_iterations_reached != 'true'` to the alert step's `if` condition at `.github/workflows/review_autofix.yml:3541` so the suspicious-no-op warning only fires on runs where the editor was actually supposed to produce output.

The disposition-validation step itself is intentionally left as-is (per the owner's direction — its `EDITOR_NOOP_SUSPICIOUS` output is already consumed as a guard on the ready-to-merge/auto-merge paths which also require `max_iterations_reached != 'true'`, so the stale flag is harmless there).

## Test plan

- [x] YAML parse check: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/review_autofix.yml'))"` passes
- [ ] Next run on a PR that hits max autofix iterations should emit only the judge CRITICAL alert, no editor-noop-suspicious WARNING alert
- [ ] Runs below the iteration cap with a genuinely suspicious no-op continue to alert as before

https://claude.ai/code/session_01PLw751tM9vkzSPSRgn3cjv