### PR TITLE
Add --include=optional flag to npm install commands for Codex

### DIFF
--- a/.github/actions/setup-runtime/action.yml
+++ b/.github/actions/setup-runtime/action.yml
@@ -57,7 +57,7 @@ runs:
       run: |
         set -euo pipefail
 
-        npm install -g "@openai/codex@${CODEX_VERSION}" --no-audit --no-fund
+        npm install -g "@openai/codex@${CODEX_VERSION}" --include=optional --no-audit --no-fund
 
         missing_tools=()
         for tool in jq curl gh; do

--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -156,7 +156,7 @@ jobs:
         run: |
           set -euo pipefail
           CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
-          npm install -g @openai/codex@"${CODEX_VERSION}" --no-audit --no-fund
+          npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
 
       - name: Resolve workflow support ref
         run: |

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           set -euo pipefail
           CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
-          npm install -g @openai/codex@"${CODEX_VERSION}" --no-audit --no-fund
+          npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
 
       - name: Install uv for Serena
         if: env.SKIP_IMPLEMENT != 'true'

--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -77,7 +77,7 @@ jobs:
           set -euo pipefail
 
           CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
-          npm install -g "@openai/codex@${CODEX_VERSION}" --no-audit --no-fund
+          npm install -g "@openai/codex@${CODEX_VERSION}" --include=optional --no-audit --no-fund
 
           missing_tools=()
           for tool in jq curl gh; do

--- a/.github/workflows/orchestrate_clarify_respond.yml
+++ b/.github/workflows/orchestrate_clarify_respond.yml
@@ -185,7 +185,7 @@ jobs:
         run: |
           set -euo pipefail
           CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
-          npm install -g @openai/codex@"${CODEX_VERSION}" --no-audit --no-fund
+          npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
 
       - name: Resolve workflow support ref
         if: steps.check_orchestrator.outputs.is_orchestrator == 'true'

--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -151,7 +151,7 @@ jobs:
           set -euo pipefail
 
           CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
-          npm install -g "@openai/codex@${CODEX_VERSION}" --no-audit --no-fund
+          npm install -g "@openai/codex@${CODEX_VERSION}" --include=optional --no-audit --no-fund
 
           missing_tools=()
           for tool in jq curl gh; do

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -59,7 +59,7 @@ jobs:
         if: steps.cache-codex.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          npm install -g @openai/codex@"${CODEX_VERSION}" --no-audit --no-fund
+          npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
           # Persist to tool cache for future runs
           CODEX_BIN="$(which codex)"
           CODEX_DIR="$(dirname "${CODEX_BIN}")"
@@ -71,7 +71,7 @@ jobs:
         if: steps.cache-codex.outputs.cache-hit == 'true'
         run: |
           set -euo pipefail
-          npm install -g "${{ runner.tool_cache }}/codex/package" --no-audit --no-fund
+          npm install -g "${{ runner.tool_cache }}/codex/package" --include=optional --no-audit --no-fund
 
       - name: Resolve integration ref
         id: refctx

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -556,7 +556,7 @@ jobs:
         run: |
           set -euo pipefail
           CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
-          npm install -g @openai/codex@"${CODEX_VERSION}" --no-audit --no-fund
+          npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
           sudo apt-get update
           sudo apt-get install -y jq curl python3
 

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -191,7 +191,7 @@ jobs:
         if: ${{ inputs.codex_mode && steps.cache-codex.outputs.cache-hit != 'true' }}
         run: |
           set -euo pipefail
-          npm install -g @openai/codex@"${CODEX_VERSION}" --no-audit --no-fund
+          npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
           CODEX_BIN="$(which codex)"
           mkdir -p "${{ runner.tool_cache }}/codex"
           cp -r "$(npm root -g)/@openai/codex" "${{ runner.tool_cache }}/codex/package"
@@ -201,7 +201,7 @@ jobs:
         if: ${{ inputs.codex_mode && steps.cache-codex.outputs.cache-hit == 'true' }}
         run: |
           set -euo pipefail
-          npm install -g "${{ runner.tool_cache }}/codex/package" --no-audit --no-fund
+          npm install -g "${{ runner.tool_cache }}/codex/package" --include=optional --no-audit --no-fund
 
       - name: Create Codex config
         if: ${{ inputs.codex_mode }}
@@ -662,7 +662,7 @@ jobs:
         if: steps.cache-codex.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          npm install -g @openai/codex@"${CODEX_VERSION}" --no-audit --no-fund
+          npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
           CODEX_BIN="$(which codex)"
           mkdir -p "${{ runner.tool_cache }}/codex"
           cp -r "$(npm root -g)/@openai/codex" "${{ runner.tool_cache }}/codex/package"
@@ -672,7 +672,7 @@ jobs:
         if: steps.cache-codex.outputs.cache-hit == 'true'
         run: |
           set -euo pipefail
-          npm install -g "${{ runner.tool_cache }}/codex/package" --no-audit --no-fund
+          npm install -g "${{ runner.tool_cache }}/codex/package" --include=optional --no-audit --no-fund
 
       - name: Create Codex config
         env:
@@ -979,7 +979,7 @@ jobs:
         if: steps.cache-codex.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          npm install -g @openai/codex@"${CODEX_VERSION}" --no-audit --no-fund
+          npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
           CODEX_BIN="$(which codex)"
           mkdir -p "${{ runner.tool_cache }}/codex"
           cp -r "$(npm root -g)/@openai/codex" "${{ runner.tool_cache }}/codex/package"
@@ -989,7 +989,7 @@ jobs:
         if: steps.cache-codex.outputs.cache-hit == 'true'
         run: |
           set -euo pipefail
-          npm install -g "${{ runner.tool_cache }}/codex/package" --no-audit --no-fund
+          npm install -g "${{ runner.tool_cache }}/codex/package" --include=optional --no-audit --no-fund
 
       - name: Create Codex config
         env:


### PR DESCRIPTION
## Summary
This PR adds the `--include=optional` flag to all npm install commands that install the `@openai/codex` package across multiple GitHub Actions workflows and configuration files.

## Key Changes
- Added `--include=optional` flag to npm install commands for `@openai/codex` in 9 workflow files:
  - `.github/workflows/workflow-log-analysis.yml` (4 occurrences)
  - `.github/workflows/plan.yml` (2 occurrences)
  - `.github/workflows/clarify.yml` (1 occurrence)
  - `.github/workflows/implement.yml` (1 occurrence)
  - `.github/workflows/orchestrate.yml` (1 occurrence)
  - `.github/workflows/orchestrate_clarify_respond.yml` (1 occurrence)
  - `.github/workflows/orchestrate_poll.yml` (1 occurrence)
  - `.github/workflows/review_autofix.yml` (1 occurrence)
- Added `--include=optional` flag to the setup-runtime GitHub Action (`.github/actions/setup-runtime/action.yml`)

## Implementation Details
The `--include=optional` flag ensures that optional dependencies of the `@openai/codex` package are installed during npm package installation. This flag is applied consistently across both fresh installations and cached package installations, maintaining uniform behavior across all workflow environments.

https://claude.ai/code/session_019mXrrN4C54b8EseEzbBwCu