### PR TITLE
Fix regex word boundaries in change detection logic

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2065,7 +2065,7 @@ jobs:
               # parenthetical suffix).
               edit_claim_regex='\b(modif(y|ied|ies)|update(d|s)?|change(d|s)?|add(ed|s)?|remove(d|s)?|delete(d|s)?|rename(d|s)?|create(d|s)?|fix(ed|es)?|patch(ed|es)?|implement(ed|s)?|refactor(ed|s|ing)?|tweak(ed|s|ing)?|adjust(ed|s|ing)?|improv(e|ed|es|ing)|resolv(e|ed|es|ing))\b'
               # Stricter bullet-start edit regex for multi-line contradiction checks.
-              bullet_edit_regex='^[[:space:]]*-[[:space:]]*(modif(y|ied|ies|ying)|updat(e|ed|es|ing)|change(d|s|ing)?|add(ed|s|ing)?|remov(e|ed|es|ing)|delet(e|ed|es|ing)|renam(e|ed|es|ing)|creat(e|ed|es|ing)|fix(ed|es|ing)?|patch(ed|es|ing)?|implement(ed|s|ing)?|refactor(ed|s|ing)?|tweak(ed|s|ing)?|adjust(ed|s|ing)?|improv(e|ed|es|ing)|resolv(e|ed|es|ing))([[:space:][:punct:]]|$)'
+              bullet_edit_regex='^[[:space:]]*-[[:space:]]*\b(modif(y|ied|ies|ying)|updat(e|ed|es|ing)|change(d|s|ing)?|add(ed|s|ing)?|remov(e|ed|es|ing)|delet(e|ed|es|ing)|renam(e|ed|es|ing)|creat(e|ed|es|ing)|fix(ed|es|ing)?|patch(ed|es|ing)?|implement(ed|s|ing)?|refactor(ed|s|ing)?|tweak(ed|s|ing)?|adjust(ed|s|ing)?|improv(e|ed|es|ing)|resolv(e|ed|es|ing))\b([[:space:][:punct:]]|$)'
               if printf '%s\n' "${first_line}" | grep -qiE '^[[:space:]]*-[[:space:]]*(no (repository )?files (were )?modified|no [^:]*modified|no [^:]*changed|no [^:]*touched|no changes( (were )?made)?|no modifications)([[:space:][:punct:]].*)?$'; then
                 # Explicit "no files modified / no changes made / no
                 # modifications" first-bullet is a deliberate declaration

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2034,7 +2034,7 @@ jobs:
               if [ "${change_status}" = "edited" ]; then
                 has_real_changes="true"
               elif [ -n "${changes_section}" ] && \
-                printf '%s\n' "${changes_section}" | grep -viE '^[[:space:]]*$|^[[:space:]]*-[[:space:]]*none([[:space:]]|$)|^[[:space:]]{2,}-|^[[:space:]]*-[[:space:]]*(Validation executed|Validation limitation|Ran [^:]*(validation|check|test)|Assumptions?( applied| made)|Missing[- ]context)' | grep -viE '^[[:space:]]*-[[:space:]]*(no (repository )?files (were )?modified|no [^:]*modified|no [^:]*changed|no [^:]*touched|no changes( (were )?made)?|no modifications)([[:space:][:punct:]]*)$' | grep -qiE 'modif(y|ied|ies)|update(d|s)?|change(d|s)?|add(ed|s)?|remove(d|s)?|delete(d|s)?|rename(d|s)?|create(d|s)?|fix(ed|es)?|patch(ed|es)?|implement(ed|s)?|refactor(ed|s|ing)?|tweak(ed|s|ing)?|adjust(ed|s|ing)?|improv(e|ed|es|ing)|resolv(e|ed|es|ing)'; then
+                printf '%s\n' "${changes_section}" | grep -viE '^[[:space:]]*$|^[[:space:]]*-[[:space:]]*none([[:space:]]|$)|^[[:space:]]{2,}-|^[[:space:]]*-[[:space:]]*(Validation executed|Validation limitation|Ran [^:]*(validation|check|test)|Assumptions?( applied| made)|Missing[- ]context)' | grep -viE '^[[:space:]]*-[[:space:]]*(no (repository )?files (were )?modified|no [^:]*modified|no [^:]*changed|no [^:]*touched|no changes( (were )?made)?|no modifications)([[:space:][:punct:]]*)$' | grep -qiE '\b(modif(y|ied|ies)|update(d|s)?|change(d|s)?|add(ed|s)?|remove(d|s)?|delete(d|s)?|rename(d|s)?|create(d|s)?|fix(ed|es)?|patch(ed|es)?|implement(ed|s)?|refactor(ed|s|ing)?|tweak(ed|s|ing)?|adjust(ed|s|ing)?|improv(e|ed|es|ing)|resolv(e|ed|es|ing))\b'; then
                 echo "::warning::Editor reported Change status: not-edited but Changes made contains edit-like claims; trusting Change status."
               fi
             elif [ -n "${changes_section}" ]; then
@@ -2057,7 +2057,13 @@ jobs:
               # headers), or are informational metadata bullets
               # (e.g. "- Validation executed").
               substantive="$(printf '%s\n' "${changes_section}" | grep -viE '^[[:space:]]*$|^[[:space:]]*-[[:space:]]*none([[:space:]]|$)|^[[:space:]]{2,}-|^[[:space:]]*-[[:space:]]*(Validation executed|Validation limitation|Ran [^:]*(validation|check|test)|Assumptions?( applied| made)|Missing[- ]context)' || true)"
-              edit_claim_regex='modif(y|ied|ies)|update(d|s)?|change(d|s)?|add(ed|s)?|remove(d|s)?|delete(d|s)?|rename(d|s)?|create(d|s)?|fix(ed|es)?|patch(ed|es)?|implement(ed|s)?|refactor(ed|s|ing)?|tweak(ed|s|ing)?|adjust(ed|s|ing)?|improv(e|ed|es|ing)|resolv(e|ed|es|ing)'
+              # Word-boundary anchors prevent substring matches inside
+              # identifiers (e.g. "WILL_FIX" in "(WILL_FIX issues after
+              # code validation: 0)." must not match `fix`, which would
+              # otherwise fire a false-positive EDITOR_CHANGES_LOST when
+              # the editor's "no files modified" bullet carries that
+              # parenthetical suffix).
+              edit_claim_regex='\b(modif(y|ied|ies)|update(d|s)?|change(d|s)?|add(ed|s)?|remove(d|s)?|delete(d|s)?|rename(d|s)?|create(d|s)?|fix(ed|es)?|patch(ed|es)?|implement(ed|s)?|refactor(ed|s|ing)?|tweak(ed|s|ing)?|adjust(ed|s|ing)?|improv(e|ed|es|ing)|resolv(e|ed|es|ing))\b'
               # Stricter bullet-start edit regex for multi-line contradiction checks.
               bullet_edit_regex='^[[:space:]]*-[[:space:]]*(modif(y|ied|ies|ying)|updat(e|ed|es|ing)|change(d|s|ing)?|add(ed|s|ing)?|remov(e|ed|es|ing)|delet(e|ed|es|ing)|renam(e|ed|es|ing)|creat(e|ed|es|ing)|fix(ed|es|ing)?|patch(ed|es|ing)?|implement(ed|s|ing)?|refactor(ed|s|ing)?|tweak(ed|s|ing)?|adjust(ed|s|ing)?|improv(e|ed|es|ing)|resolv(e|ed|es|ing))([[:space:][:punct:]]|$)'
               if printf '%s\n' "${first_line}" | grep -qiE '^[[:space:]]*-[[:space:]]*(no (repository )?files (were )?modified|no [^:]*modified|no [^:]*changed|no [^:]*touched|no changes( (were )?made)?|no modifications)([[:space:][:punct:]].*)?$'; then


### PR DESCRIPTION
## Summary
Updated the change detection regex patterns in the review autofix workflow to use word-boundary anchors (`\b`), preventing false-positive matches on substring occurrences within identifiers and other contexts.

## Key Changes
- Added word-boundary anchors (`\b...\b`) to the inline edit-claim regex on line 2037 to prevent substring matches
- Updated the `edit_claim_regex` variable definition (lines 2060-2067) with word-boundary anchors and added explanatory comments
- The word boundaries prevent false positives like matching `fix` within `WILL_FIX` identifiers

## Implementation Details
The change addresses a specific issue where action words like "fix", "modify", "update", etc. could match as substrings within identifiers or parenthetical suffixes (e.g., "WILL_FIX issues after code validation: 0"). This was causing false-positive `EDITOR_CHANGES_LOST` warnings when the editor's "no files modified" bullet contained such parenthetical text.

By adding `\b` word-boundary anchors around the entire alternation group, the regex now only matches these action words when they appear as complete words, not as parts of larger identifiers or compound terms.

https://claude.ai/code/session_01AZaKSTiTBdGWaHqsiBHjF1