### PR TITLE
Fix issue #1469: Prevent auto-labeling orchestrator-managed issues

### DIFF
--- a/.github/workflows/issue_pr_status.yml
+++ b/.github/workflows/issue_pr_status.yml
@@ -290,6 +290,8 @@ jobs:
                 [[ "${_orch_num}" =~ ^[0-9]+$ ]] || continue
                 _orch_meta="$(gh_retry gh api "repos/${REPOSITORY}/issues/${_orch_num}" --jq '{labels:[.labels[].name], body:(.body // "")}' 2>/dev/null || echo '')"
                 if [ -z "${_orch_meta}" ]; then
+                  echo "::warning::Orchestrator fallback lookup failed for issue #${_orch_num}; conservatively skipping label/close mutation for this issue."
+                  ORCHESTRATED_ISSUES+="${_orch_num}"$'\n'
                   continue
                 fi
                 if printf '%s' "${_orch_meta}" | jq -e '

--- a/.github/workflows/issue_pr_status.yml
+++ b/.github/workflows/issue_pr_status.yml
@@ -193,13 +193,20 @@ jobs:
             --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[].number' || true)"
 
           if [ -z "${ISSUE_NUMBERS}" ]; then
-            # Fallback: extract issue number from PR body/title when closing keywords are missing
+            # Fallback: extract issue number from PR body/title only when the
+            # PR explicitly references an issue via a closing keyword
+            # (closes/fixes/resolves #N) or a full repo-scoped URL/path.
+            # Bare prose mentions like "issue #N" or "issues/N" are NOT treated
+            # as closing links — those are documentation references and
+            # auto-labeling/closing on them caused incorrect ai:merged
+            # transitions on orchestrator-tracking issues mentioned in PR
+            # bodies (see issue #1469).
             PR_DATA="${PR_TITLE:-} ${PR_BODY:-}"
             if [ -z "$(printf '%s' "${PR_DATA}" | tr -d '[:space:]')" ]; then
               PR_DATA="$(gh_retry gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.title + " " + (.body // "")' 2>/dev/null || echo "")"
             fi
             REPOSITORY_ESCAPED="${REPOSITORY//./\\.}"
-            ISSUE_NUMBERS="$(echo "${PR_DATA}" | grep -oiE "(github\\.com/${REPOSITORY_ESCAPED}/issues/[0-9]+|${REPOSITORY_ESCAPED}/issues/[0-9]+|(^|[^[:alnum:]_/-])issues/[0-9]+|issue[[:space:]]*#[[:space:]]*[0-9]+|(closes|fixes|resolves)[[:space:]]*:?[[:space:]]*#[[:space:]]*[0-9]+)" | grep -oE '[0-9]+$' | sort -un || true)"
+            ISSUE_NUMBERS="$(echo "${PR_DATA}" | grep -oiE "(github\\.com/${REPOSITORY_ESCAPED}/issues/[0-9]+|${REPOSITORY_ESCAPED}/issues/[0-9]+|(closes|fixes|resolves)[[:space:]]*:?[[:space:]]*#[[:space:]]*[0-9]+)" | grep -oE '[0-9]+$' | sort -un || true)"
             if [ -z "${ISSUE_NUMBERS}" ]; then
               echo "No linked issues found for PR #${PR_NUMBER} (even after body/title fallback)."
               ISSUE_NUMBERS=""
@@ -242,8 +249,67 @@ jobs:
           fi
           ensure_label_exists "${FINAL_LABEL}" "${REPOSITORY}"
 
+          # Identify orchestrator-managed issues — those carry the
+          # ai:orchestrator-tracking label or the "Managed by: AI
+          # Orchestrator" body marker. Their terminal phase label
+          # (ai:merged / ai:closed / ai:validation-failed / etc.) is
+          # owned exclusively by scripts/orchestrate_poll_process.sh,
+          # so this PR-close path must NOT relabel or auto-close
+          # them. Single batched GraphQL call (one API request,
+          # regardless of N) per CLAUDE.md §15. Fail-open with a
+          # per-issue REST fallback so a transient GraphQL failure
+          # cannot cause the bug it is trying to prevent.
+          ORCHESTRATED_ISSUES=""
+          ORCH_ALIAS_FRAGMENT=""
+          ORCH_IDX=0
+          while IFS= read -r _orch_num; do
+            [ -n "${_orch_num}" ] || continue
+            [[ "${_orch_num}" =~ ^[0-9]+$ ]] || continue
+            ORCH_ALIAS_FRAGMENT+=" i${ORCH_IDX}: issue(number: ${_orch_num}) { number labels(first: 50) { nodes { name } } body }"
+            ORCH_IDX=$((ORCH_IDX + 1))
+          done <<< "${ISSUE_NUMBERS}"
+
+          if [ -n "${ORCH_ALIAS_FRAGMENT}" ]; then
+            ORCH_QUERY="query { repository(owner: \"${REPOSITORY%/*}\", name: \"${REPOSITORY#*/}\") {${ORCH_ALIAS_FRAGMENT} } }"
+            ORCH_RESP="$(gh_retry gh api graphql -f query="${ORCH_QUERY}" 2>/dev/null || echo '')"
+            if [ -n "${ORCH_RESP}" ]; then
+              ORCHESTRATED_ISSUES="$(printf '%s' "${ORCH_RESP}" | jq -r '
+                .data.repository // {} | to_entries[] | .value | select(. != null) |
+                select(
+                  ((.labels.nodes // []) | map(.name) | index("ai:orchestrator-tracking")) != null
+                  or
+                  ((.body // "") | contains("Managed by: AI Orchestrator"))
+                ) | .number
+              ' 2>/dev/null || echo "")"
+            else
+              # GraphQL batch failed — fall back to per-issue REST detection
+              # so we never silently re-introduce the auto-label/close bug.
+              echo "::warning::Orchestrator-issue batch detection failed; falling back to per-issue REST."
+              while IFS= read -r _orch_num; do
+                [ -n "${_orch_num}" ] || continue
+                [[ "${_orch_num}" =~ ^[0-9]+$ ]] || continue
+                _orch_meta="$(gh_retry gh api "repos/${REPOSITORY}/issues/${_orch_num}" --jq '{labels:[.labels[].name], body:(.body // "")}' 2>/dev/null || echo '')"
+                if [ -z "${_orch_meta}" ]; then
+                  continue
+                fi
+                if printf '%s' "${_orch_meta}" | jq -e '
+                  ((.labels // []) | index("ai:orchestrator-tracking")) != null
+                  or ((.body // "") | contains("Managed by: AI Orchestrator"))
+                ' >/dev/null 2>&1; then
+                  ORCHESTRATED_ISSUES+="${_orch_num}"$'\n'
+                fi
+              done <<< "${ISSUE_NUMBERS}"
+            fi
+          fi
+
           while IFS= read -r issue_number; do
             [ -n "${issue_number}" ] || continue
+
+            if [ -n "${ORCHESTRATED_ISSUES}" ] && printf '%s\n' "${ORCHESTRATED_ISSUES}" | grep -qxF "${issue_number}"; then
+              echo "Skipping orchestrator-managed issue #${issue_number} — terminal phase label and close are owned by orchestrate_poll_process.sh; PR-close path must not mutate it."
+              continue
+            fi
+
             echo "Updating issue #${issue_number} with label ${FINAL_LABEL}"
             set_issue_phase_label_resilient "${issue_number}" "${FINAL_LABEL}" "${REPOSITORY}"
 

--- a/.github/workflows/issue_pr_status.yml
+++ b/.github/workflows/issue_pr_status.yml
@@ -272,16 +272,24 @@ jobs:
           if [ -n "${ORCH_ALIAS_FRAGMENT}" ]; then
             ORCH_QUERY="query { repository(owner: \"${REPOSITORY%/*}\", name: \"${REPOSITORY#*/}\") {${ORCH_ALIAS_FRAGMENT} } }"
             ORCH_RESP="$(gh_retry gh api graphql -f query="${ORCH_QUERY}" 2>/dev/null || echo '')"
-            if [ -n "${ORCH_RESP}" ]; then
-              ORCHESTRATED_ISSUES="$(printf '%s' "${ORCH_RESP}" | jq -r '
-                .data.repository // {} | to_entries[] | .value | select(. != null) |
+            ORCH_BATCH_FAILED=true
+            if [ -n "${ORCH_RESP}" ] && printf '%s' "${ORCH_RESP}" | jq -e '
+              ((.errors // []) | length) == 0
+              and (.data.repository? != null)
+            ' >/dev/null 2>&1; then
+              if _orchestrated_issues="$(printf '%s' "${ORCH_RESP}" | jq -r '
+                .data.repository | to_entries[] | .value | select(. != null) |
                 select(
                   ((.labels.nodes // []) | map(.name) | index("ai:orchestrator-tracking")) != null
                   or
                   ((.body // "") | contains("Managed by: AI Orchestrator"))
                 ) | .number
-              ' 2>/dev/null || echo "")"
-            else
+              ' 2>/dev/null)"; then
+                ORCHESTRATED_ISSUES="${_orchestrated_issues}"
+                ORCH_BATCH_FAILED=false
+              fi
+            fi
+            if [ "${ORCH_BATCH_FAILED}" = true ]; then
               # GraphQL batch failed — fall back to per-issue REST detection
               # so we never silently re-introduce the auto-label/close bug.
               echo "::warning::Orchestrator-issue batch detection failed; falling back to per-issue REST."

--- a/.github/workflows/issue_pr_status.yml
+++ b/.github/workflows/issue_pr_status.yml
@@ -194,8 +194,9 @@ jobs:
 
           if [ -z "${ISSUE_NUMBERS}" ]; then
             # Fallback: extract issue number from PR body/title only when the
-            # PR explicitly references an issue via a closing keyword
-            # (closes/fixes/resolves #N) or a full repo-scoped URL/path.
+            # PR explicitly references an issue via a supported closing keyword
+            # (close(s|d)/fix(es|ed)/resolve(s|d) #N) or a full repo-scoped
+            # URL/path.
             # Bare prose mentions like "issue #N" or "issues/N" are NOT treated
             # as closing links — those are documentation references and
             # auto-labeling/closing on them caused incorrect ai:merged
@@ -206,7 +207,7 @@ jobs:
               PR_DATA="$(gh_retry gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.title + " " + (.body // "")' 2>/dev/null || echo "")"
             fi
             REPOSITORY_ESCAPED="${REPOSITORY//./\\.}"
-            ISSUE_NUMBERS="$(echo "${PR_DATA}" | grep -oiE "(github\\.com/${REPOSITORY_ESCAPED}/issues/[0-9]+|${REPOSITORY_ESCAPED}/issues/[0-9]+|(closes|fixes|resolves)[[:space:]]*:?[[:space:]]*#[[:space:]]*[0-9]+)" | grep -oE '[0-9]+$' | sort -un || true)"
+            ISSUE_NUMBERS="$(echo "${PR_DATA}" | grep -oiE "(github\\.com/${REPOSITORY_ESCAPED}/issues/[0-9]+|${REPOSITORY_ESCAPED}/issues/[0-9]+|(^|[^[:alnum:]_/-])(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)[[:space:]]+#[[:space:]]*[0-9]+)" | grep -oE '[0-9]+$' | sort -un || true)"
             if [ -z "${ISSUE_NUMBERS}" ]; then
               echo "No linked issues found for PR #${PR_NUMBER} (even after body/title fallback)."
               ISSUE_NUMBERS=""
@@ -273,9 +274,10 @@ jobs:
             ORCH_QUERY="query { repository(owner: \"${REPOSITORY%/*}\", name: \"${REPOSITORY#*/}\") {${ORCH_ALIAS_FRAGMENT} } }"
             ORCH_RESP="$(gh_retry gh api graphql -f query="${ORCH_QUERY}" 2>/dev/null || echo '')"
             ORCH_BATCH_FAILED=true
-            if [ -n "${ORCH_RESP}" ] && printf '%s' "${ORCH_RESP}" | jq -e '
+            if [ -n "${ORCH_RESP}" ] && printf '%s' "${ORCH_RESP}" | jq -e --argjson expected "${ORCH_IDX}" '
               ((.errors // []) | length) == 0
               and (.data.repository? != null)
+              and (([.data.repository | to_entries[] | .value | select(. != null)] | length) == $expected)
             ' >/dev/null 2>&1; then
               if _orchestrated_issues="$(printf '%s' "${ORCH_RESP}" | jq -r '
                 .data.repository | to_entries[] | .value | select(. != null) |

--- a/tests/test_issue_pr_status_payload_fallback_contract.py
+++ b/tests/test_issue_pr_status_payload_fallback_contract.py
@@ -30,6 +30,101 @@ def test_payload_first_fallback_and_shared_helper_usage() -> None:
 	assert payload_pos < fetch_pos, "Fallback GH pull fetch must only run after payload text check"
 
 
+def test_fallback_regex_drops_bare_mentions_keeps_closing_keywords_and_urls() -> None:
+	"""Regression guard for issue #1469.
+
+	The previous fallback regex matched bare prose like ``issue #1469`` and
+	bare paths like ``issues/1469``, so any PR body merely *mentioning* an
+	issue would be treated as a closing link by this workflow. That caused
+	orchestrator tracking issues to be wrongly labeled ai:merged and
+	auto-closed when a sub-issue PR's body referenced them in passing.
+
+	This test pins the tightened regex to GitHub closing-keyword semantics
+	plus full repo-scoped URLs/paths, and forbids re-introducing the two
+	bare-mention patterns.
+	"""
+	text = _workflow_text()
+
+	assert (
+		r'(github\\.com/${REPOSITORY_ESCAPED}/issues/[0-9]+|'
+		r'${REPOSITORY_ESCAPED}/issues/[0-9]+|'
+		r'(closes|fixes|resolves)[[:space:]]*:?[[:space:]]*#[[:space:]]*[0-9]+)'
+	) in text, "Tightened fallback regex must be present verbatim"
+
+	# Forbidden: bare prose mentions that triggered the original bug.
+	assert 'issue[[:space:]]*#[[:space:]]*[0-9]+' not in text, (
+		"Bare 'issue #N' fallback pattern must not be re-introduced — it caused "
+		"incorrect ai:merged labeling on issue #1469."
+	)
+	assert '(^|[^[:alnum:]_/-])issues/[0-9]+' not in text, (
+		"Bare 'issues/N' fallback pattern must not be re-introduced — it caused "
+		"incorrect ai:merged labeling on issues mentioned in PR prose."
+	)
+
+
+def test_orchestrator_tracking_issues_are_skipped_in_label_close_loop() -> None:
+	"""Regression guard for issue #1469.
+
+	When a PR's body mentions an orchestrator tracking issue (or one is
+	resolved via the regex fallback), this workflow must not relabel or
+	auto-close it. Terminal-phase ownership for orchestrator-managed
+	tracking issues belongs exclusively to scripts/orchestrate_poll_process.sh.
+
+	The Telegram alert step at the bottom of the workflow already had an
+	IS_ORCHESTRATED guard scanning the issue body for the
+	"Managed by: AI Orchestrator" marker, but the guard was not applied
+	to the label/close path above it. This test pins the new guard.
+	"""
+	text = _workflow_text()
+
+	# The detection step builds an aliased GraphQL query that fetches both
+	# labels and body for every linked issue in a single API call.
+	assert "ORCH_ALIAS_FRAGMENT" in text, (
+		"Expected batched GraphQL detection of orchestrator-managed issues"
+	)
+	assert ' i${ORCH_IDX}: issue(number: ${_orch_num}) { number labels(first: 50) { nodes { name } } body }' in text, (
+		"Expected aliased GraphQL fragment that fetches labels+body in one call"
+	)
+
+	# Detection must check both the orchestrator-tracking label and the
+	# body marker (either signal must be sufficient).
+	assert 'index("ai:orchestrator-tracking")' in text
+	assert 'contains("Managed by: AI Orchestrator")' in text
+
+	# Fail-open contract: GraphQL failure must fall back to per-issue REST,
+	# not silently degrade to the buggy "label everything" behavior.
+	assert "Orchestrator-issue batch detection failed; falling back to per-issue REST" in text, (
+		"GraphQL failure path must use per-issue REST fallback so a transient "
+		"GraphQL error cannot re-introduce the auto-label bug."
+	)
+
+	# Loop guard: the label/close loop must consult ORCHESTRATED_ISSUES
+	# and continue (skip) before touching the label or issue state.
+	assert (
+		'if [ -n "${ORCHESTRATED_ISSUES}" ] && '
+		'printf \'%s\\n\' "${ORCHESTRATED_ISSUES}" | grep -qxF "${issue_number}"; then'
+	) in text, "Expected ORCHESTRATED_ISSUES gate inside the label/close loop"
+
+	# Detection block must precede the label/close loop.
+	detect_pos = text.find("ORCH_ALIAS_FRAGMENT=\"\"")
+	gate_pos = text.find('Skipping orchestrator-managed issue #${issue_number}')
+	label_call_pos = text.find('set_issue_phase_label_resilient "${issue_number}" "${FINAL_LABEL}" "${REPOSITORY}"')
+	close_call_pos = text.find('gh_retry gh issue close "${issue_number}" -R "${REPOSITORY}"')
+	assert detect_pos != -1, "Detection block missing"
+	assert gate_pos != -1, "Skip-log marker missing inside label/close loop"
+	assert label_call_pos != -1, "set_issue_phase_label_resilient call missing"
+	assert close_call_pos != -1, "gh issue close call missing"
+	assert detect_pos < gate_pos < label_call_pos, (
+		"Orchestrator detection must run before, and the skip gate must precede, "
+		"the label apply call."
+	)
+	assert gate_pos < close_call_pos, (
+		"Skip gate must precede the gh issue close call."
+	)
+
+
 if __name__ == "__main__":
 	test_payload_first_fallback_and_shared_helper_usage()
+	test_fallback_regex_drops_bare_mentions_keeps_closing_keywords_and_urls()
+	test_orchestrator_tracking_issues_are_skipped_in_label_close_loop()
 	print("PASS")

--- a/tests/test_issue_pr_status_payload_fallback_contract.py
+++ b/tests/test_issue_pr_status_payload_fallback_contract.py
@@ -48,7 +48,7 @@ def test_fallback_regex_drops_bare_mentions_keeps_closing_keywords_and_urls() ->
 	assert (
 		r'(github\\.com/${REPOSITORY_ESCAPED}/issues/[0-9]+|'
 		r'${REPOSITORY_ESCAPED}/issues/[0-9]+|'
-		r'(closes|fixes|resolves)[[:space:]]*:?[[:space:]]*#[[:space:]]*[0-9]+)'
+		r'(^|[^[:alnum:]_/-])(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)[[:space:]]+#[[:space:]]*[0-9]+)'
 	) in text, "Tightened fallback regex must be present verbatim"
 
 	# Forbidden: bare prose mentions that triggered the original bug.
@@ -59,6 +59,10 @@ def test_fallback_regex_drops_bare_mentions_keeps_closing_keywords_and_urls() ->
 	assert '(^|[^[:alnum:]_/-])issues/[0-9]+' not in text, (
 		"Bare 'issues/N' fallback pattern must not be re-introduced — it caused "
 		"incorrect ai:merged labeling on issues mentioned in PR prose."
+	)
+	assert '[[:space:]]*:?[[:space:]]*#[[:space:]]*[0-9]+' not in text, (
+		"Optional colon between closing keyword and '#N' must not be re-introduced; "
+		"GitHub closing-link syntax expects whitespace separation."
 	)
 
 
@@ -91,11 +95,18 @@ def test_orchestrator_tracking_issues_are_skipped_in_label_close_loop() -> None:
 	assert 'index("ai:orchestrator-tracking")' in text
 	assert 'contains("Managed by: AI Orchestrator")' in text
 
+	# GraphQL validity requires complete aliased-issue coverage; any missing/null
+	# alias entry must trigger REST fallback.
+	assert 'and (([.data.repository | to_entries[] | .value | select(. != null)] | length) == $expected)' in text
+
 	# Fail-open contract: GraphQL failure must fall back to per-issue REST,
 	# not silently degrade to the buggy "label everything" behavior.
 	assert "Orchestrator-issue batch detection failed; falling back to per-issue REST" in text, (
 		"GraphQL failure path must use per-issue REST fallback so a transient "
 		"GraphQL error cannot re-introduce the auto-label bug."
+	)
+	assert 'gh_retry gh api "repos/${REPOSITORY}/issues/${_orch_num}" --jq' in text, (
+		"Per-issue REST fallback lookup must remain wired in the GraphQL-failure path."
 	)
 
 	# Loop guard: the label/close loop must consult ORCHESTRATED_ISSUES


### PR DESCRIPTION
## Summary
Fixes issue #1469 where orchestrator-managed tracking issues were incorrectly auto-labeled as `ai:merged` and auto-closed when sub-issue PRs merely mentioned them in passing. This was caused by an overly broad fallback regex that treated bare prose mentions like "issue #1469" as closing links.

## Key Changes

- **Tightened fallback regex**: Removed bare mention patterns (`issue #N` and `issues/N`) from the PR body fallback regex. Now only matches:
  - Full repo-scoped URLs: `github.com/owner/repo/issues/N`
  - Full repo-scoped paths: `owner/repo/issues/N`
  - Explicit closing keywords: `closes|fixes|resolves #N`
  
  This prevents documentation references from being treated as closing links.

- **Added orchestrator-issue detection**: Implemented a batched GraphQL query to identify orchestrator-managed issues (those with `ai:orchestrator-tracking` label or "Managed by: AI Orchestrator" body marker) in a single API call per CLAUDE.md §15.

- **Added skip guard in label/close loop**: The issue update loop now checks if an issue is orchestrator-managed and skips it if so, since terminal phase label ownership belongs exclusively to `scripts/orchestrate_poll_process.sh`.

- **Fail-open fallback**: If the batched GraphQL query fails, the workflow falls back to per-issue REST detection to ensure a transient GraphQL error cannot re-introduce the auto-label bug.

- **Comprehensive regression tests**: Added two new test cases that pin the tightened regex and verify the orchestrator-issue skip guard is properly positioned and functional.

## Implementation Details

- The orchestrator detection uses a single GraphQL query with aliased fragments (`i0`, `i1`, etc.) to fetch labels and body for all linked issues in one request
- Detection checks both the `ai:orchestrator-tracking` label and the body marker—either signal is sufficient to mark an issue as orchestrator-managed
- The skip gate is positioned before both the label apply and issue close operations
- Added detailed comments explaining the regression and the fix rationale

https://claude.ai/code/session_014zXm52hfrP3ZH7Qnzm2q5b