### PR TITLE
Fix false-positive intent fingerprints for net-no-op code changes

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -434,7 +434,7 @@ If you need a new data shape that truly cannot be satisfied by any existing call
 
 ## 18. Orchestrator Integration-Sync Auto-Heal Hardening
 
-When a sub-issue PR merges into an orchestrator integration branch (head matches `orchestrator/project-*`), the poller captures intent fingerprints from the merged diff and persists them under the new top-level state field `merged_issue_fingerprints` (object keyed by GitHub issue number). Each entry stores `must_contain` and `must_not_contain` regex pattern lists derived from added/removed lines in the PR diff.
+When a sub-issue PR merges into an orchestrator integration branch (head matches `orchestrator/project-*`), the poller captures intent fingerprints from the merged diff and persists them under the new top-level state field `merged_issue_fingerprints` (object keyed by GitHub issue number). Each entry stores `must_contain` and `must_not_contain` regex pattern lists derived from **net** added/removed lines in the PR diff: any stripped-line content that appears on both sides of the unified diff (e.g. a bare call wrapped in a new if/else fallback, which the diff records as `-bare_call` followed by `+wrapper ... +  bare_call` at a deeper indent) is load-bearing on the PR's post-state and is excluded from BOTH sets. `scripts/verify_integration_fingerprints.py` additionally skips any `(file, regex)` pair recorded in both sets for the same issue, so legacy state entries captured before this net-change filter landed do not produce perpetual false-positive `must_not_contain` failures.
 
 When a `main → integration_branch` sync conflict subsequently triggers `heal_integration_branch_conflict`:
 

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -2059,8 +2059,12 @@ ensure_integration_conflict_state_fields() {
 # regex allowlist/denylist is used by the integration-sync conflict
 # resolver (review_autofix.yml) to verify that the resolver's commit
 # preserves the sub-issue's intent — must_contain patterns are derived
-# from lines the sub-issue ADDED, must_not_contain from lines it
-# REMOVED.
+# from lines the sub-issue NET-ADDED, must_not_contain from lines it
+# NET-REMOVED. Any stripped-line that appears on both sides of the
+# unified diff (e.g. a bare call wrapped in a new if/else fallback)
+# is load-bearing on the post-state and is excluded from BOTH sets;
+# the verifier also defensively skips self-contradictory pairs still
+# present in legacy state entries.
 #
 # Storage: top-level state field `merged_issue_fingerprints`, an
 # object keyed by the sub-issue's GitHub issue number (string). Each
@@ -2203,6 +2207,31 @@ def to_patterns(by_file: dict[str, list[str]]) -> list[dict]:
         for stripped in kept:
             out.append({"file": path, "regex": re.escape(stripped)})
     return out
+
+# Net-change filter: drop any stripped line that a PR both removed and
+# re-added (same stripped content appearing on both sides of the unified
+# diff). This happens naturally when a PR wraps a bare call in an
+# if/else fallback, moves code inside a conditional, or reformats a
+# block — the line remains in the post-state, so capturing it as
+# must_not_contain would false-trigger on every downstream commit that
+# preserves the PR's intent, and simultaneously capturing it as
+# must_contain creates a self-contradictory contract. Subtract the
+# intersection from BOTH sets so only true net additions / true net
+# removals survive as fingerprints.
+for path in set(per_file_added) | set(per_file_removed):
+    added_stripped = {l.strip() for l in per_file_added.get(path, [])}
+    removed_stripped = {l.strip() for l in per_file_removed.get(path, [])}
+    shared = added_stripped & removed_stripped
+    if not shared:
+        continue
+    if path in per_file_added:
+        per_file_added[path] = [l for l in per_file_added[path] if l.strip() not in shared]
+        if not per_file_added[path]:
+            del per_file_added[path]
+    if path in per_file_removed:
+        per_file_removed[path] = [l for l in per_file_removed[path] if l.strip() not in shared]
+        if not per_file_removed[path]:
+            del per_file_removed[path]
 
 result = {
     "must_contain": to_patterns(per_file_added),

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -2130,6 +2130,7 @@ capture_intent_fingerprints_for_merged_subissue() {
     FINGERPRINT_MIN_PATTERN_CHARS="${FINGERPRINT_MIN_PATTERN_CHARS}" \
     python3 - "${diff_file}" <<'PY' 2>/dev/null || true
 import json, os, re, sys
+from collections import Counter
 
 cap = int(os.environ.get("FINGERPRINT_PER_FILE_CAP", "12"))
 minlen = int(os.environ.get("FINGERPRINT_MIN_PATTERN_CHARS", "12"))
@@ -2208,6 +2209,16 @@ def to_patterns(by_file: dict[str, list[str]]) -> list[dict]:
             out.append({"file": path, "regex": re.escape(stripped)})
     return out
 
+def subtract_shared(lines: list[str], shared_counts: Counter[str]) -> list[str]:
+    out: list[str] = []
+    for raw in lines:
+        stripped = raw.strip()
+        if shared_counts.get(stripped, 0) > 0:
+            shared_counts[stripped] -= 1
+            continue
+        out.append(raw)
+    return out
+
 # Net-change filter: drop any stripped line that a PR both removed and
 # re-added (same stripped content appearing on both sides of the unified
 # diff). This happens naturally when a PR wraps a bare call in an
@@ -2216,20 +2227,20 @@ def to_patterns(by_file: dict[str, list[str]]) -> list[dict]:
 # must_not_contain would false-trigger on every downstream commit that
 # preserves the PR's intent, and simultaneously capturing it as
 # must_contain creates a self-contradictory contract. Subtract the
-# intersection from BOTH sets so only true net additions / true net
-# removals survive as fingerprints.
+# shared occurrence count from BOTH sets so only true net additions /
+# true net removals survive as fingerprints.
 for path in set(per_file_added) | set(per_file_removed):
-    added_stripped = {l.strip() for l in per_file_added.get(path, [])}
-    removed_stripped = {l.strip() for l in per_file_removed.get(path, [])}
-    shared = added_stripped & removed_stripped
-    if not shared:
+    added_counts = Counter(l.strip() for l in per_file_added.get(path, []))
+    removed_counts = Counter(l.strip() for l in per_file_removed.get(path, []))
+    shared_counts = added_counts & removed_counts
+    if not shared_counts:
         continue
     if path in per_file_added:
-        per_file_added[path] = [l for l in per_file_added[path] if l.strip() not in shared]
+        per_file_added[path] = subtract_shared(per_file_added[path], shared_counts.copy())
         if not per_file_added[path]:
             del per_file_added[path]
     if path in per_file_removed:
-        per_file_removed[path] = [l for l in per_file_removed[path] if l.strip() not in shared]
+        per_file_removed[path] = subtract_shared(per_file_removed[path], shared_counts.copy())
         if not per_file_removed[path]:
             del per_file_removed[path]
 

--- a/scripts/verify_integration_fingerprints.py
+++ b/scripts/verify_integration_fingerprints.py
@@ -88,6 +88,39 @@ def verify(fingerprints: dict[str, Any], branch: str) -> int:
 		must_contain = entry.get("must_contain", []) or []
 		must_not_contain = entry.get("must_not_contain", []) or []
 
+		# Defensive cross-dedup: the extractor in
+		# capture_intent_fingerprints_for_merged_subissue
+		# (scripts/orchestrate_poll_process.sh) filters net-no-op lines,
+		# but that capture function is idempotent per issue — already-
+		# stored bad entries in an orchestrator state file persist until
+		# the state is rebuilt. A line a PR both removes and re-adds
+		# (e.g. wrapping a bare call in an if/else fallback) cannot
+		# simultaneously be required to appear AND required to be
+		# absent; skip any (file, regex) pair recorded in both sets for
+		# this issue so historic bad fingerprints don't produce
+		# perpetual false positives.
+		def _fp_key(fp: Any) -> tuple[str, str] | None:
+			if not isinstance(fp, dict):
+				return None
+			path = fp.get("file", "")
+			regex_src = fp.get("regex", "")
+			if not path or not regex_src:
+				return None
+			return (path, regex_src)
+
+		mc_keys = {k for k in (_fp_key(fp) for fp in must_contain) if k is not None}
+		mnc_keys = {k for k in (_fp_key(fp) for fp in must_not_contain) if k is not None}
+		shared_keys = mc_keys & mnc_keys
+		if shared_keys:
+			print(
+				f"::warning::Fingerprint cross-dedup for issue #{issue_num} (PR #{pr_num}): "
+				f"skipping {len(shared_keys)} self-contradictory pattern(s) present in both "
+				f"must_contain and must_not_contain (capture-side refactor false positive).",
+				flush=True,
+			)
+			must_contain = [fp for fp in must_contain if _fp_key(fp) not in shared_keys]
+			must_not_contain = [fp for fp in must_not_contain if _fp_key(fp) not in shared_keys]
+
 		for fp in must_contain:
 			if not isinstance(fp, dict):
 				continue

--- a/scripts/verify_integration_fingerprints.py
+++ b/scripts/verify_integration_fingerprints.py
@@ -73,6 +73,16 @@ def _read_file(path: str, cache: dict[str, str | None]) -> str | None:
 	return content
 
 
+def _fp_key(fp: Any) -> tuple[str, str] | None:
+	if not isinstance(fp, dict):
+		return None
+	path = fp.get("file", "")
+	regex_src = fp.get("regex", "")
+	if not path or not regex_src:
+		return None
+	return (path, regex_src)
+
+
 def verify(fingerprints: dict[str, Any], branch: str) -> int:
 	violations: list[str] = []
 	mc_total_expected = 0
@@ -99,17 +109,11 @@ def verify(fingerprints: dict[str, Any], branch: str) -> int:
 		# absent; skip any (file, regex) pair recorded in both sets for
 		# this issue so historic bad fingerprints don't produce
 		# perpetual false positives.
-		def _fp_key(fp: Any) -> tuple[str, str] | None:
-			if not isinstance(fp, dict):
-				return None
-			path = fp.get("file", "")
-			regex_src = fp.get("regex", "")
-			if not path or not regex_src:
-				return None
-			return (path, regex_src)
 
-		mc_keys = {k for k in (_fp_key(fp) for fp in must_contain) if k is not None}
-		mnc_keys = {k for k in (_fp_key(fp) for fp in must_not_contain) if k is not None}
+		mc_with_keys = [(fp, _fp_key(fp)) for fp in must_contain]
+		mnc_with_keys = [(fp, _fp_key(fp)) for fp in must_not_contain]
+		mc_keys = {k for _, k in mc_with_keys if k is not None}
+		mnc_keys = {k for _, k in mnc_with_keys if k is not None}
 		shared_keys = mc_keys & mnc_keys
 		if shared_keys:
 			print(
@@ -118,8 +122,8 @@ def verify(fingerprints: dict[str, Any], branch: str) -> int:
 				f"must_contain and must_not_contain (capture-side refactor false positive).",
 				flush=True,
 			)
-			must_contain = [fp for fp in must_contain if _fp_key(fp) not in shared_keys]
-			must_not_contain = [fp for fp in must_not_contain if _fp_key(fp) not in shared_keys]
+			must_contain = [fp for fp, key in mc_with_keys if key not in shared_keys]
+			must_not_contain = [fp for fp, key in mnc_with_keys if key not in shared_keys]
 
 		for fp in must_contain:
 			if not isinstance(fp, dict):

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -5215,6 +5215,182 @@ def test_verify_integration_fingerprints_skips_empty_object():
 		assert mod.main([str(empty)]) == 0
 
 
+def _extract_intent_fingerprint_extractor_py() -> str:
+	# Pull the embedded Python heredoc body out of the bash function
+	# capture_intent_fingerprints_for_merged_subissue so the extractor
+	# can be exercised directly from a test. Anchors on the function
+	# name to locate the right heredoc (the poller script has several
+	# other python3 <<'PY' blocks); if the anchor or heredoc shape
+	# changes the test fails loudly rather than silently skipping
+	# coverage.
+	script = POLLER_SCRIPT.read_text(encoding="utf-8")
+	anchor = "capture_intent_fingerprints_for_merged_subissue()"
+	anchor_idx = script.index(anchor)
+	open_marker = "<<'PY'"
+	close_marker = "\nPY\n"
+	open_idx = script.index(open_marker, anchor_idx)
+	# Skip past the opening marker line (to the start of the body).
+	body_start = script.index("\n", open_idx) + 1
+	body_end = script.index(close_marker, body_start)
+	return script[body_start:body_end]
+
+
+def test_capture_intent_fingerprints_cross_dedups_net_no_op_lines():
+	# Regression guard for the false-positive that blocked
+	# orchestrator/project-1479: PR #1491/#1487/#1505/#1526 all wrap a
+	# bare call in an if/else fallback, so the same stripped line
+	# appears on BOTH sides of the unified diff (removed at the old
+	# indent, re-added inside the new conditional at a deeper indent).
+	# Without cross-set dedup the extractor captures the line as
+	# must_not_contain, which guarantees a false must_not_contain
+	# violation on every downstream commit that preserves the PR's
+	# intent. The net-change filter must drop such lines from both
+	# contracts.
+	py_code = _extract_intent_fingerprint_extractor_py()
+
+	diff_text = (
+		"diff --git a/scripts/foo.sh b/scripts/foo.sh\n"
+		"--- a/scripts/foo.sh\n"
+		"+++ b/scripts/foo.sh\n"
+		"@@ -1,1 +1,6 @@\n"
+		"-        PW_LABELS=\"$(gh_retry _safe_gh_jq \"repos/${GITHUB_REPOSITORY}/issues/${pw_inum}/labels\" --jq '[.[].name]' || echo '[]')\"\n"
+		"+        if echo \"${PRIOR_LABELS_JSON}\" | jq -e --arg key \"${pw_inum}\" 'has($key)' >/dev/null 2>&1; then\n"
+		"+          PW_LABELS=\"$(echo \"${PRIOR_LABELS_JSON}\" | jq -c --arg key \"${pw_inum}\" '.[$key] // []')\"\n"
+		"+        else\n"
+		"+          PW_LABELS=\"$(gh_retry _safe_gh_jq \"repos/${GITHUB_REPOSITORY}/issues/${pw_inum}/labels\" --jq '[.[].name]' || echo '[]')\"\n"
+		"+        fi\n"
+	)
+
+	with tempfile.TemporaryDirectory() as td:
+		diff_file = Path(td) / "pr.diff"
+		diff_file.write_text(diff_text, encoding="utf-8")
+		env = {
+			**os.environ,
+			"FINGERPRINT_PER_FILE_CAP": "12",
+			"FINGERPRINT_MIN_PATTERN_CHARS": "12",
+		}
+		proc = subprocess.run(
+			["python3", "-c", py_code, str(diff_file)],
+			capture_output=True,
+			text=True,
+			env=env,
+			timeout=30,
+		)
+	assert proc.returncode == 0, f"extractor exited nonzero: stderr={proc.stderr!r}"
+	result = json.loads(proc.stdout or "{}")
+
+	shared_line = (
+		"PW_LABELS=\"$(gh_retry _safe_gh_jq \"repos/${GITHUB_REPOSITORY}"
+		"/issues/${pw_inum}/labels\" --jq '[.[].name]' || echo '[]')\""
+	)
+	shared_regex = re.escape(shared_line)
+	mc_regexes = [p.get("regex", "") for p in result.get("must_contain", [])]
+	mnc_regexes = [p.get("regex", "") for p in result.get("must_not_contain", [])]
+	assert shared_regex not in mnc_regexes, (
+		"shared line still present in must_not_contain — extractor did not cross-dedup. "
+		f"Got mnc_regexes={mnc_regexes!r}"
+	)
+	assert shared_regex not in mc_regexes, (
+		"shared line still present in must_contain — extractor did not cross-dedup. "
+		f"Got mc_regexes={mc_regexes!r}"
+	)
+	# Genuine additions (the new if/then/else/fi wrapper lines that are
+	# NOT also on the minus side) must still survive as must_contain so
+	# true regressions are still detected. Regexes are re.escape'd, so
+	# match on the escaped form.
+	if_line_escaped = re.escape("if echo")
+	assert any(if_line_escaped in r for r in mc_regexes), (
+		"true net-added lines must still produce must_contain entries; "
+		f"mc_regexes={mc_regexes!r}"
+	)
+
+
+def test_verify_integration_fingerprints_cross_dedups_self_contradictory_pairs():
+	# Defensive path in the verifier: if the orchestrator state file
+	# still holds legacy bad fingerprints (capture is idempotent per
+	# issue, so an already-stored entry survives the extractor fix),
+	# the verifier must treat any (file, regex) pair present in BOTH
+	# must_contain and must_not_contain as self-contradictory and
+	# skip it rather than emit a guaranteed-impossible violation.
+	mod = _verifier_module()
+	files = {
+		"scripts/foo.sh": (
+			'        PW_LABELS="$(gh_retry _safe_gh_jq '
+			'"repos/${GITHUB_REPOSITORY}/issues/${pw_inum}/labels" '
+			'--jq \'[.[].name]\' || echo \'[]\')"\n'
+		),
+	}
+	shared_regex = re.escape(
+		"PW_LABELS=\"$(gh_retry _safe_gh_jq "
+		"\"repos/${GITHUB_REPOSITORY}/issues/${pw_inum}/labels\" "
+		"--jq '[.[].name]' || echo '[]')\""
+	)
+	fingerprints = {
+		"1483": {
+			"issue": 1483,
+			"pr": 1491,
+			"must_contain": [
+				{"file": "scripts/foo.sh", "regex": shared_regex},
+			],
+			"must_not_contain": [
+				{"file": "scripts/foo.sh", "regex": shared_regex},
+			],
+		}
+	}
+	sandbox, fp = _verifier_sandbox(files, fingerprints)
+	prev_cwd = os.getcwd()
+	try:
+		os.chdir(sandbox)
+		assert mod.main([str(fp)]) == 0
+	finally:
+		os.chdir(prev_cwd)
+		shutil.rmtree(sandbox, ignore_errors=True)
+
+
+def test_verify_integration_fingerprints_still_fails_on_real_violation_when_mixed_with_shared():
+	# Belt-and-braces: the cross-dedup must ONLY skip patterns present
+	# in both sets; genuine must_not_contain entries (not also in
+	# must_contain) must still trigger a violation. Otherwise the
+	# defensive path would silently neuter the whole verifier.
+	mod = _verifier_module()
+	files = {
+		"scripts/foo.sh": (
+			'        PW_LABELS="$(gh_retry _safe_gh_jq '
+			'"repos/${GITHUB_REPOSITORY}/issues/${pw_inum}/labels" '
+			'--jq \'[.[].name]\' || echo \'[]\')"\n'
+			'        gh api -H "Accept: x" "/repos/foo/bar"\n'
+		),
+	}
+	shared_regex = re.escape(
+		"PW_LABELS=\"$(gh_retry _safe_gh_jq "
+		"\"repos/${GITHUB_REPOSITORY}/issues/${pw_inum}/labels\" "
+		"--jq '[.[].name]' || echo '[]')\""
+	)
+	fingerprints = {
+		"1483": {
+			"issue": 1483,
+			"pr": 1491,
+			"must_contain": [
+				{"file": "scripts/foo.sh", "regex": shared_regex},
+			],
+			"must_not_contain": [
+				{"file": "scripts/foo.sh", "regex": shared_regex},
+				# Genuine must_not_contain — NOT in must_contain, so
+				# the dedup leaves it alone.
+				{"file": "scripts/foo.sh", "regex": r"gh\ api\ \-H"},
+			],
+		}
+	}
+	sandbox, fp = _verifier_sandbox(files, fingerprints)
+	prev_cwd = os.getcwd()
+	try:
+		os.chdir(sandbox)
+		assert mod.main([str(fp)]) == 1
+	finally:
+		os.chdir(prev_cwd)
+		shutil.rmtree(sandbox, ignore_errors=True)
+
+
 def test_actions_runs_shared_loader_reuses_single_fetch_per_tick() -> None:
 	state = _base_state()
 	state["project_status"] = "in_progress"

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -5296,12 +5296,60 @@ def test_capture_intent_fingerprints_cross_dedups_net_no_op_lines():
 	)
 	# Genuine additions (the new if/then/else/fi wrapper lines that are
 	# NOT also on the minus side) must still survive as must_contain so
-	# true regressions are still detected. Regexes are re.escape'd, so
-	# match on the escaped form.
-	if_line_escaped = re.escape("if echo")
-	assert any(if_line_escaped in r for r in mc_regexes), (
+	# true regressions are still detected.
+	if_line = "if echo \"${PRIOR_LABELS_JSON}\" | jq -e --arg key \"${pw_inum}\" 'has($key)' >/dev/null 2>&1; then"
+	assert any(re.search(r, if_line) for r in mc_regexes), (
 		"true net-added lines must still produce must_contain entries; "
 		f"mc_regexes={mc_regexes!r}"
+	)
+
+
+def test_capture_intent_fingerprints_preserves_net_duplicate_line_additions():
+	# If a diff adds N copies and removes M copies of the same stripped
+	# line, only min(N, M) shared occurrences should be canceled. Any
+	# residual net addition must survive as must_contain.
+	py_code = _extract_intent_fingerprint_extractor_py()
+
+	diff_text = (
+		"diff --git a/scripts/foo.sh b/scripts/foo.sh\n"
+		"--- a/scripts/foo.sh\n"
+		"+++ b/scripts/foo.sh\n"
+		"@@ -1,2 +1,3 @@\n"
+		"-        echo \"duplicate-line\"\n"
+		"-        echo \"duplicate-line\"\n"
+		"+        echo \"duplicate-line\"\n"
+		"+        echo \"duplicate-line\"\n"
+		"+        echo \"duplicate-line\"\n"
+	)
+
+	with tempfile.TemporaryDirectory() as td:
+		diff_file = Path(td) / "pr.diff"
+		diff_file.write_text(diff_text, encoding="utf-8")
+		env = {
+			**os.environ,
+			"FINGERPRINT_PER_FILE_CAP": "12",
+			"FINGERPRINT_MIN_PATTERN_CHARS": "12",
+		}
+		proc = subprocess.run(
+			["python3", "-c", py_code, str(diff_file)],
+			capture_output=True,
+			text=True,
+			env=env,
+			timeout=30,
+		)
+	assert proc.returncode == 0, f"extractor exited nonzero: stderr={proc.stderr!r}"
+	result = json.loads(proc.stdout or "{}")
+
+	dup_regex = re.escape('echo "duplicate-line"')
+	mc_regexes = [p.get("regex", "") for p in result.get("must_contain", [])]
+	mnc_regexes = [p.get("regex", "") for p in result.get("must_not_contain", [])]
+	assert dup_regex in mc_regexes, (
+		"net-added duplicate line should survive as must_contain fingerprint; "
+		f"mc_regexes={mc_regexes!r}"
+	)
+	assert dup_regex not in mnc_regexes, (
+		"net-added duplicate line must not remain in must_not_contain; "
+		f"mnc_regexes={mnc_regexes!r}"
 	)
 
 


### PR DESCRIPTION
## Summary

This PR fixes a regression in the integration-sync conflict resolver's intent fingerprint verification. When a PR wraps existing code in conditional logic (e.g., adding an if/else fallback), the same line appears in both the removed and added sections of the diff. The extractor was incorrectly capturing these lines as `must_not_contain` patterns, causing false-positive violations on downstream commits that preserve the PR's intent.

## Key Changes

- **Extractor (orchestrate_poll_process.sh)**: Added net-change filtering to exclude lines that appear in both the removed and added sections of a diff. These "net-no-op" lines are load-bearing on the post-state and should not be captured as fingerprints.

- **Verifier (verify_integration_fingerprints.py)**: Added defensive cross-dedup logic to handle legacy bad fingerprints already stored in orchestrator state files. Any pattern present in both `must_contain` and `must_not_contain` is skipped as self-contradictory, preventing perpetual false positives from historic state entries.

- **Tests**: Added three comprehensive regression tests:
  - `test_capture_intent_fingerprints_cross_dedups_net_no_op_lines()`: Validates the extractor correctly filters shared lines
  - `test_verify_integration_fingerprints_cross_dedups_self_contradictory_pairs()`: Validates the verifier handles legacy bad fingerprints gracefully
  - `test_verify_integration_fingerprints_still_fails_on_real_violation_when_mixed_with_shared()`: Ensures genuine violations are still detected even when mixed with self-contradictory pairs

- **Documentation (agents.md)**: Updated comments to clarify that fingerprints are derived from NET-ADDED and NET-REMOVED lines, and documented the defensive dedup behavior.

## Implementation Details

The net-change filter works by:
1. Computing the set of stripped lines added and removed per file
2. Finding the intersection (lines appearing on both sides)
3. Removing these shared lines from both `per_file_added` and `per_file_removed` before converting to regex patterns

This ensures that code wrapping patterns (if/else fallbacks, conditional moves, reformatting) don't create false-positive fingerprints while still capturing genuine intent changes.

https://claude.ai/code/session_01MDcggFo7BM8GMZXnsAyzJU