### PR TITLE
Improve error diagnostics for orchestrator state comment posting

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1027,11 +1027,11 @@ jobs:
           # the API's errors[] payload instead of the opaque
           # "gh: Validation Failed (HTTP 422)" that happens when the response
           # body is redirected to /dev/null.
-          if ! POST_OUT="$(mktemp 2>/dev/null)"; then
+          if ! POST_OUT="$(mktemp)"; then
             echo "::error::Failed to create temp file for stdout capture (mktemp failed)"
             exit 1
           fi
-          if ! POST_ERR="$(mktemp 2>/dev/null)"; then
+          if ! POST_ERR="$(mktemp)"; then
             rm -f "${POST_OUT}"
             echo "::error::Failed to create temp file for stderr capture (mktemp failed)"
             exit 1

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1027,7 +1027,15 @@ jobs:
           # the API's errors[] payload instead of the opaque
           # "gh: Validation Failed (HTTP 422)" that happens when the response
           # body is redirected to /dev/null.
-          POST_OUT=$(mktemp); POST_ERR=$(mktemp)
+          if ! POST_OUT=$(mktemp 2>/dev/null); then
+            echo "::error::Failed to create temp file for stdout capture (mktemp failed)"
+            exit 1
+          fi
+          if ! POST_ERR=$(mktemp 2>/dev/null); then
+            rm -f "${POST_OUT}"
+            echo "::error::Failed to create temp file for stderr capture (mktemp failed)"
+            exit 1
+          fi
           if ! jq -n --arg body "${STATE_COMMENT}" '{"body": $body}' | \
               gh api "repos/${TEST_REPO}/issues/${TRACKING_NUMBER}/comments" \
                 --method POST --input - >"${POST_OUT}" 2>"${POST_ERR}"; then

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1027,11 +1027,11 @@ jobs:
           # the API's errors[] payload instead of the opaque
           # "gh: Validation Failed (HTTP 422)" that happens when the response
           # body is redirected to /dev/null.
-          if ! POST_OUT=$(mktemp 2>/dev/null); then
+          if ! POST_OUT="$(mktemp 2>/dev/null)"; then
             echo "::error::Failed to create temp file for stdout capture (mktemp failed)"
             exit 1
           fi
-          if ! POST_ERR=$(mktemp 2>/dev/null); then
+          if ! POST_ERR="$(mktemp 2>/dev/null)"; then
             rm -f "${POST_OUT}"
             echo "::error::Failed to create temp file for stderr capture (mktemp failed)"
             exit 1

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1023,9 +1023,26 @@ jobs:
           ${STATE_JSON}
           ORCHESTRATOR_STATE_V1 -->"
 
-          jq -n --arg body "${STATE_COMMENT}" '{"body": $body}' | \
-            gh api "repos/${TEST_REPO}/issues/${TRACKING_NUMBER}/comments" \
-              --method POST --input - >/dev/null
+          # Diagnostic: capture gh stdout + stderr so 4xx errors surface
+          # the API's errors[] payload instead of the opaque
+          # "gh: Validation Failed (HTTP 422)" that happens when the response
+          # body is redirected to /dev/null.
+          POST_OUT=$(mktemp); POST_ERR=$(mktemp)
+          if ! jq -n --arg body "${STATE_COMMENT}" '{"body": $body}' | \
+              gh api "repos/${TEST_REPO}/issues/${TRACKING_NUMBER}/comments" \
+                --method POST --input - >"${POST_OUT}" 2>"${POST_ERR}"; then
+            echo "::error::Failed to post orchestrator state comment (repo=${TEST_REPO} tracking_issue=${TRACKING_NUMBER})"
+            echo "::group::gh stderr"
+            cat "${POST_ERR}" || true
+            echo "::endgroup::"
+            echo "::group::API response body (first 4KB of stdout)"
+            head -c 4096 "${POST_OUT}" || true
+            echo ""
+            echo "::endgroup::"
+            rm -f "${POST_OUT}" "${POST_ERR}"
+            exit 1
+          fi
+          rm -f "${POST_OUT}" "${POST_ERR}"
 
           echo "Posted orchestrator state to tracking issue #${TRACKING_NUMBER}"
 


### PR DESCRIPTION
## Summary
Enhanced error handling and diagnostics when posting the orchestrator state comment to the tracking issue. Previously, errors were silently suppressed, making it difficult to debug API failures.

## Key Changes
- Capture both stdout and stderr from the `gh api` command to temporary files instead of redirecting to `/dev/null`
- Add explicit error handling that checks the exit code of the `gh api` command
- Output detailed error information to GitHub Actions logs when the API call fails:
  - Error message with context (repo and tracking issue number)
  - Full `gh` stderr output
  - First 4KB of API response body (which contains the actual error details)
- Properly clean up temporary files in both success and failure paths

## Implementation Details
- Uses `mktemp` to create temporary files for capturing output
- Wraps the `gh api` call in a conditional to detect failures
- Uses GitHub Actions `::error::` and `::group::` annotations for better log visibility
- Ensures cleanup with `rm -f` even if the script exits with an error
- Limits API response output to 4KB to avoid excessively large logs while still capturing meaningful error information

https://claude.ai/code/session_01MkSkiHm5e8wxiw5jMgyqm8