### PR TITLE
Fix phase-group label conflicts when forcing terminal states

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1224,6 +1224,7 @@ backfill_validation_fix_issue_merged_label() {
   # `get_issue_labels_json` round-trip.  When empty/omitted the helper
   # falls back to fetching itself, preserving the original contract.
   local cached_labels="${2:-}"
+  local contract_file=".github/ai/label_contract.v1.json"
   local fix_labels
   local edit_args=()
   local _label_err_file
@@ -1236,6 +1237,10 @@ backfill_validation_fix_issue_merged_label() {
     fix_labels="$(get_issue_labels_json "${issue_num}")"
   fi
   if has_label "${fix_labels}" "ai:merged"; then
+    return 0
+  fi
+
+  if [ -f "${contract_file}" ] && set_issue_phase_label "${issue_num}" "ai:merged"; then
     return 0
   fi
 

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1226,7 +1226,9 @@ backfill_validation_fix_issue_merged_label() {
   local cached_labels="${2:-}"
   local contract_file=".github/ai/label_contract.v1.json"
   local fix_labels
+  local phase_changes
   local edit_args=()
+  local remove_label
   local _label_err_file
 
   ensure_label_exists "ai:merged"
@@ -1244,8 +1246,20 @@ backfill_validation_fix_issue_merged_label() {
     return 0
   fi
 
+  if [ -f "${contract_file}" ]; then
+    echo "::warning::set_issue_phase_label failed for #${issue_num}; falling back to manual ai:merged label edit." >&2
+  fi
+
   edit_args+=(--add-label "ai:merged")
-  if has_label "${fix_labels}" "ai:closed"; then
+  if [ -f "${contract_file}" ]; then
+    phase_changes="$(python3 scripts/ai_labels.py resolve-phase --contract-file "${contract_file}" --phase "ai:merged" 2>/dev/null || echo '{"remove":["ai:closed"]}')"
+    while IFS= read -r remove_label; do
+      [ -n "${remove_label}" ] || continue
+      if has_label "${fix_labels}" "${remove_label}"; then
+        edit_args+=(--remove-label "${remove_label}")
+      fi
+    done < <(echo "${phase_changes}" | jq -r '.remove[]?' 2>/dev/null || true)
+  elif has_label "${fix_labels}" "ai:closed"; then
     edit_args+=(--remove-label "ai:closed")
   fi
 
@@ -1445,7 +1459,12 @@ if forced and contract_file:
         contract = None
     if isinstance(contract, dict):
         for group in contract.get("phase_groups", []) or []:
-            members = [str(item) for item in (group.get("members") or [])]
+            if not isinstance(group, dict):
+                continue
+            raw_members = group.get("members")
+            if not isinstance(raw_members, list):
+                continue
+            members = [str(item) for item in raw_members]
             if forced in members:
                 for label in members:
                     if label != forced:

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1400,7 +1400,7 @@ reconcile_managed_issue_labels() {
   repair_json="$(python3 scripts/ai_labels.py repair-labels --contract-file "${contract_file}" --issue-labels "${labels_csv}" 2>/dev/null || echo '{"add":[],"remove":[]}')"
 
   local plan_json
-  plan_json="$(python3 - "${labels_json}" "${repair_json}" "${issue_state}" "${pr_merged}" <<'PY'
+  plan_json="$(python3 - "${labels_json}" "${repair_json}" "${issue_state}" "${pr_merged}" "${contract_file}" <<'PY'
 import json
 import sys
 
@@ -1408,6 +1408,7 @@ current = set(json.loads(sys.argv[1]))
 repair = json.loads(sys.argv[2])
 issue_state = (sys.argv[3] or "").strip().lower()
 pr_merged = (sys.argv[4] or "").strip().lower() == "true"
+contract_file = sys.argv[5] if len(sys.argv) > 5 else ""
 
 final = set(current)
 for label in repair.get("remove", []):
@@ -1415,11 +1416,35 @@ for label in repair.get("remove", []):
 for label in repair.get("add", []):
     final.add(label)
 
+forced = ""
 if pr_merged:
     final.discard("ai:closed")
     final.add("ai:merged")
+    forced = "ai:merged"
 elif issue_state == "closed" and "ai:closed" not in final and "ai:merged" not in final:
     final.add("ai:closed")
+    forced = "ai:closed"
+
+# Phase-group repair above ran on the original `current` set, so if
+# `current` had only one phase-group member the repair was a no-op —
+# then we force ai:merged/ai:closed on top, producing a dual-phase
+# state (e.g. {ai:review-blocked, ai:merged}) that the wave-status
+# resolver treats as terminal via ai:merged priority and never
+# re-processes, stranding the non-terminal label forever. Re-apply
+# phase exclusivity so only the forced terminal member survives.
+if forced and contract_file:
+    try:
+        with open(contract_file, "r") as fh:
+            contract = json.load(fh)
+    except (OSError, ValueError):
+        contract = None
+    if isinstance(contract, dict):
+        for group in contract.get("phase_groups", []) or []:
+            members = [str(item) for item in (group.get("members") or [])]
+            if forced in members:
+                for label in members:
+                    if label != forced:
+                        final.discard(label)
 
 add = sorted(final - current)
 remove = sorted(current - final)

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1252,7 +1252,7 @@ backfill_validation_fix_issue_merged_label() {
 
   edit_args+=(--add-label "ai:merged")
   if [ -f "${contract_file}" ]; then
-    phase_changes="$(python3 scripts/ai_labels.py resolve-phase --contract-file "${contract_file}" --phase "ai:merged" 2>/dev/null || echo '{"remove":["ai:closed"]}')"
+    phase_changes="$(python3 scripts/ai_labels.py resolve-phase --contract-file "${contract_file}" --phase "ai:merged" 2>/dev/null || jq -c --arg phase "ai:merged" '[((.phase_groups // [])[]? | select(type == "object") | .members as $members | select(($members | type) == "array" and ($members | index($phase) != null)) | $members[]? | select(type == "string" and . != $phase))] | unique | {remove: .}' "${contract_file}" 2>/dev/null || echo '{"remove":["ai:closed"]}')"
     while IFS= read -r remove_label; do
       [ -n "${remove_label}" ] || continue
       if has_label "${fix_labels}" "${remove_label}"; then
@@ -1455,7 +1455,8 @@ if forced and contract_file:
     try:
         with open(contract_file, "r") as fh:
             contract = json.load(fh)
-    except (OSError, ValueError):
+    except (OSError, ValueError) as exc:
+        print(f"::warning::reconcile_managed_issue_labels: failed to load contract file {contract_file}: {exc}", file=sys.stderr)
         contract = None
     if isinstance(contract, dict):
         for group in contract.get("phase_groups", []) or []:

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -4139,6 +4139,32 @@ def test_stale_pending_terminal_truth_from_merged_pr_is_auto_corrected():
 	assert "ai:merged" in result["issues"]["10"]["labels"]
 
 
+def test_forced_terminal_merged_phase_repair_removes_single_existing_phase_label():
+	"""Regression: forcing ai:merged must evict an existing single phase label."""
+	state = _base_state(status="in_progress")
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		issue_labels={10: ["ai:review-blocked"]},
+		issue_linked_prs={10: 900},
+		prs=[
+			{
+				"number": 900,
+				"state": "closed",
+				"merged": True,
+				"merged_at": "2026-04-12T08:00:00Z",
+				"baseRefName": "main",
+				"headRefName": "ai/issue-10",
+				"mergeable": None,
+				"mergeable_state": "unknown",
+			},
+		],
+	)
+	final_labels = result["issues"]["10"]["labels"]
+	assert final_labels == ["ai:merged"]
+
+
 def test_conflicting_phase_labels_are_repaired_to_single_phase():
 	state = _base_state(status="in_progress")
 	result = _run_poller(


### PR DESCRIPTION
## Summary
This change fixes a bug in the managed issue label reconciliation logic where forcing terminal labels (ai:merged or ai:closed) could result in invalid dual-phase states when the original label set contained only one phase-group member.

## Problem
The phase-group repair logic runs on the original label set. When that set contains only a single phase-group member, the repair is a no-op. Subsequently, when a terminal label (ai:merged or ai:closed) is forced, it gets added to the set without removing the existing phase-group member, creating an invalid state like {ai:review-blocked, ai:merged}. The wave-status resolver treats this as terminal and never reprocesses it, leaving the non-terminal label stranded.

## Changes
- Pass the contract file path to the Python label planning logic
- Track which terminal label is being forced (ai:merged or ai:closed)
- After forcing a terminal label, re-apply phase-group exclusivity rules by:
  - Loading the contract file to access phase-group definitions
  - Finding which phase-group contains the forced label
  - Removing all other members of that phase-group from the final set
  - Ensuring only the forced terminal label survives

This ensures that terminal state transitions maintain label consistency and allow proper reprocessing by the wave-status resolver.

https://claude.ai/code/session_01X8XMAZtSJFcutewATceExQ