### PR TITLE
validate_process: skip tg_notify for duplicate-label alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning follows [Semantic Versioning](https://semver.org/) per `docs/release-
 ## [Unreleased]
 
 ### Changed
+- `ensure_label_exists` in `scripts/validate_process.sh` no longer routes the "label already exists, skipping" duplicate-label case through `tg_notify` (DEBUG); it now emits a local `::debug::` stderr line, matching the existing behaviour in `scripts/label_helpers.sh` and `scripts/orchestrate_poll_process.sh`. Genuine label-create failures still raise a `tg_notify` WARNING. No Telegram alert is sent for expected duplicate-label races.
 - H8: made reviewer watchdog PR-state polling interval configurable via `REVIEW_PR_STATE_POLL_INTERVAL_SECS` in `scripts/review_run_reviewers.sh` (default `10`, valid `10..3600`), with `rate_limit_audit_fallback` warning and fail-open fallback to default for invalid/out-of-range inputs.
 - Added H4 PR comment hydration shim in `scripts/gh_helpers.sh`: `gh_pr_with_all_comments` now uses a single GraphQL call for PR metadata + issue/review comments with deterministic ordering, mandatory fail-open REST fallback, and shared legacy JSON output contract for judge consumers.
 - review/autofix now caches PR `closingIssuesReferences(first: 50)` once per job in `LINKED_ISSUES_JSON` and reuses it for linked-issue status/label updates and Telegram single-issue links, preserving existing PR title/body REST fallback and downstream behavior.

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -465,7 +465,7 @@ ensure_label_exists()
   [ "${_label_err_file}" = "/dev/null" ] || rm -f "${_label_err_file}"
 
   if printf '%s' "${_label_err}" | grep -Eiq 'already[ _-]*exists|already_exists'; then
-    tg_notify "ensure_label_exists: label already exists, skipping '${label_name}'." "DEBUG"
+    echo "::debug::ensure_label_exists: label already exists, skipping '${label_name}'." >&2
     return 0
   fi
 

--- a/tests/test_validate_process_fixup_labels.py
+++ b/tests/test_validate_process_fixup_labels.py
@@ -298,9 +298,11 @@ ensure_label_exists "ai:orchestrator-managed"
 			"/labels/" in path
 			for path in state.get("api_calls", [])
 		)
-		notify_text = notify_file.read_text(encoding="utf-8")
-		assert "label already exists, skipping 'ai:clarification'" in notify_text
-		assert "label already exists, skipping 'ai:orchestrator-managed'" in notify_text
+		notify_text = notify_file.read_text(encoding="utf-8") if notify_file.exists() else ""
+		assert "label already exists, skipping 'ai:clarification'" not in notify_text
+		assert "label already exists, skipping 'ai:orchestrator-managed'" not in notify_text
+		assert "::debug::ensure_label_exists: label already exists, skipping 'ai:clarification'." in proc.stderr
+		assert "::debug::ensure_label_exists: label already exists, skipping 'ai:orchestrator-managed'." in proc.stderr
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- `ensure_label_exists` in `scripts/validate_process.sh` was the only one of the three label-create helpers paging Telegram (DEBUG) when `gh label create` returned "already exists". Aligned it with `scripts/label_helpers.sh` and `scripts/orchestrate_poll_process.sh`, which already log a local `::debug::` stderr line instead. Genuine label-create failures still raise the WARNING `tg_notify`.
- Updated `tests/test_validate_process_fixup_labels.py::test_validate_needs_fixes_label_create_already_exists_is_idempotent` to assert the `::debug::` stderr line is emitted and that no `notify.log` entry is written.
- Added a `[Unreleased] → Changed` entry in `CHANGELOG.md` describing the suppression.

Triggering event: repeated `🔍 DEBUG: ensure_label_exists: label already exists, skipping 'ai:validating'.` alert on https://github.com/shubhodeep1/coding-workflows/issues/1272 (run https://github.com/shubhodeep1/coding-workflows/actions/runs/24554212757).

## Test plan
- [x] `python3 tests/test_validate_process_fixup_labels.py` — both tests pass
- [x] `bash -n scripts/validate_process.sh` — no syntax errors
- [ ] Next validate run on a tracking issue with a pre-existing `ai:*` label should not produce a Telegram DEBUG notification for "label already exists" (verify on first real run)

https://claude.ai/code/session_01ATH4ZwhvfESmJVbeqfnNTT