### PR TITLE
Add workflow run URLs to issue comments for better traceability

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -983,6 +983,7 @@ jobs:
             --remove-label 'ai:planning' \
             --remove-label 'ai:awaiting-approval' >/dev/null 2>&1 || true
 
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BLOCKED_COMMENT_FILE="${RUNTIME_DIR}/blocked_comment.md"
           {
             printf '%s\n' "Clarification blocked: human input required."
@@ -991,12 +992,12 @@ jobs:
             printf '\n'
             printf '%s\n' "Auto-answer has been paused to avoid unsatisfiable clarification loops."
             printf '%s\n' "Provide the required input, then run /reclarify or continue with /answer as appropriate."
+            printf '\n'
+            printf '%s\n' "Run: ${RUN_URL}"
           } > "${BLOCKED_COMMENT_FILE}"
 
           gh_retry gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
             -f body="$(cat "${BLOCKED_COMMENT_FILE}")" >/dev/null
-
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           MSG="Clarification blocked for issue #${ISSUE_NUMBER}: ${BLOCKED_REASON}"
           MSG+=$'\n'
           MSG+="Issue: ${ISSUE_URL}"

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1794,6 +1794,7 @@ jobs:
           # treating this as success.
           echo "::warning::Implementation produced no repository changes. Labeling issue #${ISSUE_NUMBER} as ai:implementation-failed."
 
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           remaining_changes="${REMAINING_CHANGES:-}"
           noop_body="⚠️ AI implementation produced no repository changes despite an approved plan."
           if [ -n "${remaining_changes}" ]; then
@@ -1811,7 +1812,9 @@ jobs:
           fi
           noop_body="${noop_body}
 
-          Labeling \`ai:implementation-failed\` for orchestrator re-processing."
+          Labeling \`ai:implementation-failed\` for orchestrator re-processing.
+
+          Run: ${RUN_URL}"
 
           gh_retry gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
             -f body="${noop_body}"
@@ -2709,6 +2712,7 @@ jobs:
 
           DIAG_STATUS="$(jq -r '.status // "harness_error"' "${IMPLEMENT_DIAGNOSE_RESULT_FILE}")"
           DIAG_TEXT="$(jq -r '.diagnosis // "Implementation failed after Codex execution."' "${IMPLEMENT_DIAGNOSE_RESULT_FILE}")"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           case "${DIAG_STATUS}" in
             needs_fixes)
@@ -2814,10 +2818,11 @@ jobs:
                 }')"
               BLOCKER_METADATA_BLOCK="$(printf '<!-- IMPLEMENT_FIXUP_BLOCKERS_V1\n%s\nIMPLEMENT_FIXUP_BLOCKERS_V1 -->' "${BLOCKER_METADATA_JSON}")"
 
-              SUMMARY_COMMENT_BODY="$(printf '## Post-Codex validation diagnosed follow-up fixes\n\n%s\n\nFailed step: %s\n\nCreated fix-up issues:\n%s\n\n%s\n' \
+              SUMMARY_COMMENT_BODY="$(printf '## Post-Codex validation diagnosed follow-up fixes\n\n%s\n\nFailed step: %s\n\nCreated fix-up issues:\n%s\n\nRun: %s\n\n%s\n' \
                 "${DIAG_TEXT}" \
                 "${FAILED_STEP_NAME}" \
                 "${issue_list_md}" \
+                "${RUN_URL}" \
                 "${BLOCKER_METADATA_BLOCK}")"
 
               gh_retry gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
@@ -2829,21 +2834,21 @@ jobs:
             harness_error)
               HARNESS_FIXES="$(jq -r '.harness_fixes // "No harness fixes were provided."' "${IMPLEMENT_DIAGNOSE_RESULT_FILE}")"
               gh_retry gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
-                -f body="## Post-Codex validation harness error\n\n${DIAG_TEXT}\n\nFailed step: ${FAILED_STEP_NAME}\n\nHarness fix guidance:\n\n${HARNESS_FIXES}" >/dev/null || true
+                -f body="## Post-Codex validation harness error\n\n${DIAG_TEXT}\n\nFailed step: ${FAILED_STEP_NAME}\n\nHarness fix guidance:\n\n${HARNESS_FIXES}\n\nRun: ${RUN_URL}" >/dev/null || true
 
               ensure_implementation_failed_label
               ;;
 
             infeasible)
               gh_retry gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
-                -f body="## Post-Codex validation marked infeasible\n\n${DIAG_TEXT}\n\nFailed step: ${FAILED_STEP_NAME}" >/dev/null || true
+                -f body="## Post-Codex validation marked infeasible\n\n${DIAG_TEXT}\n\nFailed step: ${FAILED_STEP_NAME}\n\nRun: ${RUN_URL}" >/dev/null || true
 
               ensure_implementation_failed_label
               ;;
 
             *)
               gh_retry gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
-                -f body="## Post-Codex validation diagnosis returned unknown status\n\nStatus: ${DIAG_STATUS}\n\n${DIAG_TEXT}\n\nFailed step: ${FAILED_STEP_NAME}" >/dev/null || true
+                -f body="## Post-Codex validation diagnosis returned unknown status\n\nStatus: ${DIAG_STATUS}\n\n${DIAG_TEXT}\n\nFailed step: ${FAILED_STEP_NAME}\n\nRun: ${RUN_URL}" >/dev/null || true
 
               ensure_implementation_failed_label
               ;;

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -1074,6 +1074,7 @@ jobs:
             --remove-label 'ai:clarification' \
             --remove-label 'ai:awaiting-approval' >/dev/null 2>&1 || true
 
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           {
             printf '%s\n' "Planning blocked: human input required."
             printf '\n'
@@ -1081,12 +1082,13 @@ jobs:
             printf '\n'
             printf '%s\n' "Auto-answer has been paused to avoid unsatisfiable clarification loops."
             printf '%s\n' "Provide the required input, then reply with /answer."
+            printf '\n'
+            printf '%s\n' "Run: ${RUN_URL}"
           } > "${PLAN_COMMENT_FILE}"
 
           gh_retry gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
             -f body="$(cat "${PLAN_COMMENT_FILE}")" >/dev/null
 
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           MSG="Planning blocked for issue #${ISSUE_NUMBER}: ${BLOCKED_REASON}"
           MSG+=$'\n'
           MSG+="Issue: ${ISSUE_URL}"
@@ -1293,7 +1295,8 @@ jobs:
             if [ -n "${PLAN_PROGRESS_COMMENT_ID:-}" ]; then
               gh_retry gh api -X DELETE "repos/${{ github.repository }}/issues/comments/${PLAN_PROGRESS_COMMENT_ID}" >/dev/null 2>&1 || true
             fi
-            REJECTION_BODY=$'The generated plan targets template-owned paths (`scripts/`, `.github/prompts/`, or `.github/scripts/`) which are fetched from the `coding-workflows` repository at runtime and are excluded from Codex commits in `implement.yml`. Implementing this plan would produce a no-op PR.\n\nIf a change to those files is genuinely required, open an issue or PR directly against [`shubhodeep1/coding-workflows`](https://github.com/shubhodeep1/coding-workflows) instead.'
+            RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            REJECTION_BODY=$'The generated plan targets template-owned paths (`scripts/`, `.github/prompts/`, or `.github/scripts/`) which are fetched from the `coding-workflows` repository at runtime and are excluded from Codex commits in `implement.yml`. Implementing this plan would produce a no-op PR.\n\nIf a change to those files is genuinely required, open an issue or PR directly against [`shubhodeep1/coding-workflows`](https://github.com/shubhodeep1/coding-workflows) instead.\n\nRun: '"${RUN_URL}"
             gh_retry gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
               -f body="${REJECTION_BODY}" >/dev/null 2>&1 || true
             exit 1

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3414,6 +3414,7 @@ jobs:
           set -euo pipefail
           source "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh" 2>/dev/null || true
 
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BODY="$(cat <<EOF
           **AI review/autofix blocked — needs human intervention**
 
@@ -3425,6 +3426,8 @@ jobs:
           - Push a new commit to re-trigger the review workflow
 
           Linked issues have been labeled \`ai:review-blocked\`.
+
+          Run: ${RUN_URL}
           EOF
           )"
 
@@ -3739,6 +3742,8 @@ jobs:
               BODY+="Auto-merge has been **blocked**. All automated retry attempts have been exhausted."
               BODY+=$'\n'
               BODY+="**Next steps:** re-run the review workflow manually or apply the changes from the editor summary above."
+              BODY+=$'\n\n'
+              BODY+="Run: ${RUN_URL}"
               gh_retry gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -f body="${BODY}" >/dev/null 2>&1 || true
             else
               MSG="⚠️ Editor changes lost (push disabled): #${PR_NUMBER}"


### PR DESCRIPTION
## Summary
This change adds GitHub Actions run URLs to issue comments across multiple workflows to improve traceability and debugging. Users can now easily navigate to the specific workflow run that generated each comment.

## Key Changes
- **implement.yml**: Added run URL to comments for:
  - No-op implementation failures (when no repository changes are produced)
  - Post-Codex validation diagnosis comments (needs_fixes, harness_error, infeasible, and unknown status cases)

- **plan.yml**: Added run URL to comments for:
  - Planning blocked due to human input required
  - Plan rejection for template-owned paths

- **clarify.yml**: Added run URL to comments for:
  - Clarification blocked due to human input required

- **review_autofix.yml**: Added run URL to comments for:
  - Review/autofix blocked requiring human intervention
  - Auto-merge blocked after exhausted retry attempts

## Implementation Details
- Run URL is constructed using GitHub context variables: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
- The URL is added consistently to the end of comment bodies with a "Run:" label
- Variable is defined once per relevant code section and reused in multiple comment bodies where applicable
- Maintains existing comment formatting and structure while appending the run URL information

https://claude.ai/code/session_01F8vFcvqvw8k38tSNemk6Mr