### PR TITLE
Fix false-positive EDITOR_CHANGES_LOST detection with defense-in-depth

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2138,6 +2138,24 @@ jobs:
             fi
 
             if [ "${has_real_changes}" = "true" ]; then
+              # Defense-in-depth: before firing the warning and blocking
+              # auto-merge, re-check the working-tree state and the
+              # narrative "Changes made:" block via the shared shim. If
+              # both indicate no real edits, downgrade to an
+              # informational log line and do not block auto-merge.
+              # Keeps the hard failure only when there is real evidence
+              # of lost edits. See: fun-token-multi-chain PR #117.
+              recheck_script="${GITHUB_WORKSPACE}/scripts/detect_editor_changes_lost.sh"
+              if [ -x "${recheck_script}" ]; then
+                recheck_result="$(bash "${recheck_script}" "${EDITOR_SUMMARY_FILE}" 2>/dev/null || echo "true")"
+                if [ "${recheck_result}" = "false" ]; then
+                  echo "Notice: Change status: reported edited but working tree is clean and narrative claims no concrete changes; treating as false positive (no warning, auto-merge not blocked)."
+                  has_real_changes="false"
+                fi
+              fi
+            fi
+
+            if [ "${has_real_changes}" = "true" ]; then
               if [ "${CAN_PUSH:-}" = "true" ]; then
                 echo "::error::Editor claimed changes but no commit was produced. This indicates a mismatch between the editor summary and final git state (changes may have failed to persist, or may have been discarded during commit validation)."
               else

--- a/scripts/detect_editor_changes_lost.sh
+++ b/scripts/detect_editor_changes_lost.sh
@@ -17,7 +17,8 @@
 #   $1 — path to the editor summary file (EDITOR_SUMMARY_FILE).
 # Output shape:
 #   stdout: single token "true" or "false", newline-terminated.
-#   exit code: always 0 unless argv[1] is wildly malformed.
+#   exit code: 0 for handled fail-open paths; may be non-zero on
+#   unexpected command errors (caller should use `|| echo "true"`).
 # Git calls: one (`git status --porcelain`) in the caller's CWD.
 # Fail-open: yes — when the summary is unreadable we print "true" and
 #   leave the existing heuristic in control.
@@ -33,7 +34,10 @@ if [ -z "${summary_file}" ] || [ ! -s "${summary_file}" ]; then
 	exit 0
 fi
 
-porcelain="$(git status --porcelain 2>/dev/null || true)"
+if ! porcelain="$(git status --porcelain 2>/dev/null)"; then
+	echo "true"
+	exit 0
+fi
 
 changes_section="$(awk '
 	/^[[:space:]]*Changes made:/ { in_section=1; next }

--- a/scripts/detect_editor_changes_lost.sh
+++ b/scripts/detect_editor_changes_lost.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Defense-in-depth guard for the EDITOR_CHANGES_LOST detection step in
+# .github/workflows/review_autofix.yml.
+#
+# Given an editor summary file on argv[1], print either:
+#   "true"  — the summary + working tree show concrete evidence of edits
+#             that were not committed (real changes-lost scenario).
+#   "false" — the narrative "Changes made:" block reports no concrete
+#             edits AND `git status --porcelain` is empty, so treating
+#             this as EDITOR_CHANGES_LOST is a false positive.
+#
+# The script is intentionally conservative: on any read error or missing
+# input it prints "true" (fail-open) so the existing detection behaviour
+# is preserved.
+#
+# Input shape:
+#   $1 — path to the editor summary file (EDITOR_SUMMARY_FILE).
+# Output shape:
+#   stdout: single token "true" or "false", newline-terminated.
+#   exit code: always 0 unless argv[1] is wildly malformed.
+# Git calls: one (`git status --porcelain`) in the caller's CWD.
+# Fail-open: yes — when the summary is unreadable we print "true" and
+#   leave the existing heuristic in control.
+#
+# See fun-token-multi-chain PR #117 (runs 24537598009 / 24540975236)
+# for the reproducing false-positive case.
+set -euo pipefail
+
+summary_file="${1:-}"
+
+if [ -z "${summary_file}" ] || [ ! -s "${summary_file}" ]; then
+	echo "true"
+	exit 0
+fi
+
+porcelain="$(git status --porcelain 2>/dev/null || true)"
+
+changes_section="$(awk '
+	/^[[:space:]]*Changes made:/ { in_section=1; next }
+	in_section && /^[[:space:]]*[A-Za-z].*:/ { exit }
+	in_section { print }
+' "${summary_file}")"
+
+narrative_claims=""
+if [ -n "${changes_section}" ]; then
+	narrative_claims="$(printf '%s\n' "${changes_section}" | grep -viE '^[[:space:]]*$|^[[:space:]]*-[[:space:]]*none([[:space:]]|$)|^[[:space:]]{2,}-|^[[:space:]]*-[[:space:]]*(Validation executed|Validation limitation|Ran [^:]*(validation|check|test)|Assumptions?( applied| made)|Missing[- ]context|No [^:]*modified|No [^:]*changed|No [^:]*touched|No changes|No modifications)' || true)"
+fi
+
+if [ -z "${porcelain}" ] && [ -z "${narrative_claims}" ]; then
+	echo "false"
+else
+	echo "true"
+fi

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -660,6 +660,56 @@ while [ "${attempt}" -le 3 ]; do
         fi
 
         if [ "${reviewer_validation_ok}" = true ]; then
+          # ── Normalize contradictory "Change status:" signals ──
+          # The editor emits two signals in its summary: a narrative
+          # "Changes made:" block and a machine-readable "Change status:"
+          # bullet ("edited" | "not-edited"). They can disagree when the
+          # narrative correctly reports "- none" but the status bullet
+          # still says "edited". Downstream the workflow treats
+          # "Change status:" as authoritative and fires a false-positive
+          # EDITOR_CHANGES_LOST warning (see fun-token-multi-chain PR #117
+          # runs 24537598009 / 24540975236).
+          #
+          # If the narrative reports no concrete changes (_claimed_changes
+          # is empty after the same filter the retry loop uses) AND the
+          # working tree is clean, rewrite "Change status:" to
+          # "- not-edited" so the authoritative signal agrees with reality.
+          if [ -z "${_claimed_changes}" ]; then
+            _norm_git_clean=true
+            if ! git diff --quiet HEAD 2>/dev/null; then
+              _norm_git_clean=false
+            elif [ -n "$(git ls-files --others --exclude-standard 2>/dev/null)" ]; then
+              _norm_git_clean=false
+            fi
+            if [ "${_norm_git_clean}" = true ]; then
+              _norm_status="$(awk '
+                /^[[:space:]]*Change status:/ {
+                  header=$0
+                  sub(/^[[:space:]]*Change status:[[:space:]]*/, "", header)
+                  if (header != "") print header
+                  in_section=1
+                  next
+                }
+                in_section && /^[[:space:]]*[A-Za-z].*:/ { exit }
+                in_section { print }
+              ' "${tmp_output}" | grep -iE '^[[:space:]]*-?[[:space:]]*(edited|not-edited|not[[:space:]]+edited)[[:space:]]*$' | head -1 | sed -E 's/^[[:space:]]*-?[[:space:]]*//; s/[[:space:]]*$//; s/^not[[:space:]]+edited$/not-edited/I' | tr '[:upper:]' '[:lower:]' || true)"
+              if [ "${_norm_status}" = "edited" ]; then
+                echo "Notice: normalizing Change status: edited → not-edited on attempt ${attempt} (Changes made: narrative reports no changes and working tree is clean)."
+                awk '
+                  /^[[:space:]]*Change status:/ {
+                    print "Change status:"
+                    print "- not-edited"
+                    in_section=1
+                    next
+                  }
+                  in_section && /^[[:space:]]*[A-Za-z].*:/ { in_section=0; print; next }
+                  in_section { next }
+                  { print }
+                ' "${tmp_output}" > "${tmp_output}.norm" && mv -f "${tmp_output}.norm" "${tmp_output}"
+              fi
+            fi
+          fi
+
           # Record on-disk change stats at the moment of success so that a later
           # "Editor claimed changes but no commit was produced" alert can be
           # diagnosed against an authoritative baseline instead of speculation.

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -705,7 +705,7 @@ while [ "${attempt}" -le 3 ]; do
                   in_section && /^[[:space:]]*[A-Za-z].*:/ { in_section=0; print; next }
                   in_section { next }
                   { print }
-                ' "${tmp_output}" > "${tmp_output}.norm" && mv -f "${tmp_output}.norm" "${tmp_output}"
+                ' "${tmp_output}" > "${tmp_output}.norm" && [ -s "${tmp_output}.norm" ] && mv -f "${tmp_output}.norm" "${tmp_output}"
               fi
             fi
           fi

--- a/tests/fixtures/editor_summaries/narrative_none_status_edited.txt
+++ b/tests/fixtures/editor_summaries/narrative_none_status_edited.txt
@@ -1,0 +1,26 @@
+Changes made:
+- none
+
+Change status:
+- edited
+
+Already satisfied (suggested but already present):
+- reviewer concerns were already addressed in a prior commit
+
+Ignored suggestions (with short reason):
+- speculative reviewer finding without evidence
+
+Reviewer files processed:
+- /runtime/reviewer_1.txt checksum=aaaa used (no WILL_FIX items produced)
+
+Review file issue audit:
+- /runtime/reviewer_1.txt total issues listed: 3 issues applied: 0 issues already applied: 2 issues ignored: 1
+
+PR comment audit:
+- none
+
+Regression fingerprint:
+- n/a (no prior-hunk overlap)
+
+Runtime failure path:
+- n/a (no prior-hunk overlap)

--- a/tests/fixtures/editor_summaries/narrative_real_edit_status_edited.txt
+++ b/tests/fixtures/editor_summaries/narrative_real_edit_status_edited.txt
@@ -1,0 +1,26 @@
+Changes made:
+- Modified scripts/example.sh to fix the null-deref reported by reviewer 1
+
+Change status:
+- edited
+
+Already satisfied (suggested but already present):
+- none
+
+Ignored suggestions (with short reason):
+- none
+
+Reviewer files processed:
+- /runtime/reviewer_1.txt checksum=aaaa used
+
+Review file issue audit:
+- /runtime/reviewer_1.txt total issues listed: 1 issues applied: 1 issues already applied: 0 issues ignored: 0
+
+PR comment audit:
+- none
+
+Regression fingerprint:
+- n/a (no prior-hunk overlap)
+
+Runtime failure path:
+- n/a (no prior-hunk overlap)

--- a/tests/test_detect_editor_changes_lost.py
+++ b/tests/test_detect_editor_changes_lost.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Regression tests for the EDITOR_CHANGES_LOST false-positive fix.
+
+Reproducing case: shubhodeep1/fun-token-multi-chain PR #117, runs
+24537598009 and 24540975236. The editor emitted a summary where the
+narrative "Changes made:" block was "- none" but the authoritative
+"Change status:" bullet was "edited". The workflow's
+"Detect editor-claimed-but-uncommitted changes" step trusted
+"Change status: edited" as authoritative, set EDITOR_CHANGES_LOST=true,
+and blocked auto-merge despite the working tree being clean.
+
+These tests exercise the defense-in-depth shim
+(scripts/detect_editor_changes_lost.sh) that the workflow consults
+before firing the warning.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SHIM = REPO_ROOT / "scripts" / "detect_editor_changes_lost.sh"
+FIXTURES = REPO_ROOT / "tests" / "fixtures" / "editor_summaries"
+REVIEW_AUTOFIX_WF = REPO_ROOT / ".github" / "workflows" / "review_autofix.yml"
+APPLY_FIXES_SH = REPO_ROOT / "scripts" / "review_apply_fixes.sh"
+
+
+def _init_clean_repo(tmp_path: Path) -> None:
+	subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+	# Test-local config only: disable signing + gpg inside this throwaway
+	# repo so environments that mandate signed commits still let the
+	# fixture boot (the repo is never pushed anywhere).
+	for key, val in (
+		("user.email", "test@local"),
+		("user.name", "test"),
+		("commit.gpgsign", "false"),
+		("tag.gpgsign", "false"),
+		("gpg.format", "openpgp"),
+	):
+		subprocess.run(["git", "config", key, val], cwd=tmp_path, check=True)
+	(tmp_path / "placeholder").write_text("seed\n", encoding="utf-8")
+	subprocess.run(["git", "add", "placeholder"], cwd=tmp_path, check=True)
+	subprocess.run(
+		["git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "seed"],
+		cwd=tmp_path,
+		check=True,
+	)
+
+
+def _run_shim(tmp_path: Path, summary: Path) -> str:
+	result = subprocess.run(
+		["bash", str(SHIM), str(summary)],
+		cwd=tmp_path,
+		capture_output=True,
+		text=True,
+		check=True,
+	)
+	return result.stdout.strip()
+
+
+def test_shim_exists_and_is_executable() -> None:
+	assert SHIM.exists(), f"Expected shim at {SHIM}"
+	assert SHIM.stat().st_mode & 0o111, "Expected shim to be executable"
+
+
+def test_false_positive_narrative_none_status_edited_clean_tree(tmp_path: Path) -> None:
+	"""Reproducing case from PR #117: narrative '- none', Change status
+	'edited', working tree clean. Shim must report 'false' (not
+	changes-lost) so the workflow can downgrade to an informational log
+	and leave auto-merge unblocked."""
+	_init_clean_repo(tmp_path)
+	result = _run_shim(tmp_path, FIXTURES / "narrative_none_status_edited.txt")
+	assert result == "false", (
+		"Expected shim to treat narrative='- none' + Change status='edited' + "
+		f"clean working tree as a false positive; got {result!r}."
+	)
+
+
+def test_real_edit_with_uncommitted_worktree_is_changes_lost(tmp_path: Path) -> None:
+	"""Sanity guard: when the narrative actually claims concrete edits and
+	the working tree has uncommitted modifications, the shim must still
+	report 'true' so the existing warning path remains intact."""
+	_init_clean_repo(tmp_path)
+	(tmp_path / "placeholder").write_text("seed\nmodified\n", encoding="utf-8")
+	result = _run_shim(tmp_path, FIXTURES / "narrative_real_edit_status_edited.txt")
+	assert result == "true", (
+		"Expected shim to preserve changes-lost detection when narrative "
+		f"claims edits and working tree has uncommitted changes; got {result!r}."
+	)
+
+
+def test_real_edit_narrative_with_clean_tree_is_changes_lost(tmp_path: Path) -> None:
+	"""Narrative claims concrete edits but the working tree is clean — the
+	classic Serena-persistence-failure case that the original detector
+	exists to catch. Shim must still report 'true'."""
+	_init_clean_repo(tmp_path)
+	result = _run_shim(tmp_path, FIXTURES / "narrative_real_edit_status_edited.txt")
+	assert result == "true", (
+		"Expected shim to keep reporting 'true' when narrative claims edits "
+		f"even if working tree is clean; got {result!r}."
+	)
+
+
+def test_missing_summary_fails_open(tmp_path: Path) -> None:
+	"""If the summary file is missing the shim must fail open ('true') so
+	the existing heuristic keeps control rather than silently unblocking
+	auto-merge."""
+	_init_clean_repo(tmp_path)
+	result = _run_shim(tmp_path, tmp_path / "does-not-exist.txt")
+	assert result == "true", (
+		f"Expected fail-open 'true' for missing summary; got {result!r}."
+	)
+
+
+# ---------------------------------------------------------------------------
+# Static assertions: the normalization + defense-in-depth wiring stays wired
+# ---------------------------------------------------------------------------
+
+def test_apply_fixes_contains_change_status_normalization() -> None:
+	contents = APPLY_FIXES_SH.read_text(encoding="utf-8")
+	assert "normalizing Change status: edited" in contents, (
+		"Expected scripts/review_apply_fixes.sh to normalize Change status: "
+		"when narrative reports no changes and git is clean"
+	)
+	assert "_norm_git_clean" in contents
+
+
+def test_workflow_uses_defense_in_depth_shim() -> None:
+	wf = REVIEW_AUTOFIX_WF.read_text(encoding="utf-8")
+	assert "scripts/detect_editor_changes_lost.sh" in wf, (
+		"Expected review_autofix.yml to invoke the defense-in-depth shim"
+	)
+	assert "treating as false positive (no warning, auto-merge not blocked)" in wf

--- a/tests/test_detect_editor_changes_lost.py
+++ b/tests/test_detect_editor_changes_lost.py
@@ -114,6 +114,15 @@ def test_missing_summary_fails_open(tmp_path: Path) -> None:
 	)
 
 
+def test_non_git_directory_fails_open(tmp_path: Path) -> None:
+	"""If the shim runs outside a git worktree, git-state is unknown and it
+	must fail open ('true') rather than classifying as a clean tree."""
+	result = _run_shim(tmp_path, FIXTURES / "narrative_none_status_edited.txt")
+	assert result == "true", (
+		f"Expected fail-open 'true' when git status is unavailable; got {result!r}."
+	)
+
+
 # ---------------------------------------------------------------------------
 # Static assertions: the normalization + defense-in-depth wiring stays wired
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a false-positive detection in the `EDITOR_CHANGES_LOST` workflow step that was incorrectly blocking auto-merge when an editor's summary reported no concrete changes but the "Change status:" bullet still claimed "edited". This implements a defense-in-depth approach with both preventive normalization and runtime re-validation.

## Key Changes

- **New defense-in-depth shim** (`scripts/detect_editor_changes_lost.sh`): A conservative guard script that validates whether the editor summary's narrative "Changes made:" block and working tree state actually indicate lost changes. Fails open (reports "true") on any read errors to preserve existing behavior.

- **Preventive normalization** (`scripts/review_apply_fixes.sh`): When the narrative reports no concrete changes AND the working tree is clean, automatically normalize the "Change status:" bullet from "edited" to "not-edited" to prevent downstream false positives.

- **Workflow integration** (`.github/workflows/review_autofix.yml`): Added a re-check step before firing the `EDITOR_CHANGES_LOST` warning that invokes the shim. If the shim reports "false" (no real changes lost), downgrades to an informational log and does not block auto-merge.

- **Comprehensive test coverage** (`tests/test_detect_editor_changes_lost.py`): Regression tests covering:
  - The reproducing false-positive case (narrative "- none" + status "edited" + clean tree)
  - Real edit detection with uncommitted changes
  - Real edit detection with clean tree (classic Serena persistence failure)
  - Missing summary file fail-open behavior
  - Static assertions that normalization and shim wiring remain in place

- **Test fixtures** (`tests/fixtures/editor_summaries/`): Sample editor summary files for both false-positive and real-change scenarios.

## Implementation Details

The solution uses a layered approach:
1. **Normalization layer**: Proactively fixes contradictory signals in the summary when narrative and git state agree
2. **Validation layer**: The shim independently verifies the narrative by filtering out known false-positive patterns (e.g., "- none", validation-only messages)
3. **Workflow layer**: Re-checks before firing the hard failure, allowing downgrade to informational logging for confirmed false positives

The shim is intentionally conservative—it only reports "false" when both the narrative claims no changes AND `git status --porcelain` is empty, ensuring the existing detection remains active for real changes-lost scenarios.

Addresses: fun-token-multi-chain PR #117 (runs 24537598009 / 24540975236)

https://claude.ai/code/session_015U3yMGQzGMNMtjof5dPVA1