### PR TITLE
claude/analyze-job-logs-GAfmW

### DIFF
--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -685,6 +685,35 @@ CRITICAL — dependency_auditing binary audit MUST be a sidecar file (NOT inline
 - This rule applies even when the Python source would parse correctly in
   isolation. The shell quoting hazard is latent and only manifests at
   runtime inside the container.
+- Hard rule: the binary audit MUST extract candidate binary names ONLY from
+  structured sources. Permitted sources are exactly:
+  1. The `argv[0]` of each `custom_tests:` entry from `.ai/validate.yml`,
+     parsed via `shlex.split(entry)[0]` (after stripping a leading `timeout
+     <N>` / `env VAR=val ...` / `exec` / `command` prefix).
+  2. The `argv[0]` of any `subprocess.run`/`subprocess.call`/`subprocess.check_call`/
+     `subprocess.check_output`/`subprocess.Popen`/`os.system`/`os.popen` call
+     reached by `ast.walk` over the referenced test file, where `argv` is a
+     `ast.List` of `ast.Constant[str]` (list form) or a `ast.Constant[str]`
+     whose first whitespace-separated token is the binary (string form).
+- Forbidden: ANY regex/substring scan over the raw file text, docstring, or
+  comment body of a custom_test file as a "fallback" source of binary names.
+  This includes `re.finditer` patterns like `\b(command\s+-v|which)\s+(\w+)`
+  applied to `path.read_text()`. Such fallbacks match incidental English
+  prose ("which expects", "which causes", "which are compatible") and emit
+  false-positive `UNEXPECTED_BINARIES are,causes,expects` failures that
+  cannot be fixed by changing application code. If you need to inspect shell
+  fragments embedded in Python strings, narrow the scope to `ast.Constant[str]`
+  values whose content matches a shell-command shape (e.g. starts with a
+  known binary token), and still extract only `shlex.split(value)[0]` — never
+  word-tokens from arbitrary positions in the string.
+- Mandatory regression self-check before emitting the sidecar: simulate the
+  audit against the current `custom_tests:` set (all `python3 tests/<file>.py`
+  in this repo). The simulated output MUST be exactly `BINARY_AUDIT_OK`. If
+  the simulated output contains any token that is an English connector word
+  (e.g. `are`, `is`, `not`, `causes`, `expects`, `which`, `that`, `the`),
+  the extraction logic is wrong — discard the regex/substring path and
+  re-derive binaries from structured AST nodes only. Document this self-check
+  result in the generator's reasoning trace.
 
 Validation coverage (implement only when concretely applicable):
 1. Build verification


### PR DESCRIPTION
The AI-generated validation/tests/_lib/binary_audit.py was scanning raw
file text with `re.finditer(r"\b(command\s+-v|which)\s+([A-Za-z0-9_.+-]+)", text)`,
which matches English prose in docstrings/comments ("which expects",
"which causes", "which are compatible") and emits false-positive
`UNEXPECTED_BINARIES are,causes,expects` harness errors that cannot be
fixed in application code.

Update prompts/mode-validate-generate.txt to:
- restrict binary extraction to structured sources (custom_tests argv[0]
  via shlex.split, or AST nodes from subprocess/os.system calls);
- explicitly forbid regex/substring scans over raw file text;
- require a regression self-check against the current hints set before
  emitting the sidecar, with English connector words flagged as a defect.

https://claude.ai/code/session_01Em4BkZarNYGRVqx8JynSTb