### PR TITLE
claude/analyze-workflow-logs-UibKw

### DIFF
--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -361,14 +361,18 @@ gh_retry()
 			echo "::warning::GitHub API rate limit hit (attempt ${attempt}/${max_attempts}), waiting for reset…" >&2
 			_gh_ratelimit_tg_alert
 			_gh_rate_limit_trip_breaker
-			_gh_rate_limit_wait
+			if [ "${attempt}" -lt "${max_attempts}" ]; then
+				_gh_rate_limit_wait
+			fi
 		else
 			local wait_secs=$(( 2 ** (attempt - 1) ))
 			echo "::warning::gh command failed (attempt ${attempt}/${max_attempts}), retrying in ${wait_secs}s…" >&2
 			if [ -n "${stderr_content}" ]; then
 				echo "::warning::  stderr: ${stderr_content}" >&2
 			fi
-			sleep "${wait_secs}"
+			if [ "${attempt}" -lt "${max_attempts}" ]; then
+				sleep "${wait_secs}"
+			fi
 		fi
 
 		attempt=$(( attempt + 1 ))

--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -419,14 +419,18 @@ gh_retry_to_file()
 			echo "::warning::GitHub API rate limit hit (attempt ${attempt}/${max_attempts}), waiting for reset…" >&2
 			_gh_ratelimit_tg_alert
 			_gh_rate_limit_trip_breaker
-			_gh_rate_limit_wait
+			if [ "${attempt}" -lt "${max_attempts}" ]; then
+				_gh_rate_limit_wait
+			fi
 		else
 			local wait_secs=$(( 2 ** (attempt - 1) ))
 			echo "::warning::gh command failed (attempt ${attempt}/${max_attempts}), retrying in ${wait_secs}s…" >&2
 			if [ -n "${stderr_content}" ]; then
 				echo "::warning::  stderr: ${stderr_content}" >&2
 			fi
-			sleep "${wait_secs}"
+			if [ "${attempt}" -lt "${max_attempts}" ]; then
+				sleep "${wait_secs}"
+			fi
 		fi
 
 		attempt=$(( attempt + 1 ))

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -8739,10 +8739,11 @@ for (( sidx=0; sidx<STANDALONE_COUNT; sidx++ )); do
 	# A real merge conflict returns HTTP 422 with a JSON body on stdout —
 	# retrying is pointless (the conflict won't resolve itself) and the
 	# body would leak into the log with no newline. Cap retries at 1 and
-	# silence both streams; stage 2 handles the permanent-failure path.
+	# silence stdout while preserving stderr diagnostics; stage 2 handles
+	# the permanent-failure path.
 	S_HEAD_SHA="$(echo "${S_PR_JSON}" | jq -r '.head.sha // ""')"
 	if [ -n "${S_HEAD_SHA}" ] && GH_RETRY_MAX_ATTEMPTS=1 gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${S_PR}/update-branch" \
-		-X PUT -f expected_head_sha="${S_HEAD_SHA}" >/dev/null 2>&1; then
+		-X PUT -f expected_head_sha="${S_HEAD_SHA}" >/dev/null; then
 		echo "  PR #${S_PR} branch updated via API. Synchronize event will re-trigger review."
 		CONFLICT_SWEEP_FIXED=$(( CONFLICT_SWEEP_FIXED + 1 ))
 		continue

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -8735,10 +8735,14 @@ for (( sidx=0; sidx<STANDALONE_COUNT; sidx++ )); do
 
 	echo "  PR #${S_PR} (${S_HEAD_REF}) is in conflicted mergeable state. Attempting conflict recovery..."
 
-	# Stage 1: Try the GitHub API update-branch endpoint (clean merge)
+	# Stage 1: Try the GitHub API update-branch endpoint (clean merge).
+	# A real merge conflict returns HTTP 422 with a JSON body on stdout —
+	# retrying is pointless (the conflict won't resolve itself) and the
+	# body would leak into the log with no newline. Cap retries at 1 and
+	# silence both streams; stage 2 handles the permanent-failure path.
 	S_HEAD_SHA="$(echo "${S_PR_JSON}" | jq -r '.head.sha // ""')"
-	if [ -n "${S_HEAD_SHA}" ] && gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${S_PR}/update-branch" \
-		-X PUT -f expected_head_sha="${S_HEAD_SHA}" 2>/dev/null; then
+	if [ -n "${S_HEAD_SHA}" ] && GH_RETRY_MAX_ATTEMPTS=1 gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${S_PR}/update-branch" \
+		-X PUT -f expected_head_sha="${S_HEAD_SHA}" >/dev/null 2>&1; then
 		echo "  PR #${S_PR} branch updated via API. Synchronize event will re-trigger review."
 		CONFLICT_SWEEP_FIXED=$(( CONFLICT_SWEEP_FIXED + 1 ))
 		continue


### PR DESCRIPTION
The standalone conflict sweep calls the GitHub update-branch API on
PRs in `dirty` mergeable state. On a real merge conflict the endpoint
returns HTTP 422 with a JSON body written to stdout (not stderr), so
the existing `2>/dev/null` did not silence it and the body leaked into
orchestrator logs five times in a row (once per gh_retry attempt) on
a single line with no trailing newlines. Retrying a 422 cannot succeed
— the conflict will not resolve itself — so the four extra attempts
burn ~15s and four API calls per dirty PR per sweep.

Cap retries for this specific call at 1 via GH_RETRY_MAX_ATTEMPTS=1
and redirect stdout to /dev/null as well. Stage 2 of the sweep already
handles the permanent-failure path by dispatching the review workflow.

Files changed:
- scripts/orchestrate_poll_process.sh (lines 8738-8745): stage-1
  update-branch call now attempts exactly once and emits no body.