### PR TITLE
Add Gemini 2.5 Pro and Qwen3-Coder Plus models to catalog

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -57,7 +57,7 @@ env:
     moonshotai/kimi-k2.5
     deepseek/deepseek-v3.2
     z-ai/glm-5
-    google/gemini-2.5-pro
+    qwen/qwen3-coder-plus
   MODEL_EDITOR: ${{ vars.WORKFLOW_EDITOR_MODEL || 'openai/gpt-5.3-codex' }}
   REVIEWER_REASONING_EFFORT: ${{ vars.THINKING_LEVEL_REVIEWER || 'xhigh' }}
   EDITOR_REASONING_EFFORT: ${{ vars.THINKING_LEVEL_EDITOR || 'xhigh' }}

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -57,7 +57,7 @@ env:
     moonshotai/kimi-k2.5
     deepseek/deepseek-v3.2
     z-ai/glm-5
-    google/gemini-3.1-pro-preview
+    google/gemini-2.5-pro
   MODEL_EDITOR: ${{ vars.WORKFLOW_EDITOR_MODEL || 'openai/gpt-5.3-codex' }}
   REVIEWER_REASONING_EFFORT: ${{ vars.THINKING_LEVEL_REVIEWER || 'xhigh' }}
   EDITOR_REASONING_EFFORT: ${{ vars.THINKING_LEVEL_EDITOR || 'xhigh' }}

--- a/README.md
+++ b/README.md
@@ -845,7 +845,7 @@ Analyzer script: [`scripts/analyze_workflow_logs.py`](scripts/analyze_workflow_l
   1. `python3 scripts/analyze_workflow_logs.py --input workflow_log_report.json --output <report.md> --codex-mode` (writes `analysis_context.json` and prints its path)
   2. `codex exec --model <WORKFLOW_EDITOR_MODEL> --full-auto` with `prompts/mode-workflow-analysis.txt` + generated analysis context, writing the final markdown report file.
 - Legacy workflow path (`codex_mode=false`): `python3 scripts/analyze_workflow_logs.py --input workflow_log_report.json --batch-state-file workflow_log_analysis_batch_state.json`
-- `--max-output-tokens` default is `100000`. The workflow auto-caps this to `60000` when the resolved `WORKFLOW_EDITOR_MODEL` contains `gemini` (Gemini 3.1 Pro Preview's max output is 65536).
+- `--max-output-tokens` default is `100000`. The workflow auto-caps this to `60000` when the resolved `WORKFLOW_EDITOR_MODEL` contains `gemini` (Gemini 2.5 Pro's max output is 65536).
 - Model resolution for this workflow only: the `Run workflow log analysis` step defaults `WORKFLOW_EDITOR_MODEL` to `openai/gpt-5.4` and allows override via repo variable `WORKFLOW_LOG_ANALYSIS_MODEL`. This override is scoped to this workflow and does not affect the global `WORKFLOW_EDITOR_MODEL` used by `clarify`/`plan`/`implement`/`review_autofix`/`validate`/`orchestrate`.
 - `load_input_data` accepts either:
   - `--input` with a collector report (`runs` list; `runs[].log_excerpts` are flattened into `deep_dive_logs` as `{name: <repo>/<run_id>/<step_name>, excerpt}`), a combined bundle object (`run_metrics`, `summary_stats`, optional `deep_dive_logs`), or a JSON array of run metrics

--- a/scripts/codex_model_catalog.json
+++ b/scripts/codex_model_catalog.json
@@ -91,6 +91,36 @@
       "input_modalities": ["text", "image"]
     },
     {
+      "slug": "google/gemini-2.5-pro",
+      "display_name": "Gemini 2.5 Pro",
+      "description": "Google Gemini 2.5 Pro - 1M context, multimodal, strong reasoning at materially lower cost than Gemini 3.1 Pro Preview",
+      "supported_reasoning_levels": [
+        {"effort": "medium", "description": "Balanced reasoning"},
+        {"effort": "high", "description": "Thorough reasoning"},
+        {"effort": "xhigh", "description": "Maximum reasoning depth"}
+      ],
+      "shell_type": "shell_command",
+      "visibility": "list",
+      "supported_in_api": true,
+      "priority": 10,
+      "upgrade": null,
+      "base_instructions": "You are a senior software engineer acting as an AI code reviewer and editor. You have access to shell commands for reading files and exploring the repository. Use them to understand the codebase before making changes. Be precise, minimal, and correct.",
+      "model_messages": null,
+      "supports_reasoning_summaries": false,
+      "default_reasoning_summary": "auto",
+      "support_verbosity": false,
+      "default_verbosity": null,
+      "apply_patch_tool_type": "freeform",
+      "truncation_policy": {"mode": "bytes", "limit": 1000000},
+      "supports_parallel_tool_calls": true,
+      "supports_image_detail_original": false,
+      "context_window": 1000000,
+      "auto_compact_token_limit": 720000,
+      "effective_context_window_percent": 90,
+      "experimental_supported_tools": [],
+      "input_modalities": ["text", "image"]
+    },
+    {
       "slug": "moonshotai/kimi-k2.5",
       "display_name": "Kimi K2.5",
       "description": "Moonshot Kimi K2.5 - 256K context, multimodal, agentic",

--- a/scripts/codex_model_catalog.json
+++ b/scripts/codex_model_catalog.json
@@ -241,6 +241,36 @@
       "input_modalities": ["text", "image"]
     },
     {
+      "slug": "qwen/qwen3-coder-plus",
+      "display_name": "Qwen3-Coder Plus",
+      "description": "Alibaba Qwen3-Coder Plus - proprietary 1M context coding agent specialising in autonomous programming via tool calling and environment interaction",
+      "supported_reasoning_levels": [
+        {"effort": "medium", "description": "Balanced reasoning"},
+        {"effort": "high", "description": "Thorough reasoning"},
+        {"effort": "xhigh", "description": "Maximum reasoning depth"}
+      ],
+      "shell_type": "shell_command",
+      "visibility": "list",
+      "supported_in_api": true,
+      "priority": 10,
+      "upgrade": null,
+      "base_instructions": "You are a senior software engineer acting as an AI code reviewer and editor. You have access to shell commands for reading files and exploring the repository. Use them to understand the codebase before making changes. Be precise, minimal, and correct.",
+      "model_messages": null,
+      "supports_reasoning_summaries": false,
+      "default_reasoning_summary": "auto",
+      "support_verbosity": false,
+      "default_verbosity": null,
+      "apply_patch_tool_type": "freeform",
+      "truncation_policy": {"mode": "bytes", "limit": 1000000},
+      "supports_parallel_tool_calls": true,
+      "supports_image_detail_original": false,
+      "context_window": 1000000,
+      "auto_compact_token_limit": 720000,
+      "effective_context_window_percent": 90,
+      "experimental_supported_tools": [],
+      "input_modalities": ["text"]
+    },
+    {
       "slug": "stepfun/step-3.5-flash",
       "display_name": "Step 3.5 Flash",
       "description": "StepFun Step 3.5 Flash - 262K context, text-only, MoE reasoning model (196B/11B active)",


### PR DESCRIPTION
## Summary
This PR adds two new AI models to the Codex model catalog and updates workflow configurations to use the newly added Qwen3-Coder Plus model as the default reviewer.

## Key Changes

- **Model Catalog Updates** (`scripts/codex_model_catalog.json`):
  - Added `google/gemini-2.5-pro`: Google's Gemini 2.5 Pro with 1M context window, multimodal support, and three reasoning effort levels (medium, high, xhigh)
  - Added `qwen/qwen3-coder-plus`: Alibaba's Qwen3-Coder Plus specialized for autonomous programming with 1M context window and three reasoning effort levels
  - Both models configured with identical settings: shell command support, parallel tool calls, 1M token context, 720k auto-compact limit, and 90% effective context window

- **Workflow Configuration** (`.github/workflows/review_autofix.yml`):
  - Updated `MODEL_REVIEWER` from `google/gemini-3.1-pro-preview` to `qwen/qwen3-coder-plus`

- **Documentation** (`README.md`):
  - Updated reference from Gemini 3.1 Pro Preview to Gemini 2.5 Pro in the workflow log analysis documentation

## Implementation Details

Both new models follow the established catalog pattern with:
- Multimodal input support (text + image for Gemini 2.5 Pro; text-only for Qwen3-Coder Plus)
- Three-tier reasoning support (medium/high/xhigh effort levels)
- Freeform patch application tool type
- Byte-mode truncation policy with 1M byte limit
- Priority level 10 for catalog ordering

https://claude.ai/code/session_01Nm9xibFDsY5gMZcyitMLaa