### PR TITLE
Downgrade actions/checkout from v5 to v4

### DIFF
--- a/.github/workflows/mark-stable.yml
+++ b/.github/workflows/mark-stable.yml
@@ -31,7 +31,7 @@ jobs:
       version: ${{ steps.resolve.outputs.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -67,7 +67,7 @@ jobs:
       version: ${{ steps.resolve.outputs.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0


### PR DESCRIPTION
## Summary
Downgrade the `actions/checkout` action from version 5 to version 4 across workflow files.

## Changes
- Updated `mark-stable.yml` workflow to use `actions/checkout@v4`
- Updated `test-and-mark-stable.yml` workflow to use `actions/checkout@v4`

## Details
Both GitHub Actions workflows that handle stable release marking have been updated to use the v4 version of the checkout action instead of v5. This change affects the repository checkout step in the job initialization phase for both workflows.

https://claude.ai/code/session_01R1R2kmw4nzHyLQMj83tdpS