### PR TITLE
Add diagnostic checkpoints to track working tree state changes

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1599,6 +1599,26 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Diagnostic: working tree state at the start of this step.
+          # Pairs with the "checkpoint=editor_exit" group emitted at the
+          # end of review_apply_fixes.sh.  If editor_exit shows edits but
+          # commit_step_start shows a clean tree, the reversion happens
+          # at the step boundary (Serena shutdown / runner transition)
+          # and no logic inside this step can recover.  See PR #1255.
+          echo "::group::Working tree state (checkpoint=commit_step_start)"
+          printf 'timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)"
+          _cp_status="$(git status --porcelain 2>/dev/null || true)"
+          if [ -n "${_cp_status}" ]; then
+            printf '%s\n' "${_cp_status}" | head -40
+            _cp_status_lines="$(printf '%s\n' "${_cp_status}" | wc -l | tr -d '[:space:]')"
+            [ "${_cp_status_lines:-0}" -gt 40 ] && echo "[truncated: ${_cp_status_lines} total porcelain lines]"
+          else
+            echo "(clean)"
+          fi
+          echo "--- git diff --stat HEAD ---"
+          git diff --stat HEAD 2>/dev/null | head -40 || true
+          echo "::endgroup::"
+
           echo "DID_COMMIT=false" >> "$GITHUB_ENV"
           echo "did_commit=false" >> "$GITHUB_OUTPUT"
 
@@ -1653,6 +1673,26 @@ jobs:
           git config user.name "codex-bot"
           git config user.email "codex@users.noreply.github.com"
           git rm -r --cached node_modules 2>/dev/null || true
+
+          # Diagnostic: working tree state immediately before the
+          # touched-file comparison loop.  If commit_step_start showed
+          # edits but pre_touched_loop shows a clean tree, the reversion
+          # happens inside this step (untracked cleanup, protected-path
+          # reset, artifact rm, or similar).  See PR #1255.
+          echo "::group::Working tree state (checkpoint=pre_touched_loop)"
+          printf 'timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)"
+          _cp_status="$(git status --porcelain 2>/dev/null || true)"
+          if [ -n "${_cp_status}" ]; then
+            printf '%s\n' "${_cp_status}" | head -40
+            _cp_status_lines="$(printf '%s\n' "${_cp_status}" | wc -l | tr -d '[:space:]')"
+            [ "${_cp_status_lines:-0}" -gt 40 ] && echo "[truncated: ${_cp_status_lines} total porcelain lines]"
+          else
+            echo "(clean)"
+          fi
+          echo "--- git diff --stat HEAD ---"
+          git diff --stat HEAD 2>/dev/null | head -40 || true
+          echo "::endgroup::"
+
           if [ "${IS_WORKFLOW_SOURCE_REPO:-false}" = "true" ]; then
             # On the workflow source repo, commit ONLY files the editor
             # actually wrote to.  Compared to the old pathspec-exclusion list,

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1609,8 +1609,8 @@ jobs:
           printf 'timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           _cp_status="$(git status --porcelain 2>/dev/null || true)"
           if [ -n "${_cp_status}" ]; then
-            printf '%s\n' "${_cp_status}" | head -40
-            _cp_status_lines="$(printf '%s\n' "${_cp_status}" | wc -l | tr -d '[:space:]')"
+            printf '%s\n' "${_cp_status}" | head -n 40 || true
+            _cp_status_lines="$(printf '%s\n' "${_cp_status}" | wc -l | tr -d '[:space:]' || echo 0)"
             [ "${_cp_status_lines:-0}" -gt 40 ] && echo "[truncated: ${_cp_status_lines} total porcelain lines]"
           else
             echo "(clean)"
@@ -1618,8 +1618,8 @@ jobs:
           echo "--- git diff --stat HEAD ---"
           _cp_diffstat="$(git diff --stat HEAD 2>/dev/null || true)"
           if [ -n "${_cp_diffstat}" ]; then
-            printf '%s\n' "${_cp_diffstat}" | head -40
-            _cp_diffstat_lines="$(printf '%s\n' "${_cp_diffstat}" | wc -l | tr -d '[:space:]')"
+            printf '%s\n' "${_cp_diffstat}" | head -n 40 || true
+            _cp_diffstat_lines="$(printf '%s\n' "${_cp_diffstat}" | wc -l | tr -d '[:space:]' || echo 0)"
             [ "${_cp_diffstat_lines:-0}" -gt 40 ] && echo "[truncated: ${_cp_diffstat_lines} total diffstat lines]"
           fi
           echo "::endgroup::"
@@ -1688,8 +1688,8 @@ jobs:
           printf 'timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           _cp_status="$(git status --porcelain 2>/dev/null || true)"
           if [ -n "${_cp_status}" ]; then
-            printf '%s\n' "${_cp_status}" | head -40
-            _cp_status_lines="$(printf '%s\n' "${_cp_status}" | wc -l | tr -d '[:space:]')"
+            printf '%s\n' "${_cp_status}" | head -n 40 || true
+            _cp_status_lines="$(printf '%s\n' "${_cp_status}" | wc -l | tr -d '[:space:]' || echo 0)"
             [ "${_cp_status_lines:-0}" -gt 40 ] && echo "[truncated: ${_cp_status_lines} total porcelain lines]"
           else
             echo "(clean)"
@@ -1697,8 +1697,8 @@ jobs:
           echo "--- git diff --stat HEAD ---"
           _cp_diffstat="$(git diff --stat HEAD 2>/dev/null || true)"
           if [ -n "${_cp_diffstat}" ]; then
-            printf '%s\n' "${_cp_diffstat}" | head -40
-            _cp_diffstat_lines="$(printf '%s\n' "${_cp_diffstat}" | wc -l | tr -d '[:space:]')"
+            printf '%s\n' "${_cp_diffstat}" | head -n 40 || true
+            _cp_diffstat_lines="$(printf '%s\n' "${_cp_diffstat}" | wc -l | tr -d '[:space:]' || echo 0)"
             [ "${_cp_diffstat_lines:-0}" -gt 40 ] && echo "[truncated: ${_cp_diffstat_lines} total diffstat lines]"
           fi
           echo "::endgroup::"

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1616,7 +1616,12 @@ jobs:
             echo "(clean)"
           fi
           echo "--- git diff --stat HEAD ---"
-          git diff --stat HEAD 2>/dev/null | head -40 || true
+          _cp_diffstat="$(git diff --stat HEAD 2>/dev/null || true)"
+          if [ -n "${_cp_diffstat}" ]; then
+            printf '%s\n' "${_cp_diffstat}" | head -40
+            _cp_diffstat_lines="$(printf '%s\n' "${_cp_diffstat}" | wc -l | tr -d '[:space:]')"
+            [ "${_cp_diffstat_lines:-0}" -gt 40 ] && echo "[truncated: ${_cp_diffstat_lines} total diffstat lines]"
+          fi
           echo "::endgroup::"
 
           echo "DID_COMMIT=false" >> "$GITHUB_ENV"
@@ -1690,7 +1695,12 @@ jobs:
             echo "(clean)"
           fi
           echo "--- git diff --stat HEAD ---"
-          git diff --stat HEAD 2>/dev/null | head -40 || true
+          _cp_diffstat="$(git diff --stat HEAD 2>/dev/null || true)"
+          if [ -n "${_cp_diffstat}" ]; then
+            printf '%s\n' "${_cp_diffstat}" | head -40
+            _cp_diffstat_lines="$(printf '%s\n' "${_cp_diffstat}" | wc -l | tr -d '[:space:]')"
+            [ "${_cp_diffstat_lines:-0}" -gt 40 ] && echo "[truncated: ${_cp_diffstat_lines} total diffstat lines]"
+          fi
           echo "::endgroup::"
 
           if [ "${IS_WORKFLOW_SOURCE_REPO:-false}" = "true" ]; then

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1606,7 +1606,7 @@ jobs:
           # at the step boundary (Serena shutdown / runner transition)
           # and no logic inside this step can recover.  See PR #1255.
           echo "::group::Working tree state (checkpoint=commit_step_start)"
-          printf 'timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)"
+          printf 'timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           _cp_status="$(git status --porcelain 2>/dev/null || true)"
           if [ -n "${_cp_status}" ]; then
             printf '%s\n' "${_cp_status}" | head -40
@@ -1680,7 +1680,7 @@ jobs:
           # happens inside this step (untracked cleanup, protected-path
           # reset, artifact rm, or similar).  See PR #1255.
           echo "::group::Working tree state (checkpoint=pre_touched_loop)"
-          printf 'timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)"
+          printf 'timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           _cp_status="$(git status --porcelain 2>/dev/null || true)"
           if [ -n "${_cp_status}" ]; then
             printf '%s\n' "${_cp_status}" | head -40

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -696,7 +696,7 @@ while [ "${attempt}" -le 3 ]; do
           # edits present here (attempt 1, 9+/9-), absent ~5s later at
           # commit-prep with no visible git command in between.
           echo "::group::Working tree state (checkpoint=editor_exit)"
-          printf 'timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)"
+          printf 'timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           _cp_status="$(git status --porcelain 2>/dev/null || true)"
           if [ -n "${_cp_status}" ]; then
             printf '%s\n' "${_cp_status}" | head -40

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -706,7 +706,12 @@ while [ "${attempt}" -le 3 ]; do
             echo "(clean)"
           fi
           echo "--- git diff --stat HEAD ---"
-          git diff --stat HEAD 2>/dev/null | head -40 || true
+          _cp_diffstat="$(git diff --stat HEAD 2>/dev/null || true)"
+          if [ -n "${_cp_diffstat}" ]; then
+            printf '%s\n' "${_cp_diffstat}" | head -40
+            _cp_diffstat_lines="$(printf '%s\n' "${_cp_diffstat}" | wc -l | tr -d '[:space:]')"
+            [ "${_cp_diffstat_lines:-0}" -gt 40 ] && echo "[truncated: ${_cp_diffstat_lines} total diffstat lines]"
+          fi
           echo "::endgroup::"
           exit 0
         fi

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -699,8 +699,8 @@ while [ "${attempt}" -le 3 ]; do
           printf 'timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           _cp_status="$(git status --porcelain 2>/dev/null || true)"
           if [ -n "${_cp_status}" ]; then
-            printf '%s\n' "${_cp_status}" | head -40
-            _cp_status_lines="$(printf '%s\n' "${_cp_status}" | wc -l | tr -d '[:space:]')"
+            printf '%s\n' "${_cp_status}" | head -n 40 || true
+            _cp_status_lines="$(printf '%s\n' "${_cp_status}" | wc -l | tr -d '[:space:]' || echo 0)"
             [ "${_cp_status_lines:-0}" -gt 40 ] && echo "[truncated: ${_cp_status_lines} total porcelain lines]"
           else
             echo "(clean)"
@@ -708,8 +708,8 @@ while [ "${attempt}" -le 3 ]; do
           echo "--- git diff --stat HEAD ---"
           _cp_diffstat="$(git diff --stat HEAD 2>/dev/null || true)"
           if [ -n "${_cp_diffstat}" ]; then
-            printf '%s\n' "${_cp_diffstat}" | head -40
-            _cp_diffstat_lines="$(printf '%s\n' "${_cp_diffstat}" | wc -l | tr -d '[:space:]')"
+            printf '%s\n' "${_cp_diffstat}" | head -n 40 || true
+            _cp_diffstat_lines="$(printf '%s\n' "${_cp_diffstat}" | wc -l | tr -d '[:space:]' || echo 0)"
             [ "${_cp_diffstat_lines:-0}" -gt 40 ] && echo "[truncated: ${_cp_diffstat_lines} total diffstat lines]"
           fi
           echo "::endgroup::"

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -686,6 +686,28 @@ while [ "${attempt}" -le 3 ]; do
           mv "${tmp_output}" "${EDITOR_SUMMARY_FILE}"
           rm -f "${tmp_err}"
           echo "Editor succeeded on attempt ${attempt}."
+          # Diagnostic: capture working tree state at the very last moment
+          # before this script exits.  Combined with checkpoints at the
+          # start of the Commit step and just before the touched-file
+          # comparison loop, this pinpoints whether an observed "Editor
+          # changes lost" is caused by reversion at the step boundary
+          # (Serena shutdown / runner cleanup) or by logic inside the
+          # commit-prep step itself.  See PR #1255 investigation: editor
+          # edits present here (attempt 1, 9+/9-), absent ~5s later at
+          # commit-prep with no visible git command in between.
+          echo "::group::Working tree state (checkpoint=editor_exit)"
+          printf 'timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)"
+          _cp_status="$(git status --porcelain 2>/dev/null || true)"
+          if [ -n "${_cp_status}" ]; then
+            printf '%s\n' "${_cp_status}" | head -40
+            _cp_status_lines="$(printf '%s\n' "${_cp_status}" | wc -l | tr -d '[:space:]')"
+            [ "${_cp_status_lines:-0}" -gt 40 ] && echo "[truncated: ${_cp_status_lines} total porcelain lines]"
+          else
+            echo "(clean)"
+          fi
+          echo "--- git diff --stat HEAD ---"
+          git diff --stat HEAD 2>/dev/null | head -40 || true
+          echo "::endgroup::"
           exit 0
         fi
         echo "Editor output passed format/manifest validation but claimed changes did not persist on attempt ${attempt}; retrying."


### PR DESCRIPTION
## Summary
This PR adds diagnostic logging checkpoints to track the working tree state at critical points in the review autofix workflow. These checkpoints help identify where editor changes may be lost between the editor exit and the commit preparation step.

## Key Changes
- **review_apply_fixes.sh**: Added `checkpoint=editor_exit` diagnostic group that captures the working tree state (git status and diff) immediately before the script exits after successful editor execution
- **.github/workflows/review_autofix.yml**: Added two diagnostic checkpoints:
  - `checkpoint=commit_step_start`: Captures working tree state at the beginning of the commit step
  - `checkpoint=pre_touched_loop`: Captures working tree state just before the touched-file comparison loop
- All checkpoints include:
  - Timestamp in ISO 8601 format
  - `git status --porcelain` output (truncated to 40 lines if needed)
  - `git diff --stat HEAD` output
  - Line count indicator when output is truncated

## Implementation Details
- Diagnostic output is wrapped in GitHub Actions groups for better log organization
- All git commands include error suppression (`2>/dev/null || true`) to prevent workflow failures
- The checkpoints are designed to work together to pinpoint whether working tree changes are lost at step boundaries (Serena shutdown/runner transition) or within step logic
- References PR #1255 investigation where editor changes were present at editor exit but absent during commit preparation with no visible git commands in between

https://claude.ai/code/session_01NCqJD8FX5hk2AXcLsWZeBs