### PR TITLE
Add safety check to prevent silently dropping modified files

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1754,6 +1754,20 @@ jobs:
               sort -o "${POST_UNTRACKED_LIST}" "${POST_UNTRACKED_LIST}"
               comm -13 "${PRE_UNTRACKED_LIST}" "${POST_UNTRACKED_LIST}" >> "${CODEX_TOUCHED_FILE}"
               rm -f "${PRE_UNTRACKED_LIST}" "${POST_UNTRACKED_LIST}"
+              # Safety union: never silently drop a file that is genuinely
+              # modified vs HEAD on disk at commit time.  The SHA-based
+              # loop above can miss such files when the pre-editor snapshot
+              # SHA happens to equal the post-editor SHA (e.g. the file was
+              # already in its edited state at snapshot time, or the
+              # workflow-support overlay perturbed pre-SHAs for unrelated
+              # files).  Missing a real edit surfaces as EDITOR_CHANGES_LOST
+              # even though the edit is on disk (see run 24604441953:
+              # scripts/review_floor_rules.sh was modified but dropped).
+              # Adding a file whose on-disk content already matches HEAD is
+              # harmless — the subsequent `git add` is a no-op for unchanged
+              # content and the `git diff --cached --quiet` guard still
+              # short-circuits when nothing truly changed.
+              git diff --name-only HEAD >> "${CODEX_TOUCHED_FILE}" || true
             else
               echo "::warning::pre-editor snapshot missing; falling back to git diff HEAD."
               git diff --name-only HEAD >> "${CODEX_TOUCHED_FILE}" || true


### PR DESCRIPTION
## Summary
This change adds a safety mechanism to the review autofix workflow to prevent silently dropping files that have been genuinely modified on disk but were missed by the SHA-based change detection logic.

## Key Changes
- Added a fallback `git diff --name-only HEAD` check to capture any modified files that may have been missed by the pre/post-editor snapshot comparison
- This safety union ensures files are not dropped when the pre-editor and post-editor SHA values happen to match (e.g., when a file was already in its edited state at snapshot time, or when workflow overlays perturbed pre-SHAs for unrelated files)
- The additional check is harmless for unchanged files since subsequent `git add` operations are no-ops for unmodified content

## Implementation Details
- The new check appends to `CODEX_TOUCHED_FILE` rather than replacing it, creating a union of detected changes
- Uses `|| true` to prevent workflow failure if the git diff command encounters issues
- Includes comprehensive comments explaining the edge case being addressed and why this approach is safe
- References a specific incident (run 24604441953) where `scripts/review_floor_rules.sh` was modified but incorrectly dropped, surfacing as `EDITOR_CHANGES_LOST`

https://claude.ai/code/session_01SFWaTep3bmJjh3nF3WsKDf