### PR TITLE
Add raw_status field to distinguish harness errors from app failures

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -54,6 +54,7 @@ jobs:
     timeout-minutes: 180
     outputs:
       status: ${{ steps.collect_status.outputs.status }}
+      raw_status: ${{ steps.collect_status.outputs.raw_status }}
       summary: ${{ steps.collect_status.outputs.summary }}
       failure_summary: ${{ steps.collect_status.outputs.failure_summary }}
       status_file: ${{ steps.collect_status.outputs.status_file }}
@@ -462,6 +463,7 @@ jobs:
           fi
 
           status="$(jq -r '.status // "error"' "${STATUS_FILE_PATH}")"
+          raw_status="$(jq -r '.raw_status // .status // "error"' "${STATUS_FILE_PATH}")"
           summary="$(jq -r '.summary // ""' "${STATUS_FILE_PATH}" | tr '\n' ' ' | sed -e 's/[[:space:]]\+/ /g' -e 's/^ //; s/ $//')"
           failure_summary="$(jq -r '.failure_summary // ""' "${STATUS_FILE_PATH}" | tr '\n' ' ' | sed -e 's/[[:space:]]\+/ /g' -e 's/^ //; s/ $//')"
 
@@ -480,6 +482,7 @@ jobs:
 
           {
             echo "status=${status}"
+            echo "raw_status=${raw_status}"
             echo "summary=${summary}"
             echo "failure_summary=${failure_summary}"
             echo "status_file=${STATUS_FILE_PATH}"
@@ -649,9 +652,18 @@ jobs:
         if: always()
         env:
           VALIDATION_STATUS: ${{ steps.collect_status.outputs.status }}
+          VALIDATION_RAW_STATUS: ${{ steps.collect_status.outputs.raw_status }}
         run: |
           set -euo pipefail
-          if [ "${VALIDATION_STATUS}" != "pass" ]; then
-            echo "Validation did not pass."
-            exit 1
+          if [ "${VALIDATION_STATUS}" = "pass" ]; then
+            exit 0
           fi
+          # Exit 2 for harness_error so orchestration can distinguish a harness
+          # defect (generator/canary produced an incorrect test) from an
+          # application-side failure; exit 1 for every other non-pass outcome.
+          if [ "${VALIDATION_RAW_STATUS}" = "harness_error" ]; then
+            echo "Validation did not pass (harness error)."
+            exit 2
+          fi
+          echo "Validation did not pass."
+          exit 1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,6 +30,9 @@ name: AI Validate (Reusable)
       status:
         description: "Validation status (pass|fail|error)"
         value: ${{ jobs.validate.outputs.status }}
+      raw_status:
+        description: "Raw validation status (preserves diagnostic classifier values)"
+        value: ${{ jobs.validate.outputs.raw_status }}
       summary:
         description: "Validation summary"
         value: ${{ jobs.validate.outputs.summary }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -620,6 +620,7 @@ jobs:
         continue-on-error: true
         env:
           TRACKING_ISSUE: ${{ inputs.tracking_issue }}
+          STATUS_FILE_PATH: ${{ steps.collect_status.outputs.status_file }}
           STATUS_VALUE: ${{ steps.collect_status.outputs.status }}
           RAW_STATUS_VALUE: ${{ steps.collect_status.outputs.raw_status }}
           SUMMARY_VALUE: ${{ steps.collect_status.outputs.summary }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -456,10 +456,12 @@ jobs:
           if [ ! -f "${STATUS_FILE_PATH}" ]; then
             jq -n \
               --arg status "error" \
+              --arg raw_status "harness_error" \
               --arg summary "Validation process did not produce validation_status.json." \
               --arg failure_summary "Missing status artifact. Check validate_process.sh output and uploaded artifacts." \
               '{
                 status: $status,
+                raw_status: $raw_status,
                 summary: $summary,
                 failure_summary: $failure_summary
               }' > "${STATUS_FILE_PATH}"
@@ -473,10 +475,12 @@ jobs:
           if [ ! -f "${METADATA_FILE_PATH}" ]; then
             jq -n \
               --arg status "${status}" \
+              --arg raw_status "${raw_status}" \
               --arg summary "${summary}" \
               --arg failure_summary "${failure_summary}" \
               '{
                 status: $status,
+                raw_status: $raw_status,
                 summary: $summary,
                 failure_summary: (if ($failure_summary | length) > 0 then $failure_summary else null end),
                 generated_at_utc: (now | todateiso8601)
@@ -499,6 +503,7 @@ jobs:
           TRACKING_ISSUE: ${{ inputs.tracking_issue }}
           STATUS_FILE_PATH: ${{ steps.collect_status.outputs.status_file }}
           STATUS_VALUE: ${{ steps.collect_status.outputs.status }}
+          RAW_STATUS_VALUE: ${{ steps.collect_status.outputs.raw_status }}
           SUMMARY_VALUE: ${{ steps.collect_status.outputs.summary }}
           FAILURE_SUMMARY_VALUE: ${{ steps.collect_status.outputs.failure_summary }}
         run: |
@@ -530,6 +535,14 @@ jobs:
               failure_summary_value="${parsed_failure_summary}"
             fi
           fi
+          raw_status="${RAW_STATUS_VALUE:-}"
+          if [ -z "${raw_status}" ] && [ -n "${STATUS_FILE_PATH:-}" ] && [ -f "${STATUS_FILE_PATH}" ]; then
+            parsed_raw_status="$(jq -r '.raw_status // empty' "${STATUS_FILE_PATH}" 2>/dev/null || true)"
+            if [ -n "${parsed_raw_status}" ]; then
+              raw_status="${parsed_raw_status}"
+            fi
+          fi
+          raw_status="${raw_status:-${status_value}}"
 
           summary_compact="$(printf '%s' "${summary_value}" | tr '\n' ' ' | sed -e 's/[[:space:]]\+/ /g' -e 's/^ //; s/ $//')"
           failure_summary_compact="$(printf '%s' "${failure_summary_value}" | tr '\n' ' ' | sed -e 's/[[:space:]]\+/ /g' -e 's/^ //; s/ $//')"
@@ -540,7 +553,7 @@ jobs:
           fi
           candidate_summary="${candidate_summary:0:220}"
 
-          candidate_details="status=${status_value}; summary=${summary_compact}; failure_summary=${failure_summary_compact}"
+          candidate_details="status=${status_value}; raw_status=${raw_status}; summary=${summary_compact}; failure_summary=${failure_summary_compact}"
           candidate_details="$(printf '%s' "${candidate_details}" | tr '\n' ' ' | sed -e 's/[[:space:]]\+/ /g' -e 's/^ //; s/ $//')"
           candidate_details="${candidate_details:0:600}"
 
@@ -608,6 +621,7 @@ jobs:
         env:
           TRACKING_ISSUE: ${{ inputs.tracking_issue }}
           STATUS_VALUE: ${{ steps.collect_status.outputs.status }}
+          RAW_STATUS_VALUE: ${{ steps.collect_status.outputs.raw_status }}
           SUMMARY_VALUE: ${{ steps.collect_status.outputs.summary }}
           FAILURE_SUMMARY_VALUE: ${{ steps.collect_status.outputs.failure_summary }}
         run: |
@@ -636,8 +650,16 @@ jobs:
           completion_message="$(printf '%s' "${completion_message}" | tr '\n' ' ' | sed -e 's/[[:space:]]\+/ /g' -e 's/^ //; s/ $//')"
           completion_message="${completion_message:0:280}"
 
+          raw_status="${RAW_STATUS_VALUE:-}"
+          if [ -z "${raw_status}" ] && [ -n "${STATUS_FILE_PATH:-}" ] && [ -f "${STATUS_FILE_PATH}" ]; then
+            parsed_raw_status="$(jq -r '.raw_status // empty' "${STATUS_FILE_PATH}" 2>/dev/null || true)"
+            if [ -n "${parsed_raw_status}" ]; then
+              raw_status="${parsed_raw_status}"
+            fi
+          fi
+          raw_status="${raw_status:-${status_value}}"
           metadata_json="$(jq -cn \
-            --arg raw_status "${status_value}" \
+            --arg raw_status "${raw_status}" \
             --arg run_attempt "${{ github.run_attempt }}" \
             '{raw_status:$raw_status,run_attempt:$run_attempt}')"
 

--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -98,7 +98,9 @@ Canary requirement (mandatory):
 - The canary must validate harness infrastructure before app assertions:
   - Connectivity to each declared Docker service
   - Reachability of application port/health endpoint
-  - Required CLI tools present (`curl`, `jq`, `python3`, plus service CLIs like `mongosh`/`psql` when used)
+  - Required CLI tools present **inside the app container** (`curl`, `jq`, `python3`, and any binary that the app's own tests/scripts invoke). This is the only set that belongs in the `CANARY_TOOLS` loop below.
+  - Service CLIs (for example `mongosh`, `psql`, `redis-cli`, `mysql`) MUST be probed **inside the corresponding service container** (`docker compose exec mongo mongosh --version`, `docker compose exec postgres psql --version`, etc.), NOT inside the app container. Slim app base images (e.g. `python:3.12-slim`) do not ship DB CLIs, and installing them just to satisfy a canary is a harness smell.
+  - If the app container itself needs to issue DB queries, use the language-native client (for example `python3` + `pymongo`, `psycopg2`, `redis-py`) from the app container and add a canary assertion that imports that client — do NOT add `mongosh`/`psql`/`redis-cli` to the app-container `CANARY_TOOLS` list.
 - If canary fails, remaining tests must be skipped and the failure must clearly indicate canary/infrastructure gating.
 
 CRITICAL — robust service-state detection in canary:
@@ -443,6 +445,7 @@ CRITICAL — custom_tests external tool dependency analysis (prevents FileNotFou
       ASSERTION=$((ASSERTION + 1))
     done
   Respect the shell-mode parity rule at the top of this prompt: the canary tool-check MUST use the same `/bin/sh -c` (or `/bin/sh -lc`) form as the subsequent test invocations.
+- HARD RULE — do NOT include DB/service CLIs (`mongosh`, `psql`, `mysql`, `redis-cli`, `mongo`, etc.) in the app-container `CANARY_TOOLS` list unless `validation/Dockerfile.app` explicitly installs them for an app-side invocation. These CLIs belong to the respective service container and must be probed there (`docker compose exec mongo mongosh --version`, `docker compose exec postgres psql --version`, …). Putting `mongosh` into the app-container `CANARY_TOOLS` loop against a `python:*-slim` base image is the canonical `harness_error` classified as `mongosh is NOT available in app` — the fix is to remove it from `CANARY_TOOLS` and probe it against the DB service instead (or replace the assertion with a `python3 -c 'import pymongo'` import probe when the app itself talks to Mongo via pymongo). Apply the same rule for `psql`/`redis-cli`/`mysql` versus their respective native clients.
 - Worked example. Given `.ai/validate.yml`:
     custom_tests:
       - python3 tests/test_validate_process_driver_guard_scope.py

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -1526,7 +1526,7 @@ if ! ensure_validation_harness_not_tracked; then
   local_failure_summary="${CANONICAL_VALIDATE_HARNESS_REL} is tracked in git. Runtime validation harness must remain untracked."
   post_tracking_comment "## ⚠️ Runtime validation harness tracking violation\n\n${local_failure_summary}\n\nRemove it from git tracking in the consumer repository and rerun validation."
   set_tracking_phase_label "ai:validation-failed"
-  write_result_files "error" "Validation harness tracking violation" "${local_failure_summary}"
+  write_result_files "error" "Validation harness tracking violation" "${local_failure_summary}" "harness_error"
   tg_notify "Validation harness tracking violation for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW}." "ERROR"
   exit 1
 fi
@@ -1686,7 +1686,7 @@ if [ "${GENERATE_SUCCESS}" != "true" ]; then
   attempt_self_heal_and_reexec "generate"
   post_tracking_comment "## ⚠️ Runtime validation harness generation failed\n\n${local_failure_summary}\n\nSee workflow artifacts for generation logs."
   set_tracking_phase_label "ai:validation-failed"
-  write_result_files "error" "Validation harness generation failed" "${local_failure_summary}"
+  write_result_files "error" "Validation harness generation failed" "${local_failure_summary}" "harness_error"
   tg_notify "Validation harness generation failed for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW}." "ERROR"
   exit 1
 fi
@@ -1702,7 +1702,7 @@ if command -v git >/dev/null 2>&1; then
     local_failure_summary="Codex modified files outside validation/ during harness generation."
     post_tracking_comment "## ⚠️ Runtime validation harness generation failed\n\n${local_failure_summary}\n\nUnexpected changes:\n\n\`\`\`\n${NON_VALIDATION_CHANGES}\n\`\`\`"
     set_tracking_phase_label "ai:validation-failed"
-    write_result_files "error" "Validation harness generation violated path constraints" "${local_failure_summary}"
+    write_result_files "error" "Validation harness generation violated path constraints" "${local_failure_summary}" "harness_error"
     tg_notify "Validation harness generation touched non-validation files for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW}." "ERROR"
     exit 1
   fi
@@ -1714,7 +1714,7 @@ if ! ensure_validation_harness_not_tracked; then
   local_failure_summary="${CANONICAL_VALIDATE_HARNESS_REL} became tracked/staged after harness generation."
   post_tracking_comment "## ⚠️ Runtime validation harness tracking violation\n\n${local_failure_summary}\n\nValidation harness files must remain transient and untracked."
   set_tracking_phase_label "ai:validation-failed"
-  write_result_files "error" "Validation harness tracking violation" "${local_failure_summary}"
+  write_result_files "error" "Validation harness tracking violation" "${local_failure_summary}" "harness_error"
   tg_notify "Validation harness tracking violation after generation for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW}." "ERROR"
   exit 1
 fi
@@ -1739,7 +1739,7 @@ if ! run_preflight_checks; then
   attempt_self_heal_and_reexec "preflight"
   post_tracking_comment "## ❌ Runtime validation harness pre-flight failed\n\n${failure_summary}\n\n\`docker compose config\`, shell syntax, or build context/dockerfile path checks failed."
   set_tracking_phase_label "ai:validation-failed"
-  write_result_files "fail" "Validation failed due to harness pre-flight error" "${failure_summary}"
+  write_result_files "fail" "Validation failed due to harness pre-flight error" "${failure_summary}" "harness_error"
   tg_notify "Validation pre-flight failed for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW}." "ERROR"
   exit 0
 fi
@@ -2103,7 +2103,7 @@ case "${DIAG_STATUS}" in
       failure_summary="Diagnosis returned needs_fixes with empty fix_issues."
       post_tracking_comment "## ❌ Runtime validation failed\n\n${failure_summary}\n\nDiagnosis:\n\n${DIAG_TEXT}"
       set_tracking_phase_label "ai:validation-failed"
-      write_result_files "fail" "Runtime validation failed" "${failure_summary}"
+      write_result_files "fail" "Runtime validation failed" "${failure_summary}" "harness_error"
       tg_notify "Validation failed for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW}: invalid diagnosis payload." "ERROR"
       exit 0
     fi
@@ -2155,7 +2155,7 @@ case "${DIAG_STATUS}" in
 
     if ! is_tracking_run; then
       failure_summary="Runtime validation failed with ${FAILED_TESTS} failing test(s). Tracking issue is not set, so the consolidated fix-up issue was not created."
-      write_result_files "fail" "Validation needs fixes" "${failure_summary}"
+      write_result_files "fail" "Validation needs fixes" "${failure_summary}" "needs_fixes"
       tg_notify "Validation for ${GITHUB_REPOSITORY} reported fixable failures, but TRACKING_ISSUE is not set." "WARNING"
       exit 0
     fi
@@ -2175,7 +2175,7 @@ case "${DIAG_STATUS}" in
 	  failure_summary="Runtime validation failed with ${FAILED_TESTS} failing test(s), but creating the consolidated fix-up issue failed."
 	  post_tracking_comment "## ❌ Runtime validation failed\n\n${failure_summary}\n\nDiagnosis:\n\n${DIAG_TEXT}"
 	  set_tracking_phase_label "ai:validation-failed"
-	  write_result_files "fail" "Runtime validation failed" "${failure_summary}"
+	  write_result_files "fail" "Runtime validation failed" "${failure_summary}" "harness_error"
 	  tg_notify "Validation failed for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW}: unable to create consolidated fix-up issue." "ERROR"
 	  exit 0
 	fi
@@ -2190,7 +2190,7 @@ case "${DIAG_STATUS}" in
     set_tracking_phase_label "ai:validation-fixing"
 
     failure_summary="Runtime validation failed with ${FAILED_TESTS} failing test(s). A single consolidated fix-up issue was created for ${FIX_COUNT} root cause(s)."
-    write_result_files "fail" "Validation needs fixes" "${failure_summary}"
+    write_result_files "fail" "Validation needs fixes" "${failure_summary}" "needs_fixes"
     tg_notify "Validation for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW} needs fixes (${FIX_COUNT} root cause(s) consolidated into 1 issue)." "WARNING"
     ;;
 
@@ -2209,7 +2209,7 @@ case "${DIAG_STATUS}" in
 
     post_tracking_comment "## ❌ Runtime validation infeasible\n\n${DIAG_TEXT}"
     set_tracking_phase_label "ai:validation-failed"
-    write_result_files "fail" "Validation marked infeasible" "${failure_summary}"
+    write_result_files "fail" "Validation marked infeasible" "${failure_summary}" "infeasible"
     tg_notify "Validation infeasible for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW}." "ERROR"
     ;;
 
@@ -2218,7 +2218,7 @@ case "${DIAG_STATUS}" in
 
     post_tracking_comment "## ❌ Runtime validation failed\n\n${failure_summary}\n\nDiagnosis:\n\n${DIAG_TEXT}"
     set_tracking_phase_label "ai:validation-failed"
-    write_result_files "fail" "Validation failed" "${failure_summary}"
+    write_result_files "fail" "Validation failed" "${failure_summary}" "harness_error"
     tg_notify "Validation failed for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW}: unknown diagnosis status." "ERROR"
     ;;
 esac

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -812,14 +812,22 @@ write_status_file()
   local status="$1"
   local summary="$2"
   local failure_summary="$3"
+  # Optional 4th arg: raw_status preserves the original diagnose classifier
+  # (for example `harness_error`, `needs_fixes`, `infeasible`) so downstream
+  # consumers can distinguish harness defects from app-side failures even
+  # though `status` is normalized to `pass`/`fail`/`error`. Defaults to the
+  # normalized status for backward compatibility.
+  local raw_status="${4:-${status}}"
 
   jq -n \
     --arg status "${status}" \
+    --arg raw_status "${raw_status}" \
     --arg summary "${summary}" \
     --arg failure_summary "${failure_summary}" \
     --arg tracking_issue "${TRACKING_ISSUE_RAW}" \
     '{
       status: $status,
+      raw_status: $raw_status,
       summary: $summary,
       failure_summary: (if ($failure_summary | length) > 0 then $failure_summary else null end),
       tracking_issue: $tracking_issue
@@ -831,6 +839,7 @@ write_metadata_file()
   local status="$1"
   local summary="$2"
   local failure_summary="$3"
+  local raw_status="${4:-${status}}"
 
   local validation_file="${VALIDATION_RESULT_FILE}"
   local diagnosis_file="${DIAGNOSE_RESULT_FILE}"
@@ -845,6 +854,7 @@ write_metadata_file()
 
   jq -n \
     --arg status "${status}" \
+    --arg raw_status "${raw_status}" \
     --arg summary "${summary}" \
     --arg failure_summary "${failure_summary}" \
     --arg hints_source "${HINTS_SOURCE}" \
@@ -864,6 +874,7 @@ write_metadata_file()
     --slurpfile diagnosis "${diagnosis_file}" \
     '{
       status: $status,
+      raw_status: $raw_status,
       summary: $summary,
       failure_summary: (if ($failure_summary | length) > 0 then $failure_summary else null end),
       hints_source: $hints_source,
@@ -893,9 +904,10 @@ write_result_files()
   local status="$1"
   local summary="$2"
   local failure_summary="$3"
+  local raw_status="${4:-${status}}"
 
-  write_status_file "${status}" "${summary}" "${failure_summary}"
-  write_metadata_file "${status}" "${summary}" "${failure_summary}"
+  write_status_file "${status}" "${summary}" "${failure_summary}" "${raw_status}"
+  write_metadata_file "${status}" "${summary}" "${failure_summary}" "${raw_status}"
 }
 
 cleanup_runtime_containers()
@@ -2011,7 +2023,7 @@ if [ "${CANARY_ONLY_FAILURE}" = true ]; then
 			failure_summary="Validation harness error: ${FIRST_FAILURE}"
 			post_tracking_comment "## ❌ Runtime validation harness error\n\n${failure_summary}\n\nCanary infrastructure check failed and remaining tests were skipped."
 			set_tracking_phase_label "ai:validation-failed"
-			write_result_files "fail" "Validation failed due to harness error" "${failure_summary}"
+			write_result_files "fail" "Validation failed due to harness error" "${failure_summary}" "harness_error"
 			tg_notify "Validation harness canary failure for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW}." "ERROR"
 			exit 0
 		fi
@@ -2188,7 +2200,7 @@ case "${DIAG_STATUS}" in
 
     post_tracking_comment "## ❌ Runtime validation harness error\n\n${DIAG_TEXT}\n\nHarness fix guidance:\n\n${HARNESS_FIXES}"
     set_tracking_phase_label "ai:validation-failed"
-    write_result_files "fail" "Validation failed due to harness error" "${failure_summary}"
+    write_result_files "fail" "Validation failed due to harness error" "${failure_summary}" "harness_error"
     tg_notify "Validation harness error for ${GITHUB_REPOSITORY}#${TRACKING_ISSUE_RAW}." "ERROR"
     ;;
 


### PR DESCRIPTION
## Summary
This PR introduces a `raw_status` field to validation result files and workflow outputs to distinguish harness infrastructure defects from application-side failures. While the normalized `status` field remains `pass`/`fail`/`error` for backward compatibility, the new `raw_status` field preserves the original diagnostic classifier (e.g., `harness_error`, `needs_fixes`, `infeasible`), enabling downstream orchestration to handle harness defects differently from app failures.

## Key Changes

- **Validation script (`scripts/validate_process.sh`)**:
  - Added optional 4th parameter `raw_status` to `write_status_file()`, `write_metadata_file()`, and `write_result_files()` functions
  - `raw_status` defaults to the normalized `status` for backward compatibility
  - Updated JSON output in both status and metadata files to include the `raw_status` field
  - Passed `"harness_error"` as `raw_status` when writing result files for harness failures (canary and diagnostic harness errors)

- **GitHub Actions workflow (`.github/workflows/validate.yml`)**:
  - Added `raw_status` to job outputs by extracting it from the status file with fallback to `status` field
  - Updated the final validation check step to exit with code 2 for `harness_error` (distinguishing harness defects) and code 1 for other non-pass outcomes
  - This allows orchestration systems to differentiate between infrastructure issues and application failures

- **Validation prompt (`prompts/mode-validate-generate.txt`)**:
  - Clarified that service CLIs (`mongosh`, `psql`, `redis-cli`, etc.) must be probed **inside their respective service containers**, not in the app container
  - Added guidance that language-native clients should be used when the app itself needs DB access
  - Added explicit HARD RULE preventing DB/service CLIs from being included in app-container `CANARY_TOOLS` unless explicitly installed in the app Dockerfile
  - Documented the canonical `harness_error` case and its resolution

## Implementation Details

- The `raw_status` parameter is optional and maintains backward compatibility by defaulting to the normalized `status`
- Exit code 2 from the validation workflow signals a harness error, while exit code 1 signals application-side failures
- The changes enable better error classification and handling in CI/CD orchestration systems that consume validation results

https://claude.ai/code/session_016FRxdns9WZCpDf7SVX8gJG