### PR TITLE
Fix detection of newly-staged files in editor workflow

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1750,6 +1750,13 @@ jobs:
                 esac
               done < "${PRE_EDITOR_STATE_FILE}"
               git ls-files --others --exclude-standard > "${POST_UNTRACKED_LIST}" || true
+              # Also capture new files the editor already staged (status `A `):
+              # `git ls-files --others` excludes cached/staged paths, so without
+              # this second source, newly-created-but-staged files are invisible
+              # to the touched-file detector and get wiped by `git read-tree HEAD`
+              # below, producing a no-op commit and a false "Editor changes lost"
+              # alert (see run 24608448620 / PR #1330).
+              git diff --cached --diff-filter=A --name-only HEAD >> "${POST_UNTRACKED_LIST}" 2>/dev/null || true
               sort -o "${PRE_UNTRACKED_LIST}" "${PRE_UNTRACKED_LIST}"
               sort -o "${POST_UNTRACKED_LIST}" "${POST_UNTRACKED_LIST}"
               comm -13 "${PRE_UNTRACKED_LIST}" "${POST_UNTRACKED_LIST}" >> "${CODEX_TOUCHED_FILE}"


### PR DESCRIPTION
## Summary
This fix addresses an issue where newly-created files that were staged by the editor were not being properly detected as touched files, causing them to be wiped out and triggering false "Editor changes lost" alerts.

## Key Changes
- Added a secondary source to capture newly-created and staged files using `git diff --cached --diff-filter=A --name-only HEAD`
- This complements the existing `git ls-files --others` command, which excludes cached/staged paths and therefore misses newly-created-but-staged files
- The captured staged files are appended to the touched file list to ensure they are preserved during subsequent git operations

## Implementation Details
- The fix uses `git diff --cached --diff-filter=A` to specifically identify newly-added (status `A`) files in the staging area
- Results are appended to the `POST_UNTRACKED_LIST` which feeds into the touched file detector
- Error output is suppressed with `2>/dev/null` to maintain existing error handling behavior
- This prevents the `git read-tree HEAD` operation from inadvertently removing staged files and creating a no-op commit

Fixes issue observed in run 24608448620 / PR #1330.

https://claude.ai/code/session_01U2iKgw5RyJZPZwGhffN1Uj