### PR TITLE
Increase codex-agent runner to 4-core machine

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -198,7 +198,7 @@ jobs:
 
   codex-agent:
     needs: gate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     timeout-minutes: 180
     concurrency:
       # cancel-in-progress: false → new runs queue behind the running peer


### PR DESCRIPTION
## Summary
Updated the GitHub Actions runner configuration for the codex-agent job to use a machine with more CPU resources.

## Changes
- Changed the `runs-on` value for the codex-agent job from `ubuntu-latest` to `ubuntu-latest-4-cores`

## Details
This change allocates a 4-core Ubuntu runner instead of the default 2-core runner for the codex-agent job. This should improve build performance and reduce timeout risks for this job, which has a 180-minute timeout window.

https://claude.ai/code/session_01DujywDVnMkSbshqQAJfoTn