### PR TITLE
Add minimal validation manifest for template-mode validation

### DIFF
--- a/.ai/validate.yml
+++ b/.ai/validate.yml
@@ -1,0 +1,13 @@
+# Minimal manifest to unblock template-mode validation.
+# Required because VALIDATION_USE_TEMPLATES defaults to true (#1536) and
+# scripts/validate_process.sh refuses to fall back when this file is missing.
+# Family chosen for schema/runtime validity only — this repo ships workflow
+# templates rather than a Flask app, so rendered harness tests may need
+# tuning (skip_tests, custom_tests) in a follow-up.
+type: python-mongo-flask
+slots:
+  project_name: coding-workflows
+  canary_tools:
+    - bash
+    - python3
+    - jq


### PR DESCRIPTION
## Summary
Added a minimal `.ai/validate.yml` manifest file to unblock template-mode validation in the CI/CD pipeline.

## Key Changes
- Created `.ai/validate.yml` with a minimal configuration using the `python-mongo-flask` family type
- Configured required slots: `project_name` (coding-workflows) and `canary_tools` (bash, python3, jq)
- This file is necessary because `VALIDATION_USE_TEMPLATES` defaults to true and the validation script requires it to be present

## Implementation Details
- The manifest uses a generic family type for schema/runtime validity only, as this repository ships workflow templates rather than a Flask application
- Rendered harness tests may require additional tuning (skip_tests, custom_tests) in follow-up work
- This is a minimal configuration to unblock validation without full template customization

https://claude.ai/code/session_0161ptgVkZMX4cVHz6sPpU6e