### PR TITLE
Change pr-autofix concurrency to queue instead of cancel

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -201,8 +201,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     concurrency:
+      # cancel-in-progress: false → new runs queue behind the running peer
+      # instead of cancelling it. GitHub keeps only the most recent queued
+      # run in the group; older queued runs are auto-cancelled while pending,
+      # so a burst of pushes still collapses to "current run + newest queued"
+      # without producing the long trail of cancelled in-progress runs that
+      # cancel-in-progress: true caused. Hung runs are still bounded by the
+      # 180-min timeout-minutes above.
       group: pr-autofix-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     if: ${{ needs.gate.outputs.should_run == 'true' }}
 
     env:
@@ -3718,10 +3725,11 @@ jobs:
           # Preflight dedup: the push above fires a pull_request.synchronize
           # event that produces its own review_autofix run via the caller
           # workflow.  Both runs land in the `pr-autofix-${PR}` concurrency
-          # group with cancel-in-progress: true, so the loser burns runner
-          # minutes (and possibly LLM setup tokens) before being killed.
-          # Give the synchronize event a few seconds to show up in the Actions
-          # API, then skip our dispatch if a peer run is already queued or
+          # group with cancel-in-progress: false, so the loser is cancelled
+          # while pending — but the redundant queued run still appears in the
+          # Actions UI and consumes a workflow_dispatch API call.  Give the
+          # synchronize event a few seconds to show up in the Actions API,
+          # then skip our dispatch if a peer run is already queued or
           # running.  Fails open — any detection failure falls through to the
           # original dispatch logic so we never silently break the cycle.
           #

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -202,12 +202,12 @@ jobs:
     timeout-minutes: 180
     concurrency:
       # cancel-in-progress: false → new runs queue behind the running peer
-      # instead of cancelling it. GitHub keeps only the most recent queued
-      # run in the group; older queued runs are auto-cancelled while pending,
-      # so a burst of pushes still collapses to "current run + newest queued"
-      # without producing the long trail of cancelled in-progress runs that
+      # instead of cancelling it. If another run is already pending in this
+      # group, GitHub replaces that older pending run with the newest one.
+      # This keeps bursts near "current run + newest queued run" while
+      # avoiding the long trail of cancelled in-progress runs that
       # cancel-in-progress: true caused. Hung runs are still bounded by the
-      # 180-min timeout-minutes above.
+      # timeout-minutes above.
       group: pr-autofix-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
       cancel-in-progress: false
     if: ${{ needs.gate.outputs.should_run == 'true' }}
@@ -3725,13 +3725,13 @@ jobs:
           # Preflight dedup: the push above fires a pull_request.synchronize
           # event that produces its own review_autofix run via the caller
           # workflow.  Both runs land in the `pr-autofix-${PR}` concurrency
-          # group with cancel-in-progress: false, so the loser is cancelled
-          # while pending — but the redundant queued run still appears in the
-          # Actions UI and consumes a workflow_dispatch API call.  Give the
-          # synchronize event a few seconds to show up in the Actions API,
-          # then skip our dispatch if a peer run is already queued or
-          # running.  Fails open — any detection failure falls through to the
-          # original dispatch logic so we never silently break the cycle.
+          # group with cancel-in-progress: false, so a redundant dispatch can
+          # still queue, appear in the Actions UI, and consume a
+          # workflow_dispatch API call.  Give the synchronize event a few
+          # seconds to show up in the Actions API, then skip our dispatch if a
+          # peer run is already queued or running.  Fails open — any detection
+          # failure falls through to the original dispatch logic so we never
+          # silently break the cycle.
           #
           # Tunable via AUTOFIX_RETRIGGER_PEER_WAIT_SECS (default 8s).
           peer_wait="${AUTOFIX_RETRIGGER_PEER_WAIT_SECS:-8}"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `ALLOW_WORKFLOW_EDITS` | No | `true` | review_autofix, implement, update_workflows | Allow AI edits to `.github/workflows` files and automatic wrapper updates. Set to `false` to opt out of auto-updates. |
 | `ENABLE_AUTO_MERGE` | No | `true` | review_autofix, orchestrate_poll | Auto-merge PRs (squash) when review passes. Requires "Allow auto-merge" in repo settings. |
 | `MAX_AUTOFIX_ITERATIONS` | No | `3` | review_autofix | Maximum consecutive autofix rounds before the review loop stops and marks the PR `ai:review-blocked`. |
-| `AUTOFIX_RETRIGGER_PEER_WAIT_SECS` | No | `8` | review_autofix | Seconds the post-commit and editor-changes-lost retrigger steps wait before checking for an already-queued peer review run on the same PR branch. If a peer is found the retrigger skips its own `workflow_dispatch` to avoid the two runs cancelling each other in the `pr-autofix-${PR}` concurrency group (see [Autofix retrigger dedup](#autofix-retrigger-dedup)). Must be an integer in `0..60`; invalid values clamp to `8`. |
+| `AUTOFIX_RETRIGGER_PEER_WAIT_SECS` | No | `8` | review_autofix | Seconds the post-commit and editor-changes-lost retrigger steps wait before checking for an already-queued peer review run on the same PR branch. If a peer is found the retrigger skips its own `workflow_dispatch` to avoid creating a redundant queued run (and extra API/UI noise) in the `pr-autofix-${PR}` concurrency group (see [Autofix retrigger dedup](#autofix-retrigger-dedup)). Must be an integer in `0..60`; invalid values clamp to `8`. |
 | `ENABLE_REVIEWER_TWO_PASS` | No | `true` | review_autofix | When true, reviewers run two passes per iteration: pass 1 at `medium` reasoning (broad sweep), then pass 2 at the scheduled reasoning level with a cross-pollination summary of pass 1 findings. Set to `false` to use a single pass at the scheduled reasoning level. |
 | `ENABLE_REVIEW_BLOCKED_JUDGE` | No | `true` | review_autofix | When true, non-orchestrator PRs that exhaust autofix iterations invoke a judge (LLM) to decide: merge as-is, push a fix commit, or close and reissue. Orchestrator-managed PRs are skipped (handled by the poller). PRs without linked issues use the PR title/body as requirement context. |
 | `THINKING_LEVEL_REVIEW_BLOCKED_JUDGE` | No | `xhigh` | review_autofix | Reasoning effort for the review-blocked judge in non-orchestrator PRs (`xhigh`, `high`, `medium`, `low`). |
@@ -304,9 +304,11 @@ jobs:
 > commit, `review_autofix.yml` pushes to the PR branch and then fires a
 > `workflow_dispatch` retrigger (for the case where the `pull_request.synchronize`
 > event's merge ref is unbuildable). Both entry points land in the same
-> `pr-autofix-${PR}` concurrency group with `cancel-in-progress: true`, so the
-> loser is killed mid-flight after it has already spent runner minutes and
-> possibly LLM setup tokens. To avoid this waste, the retrigger steps now wait
+> `pr-autofix-${PR}` concurrency group with `cancel-in-progress: false`, so new
+> runs queue behind the running peer. GitHub keeps only the most recent pending
+> run in the group (older pending runs are cancelled), but that newest queued
+> run still appears in the Actions UI and consumes a `workflow_dispatch` API
+> call. To avoid this waste, the retrigger steps now wait
 > `AUTOFIX_RETRIGGER_PEER_WAIT_SECS` (default `8`) for the synchronize-event
 > run to materialize, then query the Actions API for in-flight peers on the
 > same head branch (matching workflow file paths `review_autofix.yml`,

--- a/agents.md
+++ b/agents.md
@@ -437,7 +437,7 @@ Operational rules:
 
 ## 20. Autofix Retrigger Dedup
 
-`review_autofix.yml` has two `workflow_dispatch` retrigger steps that fire after a push — the post-commit/merge-resolve retrigger and the editor-changes-lost retrigger. Both used to dispatch unconditionally, which collided with the `pull_request.synchronize` event produced by the same push (both land in `pr-autofix-${PR}` with `cancel-in-progress: true`) and the loser was killed 4–10 s after start, burning runner minutes and any already-spent LLM setup tokens.
+`review_autofix.yml` has two `workflow_dispatch` retrigger steps that fire after a push — the post-commit/merge-resolve retrigger and the editor-changes-lost retrigger. Both used to dispatch unconditionally, which collided with the `pull_request.synchronize` event produced by the same push. With `cancel-in-progress: false` those redundant dispatches can still produce queued runs (and extra API/UI noise), so the retrigger dedup guard now probes for an in-flight peer first and skips dispatch when one already exists.
 
 Contract:
 

--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -1064,9 +1064,9 @@ gh_issue_timeline_with_cross_refs()
 #   In the common case the push already fires pull_request.synchronize
 #   → internal-review.yml → review_autofix.yml, so both runs land in
 #   the same `pr-autofix-${PR}` concurrency group with
-#   cancel-in-progress: false: the loser is cancelled while pending,
-#   but the redundant queued run still surfaces in the Actions UI and
-#   consumes a workflow_dispatch API call.  This helper lets the
+#   cancel-in-progress: false. A redundant dispatch can still queue,
+#   surface in the Actions UI, and consume a workflow_dispatch API
+#   call. This helper lets the
 #   retrigger step skip its dispatch when a peer run is already
 #   in flight.
 #

--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -1064,10 +1064,11 @@ gh_issue_timeline_with_cross_refs()
 #   In the common case the push already fires pull_request.synchronize
 #   → internal-review.yml → review_autofix.yml, so both runs land in
 #   the same `pr-autofix-${PR}` concurrency group with
-#   cancel-in-progress: true and one kills the other.  The killed
-#   run has already spent runner minutes and possibly LLM setup
-#   tokens.  This helper lets the retrigger step skip its dispatch
-#   when a peer run is already in flight.
+#   cancel-in-progress: false: the loser is cancelled while pending,
+#   but the redundant queued run still surfaces in the Actions UI and
+#   consumes a workflow_dispatch API call.  This helper lets the
+#   retrigger step skip its dispatch when a peer run is already
+#   in flight.
 #
 # Input:
 #   $1 pr_number      — PR number (informational, used in log lines)


### PR DESCRIPTION
## Summary
This change modifies the GitHub Actions concurrency strategy for the `pr-autofix` job from cancelling in-progress runs to queueing them instead. This reduces wasted runner minutes and LLM setup token consumption while maintaining bounded execution time.

## Key Changes
- **Concurrency strategy**: Changed `cancel-in-progress: true` to `cancel-in-progress: false` in the `review_autofix.yml` workflow
  - New behavior: redundant runs queue behind the current run instead of immediately cancelling it
  - GitHub automatically keeps only the most recent queued run, collapsing bursts of pushes to "current run + newest queued"
  - Eliminates the long trail of cancelled in-progress runs that previously consumed runner minutes
  - Execution time remains bounded by the existing 180-minute timeout

- **Documentation updates**: Updated comments in both `review_autofix.yml` and `scripts/gh_helpers.sh` to reflect the new concurrency behavior
  - Clarified that with `cancel-in-progress: false`, redundant queued runs are cancelled while pending (not after consuming resources)
  - Noted that the queued run still appears in the Actions UI and consumes a workflow_dispatch API call
  - Updated the rationale for the preflight dedup logic to account for the new behavior

## Implementation Details
The change addresses a resource efficiency issue where simultaneous `pull_request.synchronize` events and manual dispatches would both trigger runs in the same concurrency group. With the old strategy, one run would be killed after already consuming runner minutes and potentially LLM setup tokens. The new strategy ensures that only the most recent queued run persists, reducing waste while the 180-minute timeout prevents hung runs from consuming indefinite resources.

https://claude.ai/code/session_015urts6xyyJeZMn4G3LvwVC