### PR TITLE
Add Telegram job failure alerts and fix git add pathspec issues

### DIFF
--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -456,6 +456,58 @@ jobs:
             --actor "${GITHUB_ACTOR}" \
             --metadata-json "{\"run_attempt\":\"${GITHUB_RUN_ATTEMPT}\",\"repository\":\"${GITHUB_REPOSITORY}\",\"job_status\":\"${{ job.status }}\",\"has_work\":\"${{ steps.find_tracking.outputs.has_work || 'false' }}\"}" || true
 
+      - name: Notify Telegram on job failure
+        if: failure()
+        env:
+          TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
+          TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID || '' }}
+          ALERT_MSG_LEVEL: ${{ vars.ALERT_MSG_LEVEL || 'DEBUG' }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        shell: bash
+        run: |
+          # Fire-and-forget Telegram alert on job-level failure. Inline
+          # tg_notify() calls inside scripts/orchestrate_poll_process.sh
+          # only cover semantic events (judge merged, follow-up blocked,
+          # etc.) — when the script hard-crashes via `set -e` (e.g. a
+          # bad git add), no inline alert ever runs. This step covers
+          # that gap. Body intentionally omits any step output / log
+          # tail; only the workflow name, failing step name, and run
+          # URL are sent.
+          set -uo pipefail
+          if [ ! -f scripts/tg_helpers.sh ]; then
+            echo "::warning::tg_helpers.sh not found; cannot send job-failure TG alert"
+            exit 0
+          fi
+          # shellcheck disable=SC1091
+          source scripts/tg_helpers.sh
+
+          run_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          workflow_name="${GITHUB_WORKFLOW:-orchestrate_poll}"
+
+          # Resolve the first failing step name via the GitHub API. Fail
+          # open: if the lookup fails or returns nothing, still send the
+          # alert without the step name rather than dropping the alert.
+          failing_step=""
+          if [ -n "${GH_TOKEN:-}" ]; then
+            jobs_json="$(curl -fsSL \
+              -H "Authorization: token ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT:-1}/jobs" 2>/dev/null || echo '')"
+            if [ -n "${jobs_json}" ]; then
+              failing_step="$(printf '%s' "${jobs_json}" \
+                | jq -r '.jobs[]?.steps[]? | select(.conclusion == "failure") | .name' 2>/dev/null \
+                | head -n1)"
+            fi
+          fi
+
+          msg="Workflow failed: ${workflow_name}"
+          if [ -n "${failing_step}" ]; then
+            msg+=$'\n'"Failing step: ${failing_step}"
+          fi
+          msg+=$'\n'"Run: ${run_url}"
+
+          tg_send_msg "${msg}" "ERROR" >/dev/null || true
+
       - name: Check rate-limit circuit breaker
         id: circuit_breaker
         if: always()

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -8048,12 +8048,21 @@ sys.exit(1)
                 git config user.email "codex@users.noreply.github.com"
                 if [ "${ALLOW_WORKFLOW_EDITS:-false}" = "true" ]; then
                   # Use a single add call so empty/minimal repos do not fail on
-                  # exclude-only pathspecs (e.g. ':!node_modules').
-                  git add -A -- . ':!node_modules' ':!.serena' ':!.github/prompts' ':!.github/scripts'
+                  # exclude-only pathspecs.
+                  # NOTE: do not list .gitignored directories (node_modules, .serena)
+                  # as `:!` exclude pathspecs here. `git add -A -- . ':!<dir>'`
+                  # treats the exclude path as an explicit name and fails with
+                  # "The following paths are ignored by one of your .gitignore
+                  # files" + exit 1 when that dir exists on disk. .gitignore
+                  # already excludes them; the pathspec exclude is redundant
+                  # and turns into a hard failure after Serena setup creates
+                  # .serena/ or any step creates node_modules/.
+                  git add -A -- . ':!.github/prompts' ':!.github/scripts'
                 else
                   # Keep workflow-edit guard exclusions while avoiding brittle
-                  # tracked/untracked split staging pathspec failures.
-                  git add -A -- . ':!node_modules' ':!scripts' ':!prompts' ':!.github/ai' ':!.github/workflows' ':!.serena' ':!.github/prompts' ':!.github/scripts'
+                  # tracked/untracked split staging pathspec failures. Same
+                  # gitignore-dir exclusion caveat as above applies.
+                  git add -A -- . ':!scripts' ':!prompts' ':!.github/ai' ':!.github/workflows' ':!.github/prompts' ':!.github/scripts'
                 fi
                 echo "Staged files before commit:"
                 git diff --cached --name-only | sed 's/^/ - /' || true


### PR DESCRIPTION
## Summary
This PR adds Telegram notifications for workflow job failures and fixes a critical issue with `git add` pathspec handling when `.gitignore`d directories exist on disk.

## Key Changes

- **Add Telegram job failure notifications**: New workflow step that sends Telegram alerts when the orchestrate_poll job fails. The alert includes the workflow name, failing step name (resolved via GitHub API), and run URL. This complements existing inline alerts in the orchestration script by catching hard crashes from `set -e` failures.

- **Fix git add pathspec exclusion logic**: Removed `.gitignored` directories (`node_modules`, `.serena`) from the `:!` exclude pathspecs in `git add` commands. These directories are already excluded by `.gitignore`, and explicitly listing them as exclude pathspecs causes `git add` to fail with "The following paths are ignored by one of your .gitignore files" when those directories exist on disk.

## Implementation Details

- The Telegram notification step is fire-and-forget (uses `|| true`) and gracefully degrades if `tg_helpers.sh` is missing or the GitHub API lookup fails
- The step only runs on job failure via `if: failure()` condition
- Git pathspec changes apply to both the `ALLOW_WORKFLOW_EDITS=true` and `false` code paths
- Added clarifying comments explaining why `.gitignore`d directories should not be listed in exclude pathspecs

https://claude.ai/code/session_01X3KhNYVXPRNihap1EcGo2u