### PR TITLE
Improve git merge error diagnostics and stderr capture

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2258,7 +2258,19 @@ jobs:
           echo "====================================="
 
           merge_exit=0
-          git merge --no-commit --no-ff "origin/${BASE_BRANCH}" || merge_exit=$?
+          # Capture git merge stderr so the failure annotation can surface
+          # the real cause (e.g. "refusing to merge unrelated histories",
+          # "Untracked working tree file … would be overwritten by merge").
+          # The previous implementation hard-coded "untracked files or a
+          # corrupted working tree" in the ::error:: annotation, which was
+          # misleading whenever git's actual complaint was something else.
+          MERGE_STDERR_FILE="$(mktemp)"
+          git merge --no-commit --no-ff "origin/${BASE_BRANCH}" 2> "${MERGE_STDERR_FILE}" || merge_exit=$?
+          # Echo captured stderr so it remains visible in the raw step log
+          # even when we wrap it in an annotation below.
+          if [ -s "${MERGE_STDERR_FILE}" ]; then
+            sed 's/^/git merge stderr: /' "${MERGE_STDERR_FILE}"
+          fi
 
           # Restore the stashed dirs so later steps have them available.
           for d in scripts .serena prompts ai-memory .codex-workflow-src .codex-workflow-src-main; do
@@ -2277,11 +2289,20 @@ jobs:
           # attempt a proper merge.
           if [ -z "$(git ls-files --unmerged)" ]; then
             if [ "${merge_exit}" -ne 0 ] && [ ! -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
-              if [ "${merge_exit}" -eq 128 ]; then
-                echo "::error::Merge precheck failed (exit 128): untracked files or a corrupted working tree blocked git merge. Review the pre-merge diagnostics above to identify the colliding file."
+              # Flatten the captured stderr onto a single line for the
+              # annotation (::error:: notations cannot span newlines).
+              _merge_stderr_oneline="$(tr '\n' ' ' < "${MERGE_STDERR_FILE}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
+              _merge_stderr_oneline="${_merge_stderr_oneline:-<git merge produced no stderr>}"
+              if grep -qi 'refusing to merge unrelated histories' "${MERGE_STDERR_FILE}" 2>/dev/null; then
+                _head_sha="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+                _base_sha="$(git rev-parse --short "origin/${BASE_BRANCH}" 2>/dev/null || echo unknown)"
+                echo "::error::Merge precheck failed (exit ${merge_exit}): HEAD (${_head_sha}) and origin/${BASE_BRANCH} (${_base_sha}) have no common ancestor. This PR's branch was likely force-pushed to an orphan root, or ${BASE_BRANCH} was force-pushed since this branch diverged. Manual repair required: rebase the PR branch onto a current ${BASE_BRANCH} ancestor, or recreate the branch from ${BASE_BRANCH} and re-apply the changes. git stderr: ${_merge_stderr_oneline}"
+              elif [ "${merge_exit}" -eq 128 ]; then
+                echo "::error::Merge precheck failed (exit 128): git merge aborted before entering merge state. See pre-merge diagnostics above. git stderr: ${_merge_stderr_oneline}"
               else
-                echo "::warning::git merge exited ${merge_exit} without entering merge state — treating as conflict"
+                echo "::warning::git merge exited ${merge_exit} without entering merge state — treating as conflict. git stderr: ${_merge_stderr_oneline}"
               fi
+              rm -f "${MERGE_STDERR_FILE}"
               echo "Merge conflict detected (merge command failed)"
               echo "MERGE_CONFLICT=true" >> "$GITHUB_ENV"
               for d in .serena scripts prompts; do
@@ -2305,6 +2326,7 @@ jobs:
             git reset --hard HEAD || true
             git clean -fd || true
             rm -rf "${UNTRACKED_BACKUP}"
+            rm -f "${MERGE_STDERR_FILE}"
             exit 0
           else
             echo "Merge conflict detected"
@@ -2327,6 +2349,7 @@ jobs:
             done
           fi
           rm -rf "${UNTRACKED_BACKUP}"
+          rm -f "${MERGE_STDERR_FILE}"
 
       - name: Prepare merge-conflict resolver prompt and pre-snapshot
         # Split from "Run Codex resolver, validate, stage, commit" below so

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2294,6 +2294,7 @@ jobs:
               # annotation (::error:: notations cannot span newlines).
               _merge_stderr_oneline="$(tr '\n' ' ' < "${MERGE_STDERR_FILE}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
               _merge_stderr_oneline="${_merge_stderr_oneline:-<git merge produced no stderr>}"
+              _merge_stderr_oneline="$(printf '%s' "${_merge_stderr_oneline}" | sed 's/%/%25/g; s/\r/%0D/g; s/\n/%0A/g')"
               if grep -qi 'refusing to merge unrelated histories' "${MERGE_STDERR_FILE}" 2>/dev/null; then
                 _head_sha="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
                 _base_sha="$(git rev-parse --short "origin/${BASE_BRANCH}" 2>/dev/null || echo unknown)"

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2294,7 +2294,7 @@ jobs:
               # annotation (::error:: notations cannot span newlines).
               _merge_stderr_oneline="$(tr '\n' ' ' < "${MERGE_STDERR_FILE}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
               _merge_stderr_oneline="${_merge_stderr_oneline:-<git merge produced no stderr>}"
-              _merge_stderr_oneline="$(printf '%s' "${_merge_stderr_oneline}" | sed 's/%/%25/g; s/\r/%0D/g; s/\n/%0A/g')"
+              _merge_stderr_oneline="$(printf '%s' "${_merge_stderr_oneline}" | sed 's/%/%25/g; s/\r/%0D/g')"
               if grep -qi 'refusing to merge unrelated histories' "${MERGE_STDERR_FILE}" 2>/dev/null; then
                 _head_sha="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
                 _base_sha="$(git rev-parse --short "origin/${BASE_BRANCH}" 2>/dev/null || echo unknown)"

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2265,6 +2265,7 @@ jobs:
           # corrupted working tree" in the ::error:: annotation, which was
           # misleading whenever git's actual complaint was something else.
           MERGE_STDERR_FILE="$(mktemp)"
+          trap 'rm -f "${MERGE_STDERR_FILE}"' EXIT
           git merge --no-commit --no-ff "origin/${BASE_BRANCH}" 2> "${MERGE_STDERR_FILE}" || merge_exit=$?
           # Echo captured stderr so it remains visible in the raw step log
           # even when we wrap it in an annotation below.

--- a/scripts/review_conflict_prepare.sh
+++ b/scripts/review_conflict_prepare.sh
@@ -117,6 +117,7 @@ _merge_exit=0
 # real complaint (e.g. "refusing to merge unrelated histories") instead
 # of a generic "investigate" message.
 _merge_stderr_file="$(mktemp)"
+trap 'rm -f "${_merge_stderr_file}"' EXIT INT TERM
 git merge --no-commit --no-ff "origin/${BASE_BRANCH}" 2> "${_merge_stderr_file}" || _merge_exit=$?
 if [ -s "${_merge_stderr_file}" ]; then
   sed 's/^/git merge stderr: /' "${_merge_stderr_file}"

--- a/scripts/review_conflict_prepare.sh
+++ b/scripts/review_conflict_prepare.sh
@@ -189,6 +189,7 @@ if [ "${_resolver_allowlist_count}" -eq 0 ]; then
   # without re-reading the raw log.
   _merge_stderr_oneline="$(tr '\n' ' ' < "${_merge_stderr_file}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
   _merge_stderr_oneline="${_merge_stderr_oneline:-<git merge produced no stderr>}"
+  _merge_stderr_oneline="$(printf '%s' "${_merge_stderr_oneline}" | sed 's/%/%25/g; s/\r/%0D/g; s/\n/%0A/g')"
   if grep -qi 'refusing to merge unrelated histories' "${_merge_stderr_file}" 2>/dev/null; then
     _head_sha="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
     _base_sha="$(git rev-parse --short "origin/${BASE_BRANCH}" 2>/dev/null || echo unknown)"

--- a/scripts/review_conflict_prepare.sh
+++ b/scripts/review_conflict_prepare.sh
@@ -189,7 +189,7 @@ if [ "${_resolver_allowlist_count}" -eq 0 ]; then
   # without re-reading the raw log.
   _merge_stderr_oneline="$(tr '\n' ' ' < "${_merge_stderr_file}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
   _merge_stderr_oneline="${_merge_stderr_oneline:-<git merge produced no stderr>}"
-  _merge_stderr_oneline="$(printf '%s' "${_merge_stderr_oneline}" | sed 's/%/%25/g; s/\r/%0D/g; s/\n/%0A/g')"
+  _merge_stderr_oneline="$(printf '%s' "${_merge_stderr_oneline}" | sed 's/%/%25/g; s/\r/%0D/g')"
   if grep -qi 'refusing to merge unrelated histories' "${_merge_stderr_file}" 2>/dev/null; then
     _head_sha="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
     _base_sha="$(git rev-parse --short "origin/${BASE_BRANCH}" 2>/dev/null || echo unknown)"

--- a/scripts/review_conflict_prepare.sh
+++ b/scripts/review_conflict_prepare.sh
@@ -113,7 +113,14 @@ git clean -ffdx -e .codex-workflow-src -e .codex-workflow-src-main 2>/dev/null |
 #              happens we must surface it instead of silently
 #              running Codex against an empty conflict set.
 _merge_exit=0
-git merge --no-commit --no-ff "origin/${BASE_BRANCH}" || _merge_exit=$?
+# Capture stderr so the hard-fail annotation below can surface git's
+# real complaint (e.g. "refusing to merge unrelated histories") instead
+# of a generic "investigate" message.
+_merge_stderr_file="$(mktemp)"
+git merge --no-commit --no-ff "origin/${BASE_BRANCH}" 2> "${_merge_stderr_file}" || _merge_exit=$?
+if [ -s "${_merge_stderr_file}" ]; then
+  sed 's/^/git merge stderr: /' "${_merge_stderr_file}"
+fi
 
 # Capture the set of actually-unmerged paths produced by this
 # merge replay.  This is the authoritative allowlist the Codex
@@ -170,15 +177,32 @@ if [ "${_resolver_allowlist_count}" -eq 0 ]; then
       fi
     done
     rm -rf "${RESOLVE_STASH}"
+    rm -f "${_merge_stderr_file}"
     git reset --hard HEAD 2>/dev/null || true
     echo "MERGE_CONFLICT=false" >> "$GITHUB_ENV"
     exit 0
   fi
-  echo "::error::Merge replay failed with exit ${_merge_exit} before producing any unmerged paths. The clean-tree reset at the top of this step did not yield a tree git could merge — investigate. Diagnostics:"
+  # Flatten captured stderr onto one line for the ::error:: annotation,
+  # and route "refusing to merge unrelated histories" to a dedicated
+  # message that names the two SHAs so operators can repair the branch
+  # without re-reading the raw log.
+  _merge_stderr_oneline="$(tr '\n' ' ' < "${_merge_stderr_file}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
+  _merge_stderr_oneline="${_merge_stderr_oneline:-<git merge produced no stderr>}"
+  if grep -qi 'refusing to merge unrelated histories' "${_merge_stderr_file}" 2>/dev/null; then
+    _head_sha="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    _base_sha="$(git rev-parse --short "origin/${BASE_BRANCH}" 2>/dev/null || echo unknown)"
+    echo "::error::Merge replay failed (exit ${_merge_exit}): HEAD (${_head_sha}) and origin/${BASE_BRANCH} (${_base_sha}) have no common ancestor. This PR's branch was likely force-pushed to an orphan root, or ${BASE_BRANCH} was force-pushed since this branch diverged. Manual repair required: rebase the PR branch onto a current ${BASE_BRANCH} ancestor, or recreate the branch from ${BASE_BRANCH} and re-apply the changes. git stderr: ${_merge_stderr_oneline}"
+  else
+    echo "::error::Merge replay failed with exit ${_merge_exit} before producing any unmerged paths. The clean-tree reset at the top of this step did not yield a tree git could merge — investigate. git stderr: ${_merge_stderr_oneline}"
+  fi
   git status --porcelain 2>/dev/null || true
   git ls-files --others --exclude-standard 2>/dev/null | head -20 || true
+  rm -f "${_merge_stderr_file}"
   exit 1
 fi
+# The stderr file is no longer needed past this point — the happy path
+# has unmerged entries, which the resolver handles regardless of stderr.
+rm -f "${_merge_stderr_file}"
 
 # Defensive: `git merge --no-commit` auto-stages merged hunks (and
 # conflict-marked hunks) into the index for every path both sides

--- a/scripts/review_consolidate.sh
+++ b/scripts/review_consolidate.sh
@@ -175,7 +175,23 @@ fi
 review_log "model=${REVIEW_CONSOLIDATOR_MODEL} reasoning=${REVIEW_CONSOLIDATOR_REASONING} input_bytes=${input_bytes} output_bytes=${output_bytes} wall_secs=${wall_secs} exit_code=${cmd_rc} capped=${capped} failopen=${failopen}"
 
 if [ -s "${tmp_err}" ]; then
-	sed 's/^/stage=consolidator stderr=/g' "${tmp_err}" >&2 || true
+	# Neutralise any bytes that the GitHub Actions runner would otherwise
+	# parse as a workflow command / annotation. LLM reasoning sometimes
+	# echoes literal snippets like `echo "::error::..."` or quotes
+	# `##[error]` from agents.md documentation, and a bare CR in the
+	# stderr stream can re-anchor such a token to column zero even when
+	# the enclosing line already carries the "stage=consolidator stderr="
+	# prefix. Replace CR with space, then defang `##[` → `##\[` and
+	# `::<cmd>::` → `::\<cmd>::` inline before prefixing so no transform
+	# can accidentally produce a line that the runner interprets as an
+	# annotation. The prefix itself is still applied last to keep log
+	# lines identifiable via the existing "stage=consolidator stderr="
+	# grep contract (see agents.md consolidator stderr forwarding).
+	sed -e 's/\r/ /g' \
+		-e 's/##\[/##\\[/g' \
+		-e 's/::\(error\|warning\|notice\|debug\|group\|endgroup\|add-mask\|add-matcher\|remove-matcher\|set-output\|save-state\|echo\|stop-commands\|add-path\)::/::\\\1::/g' \
+		-e 's/^/stage=consolidator stderr=/' \
+		"${tmp_err}" >&2 || true
 fi
 
 rm -f "${tmp_out}" "${tmp_err}" "${tmp_cap}"

--- a/scripts/review_consolidate.sh
+++ b/scripts/review_consolidate.sh
@@ -182,14 +182,17 @@ if [ -s "${tmp_err}" ]; then
 	# stderr stream can re-anchor such a token to column zero even when
 	# the enclosing line already carries the "stage=consolidator stderr="
 	# prefix. Replace CR with space, then defang `##[` → `##\[` and
-	# `::<cmd>::` → `::\<cmd>::` inline before prefixing so no transform
-	# can accidentally produce a line that the runner interprets as an
-	# annotation. The prefix itself is still applied last to keep log
+	# `::<cmd>` → `::\<cmd>` inline before prefixing so both bare
+	# `::<cmd>::` commands and parameterized forms like
+	# `::error file=path,line=1::message` are neutralised before any
+	# transform can accidentally produce a line that the runner interprets
+	# as an annotation. The prefix itself is still applied last to keep log
 	# lines identifiable via the existing "stage=consolidator stderr="
 	# grep contract (see agents.md consolidator stderr forwarding).
-	sed -e 's/\r/ /g' \
+	sed -e 's/%/%25/g' \
+		-e 's/\r/ /g' \
 		-e 's/##\[/##\\[/g' \
-		-e 's/::\(error\|warning\|notice\|debug\|group\|endgroup\|add-mask\|add-matcher\|remove-matcher\|set-output\|save-state\|echo\|stop-commands\|add-path\|set-env\)::/::\\\1::/g' \
+		-e 's/::\([a-z][a-z-]*\)/::\\\1/g' \
 		-e 's/^/stage=consolidator stderr=/' \
 		"${tmp_err}" >&2 || true
 fi

--- a/scripts/review_consolidate.sh
+++ b/scripts/review_consolidate.sh
@@ -189,7 +189,7 @@ if [ -s "${tmp_err}" ]; then
 	# grep contract (see agents.md consolidator stderr forwarding).
 	sed -e 's/\r/ /g' \
 		-e 's/##\[/##\\[/g' \
-		-e 's/::\(error\|warning\|notice\|debug\|group\|endgroup\|add-mask\|add-matcher\|remove-matcher\|set-output\|save-state\|echo\|stop-commands\|add-path\)::/::\\\1::/g' \
+		-e 's/::\(error\|warning\|notice\|debug\|group\|endgroup\|add-mask\|add-matcher\|remove-matcher\|set-output\|save-state\|echo\|stop-commands\|add-path\|set-env\)::/::\\\1::/g' \
 		-e 's/^/stage=consolidator stderr=/' \
 		"${tmp_err}" >&2 || true
 fi

--- a/scripts/review_consolidate.sh
+++ b/scripts/review_consolidate.sh
@@ -192,7 +192,7 @@ if [ -s "${tmp_err}" ]; then
 	sed -e 's/%/%25/g' \
 		-e 's/\r/ /g' \
 		-e 's/##\[/##\\[/g' \
-		-e 's/::\([a-z][a-z-]*\)/::\\\1/g' \
+		-e 's/^::\(error\|warning\|notice\|debug\|group\|endgroup\|add-mask\|add-matcher\|remove-matcher\|set-output\|save-state\|echo\|stop-commands\|add-path\|set-env\)\([[:space:]]\|::\)/::\\\1\2/g' \
 		-e 's/^/stage=consolidator stderr=/' \
 		"${tmp_err}" >&2 || true
 fi


### PR DESCRIPTION
## Summary
This PR enhances error reporting for git merge failures in the review workflow by capturing and surfacing actual git stderr output instead of generic error messages. It also adds safeguards to prevent LLM-generated content from being misinterpreted as GitHub Actions workflow commands.

## Key Changes

- **Capture git merge stderr**: Modified merge commands in `review_autofix.yml` and `review_conflict_prepare.sh` to redirect stderr to temporary files, allowing the actual error messages (e.g., "refusing to merge unrelated histories") to be surfaced in annotations rather than hard-coded generic messages.

- **Enhanced error messages**: Replaced generic "untracked files or corrupted working tree" error text with context-aware messages that:
  - Detect "unrelated histories" failures and provide specific remediation steps with commit SHAs
  - Include the actual git stderr output in all error annotations
  - Distinguish between different failure modes (exit code 128 vs. other failures)

- **Proper resource cleanup**: Added cleanup of temporary stderr files (`rm -f "${MERGE_STDERR_FILE}"` / `rm -f "${_merge_stderr_file}"`) in all code paths to prevent resource leaks.

- **Defang LLM output in consolidator stderr**: Enhanced `review_consolidate.sh` to neutralize bytes in LLM-generated stderr that could be misinterpreted as GitHub Actions workflow commands:
  - Replace carriage returns (CR) with spaces to prevent re-anchoring of annotation tokens
  - Escape `##[` sequences to `##\[`
  - Escape workflow command syntax (`::<cmd>::`) to `::\<cmd>::`
  - Apply the "stage=consolidator stderr=" prefix after defanging to maintain log grep contracts

## Implementation Details

- Stderr is captured to temporary files created with `mktemp` and cleaned up in all exit paths
- Multi-line stderr is flattened to single lines for GitHub Actions annotations (which don't support newlines)
- The raw stderr is also echoed to the step log before annotation wrapping for full visibility
- Defanging of LLM output uses sed with multiple `-e` expressions to handle different annotation patterns in a single pass

https://claude.ai/code/session_018JdbDSLz4jp9MuB1Qu7uhm