### PR TITLE
claude/analyze-job-logs-WjwRU

### DIFF
--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -138,8 +138,8 @@ EOF
   fi
   export CODEX_HOME="${probe_home}"
 
-  codex exec --model "${probe_model}" --full-auto "$(cat "${probe_out}")" >/dev/null 2>"${probe_log_one}" || true
-  codex exec --model "${probe_model}" --full-auto "$(cat "${probe_out}")" >/dev/null 2>"${probe_log_two}" || true
+  codex exec --model "${probe_model}" --full-auto < "${probe_out}" >/dev/null 2>"${probe_log_one}" || true
+  codex exec --model "${probe_model}" --full-auto < "${probe_out}" >/dev/null 2>"${probe_log_two}" || true
 
   normalize_openrouter_usage "${probe_log_one}" "1" "${probe_model}" || true
   normalize_openrouter_usage "${probe_log_two}" "2" "${probe_model}" || true
@@ -821,7 +821,7 @@ run_reviewer() {
       fi
     fi
     (
-      exec "${codex_bin}" exec --model "${model}" --full-auto "$(cat "${prompt_file}")"
+      exec "${codex_bin}" exec --model "${model}" --full-auto < "${prompt_file}"
     ) > "${tmp_output}" 2> >(
       while IFS= read -r line || [ -n "$line" ]; do
         # Atomic heartbeat update: write to tmp then rename


### PR DESCRIPTION
The two-pass reviewer architecture (PR #1221) appends cross-pollination
context from all 5 Pass-1 reviewers to an already-large xhigh-reasoning
prompt for Pass 2.  review_run_reviewers.sh invoked codex with the prompt
expanded into a single argv entry via "$(cat "${prompt_file}")", so
execve() fails with E2BIG ("Argument list too long") once the prompt
crosses ARG_MAX (~128 KB).  All 5 reviewers then fail 3 attempts each
and the whole job exits 1.  Command substitution also silently strips
null bytes from the prompt.

Switch to stdin redirection (< "${prompt_file}"), matching the pattern
already used by every other codex exec call in the repo
(review_apply_fixes.sh, review_rb_judge.sh, self_heal_validation.sh,
validate_process.sh, orchestrate_poll_process.sh).  Same fix applied to
the cache-probe invocations on lines 141-142 for consistency — they use
the same anti-pattern and will hit the same limit once probe prompts
grow.

https://claude.ai/code/session_01VPp4btAv1C5ef2Zd9QfQPV