### PR TITLE
validate_process: enforce app-container CANARY_TOOLS scope in preflight

### DIFF
--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -1249,7 +1249,7 @@ PY2
 			#   CANARY_TOOLS=curl jq python3         (unquoted — sol3 bug; still scannable)
 			_canary_tools_raw="$(printf '%s\n' "${_canary_tools_line}" \
 				| sed -E 's/^[[:space:]]*CANARY_TOOLS=//' \
-				| sed -E 's/[[:space:]]+#.*$//' \
+				| sed -E 's/[[:space:]]*#.*$//' \
 				| sed -E 's/^"\$\{CANARY_TOOLS:-//; s/\}"[[:space:]]*$//' \
 				| sed -E "s/^'\\\$\\{CANARY_TOOLS:-//; s/\\}'[[:space:]]*$//" \
 				| sed -E 's/^\$\{CANARY_TOOLS:-//; s/\}[[:space:]]*$//' \
@@ -1264,6 +1264,7 @@ PY2
 						psql) _tool_pattern='psql|postgresql-client' ;;
 						redis-cli) _tool_pattern='redis-cli|redis-tools' ;;
 						mysql|mysqladmin) _tool_pattern="${_tool}|mysql-client|default-mysql-client|mariadb-client" ;;
+						kcat|kafkacat) _tool_pattern='kcat|kafkacat' ;;
 						*) _tool_pattern="${_tool}" ;;
 					esac
 						# Tool is service-side. Accept it only if the app

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -1254,17 +1254,26 @@ PY2
 				| sed -E 's/^\$\{CANARY_TOOLS:-//; s/\}[[:space:]]*$//' \
 				| sed -E 's/^"//; s/"$//; s/^'"'"'//; s/'"'"'$//')"
 			local _denylist="mongosh mongo psql redis-cli mysql mysqladmin kafkacat kcat"
-			local _tool _offenders=""
+			local _tool _tool_pattern _offenders=""
+			set -f
 			for _tool in ${_canary_tools_raw}; do
 				case " ${_denylist} " in
 					*" ${_tool} "*)
+						case "${_tool}" in
+							psql) _tool_pattern='psql|postgresql-client' ;;
+							redis-cli) _tool_pattern='redis-cli|redis-tools' ;;
+							mysql|mysqladmin) _tool_pattern="${_tool}|mysql-client" ;;
+							*) _tool_pattern="${_tool}" ;;
+						esac
 						# Tool is service-side. Accept it only if the app
 						# image explicitly installs it (apt/pip/custom RUN).
 						# The token-boundary regex avoids matching the tool
 						# name inside an unrelated identifier.
 						if [ -f validation/Dockerfile.app ] && \
 							grep -Ev '^[[:space:]]*#' validation/Dockerfile.app \
-							| grep -qE "(^|[^[:alnum:]_])${_tool}([[:space:]=]|$)"; then
+							| sed -E 's/[[:space:]]+#.*$//' \
+							| sed -E ':a;N;$!ba;s/\\[[:space:]]*\n[[:space:]]*/ /g' \
+							| grep -qE "(^|[^[:alnum:]_])(${_tool_pattern})([^[:alnum:]_]|$)"; then
 							: # installed; scope satisfied
 						else
 							_offenders="${_offenders:+${_offenders} }${_tool}"
@@ -1272,6 +1281,7 @@ PY2
 						;;
 				esac
 			done
+			set +f
 			if [ -n "${_offenders}" ]; then
 				{
 					echo "validation/tests/00_canary.sh CANARY_TOOLS references service-side CLI(s) not installed in validation/Dockerfile.app: ${_offenders}"

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -1249,6 +1249,7 @@ PY2
 			#   CANARY_TOOLS=curl jq python3         (unquoted — sol3 bug; still scannable)
 			_canary_tools_raw="$(printf '%s\n' "${_canary_tools_line}" \
 				| sed -E 's/^[[:space:]]*CANARY_TOOLS=//' \
+				| sed -E 's/[[:space:]]+#.*$//' \
 				| sed -E 's/^"\$\{CANARY_TOOLS:-//; s/\}"[[:space:]]*$//' \
 				| sed -E "s/^'\\\$\\{CANARY_TOOLS:-//; s/\\}'[[:space:]]*$//" \
 				| sed -E 's/^\$\{CANARY_TOOLS:-//; s/\}[[:space:]]*$//' \
@@ -1259,12 +1260,12 @@ PY2
 			for _tool in ${_canary_tools_raw}; do
 				case " ${_denylist} " in
 					*" ${_tool} "*)
-						case "${_tool}" in
-							psql) _tool_pattern='psql|postgresql-client' ;;
-							redis-cli) _tool_pattern='redis-cli|redis-tools' ;;
-							mysql|mysqladmin) _tool_pattern="${_tool}|mysql-client" ;;
-							*) _tool_pattern="${_tool}" ;;
-						esac
+					case "${_tool}" in
+						psql) _tool_pattern='psql|postgresql-client' ;;
+						redis-cli) _tool_pattern='redis-cli|redis-tools' ;;
+						mysql|mysqladmin) _tool_pattern="${_tool}|mysql-client|default-mysql-client|mariadb-client" ;;
+						*) _tool_pattern="${_tool}" ;;
+					esac
 						# Tool is service-side. Accept it only if the app
 						# image explicitly installs it (apt/pip/custom RUN).
 						# The token-boundary regex avoids matching the tool

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -1223,6 +1223,70 @@ PY2
 		fi
 	done
 
+	# Preflight: app-container CANARY_TOOLS scope check.
+	#
+	# mode-validate-generate.txt hard rule: service-side CLIs (mongosh, mongo,
+	# psql, redis-cli, mysql, mysqladmin, kafkacat, kcat) must NOT appear in
+	# the app container's CANARY_TOOLS loop unless the app image explicitly
+	# installs that exact binary. Canonical false-positive symptom:
+	# `not ok N - mongosh is NOT available in app` on a python:*-slim-based
+	# image whose app never invokes mongosh (Mongo reachability is already
+	# covered by a service-side assertion that runs inside the mongo
+	# container). The generator prompt already forbids this at lines 491-492,
+	# but the LLM has been observed to violate it; mechanical enforcement
+	# here routes the violation through the preflight self-heal path so the
+	# regenerate/self-heal loop can intercept before a validation cycle
+	# burns. See docs/validation-improvements.md for the motivating run.
+	if [ -f validation/tests/00_canary.sh ]; then
+		local _canary_tools_line
+		_canary_tools_line="$(grep -E '^[[:space:]]*CANARY_TOOLS=' validation/tests/00_canary.sh | head -n 1 || true)"
+		if [ -n "${_canary_tools_line}" ]; then
+			local _canary_tools_raw
+			# Strip the default-value wrapper from any of these shapes:
+			#   CANARY_TOOLS="${CANARY_TOOLS:-curl jq python3 mongosh}"
+			#   CANARY_TOOLS='${CANARY_TOOLS:-curl jq python3}'
+			#   CANARY_TOOLS="curl jq python3 mongosh"
+			#   CANARY_TOOLS=curl jq python3         (unquoted — sol3 bug; still scannable)
+			_canary_tools_raw="$(printf '%s\n' "${_canary_tools_line}" \
+				| sed -E 's/^[[:space:]]*CANARY_TOOLS=//' \
+				| sed -E 's/^"\$\{CANARY_TOOLS:-//; s/\}"[[:space:]]*$//' \
+				| sed -E "s/^'\\\$\\{CANARY_TOOLS:-//; s/\\}'[[:space:]]*$//" \
+				| sed -E 's/^\$\{CANARY_TOOLS:-//; s/\}[[:space:]]*$//' \
+				| sed -E 's/^"//; s/"$//; s/^'"'"'//; s/'"'"'$//')"
+			local _denylist="mongosh mongo psql redis-cli mysql mysqladmin kafkacat kcat"
+			local _tool _offenders=""
+			for _tool in ${_canary_tools_raw}; do
+				case " ${_denylist} " in
+					*" ${_tool} "*)
+						# Tool is service-side. Accept it only if the app
+						# image explicitly installs it (apt/pip/custom RUN).
+						# The token-boundary regex avoids matching the tool
+						# name inside an unrelated identifier.
+						if [ -f validation/Dockerfile.app ] && \
+							grep -Ev '^[[:space:]]*#' validation/Dockerfile.app \
+							| grep -qE "(^|[^[:alnum:]_])${_tool}([[:space:]=]|$)"; then
+							: # installed; scope satisfied
+						else
+							_offenders="${_offenders:+${_offenders} }${_tool}"
+						fi
+						;;
+				esac
+			done
+			if [ -n "${_offenders}" ]; then
+				{
+					echo "validation/tests/00_canary.sh CANARY_TOOLS references service-side CLI(s) not installed in validation/Dockerfile.app: ${_offenders}"
+					echo "mode-validate-generate.txt hard rule: do NOT include service-side CLIs (mongosh, mongo, psql, redis-cli, mysql, mysqladmin, kafkacat, kcat) in the app-container CANARY_TOOLS unless the app image explicitly installs that exact binary."
+					echo "Fix options (choose one per offending tool):"
+					echo "  1) Remove the tool from CANARY_TOOLS in 00_canary.sh. For DB reachability, probe from the service container (docker compose exec -T <service> <cli> ...) or use a native client inside the app (python3 + pymongo, psycopg2, redis-py, etc.)."
+					echo "  2) Install the tool in validation/Dockerfile.app via apt (plus any required repo/GPG plumbing, e.g. MongoDB official apt repo for mongosh) and leave CANARY_TOOLS unchanged."
+				} >> "${PRE_FLIGHT_LOG_FILE}"
+				PRE_FLIGHT_STATUS="fail"
+				_emit_preflight_tail "CANARY_TOOLS scope violation: service-side CLI(s) referenced in app canary but not installed in app image: ${_offenders}"
+				return 1
+			fi
+		fi
+	fi
+
 	PRE_FLIGHT_STATUS="pass"
 	return 0
 }

--- a/tests/test_validate_preflight_canary_tools_scope.py
+++ b/tests/test_validate_preflight_canary_tools_scope.py
@@ -56,12 +56,21 @@ _LINT_SNIPPET = textwrap.dedent(r"""
 
     _denylist="mongosh mongo psql redis-cli mysql mysqladmin kafkacat kcat"
     _offenders=""
+    set -f
     for _tool in ${_canary_tools_raw}; do
         case " ${_denylist} " in
             *" ${_tool} "*)
+                case "${_tool}" in
+                    psql) _tool_pattern='psql|postgresql-client' ;;
+                    redis-cli) _tool_pattern='redis-cli|redis-tools' ;;
+                    mysql|mysqladmin) _tool_pattern="${_tool}|mysql-client" ;;
+                    *) _tool_pattern="${_tool}" ;;
+                esac
                 if [ -f validation/Dockerfile.app ] && \
                     grep -Ev '^[[:space:]]*#' validation/Dockerfile.app \
-                    | grep -qE "(^|[^[:alnum:]_])${_tool}([[:space:]=]|$)"; then
+                    | sed -E 's/[[:space:]]+#.*$//' \
+                    | sed -E ':a;N;$!ba;s/\\[[:space:]]*\n[[:space:]]*/ /g' \
+                    | grep -qE "(^|[^[:alnum:]_])(${_tool_pattern})([^[:alnum:]_]|$)"; then
                     :
                 else
                     _offenders="${_offenders:+${_offenders} }${_tool}"
@@ -69,6 +78,7 @@ _LINT_SNIPPET = textwrap.dedent(r"""
                 ;;
         esac
     done
+    set +f
 
     if [ -n "${_offenders}" ]; then
         echo "OFFENDERS:${_offenders}"
@@ -216,6 +226,81 @@ class CanaryToolsScopeLintTests(unittest.TestCase):
             result = _run(tmp)
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("OFFENDERS:mongosh", result.stdout)
+
+    def test_inline_comment_does_not_satisfy_install(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _write(
+                os.path.join(tmp, "validation/tests/00_canary.sh"),
+                'CANARY_TOOLS="${CANARY_TOOLS:-curl jq mongosh}"\n',
+            )
+            _write(
+                os.path.join(tmp, "validation/Dockerfile.app"),
+                "FROM python:3.12-slim\n"
+                "RUN apt-get install -y curl jq # mongosh\n",
+            )
+            result = _run(tmp)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("OFFENDERS:mongosh", result.stdout)
+
+    def test_package_alias_install_is_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _write(
+                os.path.join(tmp, "validation/tests/00_canary.sh"),
+                'CANARY_TOOLS="${CANARY_TOOLS:-curl jq psql}"\n',
+            )
+            _write(
+                os.path.join(tmp, "validation/Dockerfile.app"),
+                "FROM python:3.12-slim\n"
+                "RUN apt-get install -y curl jq postgresql-client\n",
+            )
+            result = _run(tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("OK", result.stdout)
+
+    def test_tool_match_handles_shell_punctuation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _write(
+                os.path.join(tmp, "validation/tests/00_canary.sh"),
+                'CANARY_TOOLS="${CANARY_TOOLS:-curl jq psql}"\n',
+            )
+            _write(
+                os.path.join(tmp, "validation/Dockerfile.app"),
+                "FROM python:3.12-slim\n"
+                "RUN apt-get install -y psql; echo done\n",
+            )
+            result = _run(tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("OK", result.stdout)
+
+    def test_line_continuation_install_is_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _write(
+                os.path.join(tmp, "validation/tests/00_canary.sh"),
+                'CANARY_TOOLS="${CANARY_TOOLS:-curl jq redis-cli}"\n',
+            )
+            _write(
+                os.path.join(tmp, "validation/Dockerfile.app"),
+                "FROM python:3.12-slim\n"
+                "RUN apt-get install -y curl jq \\\n                    redis-tools\n",
+            )
+            result = _run(tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("OK", result.stdout)
+
+    def test_glob_literal_does_not_expand_to_filenames(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _write(
+                os.path.join(tmp, "validation/tests/00_canary.sh"),
+                'CANARY_TOOLS="${CANARY_TOOLS:-*}"\n',
+            )
+            _write(
+                os.path.join(tmp, "validation/Dockerfile.app"),
+                "FROM python:3.12-slim\nRUN apt-get install -y curl jq\n",
+            )
+            _write(os.path.join(tmp, "mongosh"), "sentinel\n")
+            result = _run(tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("OK", result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_preflight_canary_tools_scope.py
+++ b/tests/test_validate_preflight_canary_tools_scope.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Tests for the CANARY_TOOLS scope preflight check in validate_process.sh.
+
+The check enforces mode-validate-generate.txt lines 491-492: service-side CLIs
+(mongosh, mongo, psql, redis-cli, mysql, mysqladmin, kafkacat, kcat) must not
+appear in the app container's CANARY_TOOLS unless the app image explicitly
+installs that exact binary. See the motivating run documented in the
+validation-improvements ledger (false-positive `mongosh is NOT available in
+app` on a python:3.12-slim image where the app uses pymongo).
+
+The check is embedded inside run_preflight_checks() in scripts/validate_process.sh.
+These tests reproduce the canonical extraction + denylist logic in a
+standalone bash harness so regressions in the pattern (for example a sed
+expression that fails on a new CANARY_TOOLS literal shape) surface here before
+reaching a live validation run.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+# The canonical lint snippet lifted from scripts/validate_process.sh. Keep in
+# sync with the run_preflight_checks() implementation.
+_LINT_SNIPPET = textwrap.dedent(r"""
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Arg 1: working directory containing validation/tests/00_canary.sh and
+    # validation/Dockerfile.app. The snippet chdirs into it and runs the same
+    # extraction/denylist logic used inside run_preflight_checks().
+
+    cd "$1"
+
+    if [ ! -f validation/tests/00_canary.sh ]; then
+        echo "NO_CANARY"
+        exit 0
+    fi
+
+    _canary_tools_line="$(grep -E '^[[:space:]]*CANARY_TOOLS=' validation/tests/00_canary.sh | head -n 1 || true)"
+    if [ -z "${_canary_tools_line}" ]; then
+        echo "NO_CANARY_TOOLS_LINE"
+        exit 0
+    fi
+
+    _canary_tools_raw="$(printf '%s\n' "${_canary_tools_line}" \
+        | sed -E 's/^[[:space:]]*CANARY_TOOLS=//' \
+        | sed -E 's/^"\$\{CANARY_TOOLS:-//; s/\}"[[:space:]]*$//' \
+        | sed -E "s/^'\\\$\\{CANARY_TOOLS:-//; s/\\}'[[:space:]]*$//" \
+        | sed -E 's/^\$\{CANARY_TOOLS:-//; s/\}[[:space:]]*$//' \
+        | sed -E 's/^"//; s/"$//; s/^'"'"'//; s/'"'"'$//')"
+
+    _denylist="mongosh mongo psql redis-cli mysql mysqladmin kafkacat kcat"
+    _offenders=""
+    for _tool in ${_canary_tools_raw}; do
+        case " ${_denylist} " in
+            *" ${_tool} "*)
+                if [ -f validation/Dockerfile.app ] && \
+                    grep -Ev '^[[:space:]]*#' validation/Dockerfile.app \
+                    | grep -qE "(^|[^[:alnum:]_])${_tool}([[:space:]=]|$)"; then
+                    :
+                else
+                    _offenders="${_offenders:+${_offenders} }${_tool}"
+                fi
+                ;;
+        esac
+    done
+
+    if [ -n "${_offenders}" ]; then
+        echo "OFFENDERS:${_offenders}"
+        exit 1
+    fi
+    echo "OK"
+""")
+
+
+def _write(path: str, content: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(content)
+
+
+def _run(tmpdir: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-c", _LINT_SNIPPET, "_", tmpdir],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class CanaryToolsScopeLintTests(unittest.TestCase):
+    def test_no_canary_file_is_not_a_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = _run(tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("NO_CANARY", result.stdout)
+
+    def test_clean_canary_tools_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _write(
+                os.path.join(tmp, "validation/tests/00_canary.sh"),
+                'CANARY_TOOLS="${CANARY_TOOLS:-curl jq python3 pytest}"\n',
+            )
+            _write(
+                os.path.join(tmp, "validation/Dockerfile.app"),
+                "FROM python:3.12-slim\nRUN apt-get install -y curl jq\n",
+            )
+            result = _run(tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("OK", result.stdout)
+
+    def test_mongosh_in_canary_without_dockerfile_install_fails(self) -> None:
+        # Reproduction of the log-5 failure: CANARY_TOOLS asserts mongosh
+        # against the app container on a python:slim image that never
+        # installs mongosh (app uses pymongo).
+        with tempfile.TemporaryDirectory() as tmp:
+            _write(
+                os.path.join(tmp, "validation/tests/00_canary.sh"),
+                'CANARY_TOOLS="${CANARY_TOOLS:-curl jq python3 pytest mongosh}"\n',
+            )
+            _write(
+                os.path.join(tmp, "validation/Dockerfile.app"),
+                "FROM python:3.12-slim\nRUN apt-get install -y curl jq\n",
+            )
+            result = _run(tmp)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("OFFENDERS:mongosh", result.stdout)
+
+    def test_mongosh_installed_via_dockerfile_is_accepted(self) -> None:
+        # Satisfies the "fix option 2" path: if the app image genuinely
+        # installs mongosh, leaving it in CANARY_TOOLS is consistent.
+        with tempfile.TemporaryDirectory() as tmp:
+            _write(
+                os.path.join(tmp, "validation/tests/00_canary.sh"),
+                'CANARY_TOOLS="${CANARY_TOOLS:-curl jq python3 mongosh}"\n',
+            )
+            _write(
+                os.path.join(tmp, "validation/Dockerfile.app"),
+                "FROM python:3.12-slim\n"
+                "RUN apt-get install -y curl jq mongodb-mongosh\n",
+            )
+            result = _run(tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("OK", result.stdout)
+
+    def test_multiple_offenders_reported_together(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _write(
+                os.path.join(tmp, "validation/tests/00_canary.sh"),
+                'CANARY_TOOLS="${CANARY_TOOLS:-curl jq mongosh psql redis-cli}"\n',
+            )
+            _write(
+                os.path.join(tmp, "validation/Dockerfile.app"),
+                "FROM python:3.12-slim\nRUN apt-get install -y curl jq\n",
+            )
+            result = _run(tmp)
+            self.assertNotEqual(result.returncode, 0)
+            # All three denylisted tools should be listed as offenders.
+            self.assertIn("mongosh", result.stdout)
+            self.assertIn("psql", result.stdout)
+            self.assertIn("redis-cli", result.stdout)
+
+    def test_non_denylist_tools_never_fail(self) -> None:
+        # `git` and `make` are legitimate extras installed via Dockerfile.app
+        # per the prompt's custom-test dependency analysis rule. They must
+        # never trip the denylist.
+        with tempfile.TemporaryDirectory() as tmp:
+            _write(
+                os.path.join(tmp, "validation/tests/00_canary.sh"),
+                'CANARY_TOOLS="${CANARY_TOOLS:-curl jq python3 git make}"\n',
+            )
+            _write(
+                os.path.join(tmp, "validation/Dockerfile.app"),
+                "FROM python:3.12-slim\nRUN apt-get install -y curl jq git make\n",
+            )
+            result = _run(tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("OK", result.stdout)
+
+    def test_commented_dockerfile_install_does_not_satisfy(self) -> None:
+        # A commented-out apt-get install must not be counted as installing
+        # the tool, otherwise the lint is trivially bypassable.
+        with tempfile.TemporaryDirectory() as tmp:
+            _write(
+                os.path.join(tmp, "validation/tests/00_canary.sh"),
+                'CANARY_TOOLS="${CANARY_TOOLS:-curl jq mongosh}"\n',
+            )
+            _write(
+                os.path.join(tmp, "validation/Dockerfile.app"),
+                "FROM python:3.12-slim\n"
+                "# RUN apt-get install -y mongosh\n"
+                "RUN apt-get install -y curl jq\n",
+            )
+            result = _run(tmp)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("OFFENDERS:mongosh", result.stdout)
+
+    def test_single_quoted_canary_tools_literal(self) -> None:
+        # The prompt's recommended pattern uses double quotes, but a
+        # single-quoted literal still appears in the wild and must extract
+        # correctly.
+        with tempfile.TemporaryDirectory() as tmp:
+            _write(
+                os.path.join(tmp, "validation/tests/00_canary.sh"),
+                "CANARY_TOOLS='${CANARY_TOOLS:-curl jq python3 mongosh}'\n",
+            )
+            _write(
+                os.path.join(tmp, "validation/Dockerfile.app"),
+                "FROM python:3.12-slim\nRUN apt-get install -y curl jq\n",
+            )
+            result = _run(tmp)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("OFFENDERS:mongosh", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_preflight_canary_tools_scope.py
+++ b/tests/test_validate_preflight_canary_tools_scope.py
@@ -49,6 +49,7 @@ _LINT_SNIPPET = textwrap.dedent(r"""
 
     _canary_tools_raw="$(printf '%s\n' "${_canary_tools_line}" \
         | sed -E 's/^[[:space:]]*CANARY_TOOLS=//' \
+        | sed -E 's/[[:space:]]+#.*$//' \
         | sed -E 's/^"\$\{CANARY_TOOLS:-//; s/\}"[[:space:]]*$//' \
         | sed -E "s/^'\\\$\\{CANARY_TOOLS:-//; s/\\}'[[:space:]]*$//" \
         | sed -E 's/^\$\{CANARY_TOOLS:-//; s/\}[[:space:]]*$//' \
@@ -63,7 +64,7 @@ _LINT_SNIPPET = textwrap.dedent(r"""
                 case "${_tool}" in
                     psql) _tool_pattern='psql|postgresql-client' ;;
                     redis-cli) _tool_pattern='redis-cli|redis-tools' ;;
-                    mysql|mysqladmin) _tool_pattern="${_tool}|mysql-client" ;;
+                    mysql|mysqladmin) _tool_pattern="${_tool}|mysql-client|default-mysql-client|mariadb-client" ;;
                     *) _tool_pattern="${_tool}" ;;
                 esac
                 if [ -f validation/Dockerfile.app ] && \
@@ -257,6 +258,21 @@ class CanaryToolsScopeLintTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("OK", result.stdout)
 
+    def test_mysql_alias_install_is_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _write(
+                os.path.join(tmp, "validation/tests/00_canary.sh"),
+                'CANARY_TOOLS="${CANARY_TOOLS:-curl jq mysql mysqladmin}"\n',
+            )
+            _write(
+                os.path.join(tmp, "validation/Dockerfile.app"),
+                "FROM python:3.12-slim\n"
+                "RUN apt-get install -y curl jq default-mysql-client mariadb-client\n",
+            )
+            result = _run(tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("OK", result.stdout)
+
     def test_tool_match_handles_shell_punctuation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             _write(
@@ -298,6 +314,20 @@ class CanaryToolsScopeLintTests(unittest.TestCase):
                 "FROM python:3.12-slim\nRUN apt-get install -y curl jq\n",
             )
             _write(os.path.join(tmp, "mongosh"), "sentinel\n")
+            result = _run(tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("OK", result.stdout)
+
+    def test_canary_tools_line_trailing_comment_is_ignored(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _write(
+                os.path.join(tmp, "validation/tests/00_canary.sh"),
+                'CANARY_TOOLS="${CANARY_TOOLS:-curl jq python3}" # mongosh\n',
+            )
+            _write(
+                os.path.join(tmp, "validation/Dockerfile.app"),
+                "FROM python:3.12-slim\nRUN apt-get install -y curl jq\n",
+            )
             result = _run(tmp)
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("OK", result.stdout)

--- a/tests/test_validate_preflight_canary_tools_scope.py
+++ b/tests/test_validate_preflight_canary_tools_scope.py
@@ -49,7 +49,7 @@ _LINT_SNIPPET = textwrap.dedent(r"""
 
     _canary_tools_raw="$(printf '%s\n' "${_canary_tools_line}" \
         | sed -E 's/^[[:space:]]*CANARY_TOOLS=//' \
-        | sed -E 's/[[:space:]]+#.*$//' \
+        | sed -E 's/[[:space:]]*#.*$//' \
         | sed -E 's/^"\$\{CANARY_TOOLS:-//; s/\}"[[:space:]]*$//' \
         | sed -E "s/^'\\\$\\{CANARY_TOOLS:-//; s/\\}'[[:space:]]*$//" \
         | sed -E 's/^\$\{CANARY_TOOLS:-//; s/\}[[:space:]]*$//' \
@@ -65,6 +65,7 @@ _LINT_SNIPPET = textwrap.dedent(r"""
                     psql) _tool_pattern='psql|postgresql-client' ;;
                     redis-cli) _tool_pattern='redis-cli|redis-tools' ;;
                     mysql|mysqladmin) _tool_pattern="${_tool}|mysql-client|default-mysql-client|mariadb-client" ;;
+                    kcat|kafkacat) _tool_pattern='kcat|kafkacat' ;;
                     *) _tool_pattern="${_tool}" ;;
                 esac
                 if [ -f validation/Dockerfile.app ] && \


### PR DESCRIPTION
## Summary

- Add a mechanical preflight check in `run_preflight_checks()` that fails when `validation/tests/00_canary.sh` references service-side CLIs (`mongosh`, `mongo`, `psql`, `redis-cli`, `mysql`, `mysqladmin`, `kafkacat`, `kcat`) in `CANARY_TOOLS` without `validation/Dockerfile.app` actually installing the binary.
- Failure routes through the existing `attempt_self_heal_and_reexec "preflight"` path at `scripts/validate_process.sh:1763`, so a regenerate/self-heal can intercept before a validation cycle is burned.
- Add `tests/test_validate_preflight_canary_tools_scope.py` (8 cases, unittest) covering: absent canary file, clean list, offender missing from image, offender installed via `mongodb-mongosh`, multi-offender aggregation, commented-out apt line, single-quoted literal, non-denylist tools.

## Motivation

The generator prompt already forbids this pattern at `prompts/mode-validate-generate.txt:491-492`, but the generator LLM was observed to add `mongosh` to the app-container `CANARY_TOOLS` anyway, producing the canonical false positive `not ok N - mongosh is NOT available in app` on a `python:3.12-slim` image where the app uses PyMongo. The existing self-heal loop could not remediate it because there was no prompt gap to patch — the rule existed and was ignored. Mechanical enforcement closes that gap.

## Test plan

- [x] `python3 -m unittest tests.test_validate_preflight_canary_tools_scope -v` — all 8 tests pass locally.
- [x] `bash -n scripts/validate_process.sh` — syntax OK.
- [ ] Next live validation cycle on `tele-funtoken-msg-scoring` (the repo that produced the motivating failure) should either fail fast in preflight with the actionable message below, or pass cleanly if regeneration has already removed `mongosh` from the app canary loop.

Preflight failure message (example):
```
validation/tests/00_canary.sh CANARY_TOOLS references service-side CLI(s) not installed in validation/Dockerfile.app: mongosh
mode-validate-generate.txt hard rule: do NOT include service-side CLIs ...
Fix options (choose one per offending tool):
  1) Remove the tool from CANARY_TOOLS in 00_canary.sh. For DB reachability, probe from the service container ...
  2) Install the tool in validation/Dockerfile.app via apt ...
```

## Scope

Minimal standalone change. This is interim defense-in-depth pending the template-scaffold project (see follow-up plan in issue thread) that will eliminate the root cause by replacing LLM-freehand harness generation with template rendering.

https://claude.ai/code/session_01E9DdhEGoQ3VjXieuWdN2h5