### PR TITLE
Add git diagnostic probes to CI workflow for checkout exit-128 debugging

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -125,15 +125,23 @@ jobs:
           git status 2>&1; echo "status_rc=$?"
           git log -1 --oneline 2>&1; echo "log_rc=$?"
           echo "--- simulate post-step extraheader ops ---"
-          git config --local --name-only --get-regexp 'http\..*\.extraheader' 2>&1; echo "getregexp_rc=$?"
-          EXTRAHEADER_KEYS=$(git config --local --name-only --get-regexp 'http\..*\.extraheader' 2>/dev/null || true)
-          if [ -n "$EXTRAHEADER_KEYS" ]; then
+          EXTRAHEADER_KEYS_OUTPUT=$(git config --local --name-only --get-regexp 'http\..*\.extraheader' 2>&1)
+          GETREGEXP_RC=$?
+          printf '%s\n' "$EXTRAHEADER_KEYS_OUTPUT"
+          echo "getregexp_rc=$GETREGEXP_RC"
+          if [ "$GETREGEXP_RC" -eq 0 ] && [ -n "$EXTRAHEADER_KEYS_OUTPUT" ]; then
             TEMP_GIT_CONFIG=$(mktemp)
-            cp .git/config "$TEMP_GIT_CONFIG" 2>/dev/null || true
-            while IFS= read -r EXTRAHEADER_KEY; do
-              [ -n "$EXTRAHEADER_KEY" ] || continue
-              git config --file "$TEMP_GIT_CONFIG" --unset-all "$EXTRAHEADER_KEY" 2>&1; echo "unset_rc[$EXTRAHEADER_KEY]=$?"
-            done <<< "$EXTRAHEADER_KEYS"
+            cp .git/config "$TEMP_GIT_CONFIG" 2>&1
+            CP_RC=$?
+            echo "cp_config_rc=$CP_RC"
+            if [ "$CP_RC" -eq 0 ]; then
+              while IFS= read -r EXTRAHEADER_KEY; do
+                [ -n "$EXTRAHEADER_KEY" ] || continue
+                git config --file "$TEMP_GIT_CONFIG" --unset-all "$EXTRAHEADER_KEY" 2>&1; echo "unset_rc[$EXTRAHEADER_KEY]=$?"
+              done <<< "$EXTRAHEADER_KEYS_OUTPUT"
+            else
+              echo "unset_rc=skipped (config copy failed)"
+            fi
             rm -f "$TEMP_GIT_CONFIG"
           else
             echo "unset_rc=skipped (no matching key)"
@@ -142,6 +150,8 @@ jobs:
           git submodule foreach --recursive 'echo ok' 2>&1; echo "foreach_rc=$?"
           echo "--- .git directory listing (first 40) ---"
           ls -la .git/ 2>&1 | head -n 40; echo "ls_rc=$?"
+          echo "--- lock files ---"
+          ls -l .git/*.lock 2>&1; echo "lock_ls_rc=$?"
           echo "=== end diagnostic ==="
           exit 0
 

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -106,6 +106,32 @@ jobs:
 
           echo "version=${NEXT}" >> "$GITHUB_OUTPUT"
 
+      # Temporary: reveal which git invocation in checkout's post-step
+      # produces `The process '/usr/bin/git' failed with exit code 128`.
+      # Runs immediately before checkout@post so the dumped state is the
+      # exact state the post-step sees. Remove after root-cause is
+      # identified and a targeted fix lands.
+      - name: git diagnostic (checkout exit-128 probe)
+        if: always()
+        run: |
+          set +e
+          echo "=== git diagnostic: state before checkout post-step ==="
+          git --version
+          echo "--- config (first 200) ---"
+          git config --list --show-origin 2>&1 | head -n 200
+          echo "--- status / head ---"
+          git status 2>&1; echo "status_rc=$?"
+          git log -1 --oneline 2>&1; echo "log_rc=$?"
+          echo "--- simulate post-step extraheader ops ---"
+          git config --local --name-only --get-regexp 'http\..*\.extraheader' 2>&1; echo "getregexp_rc=$?"
+          git config --local --unset-all 'http.https://github.com/.extraheader' 2>&1; echo "unset_rc=$?"
+          echo "--- simulate post-step submodule foreach ---"
+          git submodule foreach --recursive 'echo ok' 2>&1; echo "foreach_rc=$?"
+          echo "--- .git listing (first 40) ---"
+          ls -la .git/ 2>&1 | head -n 40; echo "ls_rc=$?"
+          echo "=== end diagnostic ==="
+          exit 0
+
   # ──────────────────────────────────────────────────────────────────
   # Job 1: End-to-end smoke test — exercises every pipeline phase
   # ──────────────────────────────────────────────────────────────────
@@ -1602,6 +1628,30 @@ jobs:
 
           echo "Cleanup complete."
 
+      # Temporary: reveal which git invocation in checkout's post-step
+      # produces `The process '/usr/bin/git' failed with exit code 128`.
+      # Remove after root-cause is identified and a targeted fix lands.
+      - name: git diagnostic (checkout exit-128 probe)
+        if: always()
+        run: |
+          set +e
+          echo "=== git diagnostic: state before checkout post-step ==="
+          git --version
+          echo "--- config (first 200) ---"
+          git config --list --show-origin 2>&1 | head -n 200
+          echo "--- status / head ---"
+          git status 2>&1; echo "status_rc=$?"
+          git log -1 --oneline 2>&1; echo "log_rc=$?"
+          echo "--- simulate post-step extraheader ops ---"
+          git config --local --name-only --get-regexp 'http\..*\.extraheader' 2>&1; echo "getregexp_rc=$?"
+          git config --local --unset-all 'http.https://github.com/.extraheader' 2>&1; echo "unset_rc=$?"
+          echo "--- simulate post-step submodule foreach ---"
+          git submodule foreach --recursive 'echo ok' 2>&1; echo "foreach_rc=$?"
+          echo "--- .git listing (first 40) ---"
+          ls -la .git/ 2>&1 | head -n 40; echo "ls_rc=$?"
+          echo "=== end diagnostic ==="
+          exit 0
+
   # ──────────────────────────────────────────────────────────────────
   # Job 1b: Script correctness validation — runs parallel with E2E
   # ──────────────────────────────────────────────────────────────────
@@ -1730,6 +1780,30 @@ jobs:
           fi
           echo "All referenced scripts exist."
 
+      # Temporary: reveal which git invocation in checkout's post-step
+      # produces `The process '/usr/bin/git' failed with exit code 128`.
+      # Remove after root-cause is identified and a targeted fix lands.
+      - name: git diagnostic (checkout exit-128 probe)
+        if: always()
+        run: |
+          set +e
+          echo "=== git diagnostic: state before checkout post-step ==="
+          git --version
+          echo "--- config (first 200) ---"
+          git config --list --show-origin 2>&1 | head -n 200
+          echo "--- status / head ---"
+          git status 2>&1; echo "status_rc=$?"
+          git log -1 --oneline 2>&1; echo "log_rc=$?"
+          echo "--- simulate post-step extraheader ops ---"
+          git config --local --name-only --get-regexp 'http\..*\.extraheader' 2>&1; echo "getregexp_rc=$?"
+          git config --local --unset-all 'http.https://github.com/.extraheader' 2>&1; echo "unset_rc=$?"
+          echo "--- simulate post-step submodule foreach ---"
+          git submodule foreach --recursive 'echo ok' 2>&1; echo "foreach_rc=$?"
+          echo "--- .git listing (first 40) ---"
+          ls -la .git/ 2>&1 | head -n 40; echo "ls_rc=$?"
+          echo "=== end diagnostic ==="
+          exit 0
+
   # ──────────────────────────────────────────────────────────────────
   # Job 2: Validate release prerequisites (same as mark-stable.yml)
   # ──────────────────────────────────────────────────────────────────
@@ -1781,6 +1855,30 @@ jobs:
             exit 1
           fi
           echo "CI state: $STATE — OK"
+
+      # Temporary: reveal which git invocation in checkout's post-step
+      # produces `The process '/usr/bin/git' failed with exit code 128`.
+      # Remove after root-cause is identified and a targeted fix lands.
+      - name: git diagnostic (checkout exit-128 probe)
+        if: always()
+        run: |
+          set +e
+          echo "=== git diagnostic: state before checkout post-step ==="
+          git --version
+          echo "--- config (first 200) ---"
+          git config --list --show-origin 2>&1 | head -n 200
+          echo "--- status / head ---"
+          git status 2>&1; echo "status_rc=$?"
+          git log -1 --oneline 2>&1; echo "log_rc=$?"
+          echo "--- simulate post-step extraheader ops ---"
+          git config --local --name-only --get-regexp 'http\..*\.extraheader' 2>&1; echo "getregexp_rc=$?"
+          git config --local --unset-all 'http.https://github.com/.extraheader' 2>&1; echo "unset_rc=$?"
+          echo "--- simulate post-step submodule foreach ---"
+          git submodule foreach --recursive 'echo ok' 2>&1; echo "foreach_rc=$?"
+          echo "--- .git listing (first 40) ---"
+          ls -la .git/ 2>&1 | head -n 40; echo "ls_rc=$?"
+          echo "=== end diagnostic ==="
+          exit 0
 
   # ──────────────────────────────────────────────────────────────────
   # Job 3: Create release (same as mark-stable.yml)
@@ -1884,6 +1982,30 @@ jobs:
           echo ""
           echo "Changelog notes:"
           cat "${{ steps.changelog.outputs.notes_file }}"
+
+      # Temporary: reveal which git invocation in checkout's post-step
+      # produces `The process '/usr/bin/git' failed with exit code 128`.
+      # Remove after root-cause is identified and a targeted fix lands.
+      - name: git diagnostic (checkout exit-128 probe)
+        if: always()
+        run: |
+          set +e
+          echo "=== git diagnostic: state before checkout post-step ==="
+          git --version
+          echo "--- config (first 200) ---"
+          git config --list --show-origin 2>&1 | head -n 200
+          echo "--- status / head ---"
+          git status 2>&1; echo "status_rc=$?"
+          git log -1 --oneline 2>&1; echo "log_rc=$?"
+          echo "--- simulate post-step extraheader ops ---"
+          git config --local --name-only --get-regexp 'http\..*\.extraheader' 2>&1; echo "getregexp_rc=$?"
+          git config --local --unset-all 'http.https://github.com/.extraheader' 2>&1; echo "unset_rc=$?"
+          echo "--- simulate post-step submodule foreach ---"
+          git submodule foreach --recursive 'echo ok' 2>&1; echo "foreach_rc=$?"
+          echo "--- .git listing (first 40) ---"
+          ls -la .git/ 2>&1 | head -n 40; echo "ls_rc=$?"
+          echo "=== end diagnostic ==="
+          exit 0
 
   # ──────────────────────────────────────────────────────────────────
   # Job 4: Combined Telegram notification (runs after ALL jobs)

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -125,24 +125,41 @@ jobs:
           git status 2>&1; echo "status_rc=$?"
           git log -1 --oneline 2>&1; echo "log_rc=$?"
           echo "--- simulate post-step extraheader ops ---"
-          EXTRAHEADER_KEYS_OUTPUT=$(git config --local --name-only --get-regexp 'http\..*\.extraheader' 2>&1)
+          # Capture stdout (keys) and stderr (diagnostics) separately
+          EXTRAHEADER_STDERR_FILE=$(mktemp)
+          EXTRAHEADER_KEYS_STDOUT=$(git config --local --name-only --get-regexp 'http\..*\.extraheader' 2>"$EXTRAHEADER_STDERR_FILE")
           GETREGEXP_RC=$?
-          printf '%s\n' "$EXTRAHEADER_KEYS_OUTPUT"
+          EXTRAHEADER_KEYS_STDERR=$(cat "$EXTRAHEADER_STDERR_FILE" 2>/dev/null || true)
+          rm -f "$EXTRAHEADER_STDERR_FILE"
+          printf '%s\n' "$EXTRAHEADER_KEYS_STDOUT"
+          [ -n "$EXTRAHEADER_KEYS_STDERR" ] && printf 'stderr: %s\n' "$EXTRAHEADER_KEYS_STDERR" || true
           echo "getregexp_rc=$GETREGEXP_RC"
-          if [ "$GETREGEXP_RC" -eq 0 ] && [ -n "$EXTRAHEADER_KEYS_OUTPUT" ]; then
+          if [ "$GETREGEXP_RC" -eq 0 ] && [ -n "$EXTRAHEADER_KEYS_STDOUT" ]; then
             TEMP_GIT_CONFIG=$(mktemp)
-            cp .git/config "$TEMP_GIT_CONFIG" 2>&1
-            CP_RC=$?
-            echo "cp_config_rc=$CP_RC"
-            if [ "$CP_RC" -eq 0 ]; then
-              while IFS= read -r EXTRAHEADER_KEY; do
-                [ -n "$EXTRAHEADER_KEY" ] || continue
-                git config --file "$TEMP_GIT_CONFIG" --unset-all "$EXTRAHEADER_KEY" 2>&1; echo "unset_rc[$EXTRAHEADER_KEY]=$?"
-              done <<< "$EXTRAHEADER_KEYS_OUTPUT"
+            # Ensure temp file cleanup on any exit
+            trap 'rm -f "$TEMP_GIT_CONFIG"' EXIT
+            # Copy .git/config carefully; if missing, skip unset simulation
+            if [ -f .git/config ]; then
+              CP_STDERR_FILE=$(mktemp)
+              cp .git/config "$TEMP_GIT_CONFIG" 2>"$CP_STDERR_FILE"
+              CP_RC=$?
+              [ -s "$CP_STDERR_FILE" ] && printf 'cp_stderr: %s\n' "$(cat "$CP_STDERR_FILE")" || true
+              rm -f "$CP_STDERR_FILE"
+              echo "cp_config_rc=$CP_RC"
+              if [ "$CP_RC" -eq 0 ]; then
+                while IFS= read -r EXTRAHEADER_KEY; do
+                  [ -n "$EXTRAHEADER_KEY" ] || continue
+                  git config --file "$TEMP_GIT_CONFIG" --unset-all "$EXTRAHEADER_KEY" 2>&1
+                  echo "unset_rc[$EXTRAHEADER_KEY]=$?"
+                done <<< "$EXTRAHEADER_KEYS_STDOUT"
+              else
+                echo "unset_rc=skipped (config copy failed)"
+              fi
             else
-              echo "unset_rc=skipped (config copy failed)"
+              echo "config file .git/config missing — skipping unset simulation"
             fi
-            rm -f "$TEMP_GIT_CONFIG"
+          elif [ "$GETREGEXP_RC" -ne 0 ]; then
+            echo "unset_rc=skipped (git config --get-regexp failed with rc=$GETREGEXP_RC)"
           else
             echo "unset_rc=skipped (no matching key)"
           fi

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -108,14 +108,16 @@ jobs:
 
       # Temporary: reveal which git invocation in checkout's post-step
       # produces `The process '/usr/bin/git' failed with exit code 128`.
-      # Runs immediately before checkout@post so the dumped state is the
-      # exact state the post-step sees. Remove after root-cause is
-      # identified and a targeted fix lands.
-      - name: git diagnostic (checkout exit-128 probe)
+      # This diagnostic runs after checkout's main step and before
+      # checkout's post-step cleanup, then re-executes the same git
+      # operations to isolate the failing command.
+      # Remove after root-cause is identified and a targeted fix lands.
+      - &git-checkout-diag
+        name: git diagnostic (checkout exit-128 probe)
         if: always()
         run: |
           set +e
-          echo "=== git diagnostic: state before checkout post-step ==="
+          echo "=== git diagnostic: simulating checkout post-step operations ==="
           git --version
           echo "--- config (first 200) ---"
           git config --list --show-origin 2>&1 | head -n 200
@@ -124,10 +126,21 @@ jobs:
           git log -1 --oneline 2>&1; echo "log_rc=$?"
           echo "--- simulate post-step extraheader ops ---"
           git config --local --name-only --get-regexp 'http\..*\.extraheader' 2>&1; echo "getregexp_rc=$?"
-          git config --local --unset-all 'http.https://github.com/.extraheader' 2>&1; echo "unset_rc=$?"
+          EXTRAHEADER_KEYS=$(git config --local --name-only --get-regexp 'http\..*\.extraheader' 2>/dev/null || true)
+          if [ -n "$EXTRAHEADER_KEYS" ]; then
+            TEMP_GIT_CONFIG=$(mktemp)
+            cp .git/config "$TEMP_GIT_CONFIG" 2>/dev/null || true
+            while IFS= read -r EXTRAHEADER_KEY; do
+              [ -n "$EXTRAHEADER_KEY" ] || continue
+              git config --file "$TEMP_GIT_CONFIG" --unset-all "$EXTRAHEADER_KEY" 2>&1; echo "unset_rc[$EXTRAHEADER_KEY]=$?"
+            done <<< "$EXTRAHEADER_KEYS"
+            rm -f "$TEMP_GIT_CONFIG"
+          else
+            echo "unset_rc=skipped (no matching key)"
+          fi
           echo "--- simulate post-step submodule foreach ---"
           git submodule foreach --recursive 'echo ok' 2>&1; echo "foreach_rc=$?"
-          echo "--- .git listing (first 40) ---"
+          echo "--- .git directory listing (first 40) ---"
           ls -la .git/ 2>&1 | head -n 40; echo "ls_rc=$?"
           echo "=== end diagnostic ==="
           exit 0
@@ -1631,26 +1644,7 @@ jobs:
       # Temporary: reveal which git invocation in checkout's post-step
       # produces `The process '/usr/bin/git' failed with exit code 128`.
       # Remove after root-cause is identified and a targeted fix lands.
-      - name: git diagnostic (checkout exit-128 probe)
-        if: always()
-        run: |
-          set +e
-          echo "=== git diagnostic: state before checkout post-step ==="
-          git --version
-          echo "--- config (first 200) ---"
-          git config --list --show-origin 2>&1 | head -n 200
-          echo "--- status / head ---"
-          git status 2>&1; echo "status_rc=$?"
-          git log -1 --oneline 2>&1; echo "log_rc=$?"
-          echo "--- simulate post-step extraheader ops ---"
-          git config --local --name-only --get-regexp 'http\..*\.extraheader' 2>&1; echo "getregexp_rc=$?"
-          git config --local --unset-all 'http.https://github.com/.extraheader' 2>&1; echo "unset_rc=$?"
-          echo "--- simulate post-step submodule foreach ---"
-          git submodule foreach --recursive 'echo ok' 2>&1; echo "foreach_rc=$?"
-          echo "--- .git listing (first 40) ---"
-          ls -la .git/ 2>&1 | head -n 40; echo "ls_rc=$?"
-          echo "=== end diagnostic ==="
-          exit 0
+      - *git-checkout-diag
 
   # ──────────────────────────────────────────────────────────────────
   # Job 1b: Script correctness validation — runs parallel with E2E
@@ -1783,26 +1777,7 @@ jobs:
       # Temporary: reveal which git invocation in checkout's post-step
       # produces `The process '/usr/bin/git' failed with exit code 128`.
       # Remove after root-cause is identified and a targeted fix lands.
-      - name: git diagnostic (checkout exit-128 probe)
-        if: always()
-        run: |
-          set +e
-          echo "=== git diagnostic: state before checkout post-step ==="
-          git --version
-          echo "--- config (first 200) ---"
-          git config --list --show-origin 2>&1 | head -n 200
-          echo "--- status / head ---"
-          git status 2>&1; echo "status_rc=$?"
-          git log -1 --oneline 2>&1; echo "log_rc=$?"
-          echo "--- simulate post-step extraheader ops ---"
-          git config --local --name-only --get-regexp 'http\..*\.extraheader' 2>&1; echo "getregexp_rc=$?"
-          git config --local --unset-all 'http.https://github.com/.extraheader' 2>&1; echo "unset_rc=$?"
-          echo "--- simulate post-step submodule foreach ---"
-          git submodule foreach --recursive 'echo ok' 2>&1; echo "foreach_rc=$?"
-          echo "--- .git listing (first 40) ---"
-          ls -la .git/ 2>&1 | head -n 40; echo "ls_rc=$?"
-          echo "=== end diagnostic ==="
-          exit 0
+      - *git-checkout-diag
 
   # ──────────────────────────────────────────────────────────────────
   # Job 2: Validate release prerequisites (same as mark-stable.yml)
@@ -1859,26 +1834,7 @@ jobs:
       # Temporary: reveal which git invocation in checkout's post-step
       # produces `The process '/usr/bin/git' failed with exit code 128`.
       # Remove after root-cause is identified and a targeted fix lands.
-      - name: git diagnostic (checkout exit-128 probe)
-        if: always()
-        run: |
-          set +e
-          echo "=== git diagnostic: state before checkout post-step ==="
-          git --version
-          echo "--- config (first 200) ---"
-          git config --list --show-origin 2>&1 | head -n 200
-          echo "--- status / head ---"
-          git status 2>&1; echo "status_rc=$?"
-          git log -1 --oneline 2>&1; echo "log_rc=$?"
-          echo "--- simulate post-step extraheader ops ---"
-          git config --local --name-only --get-regexp 'http\..*\.extraheader' 2>&1; echo "getregexp_rc=$?"
-          git config --local --unset-all 'http.https://github.com/.extraheader' 2>&1; echo "unset_rc=$?"
-          echo "--- simulate post-step submodule foreach ---"
-          git submodule foreach --recursive 'echo ok' 2>&1; echo "foreach_rc=$?"
-          echo "--- .git listing (first 40) ---"
-          ls -la .git/ 2>&1 | head -n 40; echo "ls_rc=$?"
-          echo "=== end diagnostic ==="
-          exit 0
+      - *git-checkout-diag
 
   # ──────────────────────────────────────────────────────────────────
   # Job 3: Create release (same as mark-stable.yml)
@@ -1986,26 +1942,7 @@ jobs:
       # Temporary: reveal which git invocation in checkout's post-step
       # produces `The process '/usr/bin/git' failed with exit code 128`.
       # Remove after root-cause is identified and a targeted fix lands.
-      - name: git diagnostic (checkout exit-128 probe)
-        if: always()
-        run: |
-          set +e
-          echo "=== git diagnostic: state before checkout post-step ==="
-          git --version
-          echo "--- config (first 200) ---"
-          git config --list --show-origin 2>&1 | head -n 200
-          echo "--- status / head ---"
-          git status 2>&1; echo "status_rc=$?"
-          git log -1 --oneline 2>&1; echo "log_rc=$?"
-          echo "--- simulate post-step extraheader ops ---"
-          git config --local --name-only --get-regexp 'http\..*\.extraheader' 2>&1; echo "getregexp_rc=$?"
-          git config --local --unset-all 'http.https://github.com/.extraheader' 2>&1; echo "unset_rc=$?"
-          echo "--- simulate post-step submodule foreach ---"
-          git submodule foreach --recursive 'echo ok' 2>&1; echo "foreach_rc=$?"
-          echo "--- .git listing (first 40) ---"
-          ls -la .git/ 2>&1 | head -n 40; echo "ls_rc=$?"
-          echo "=== end diagnostic ==="
-          exit 0
+      - *git-checkout-diag
 
   # ──────────────────────────────────────────────────────────────────
   # Job 4: Combined Telegram notification (runs after ALL jobs)


### PR DESCRIPTION
## Summary
This PR adds temporary diagnostic steps to the CI workflow to investigate intermittent `git` command failures (exit code 128) occurring in the `actions/checkout@v4` post-step cleanup phase.

## Changes
- Added identical `git diagnostic (checkout exit-128 probe)` steps to 5 different jobs in the workflow:
  - Setup job (after version calculation)
  - E2E smoke test job
  - Script validation job (Job 1b)
  - Release prerequisites validation job (Job 2)
  - Release creation job (Job 3)

Each diagnostic step:
- Runs with `if: always()` to execute regardless of previous step outcomes
- Captures git version and configuration state
- Tests git status and log operations
- Simulates the exact git operations performed by checkout's post-step (extraheader config cleanup and submodule foreach)
- Inspects `.git` directory contents
- Logs all return codes to help identify which specific git invocation fails

## Implementation Details
- All diagnostic output is captured before the checkout post-step runs, preserving the exact state that triggers the failure
- Commands use `set +e` to continue execution even if individual git commands fail
- Output is limited (e.g., first 200 config lines, first 40 `.git` listing lines) to avoid excessive log spam
- Steps always exit with code 0 to avoid blocking the workflow
- Marked as temporary with comments indicating removal after root cause is identified

This is a non-invasive debugging approach that will help identify which git operation is failing and under what conditions.

https://claude.ai/code/session_01UqU7uR5PfLWEL7Ngd1a8dj