### PR TITLE
Add autonomous escape from ai:review-blocked via stall recovery

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1162,7 +1162,7 @@ jobs:
         id: retrigger_guard
         env:
           MAX_AUTOFIX_ITERATIONS: ${{ vars.MAX_AUTOFIX_ITERATIONS || '3' }}
-          FORCE_RB_JUDGE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.force_rb_judge == 'true') || (github.event_name != 'workflow_dispatch' && inputs.force_rb_judge) && 'true' || 'false' }}
+          FORCE_RB_JUDGE: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.force_rb_judge == 'true') || (github.event_name != 'workflow_dispatch' && inputs.force_rb_judge)) && 'true' || 'false' }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -32,6 +32,11 @@ on:
         required: false
         default: true
         type: boolean
+      force_rb_judge:
+        description: "Skip reviewers/editor/commit and run only the review-blocked judge (used by the stall poller to escape ai:review-blocked)"
+        required: false
+        default: false
+        type: boolean
     secrets:
       GH_PAT:
         required: true
@@ -47,6 +52,11 @@ on:
         type: string
       allow_workflow_edits:
         description: "Allow AI/editor changes to .github/workflows files"
+        required: false
+        default: false
+        type: boolean
+      force_rb_judge:
+        description: "Skip reviewers/editor/commit and run only the review-blocked judge (used by the stall poller to escape ai:review-blocked)"
         required: false
         default: false
         type: boolean
@@ -1152,6 +1162,7 @@ jobs:
         id: retrigger_guard
         env:
           MAX_AUTOFIX_ITERATIONS: ${{ vars.MAX_AUTOFIX_ITERATIONS || '3' }}
+          FORCE_RB_JUDGE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.force_rb_judge == 'true') || (github.event_name != 'workflow_dispatch' && inputs.force_rb_judge) && 'true' || 'false' }}
         run: |
           set -euo pipefail
 
@@ -1169,7 +1180,17 @@ jobs:
           echo "Consecutive autofix commits: ${autofix_count} (max: ${MAX_AUTOFIX_ITERATIONS})"
           echo "autofix_iteration=${autofix_count}" >> "$GITHUB_OUTPUT"
 
-          if [ "${autofix_count}" -ge "${MAX_AUTOFIX_ITERATIONS}" ]; then
+          # force_rb_judge short-circuit: the stall poller dispatches the
+          # review workflow with this input set when a linked issue has
+          # been stuck at ai:review-blocked past the stall threshold.
+          # Force max_iterations_reached=true so the reviewer/editor/
+          # commit steps (all gated on max_iterations_reached != 'true')
+          # are skipped and the rb_judge step fires directly against the
+          # existing PR state.
+          if [ "${FORCE_RB_JUDGE}" = "true" ]; then
+            echo "force_rb_judge=true — forcing max_iterations_reached=true to run only the review-blocked judge."
+            echo "max_iterations_reached=true" >> "$GITHUB_OUTPUT"
+          elif [ "${autofix_count}" -ge "${MAX_AUTOFIX_ITERATIONS}" ]; then
             echo "Max autofix iterations reached — skipping review/editor."
             echo "max_iterations_reached=true" >> "$GITHUB_OUTPUT"
           else
@@ -1779,6 +1800,34 @@ jobs:
         run: |
           set -euo pipefail
           source "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh" 2>/dev/null || true
+          type gh_retry >/dev/null 2>&1 || gh_retry() { "$@"; }
+
+          # Empty-editor-output short-circuit.
+          #
+          # If the editor produced no structured summary AND no file
+          # changes were committed, this run has nothing meaningful to
+          # report — the synthetic fallback summary (below) would be a
+          # false positive that masks a codex crash/timeout/empty-prompt.
+          # Post a distinct, retry-friendly comment, signal the
+          # failure handlers to NOT apply ai:review-blocked for this
+          # specific cause, and fail the step so the stall poller can
+          # retry the review later instead of poisoning the linked
+          # issue with an unrecoverable label.
+          if [ ! -s "${EDITOR_SUMMARY_FILE}" ] && [ ! -s "${COMMITTED_FILES_FILE:-/dev/null}" ]; then
+            echo "::warning::Editor produced no summary and no committed changes — treating as retryable no-op."
+            RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            NOOP_BODY="$(cat <<EOF
+          **AI review/autofix produced no output — will retry**
+
+          The editor stage completed without a structured summary and without committing any file changes. This typically indicates a transient codex crash, timeout, or empty prompt rather than a reviewable defect in the PR. No \`ai:review-blocked\` label is being applied for this run.
+
+          [View workflow run](${RUN_URL}) for details. The stall poller will retry the review on a subsequent cycle.
+          EOF
+          )"
+            gh_retry gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -f body="${NOOP_BODY}" >/dev/null 2>&1 || true
+            echo "AUTOFIX_EDITOR_EMPTY_NOOP=true" >> "$GITHUB_ENV"
+            exit 1
+          fi
 
           if [ ! -s "${EDITOR_SUMMARY_FILE}" ]; then
             cat > "${EDITOR_SUMMARY_FILE}" <<'__EDITOR_SUMMARY__'
@@ -3249,7 +3298,7 @@ jobs:
           fi
 
       - name: Mark linked issues review-blocked (workflow failure)
-        if: failure() && env.PR_CLOSED != 'true'
+        if: failure() && env.PR_CLOSED != 'true' && env.AUTOFIX_EDITOR_EMPTY_NOOP != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           REPOSITORY: ${{ github.repository }}
@@ -3307,7 +3356,7 @@ jobs:
           done <<< "${ISSUE_NUMBERS}"
 
       - name: Post review-blocked comment on PR (workflow failure)
-        if: failure() && env.PR_CLOSED != 'true'
+        if: failure() && env.PR_CLOSED != 'true' && env.AUTOFIX_EDITOR_EMPTY_NOOP != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |

--- a/.github/workflows/review_rb_judge_dispatch.yml
+++ b/.github/workflows/review_rb_judge_dispatch.yml
@@ -1,0 +1,53 @@
+name: "Internal: Review-Blocked Judge Dispatch"
+
+# Thin wrapper around review_autofix.yml that runs only the
+# review-blocked judge step (scripts/review_rb_judge.sh) against a given
+# open PR.  Used by the orchestrator poller's standalone stall loop to
+# escape the ai:review-blocked phase once an issue has been stuck past
+# the per-phase stall threshold with no active autofix run.  See
+# scripts/orchestrate_poll_process.sh (dispatch_rb_judge action) and
+# orchestrate_lib.py:STALL_RECOVERY_ACTIONS["ai:review-blocked"].
+#
+# Contract:
+#   - Expects an open PR at ${pr_number}.
+#   - Forwards force_rb_judge=true to review_autofix.yml, which makes
+#     retrigger_guard report max_iterations_reached=true immediately so
+#     the reviewer/editor/commit path is skipped and the rb_judge step
+#     fires directly.
+#   - Does NOT allow AI workflow edits (defaults to false) — the judge
+#     only decides merge/fix/close_and_reissue and should not be able to
+#     rewrite workflow YAML.
+#
+# This workflow is workflow_dispatch-only on purpose: it is not a
+# push/PR-event handler.  The poller triggers it via `gh workflow run`.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to run the review-blocked judge against"
+        required: true
+        type: string
+      allow_workflow_edits:
+        description: "Allow AI/editor changes to .github/workflows files (default false for judge-only dispatch)"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  judge:
+    uses: shubhodeep1/coding-workflows/.github/workflows/review_autofix.yml@main
+    with:
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_is_draft: false
+      pr_title: ""
+      pr_body: ""
+      pr_skip_ai: false
+      allow_workflow_edits: ${{ github.event.inputs.allow_workflow_edits == 'true' }}
+      force_rb_judge: true
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `STALL_THRESHOLD_IMPLEMENTING_MINUTES` | No | `120` | orchestrate_poll | Stall threshold for `ai:implementing` phase. |
 | `STALL_THRESHOLD_DONE_MINUTES` | No | `120` | orchestrate_poll | Stall threshold for `ai:done` phase (review/autofix). |
 | `STALL_THRESHOLD_READY_TO_MERGE_MINUTES` | No | `60` | orchestrate_poll | Stall threshold for `ai:ready-to-merge` phase. |
+| `STALL_THRESHOLD_REVIEW_BLOCKED_MINUTES` | No | `120` | orchestrate_poll | Stall threshold for `ai:review-blocked` phase. Past this threshold the poller dispatches `review_rb_judge_dispatch.yml` (which runs `review_autofix.yml` with `force_rb_judge=true`) so `scripts/review_rb_judge.sh` decides merge, fix, or close-and-reissue. Review-blocked was previously a dedicated-handler phase with no standalone trigger; issues stamped `ai:review-blocked` by a review/autofix workflow failure that never reached the inline judge had no autonomous escape path. Matches the `ai:done` threshold so genuinely long in-flight autofix runs are not double-dispatched. |
 | `MAX_STALL_RECOVERIES_PER_ISSUE` | No | `5` | orchestrate_poll | Maximum stall recovery attempts per individual issue. Recovery selection uses `stall_recovery_count` against `STALL_RECOVERY_ACTIONS` (clamped to the last action), with optional escalation to `run_stall_judge` when enabled and the trigger count is reached. After exhausting this limit the issue is skipped (`ai:closed`) so the wave can advance; the judge evaluates the gap at wave completion. |
 | `STALL_JUDGE_TRIGGER_COUNT` | No | `2` | orchestrate_poll | Stall recovery attempt threshold at which the poller escalates from declarative ladder actions to `run_stall_judge` for deeper diagnostics and action selection. |
 | `ENABLE_STALL_JUDGE` | No | `true` | orchestrate_poll | Enables/disables stall-judge escalation (`run_stall_judge`) in orchestrator-managed and standalone stall recovery paths. |
@@ -912,6 +913,7 @@ Analyzer script: [`scripts/analyze_workflow_logs.py`](scripts/analyze_workflow_l
 | `STALL_THRESHOLD_IMPLEMENTING_MINUTES` | `120` | Stall threshold for implementation phase |
 | `STALL_THRESHOLD_DONE_MINUTES` | `120` | Stall threshold for review/autofix phase |
 | `STALL_THRESHOLD_READY_TO_MERGE_MINUTES` | `60` | Stall threshold for ready-to-merge phase |
+| `STALL_THRESHOLD_REVIEW_BLOCKED_MINUTES` | `120` | Stall threshold for `ai:review-blocked` phase; past threshold the poller dispatches `review_rb_judge_dispatch.yml` to run `review_rb_judge.sh` against the linked PR |
 | `MAX_STALL_RECOVERIES_PER_ISSUE` | `5` | Max stall recovery attempts per issue before skipping (declarative `STALL_RECOVERY_ACTIONS` + optional `run_stall_judge` escalation) |
 | `STALL_JUDGE_TRIGGER_COUNT` | `2` | Recovery-attempt threshold to invoke stall judge escalation (`run_stall_judge`) |
 | `ENABLE_STALL_JUDGE` | `true` | Enable/disable stall-judge escalation in orchestrator and standalone stall recovery |

--- a/agents.md
+++ b/agents.md
@@ -652,7 +652,8 @@ Contract:
 - The failure-notification step branches its `BODY` on `${EDITOR_SUMMARY_POSTED:-false}`:
   - When `true` — post a narrower "AI review/autofix encountered a post-editor failure" body that names the downstream step domains (push, conflict resolver, label/auto-merge, telemetry) and notes that the summary comment is visible, not that editor execution necessarily succeeded.
   - When unset/false — post the original generic body (true editor / dependency / infra failure path).
-- The label step (`Mark linked issues review-blocked (workflow failure)`) and `Telegram failure` are **not** gated on `EDITOR_SUMMARY_POSTED`. A failure is still a failure regardless of which comment variant is appropriate; the linked issue still needs `ai:review-blocked` and the operator still needs the Telegram alert.
+- The label step (`Mark linked issues review-blocked (workflow failure)`) and the failure-notification step **are** gated on `env.AUTOFIX_EDITOR_EMPTY_NOOP != 'true'` (see §20.6). This gate has a tighter scope than `EDITOR_SUMMARY_POSTED`: it fires only when the editor produced no structured summary AND no committed changes — i.e. there was nothing meaningful for the workflow to report. A generic post-editor failure (push race, conflict resolver abort, auto-merge config error) does not set `AUTOFIX_EDITOR_EMPTY_NOOP`, so it still flows through the label step and still tags `ai:review-blocked` as before.
+- `Telegram failure` remains **ungated** by both signals. An operator still wants the alert regardless of which branch fired — the alert wording is generic ("PR autofix failed"), so it does not mis-attribute anything.
 
 Operational rules:
 
@@ -663,6 +664,46 @@ Operational rules:
 API cost audit (CLAUDE.md §15):
 
 - Zero new `gh` calls. The branch is a local `if [ "${EDITOR_SUMMARY_POSTED:-false}" = "true" ]; then ... fi` around the existing single `gh api .../comments` POST. No new batched data, no new cache.
+
+### 20.6 Empty-Editor-Output Retry Gate (`AUTOFIX_EDITOR_EMPTY_NOOP`)
+
+`jobs.codex-agent`'s `Post editor summary comment` step now short-circuits when both invariants hold:
+
+1. `EDITOR_SUMMARY_FILE` is empty or missing (codex produced no structured summary).
+2. `COMMITTED_FILES_FILE` is empty (no file changes landed on the branch).
+
+In that combined state the step:
+
+- Posts a distinct "AI review/autofix produced no output — will retry" comment on the PR. This body explicitly tells the reader that **no `ai:review-blocked` label is being applied** and that the stall poller will retry the review.
+- Sets `AUTOFIX_EDITOR_EMPTY_NOOP=true` in `$GITHUB_ENV`.
+- Exits the step non-zero (so CI still fails, `Telegram failure` still alerts).
+
+Contract:
+
+- `AUTOFIX_EDITOR_EMPTY_NOOP` is set **only** from `Post editor summary comment` when both invariants above hold. Do not set it from any other step; no other failure mode qualifies.
+- `Mark linked issues review-blocked (workflow failure)` and `Post review-blocked comment on PR (workflow failure)` both add `env.AUTOFIX_EDITOR_EMPTY_NOOP != 'true'` to their `if:`. That gate is *additive* over the existing `failure() && env.PR_CLOSED != 'true'` condition — it only narrows, never widens.
+- The failure domain this guard closes: the empty-editor run used to synthesize a fallback summary comment, pretend the editor "completed", and let a downstream step (telemetry plumbing, label/auto-merge) trip the generic `failure()` handlers — which then stamped `ai:review-blocked` on the linked issue with no autonomous escape. See the §4 dispatch_rb_judge ladder for why that stamping is now the escape-less state it was.
+- Rollback: if this gate misfires (e.g. codex's summary file format changes and the workflow no longer recognizes a legitimate summary), remove the `AUTOFIX_EDITOR_EMPTY_NOOP != 'true'` conditions from the two failure handlers. The empty-output short-circuit can stay; its worst-case effect is a single extra comment on the PR.
+
+Rename is a breaking change per CLAUDE.md §6 — add alongside, never in place.
+
+### 20.7 Autonomous `ai:review-blocked` Escape (`dispatch_rb_judge`)
+
+Historically `ai:review-blocked` lived in `orchestrate_lib.DEDICATED_HANDLER_PHASES`: the stall detector ignored the phase on the assumption that `review_rb_judge.sh` (step `Review-blocked judge decision` inside `review_autofix.yml`) would always run when an issue entered it. That assumption fails for any PR where `review_autofix.yml` itself errors before reaching the judge step (empty-editor run, push race, conflict resolver abort, etc.) — the workflow's `failure()` handler still stamps `ai:review-blocked` on the linked issue, but the judge never fires.
+
+Fix:
+
+- `ai:review-blocked` is **no longer** in `DEDICATED_HANDLER_PHASES`. The stall detector now sees the phase.
+- `STALL_RECOVERY_ACTIONS["ai:review-blocked"] = ["dispatch_rb_judge", "dispatch_rb_judge", "escalate_human"]` with threshold `DEFAULT_PHASE_STALL_THRESHOLDS["ai:review-blocked"] = 120` min (matches `ai:done` so long in-flight autofix runs are not double-dispatched). Override via `STALL_THRESHOLD_REVIEW_BLOCKED_MINUTES`.
+- `dispatch_rb_judge` (priority 68 in `STALL_RECOVERY_ACTION_PRIORITY`) calls helper `_dispatch_rb_judge_for_pr <pr_number>` in `scripts/orchestrate_poll_process.sh`, which fires `review_rb_judge_dispatch.yml` via `gh workflow run`. That workflow in turn calls `review_autofix.yml` with `force_rb_judge=true`.
+- `review_autofix.yml`'s `Count autofix iterations` step reads `force_rb_judge` and, when true, forces `max_iterations_reached=true` so all reviewer/editor/commit steps (gated on `max_iterations_reached != 'true'`) are skipped and the `Review-blocked judge decision` step fires directly against the existing PR state.
+- Linked-PR lookup prefers the shared `STALL_MANAGED_LINKED_PR_CACHE` (managed path) / `_STD_ITER_PR_NUM_CACHED` (standalone path), falling back to `_issue_cross_ref_pr_number_last` (legacy REST). No new per-issue API calls in the common case.
+- Cycle-local duplicate-dispatch guard: `_dispatch_rb_judge_for_pr` records `rb-judge:<pr_number>` into `_CONFLICT_DISPATCH_TRACKER` (reused because both dispatches ultimately target `review_autofix.yml` and cancel-in-progress concurrency would otherwise kill one with the other).
+
+Rollback plan:
+
+- To disable autonomous escape without reverting the phase-ladder change, either set `ENABLE_STALL_HUMAN_TERMINALIZATION=true` (then `dispatch_rb_judge → escalate_human` on the third attempt) or restore `ai:review-blocked` into `DEDICATED_HANDLER_PHASES`. Both are surface-area-small reverts.
+- Renames of `dispatch_rb_judge`, `force_rb_judge`, or `_dispatch_rb_judge_for_pr` are breaking changes per CLAUDE.md §6.
 
 ---
 

--- a/scripts/orchestrate_lib.py
+++ b/scripts/orchestrate_lib.py
@@ -830,7 +830,18 @@ TERMINAL_WAVE_STATUSES: set[str] = {"merged", "closed", "skipped", "not_created"
 
 # Phases already handled by dedicated logic in the poller — stall detector
 # should not double-act on these.
-DEDICATED_HANDLER_PHASES: set[str] = {"ai:needs-human", "ai:blocked", "ai:review-blocked", "ai:implementation-failed", "ai:validating", "ai:validation-fixing"}
+#
+# ai:review-blocked was previously in this set, but the review/autofix
+# workflow's dedicated handler (review_rb_judge.sh) only runs inline at
+# the end of a review_autofix.yml run — it has no standalone trigger.
+# When the dedicated handler goes silent (e.g. the empty-editor failure
+# mode that stamps ai:review-blocked on linked issues without ever
+# running the judge), the phase has no autonomous escape.  The stall
+# detector therefore now covers ai:review-blocked too: its ladder
+# dispatches review_rb_judge_dispatch.yml (which runs review_autofix.yml
+# with force_rb_judge=true) past the per-phase stall threshold.  See
+# STALL_RECOVERY_ACTIONS["ai:review-blocked"] below.
+DEDICATED_HANDLER_PHASES: set[str] = {"ai:needs-human", "ai:blocked", "ai:implementation-failed", "ai:validating", "ai:validation-fixing"}
 
 # Escalating recovery actions per detected phase.
 # The poller indexes into this list using the per-issue stall_recovery_count.
@@ -847,6 +858,11 @@ DEFAULT_PHASE_STALL_THRESHOLDS: dict[str, int] = {
 	"ai:implementing": 120,
 	"ai:done": 120,
 	"ai:ready-to-merge": 60,
+	# ai:review-blocked: matches ai:done (120 min) so an in-flight
+	# review_autofix run that legitimately takes a long time to reach
+	# the inline rb_judge step does not get double-dispatched by the
+	# stall loop's dispatch_rb_judge action.
+	"ai:review-blocked": 120,
 }
 
 RUN_STALL_JUDGE_ACTION = "run_stall_judge"
@@ -892,6 +908,18 @@ STALL_RECOVERY_ACTIONS: dict[str, list[str]] = {
 		"retrigger_validate",
 		"escalate_human",
 	],
+	# ai:review-blocked recovery: the dispatch_rb_judge action triggers
+	# review_rb_judge_dispatch.yml via workflow_dispatch, which runs
+	# review_autofix.yml with force_rb_judge=true — i.e. the dedicated
+	# review-blocked judge (scripts/review_rb_judge.sh) decides the next
+	# step (merge, fix, or close_and_reissue).  The two dispatch_rb_judge
+	# rungs mirror the two-retry allowance used elsewhere; escalate_human
+	# is the terminal fallback when ENABLE_STALL_HUMAN_TERMINALIZATION=true.
+	"ai:review-blocked": [
+		"dispatch_rb_judge",
+		"dispatch_rb_judge",
+		"escalate_human",
+	],
 }
 
 VALID_STALL_RECOVERY_ACTIONS: set[str] = {
@@ -913,6 +941,7 @@ STALL_RECOVERY_ACTION_PRIORITY: dict[str, int] = {
 	"retrigger_implement": 50,
 	"retrigger_review": 60,
 	"resolve_merge_conflict": 65,
+	"dispatch_rb_judge": 68,
 	"retrigger_validate": 70,
 	"attempt_merge": 80,
 	"close_and_reissue": 90,

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -618,6 +618,7 @@ STALL_THRESHOLD_AWAITING_APPROVAL_MINUTES="${STALL_THRESHOLD_AWAITING_APPROVAL_M
 STALL_THRESHOLD_IMPLEMENTING_MINUTES="${STALL_THRESHOLD_IMPLEMENTING_MINUTES:-}"
 STALL_THRESHOLD_DONE_MINUTES="${STALL_THRESHOLD_DONE_MINUTES:-}"
 STALL_THRESHOLD_READY_TO_MERGE_MINUTES="${STALL_THRESHOLD_READY_TO_MERGE_MINUTES:-}"
+STALL_THRESHOLD_REVIEW_BLOCKED_MINUTES="${STALL_THRESHOLD_REVIEW_BLOCKED_MINUTES:-}"
 
 _validate_phase_threshold STALL_THRESHOLD_NO_LABELS_MINUTES
 _validate_phase_threshold STALL_THRESHOLD_CLARIFICATION_MINUTES
@@ -626,6 +627,7 @@ _validate_phase_threshold STALL_THRESHOLD_AWAITING_APPROVAL_MINUTES
 _validate_phase_threshold STALL_THRESHOLD_IMPLEMENTING_MINUTES
 _validate_phase_threshold STALL_THRESHOLD_DONE_MINUTES
 _validate_phase_threshold STALL_THRESHOLD_READY_TO_MERGE_MINUTES
+_validate_phase_threshold STALL_THRESHOLD_REVIEW_BLOCKED_MINUTES
 
 # Build the JSON dict for per-phase overrides (only include vars that are set).
 _build_phase_thresholds_json() {
@@ -637,6 +639,7 @@ _build_phase_thresholds_json() {
   [ -n "${STALL_THRESHOLD_IMPLEMENTING_MINUTES:-}" ] && parts+=("\"ai:implementing\":${STALL_THRESHOLD_IMPLEMENTING_MINUTES}")
   [ -n "${STALL_THRESHOLD_DONE_MINUTES:-}" ] && parts+=("\"ai:done\":${STALL_THRESHOLD_DONE_MINUTES}")
   [ -n "${STALL_THRESHOLD_READY_TO_MERGE_MINUTES:-}" ] && parts+=("\"ai:ready-to-merge\":${STALL_THRESHOLD_READY_TO_MERGE_MINUTES}")
+  [ -n "${STALL_THRESHOLD_REVIEW_BLOCKED_MINUTES:-}" ] && parts+=("\"ai:review-blocked\":${STALL_THRESHOLD_REVIEW_BLOCKED_MINUTES}")
 
   if [ "${#parts[@]}" -eq 0 ]; then
     echo ""
@@ -4599,6 +4602,40 @@ The judge will evaluate this gap when the wave completes and decide whether to r
       STALL_RECOVERY_SHOULD_INCREMENT="true"
       ;;
 
+    dispatch_rb_judge)
+      # Autonomous escape from ai:review-blocked: dispatch the
+      # standalone review-blocked judge workflow for the linked PR.
+      # The judge (scripts/review_rb_judge.sh) then decides merge,
+      # fix, or close_and_reissue.  Linked PR lookup prefers the
+      # shared stall cache (STALL_MANAGED_LINKED_PR_CACHE) and falls
+      # back to the legacy per-issue REST cross-ref helper.
+      local rb_pr_num=""
+      if [ -n "${STALL_MANAGED_LINKED_PR_CACHE:-}" ]; then
+        rb_pr_num="$(printf '%s' "${STALL_MANAGED_LINKED_PR_CACHE}" \
+          | jq -r --arg n "${issue_num}" '.[$n].number // empty' 2>/dev/null || echo "")"
+      fi
+      if ! [[ "${rb_pr_num}" =~ ^[0-9]+$ ]]; then
+        rb_pr_num="$(_issue_cross_ref_pr_number_last "${issue_num}" 2>/dev/null || echo "")"
+      fi
+      if ! [[ "${rb_pr_num}" =~ ^[0-9]+$ ]]; then
+        echo "::warning::dispatch_rb_judge: no linked PR found for issue #${issue_num}; skipping."
+        return 1
+      fi
+      local rb_dispatch_rc=0
+      _dispatch_rb_judge_for_pr "${rb_pr_num}" || rb_dispatch_rc=$?
+      if [ "${rb_dispatch_rc}" -eq 1 ]; then
+        return 1
+      fi
+      if [ "${rb_dispatch_rc}" -eq 2 ]; then
+        # Already dispatched this cycle.  Don't increment recovery
+        # count — let the next cycle re-check; the judge run is in
+        # flight.
+        return 0
+      fi
+      tg_notify "Stall recovery: dispatched review-blocked judge for issue #${issue_num} (PR #${rb_pr_num}, stuck ${stall_minutes}m, attempt $((recovery_count + 1)))."$'\n'"Issue: $(_gh_url "issues/${issue_num}")"$'\n'"PR: $(_gh_url "pull/${rb_pr_num}")" "WARNING"
+      STALL_RECOVERY_SHOULD_INCREMENT="true"
+      ;;
+
     *)
       echo "::warning::Unknown stall recovery action: ${action} for issue #${issue_num}"
       return 1
@@ -5502,10 +5539,15 @@ run_standalone_stall_recovery() {
   fi
   orchestrator_managed_set="$(printf '%s\n' "${orchestrator_managed_set}" | grep -E '^[0-9]+$' | sort -u || true)"
 
-  local pipeline_labels='["ai:clarification","ai:planning","ai:awaiting-approval","ai:implementing","ai:done","ai:ready-to-merge"]'
+  # ai:review-blocked is included so the standalone stall loop picks up
+  # issues stuck at that phase (e.g. autofix workflow failure poisoning
+  # the linked issue) and can dispatch the review-blocked judge via the
+  # dispatch_rb_judge recovery action.  See STALL_RECOVERY_ACTIONS
+  # ["ai:review-blocked"] in scripts/orchestrate_lib.py.
+  local pipeline_labels='["ai:clarification","ai:planning","ai:awaiting-approval","ai:implementing","ai:done","ai:ready-to-merge","ai:review-blocked"]'
   local labeled_issues='[]'
   local lbl
-  for lbl in ai:clarification ai:planning ai:awaiting-approval ai:implementing ai:done ai:ready-to-merge; do
+  for lbl in ai:clarification ai:planning ai:awaiting-approval ai:implementing ai:done ai:ready-to-merge ai:review-blocked; do
     local by_label
     by_label="$(gh_retry gh issue list --repo "${GITHUB_REPOSITORY}" --state open --label "${lbl}" --json number --limit 1000 2>/dev/null || echo '[]')"
     labeled_issues="$(jq -s 'add | unique_by(.number)' <(printf '%s\n' "${labeled_issues}") <(printf '%s\n' "${by_label}"))"
@@ -5578,7 +5620,15 @@ print(determine_phase(labels))
 PY
 )"
 
-    if [ "${phase}" = "ai:needs-human" ] || [ "${phase}" = "ai:blocked" ] || [ "${phase}" = "ai:review-blocked" ] || [ "${phase}" = "ai:implementation-failed" ] || [ "${phase}" = "ai:validating" ] || [ "${phase}" = "ai:validation-fixing" ] || [ "${phase}" = "ai:merged" ] || [ "${phase}" = "ai:closed" ] || [ "${phase}" = "ai:validated" ] || [[ "${phase}" == ai:*-failed ]]; then
+    # Phases the standalone loop does NOT act on.  ai:review-blocked was
+    # historically in this skip list because it had a dedicated inline
+    # handler (review_rb_judge.sh runs at the end of review_autofix.yml
+    # when max_iterations is reached).  That handler has no standalone
+    # trigger, so phases that land in ai:review-blocked without ever
+    # invoking the judge (e.g. the empty-editor failure mode) never
+    # escape.  ai:review-blocked is now recovered here via the
+    # dispatch_rb_judge action (see execute_stall_recovery_action).
+    if [ "${phase}" = "ai:needs-human" ] || [ "${phase}" = "ai:blocked" ] || [ "${phase}" = "ai:implementation-failed" ] || [ "${phase}" = "ai:validating" ] || [ "${phase}" = "ai:validation-fixing" ] || [ "${phase}" = "ai:merged" ] || [ "${phase}" = "ai:closed" ] || [ "${phase}" = "ai:validated" ] || [[ "${phase}" == ai:*-failed ]]; then
       continue
     fi
 
@@ -6138,6 +6188,39 @@ PY
         STALL_RECOVERY_SHOULD_INCREMENT="false"
         took_action="true"
         ;;
+      dispatch_rb_judge)
+        # Autonomous escape from ai:review-blocked: dispatch the
+        # standalone review-blocked judge workflow for the linked PR.
+        # See execute_stall_recovery_action's dispatch_rb_judge case
+        # for the authoritative implementation pattern; this mirrors
+        # it within the standalone loop's switch.
+        local _std_rb_pr_num=""
+        if [[ "${_STD_ITER_PR_NUM_CACHED:-}" =~ ^[0-9]+$ ]]; then
+          _std_rb_pr_num="${_STD_ITER_PR_NUM_CACHED}"
+        else
+          _std_rb_pr_num="$(_issue_cross_ref_pr_number_last "${issue_num}" 2>/dev/null || echo "")"
+        fi
+        if ! [[ "${_std_rb_pr_num}" =~ ^[0-9]+$ ]]; then
+          echo "::warning::[standalone-stall] dispatch_rb_judge: no linked PR found for issue #${issue_num}; skipping."
+          STALL_RECOVERY_SHOULD_INCREMENT="false"
+        else
+          local _std_rb_rc=0
+          _dispatch_rb_judge_for_pr "${_std_rb_pr_num}" || _std_rb_rc=$?
+          if [ "${_std_rb_rc}" -eq 0 ]; then
+            echo "STALL_RECOVERY issue=${issue_num} reason=ai_review_blocked pr=${_std_rb_pr_num} phase=${phase} action=dispatch_rb_judge"
+            tg_notify_issue "${issue_num}" "Standalone stall recovery: dispatched review-blocked judge for PR #${_std_rb_pr_num} (stuck ${elapsed_minutes}m, attempt $((recovery_count + 1)))." "WARNING"
+            STALL_RECOVERY_SHOULD_INCREMENT="true"
+          elif [ "${_std_rb_rc}" -eq 2 ]; then
+            # Already dispatched this cycle — judge is in flight.
+            echo "STALL_SKIP issue=${issue_num} reason=rb_judge_dispatch_deduped pr=${_std_rb_pr_num} phase=${phase} action=dispatch_rb_judge"
+            STALL_RECOVERY_SHOULD_INCREMENT="false"
+          else
+            echo "::warning::[standalone-stall] dispatch_rb_judge for issue #${issue_num} PR #${_std_rb_pr_num} failed (rc=${_std_rb_rc})."
+            STALL_RECOVERY_SHOULD_INCREMENT="false"
+          fi
+        fi
+        took_action="true"
+        ;;
       *)
         echo "::warning::Unknown standalone stall action ${action} for issue #${issue_num}"
         ;;
@@ -6634,6 +6717,57 @@ _dispatch_review_for_conflicts()
 	done
 
 	echo "::warning::${log_prefix} Could not dispatch review workflow via workflow_dispatch."
+	return 1
+}
+
+# _dispatch_rb_judge_for_pr <pr_number>
+#
+# Trigger review_rb_judge_dispatch.yml via workflow_dispatch for the
+# given PR.  That workflow calls review_autofix.yml with
+# force_rb_judge=true, which short-circuits retrigger_guard to run only
+# the review-blocked judge (scripts/review_rb_judge.sh).  The judge
+# decides merge, fix, or close_and_reissue — giving ai:review-blocked
+# issues an autonomous escape path.
+#
+# Returns:
+#   0 — dispatched successfully (or already dispatched this cycle).
+#   1 — dispatch failed (e.g. workflow missing, PAT scope insufficient).
+#   2 — skipped (cycle-local duplicate-dispatch guard).
+#
+# API hygiene: reuses the cycle-local _CONFLICT_DISPATCH_TRACKER to
+# prevent duplicate dispatches within the same poll cycle, same as
+# _dispatch_review_for_conflicts.  ref resolves from the repo default
+# branch (main) because the judge does not need the PR's head ref to
+# run — it operates on the PR metadata directly via gh api.
+_dispatch_rb_judge_for_pr()
+{
+	local pr_number="$1"
+	local log_prefix="[rb-judge-dispatch] PR #${pr_number}"
+
+	if ! [[ "${pr_number}" =~ ^[0-9]+$ ]]; then
+		echo "::warning::${log_prefix} invalid pr_number; skipping."
+		return 1
+	fi
+
+	# Cycle-local duplicate-dispatch guard.  Reuses the conflict
+	# tracker file because both dispatches target review_autofix.yml
+	# (directly or indirectly) and cancel-in-progress concurrency
+	# would otherwise kill one with the other.
+	if grep -qx "rb-judge:${pr_number}" "${_CONFLICT_DISPATCH_TRACKER}" 2>/dev/null; then
+		echo "  ${log_prefix} Already dispatched in this poll cycle. Skipping."
+		return 2
+	fi
+
+	echo "  ${log_prefix} Dispatching review_rb_judge_dispatch.yml..."
+	if gh_retry gh workflow run review_rb_judge_dispatch.yml \
+		--repo "${GITHUB_REPOSITORY}" \
+		-f pr_number="${pr_number}" 2>/dev/null; then
+		echo "  ${log_prefix} Dispatched review_rb_judge_dispatch.yml."
+		echo "rb-judge:${pr_number}" >> "${_CONFLICT_DISPATCH_TRACKER}"
+		return 0
+	fi
+
+	echo "::warning::${log_prefix} Could not dispatch review_rb_judge_dispatch.yml. Ensure the workflow exists on the default branch and the GH_PAT has workflow-dispatch scope."
 	return 1
 }
 

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -4618,8 +4618,17 @@ The judge will evaluate this gap when the wave completes and decide whether to r
         rb_pr_num="$(_issue_cross_ref_pr_number_last "${issue_num}" 2>/dev/null || echo "")"
       fi
       if ! [[ "${rb_pr_num}" =~ ^[0-9]+$ ]]; then
-        echo "::warning::dispatch_rb_judge: no linked PR found for issue #${issue_num}; skipping."
-        return 1
+        # No linked PR — the judge has nothing to act on.  Increment
+        # the recovery count so the ladder can progress to the next
+        # rung (escalate_human after MAX_STALL_RECOVERIES_PER_ISSUE).
+        # Returning 1 without incrementing would trap the issue in an
+        # infinite dispatch_rb_judge loop because the count never
+        # advances.  Operator visibility is preserved via the warning
+        # and Telegram note below.
+        echo "::warning::dispatch_rb_judge: no linked PR found for issue #${issue_num}; counting as an attempt so the ladder can escalate."
+        tg_notify "Stall recovery: dispatch_rb_judge for issue #${issue_num} could not find a linked PR (stuck ${stall_minutes}m, attempt $((recovery_count + 1))). Counting as an attempt — will escalate to escalate_human at the end of the ladder."$'\n'"Issue: $(_gh_url "issues/${issue_num}")" "WARNING"
+        STALL_RECOVERY_SHOULD_INCREMENT="true"
+        return 0
       fi
       local rb_dispatch_rc=0
       _dispatch_rb_judge_for_pr "${rb_pr_num}" || rb_dispatch_rc=$?
@@ -6212,8 +6221,13 @@ PY
           _std_rb_pr_num="$(_issue_cross_ref_pr_number_last "${issue_num}" 2>/dev/null || echo "")"
         fi
         if ! [[ "${_std_rb_pr_num}" =~ ^[0-9]+$ ]]; then
-          echo "::warning::[standalone-stall] dispatch_rb_judge: no linked PR found for issue #${issue_num}; skipping."
-          STALL_RECOVERY_SHOULD_INCREMENT="false"
+          # No linked PR — see execute_stall_recovery_action's
+          # dispatch_rb_judge case for the same rationale: count this
+          # as an attempt so the ladder can escalate to escalate_human
+          # instead of looping forever.
+          echo "::warning::[standalone-stall] dispatch_rb_judge: no linked PR found for issue #${issue_num}; counting as an attempt so the ladder can escalate."
+          tg_notify_issue "${issue_num}" "Standalone stall recovery: dispatch_rb_judge could not find a linked PR (stuck ${elapsed_minutes}m, attempt $((recovery_count + 1))). Counting as an attempt — will escalate to escalate_human at the end of the ladder." "WARNING"
+          STALL_RECOVERY_SHOULD_INCREMENT="true"
         else
           local _std_rb_rc=0
           _dispatch_rb_judge_for_pr "${_std_rb_pr_num}" || _std_rb_rc=$?
@@ -6741,9 +6755,13 @@ _dispatch_review_for_conflicts()
 # issues an autonomous escape path.
 #
 # Returns:
-#   0 — dispatched successfully (or already dispatched this cycle).
-#   1 — dispatch failed (e.g. workflow missing, PAT scope insufficient).
-#   2 — skipped (cycle-local duplicate-dispatch guard).
+#   0 — dispatched successfully this cycle.
+#   1 — dispatch failed (e.g. invalid pr_number, workflow missing, PAT
+#       scope insufficient).
+#   2 — skipped (cycle-local duplicate-dispatch guard: the same PR
+#       already had a judge dispatch queued earlier this tick).  Callers
+#       must treat this as an in-flight success — do NOT increment the
+#       stall recovery count, and do NOT re-attempt in the same tick.
 #
 # API hygiene: reuses the cycle-local _CONFLICT_DISPATCH_TRACKER to
 # prevent duplicate dispatches within the same poll cycle, same as

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -6194,10 +6194,21 @@ PY
         # See execute_stall_recovery_action's dispatch_rb_judge case
         # for the authoritative implementation pattern; this mirrors
         # it within the standalone loop's switch.
+        #
+        # Linked-PR lookup uses the per-iteration _std_linked_json cache
+        # (populated at the top of this loop iteration from the
+        # batched GraphQL _candidate_details_json — same shape:
+        # {number, state, merged, head_ref, ...}), NOT
+        # _STD_ITER_PR_NUM_CACHED.  The latter is only declared inside
+        # the `if action == retrigger_review` block above; because
+        # bash `local` is function-scoped (not block-scoped), a prior
+        # iteration's retrigger_review value would otherwise leak into
+        # this iteration's dispatch_rb_judge and dispatch against the
+        # wrong PR.  Using _std_linked_json avoids both the leak and
+        # the redundant REST fallback.
         local _std_rb_pr_num=""
-        if [[ "${_STD_ITER_PR_NUM_CACHED:-}" =~ ^[0-9]+$ ]]; then
-          _std_rb_pr_num="${_STD_ITER_PR_NUM_CACHED}"
-        else
+        _std_rb_pr_num="$(printf '%s' "${_std_linked_json:-null}" | jq -r '.number // empty' 2>/dev/null || echo "")"
+        if ! [[ "${_std_rb_pr_num}" =~ ^[0-9]+$ ]]; then
           _std_rb_pr_num="$(_issue_cross_ref_pr_number_last "${issue_num}" 2>/dev/null || echo "")"
         fi
         if ! [[ "${_std_rb_pr_num}" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Summary

Adds autonomous recovery mechanism for issues stuck in the `ai:review-blocked` phase by dispatching the review-blocked judge workflow when the stall threshold is exceeded. Previously, `ai:review-blocked` was treated as a dedicated-handler phase with no standalone escape path, leaving issues permanently stuck if the inline judge never ran (e.g., due to workflow failures before reaching the judge step).

## Key Changes

- **Removed `ai:review-blocked` from dedicated handler phases** in `orchestrate_lib.py`, allowing the stall detector to now monitor and act on this phase.

- **Added `dispatch_rb_judge` stall recovery action** that triggers `review_rb_judge_dispatch.yml` workflow via `gh workflow run`, which in turn calls `review_autofix.yml` with `force_rb_judge=true` to skip reviewer/editor/commit steps and run only the review-blocked judge.

- **Implemented `_dispatch_rb_judge_for_pr()` helper** in `orchestrate_poll_process.sh` that:
  - Validates PR number and looks up linked PR via shared cache or legacy REST fallback
  - Enforces cycle-local duplicate-dispatch guard using `_CONFLICT_DISPATCH_TRACKER`
  - Returns distinct exit codes (0=success, 1=failure, 2=already-dispatched)

- **Added `force_rb_judge` input parameter** to `review_autofix.yml` that forces `max_iterations_reached=true` in the `Count autofix iterations` step, bypassing all reviewer/editor/commit logic and jumping directly to the judge step.

- **Created new `review_rb_judge_dispatch.yml` workflow** as a thin dispatch wrapper that accepts a PR number and calls `review_autofix.yml` with `force_rb_judge=true`.

- **Added empty-editor-output short-circuit** in `Post editor summary comment` step that detects when editor produced no summary AND no file changes, posts a distinct retry-friendly comment, sets `AUTOFIX_EDITOR_EMPTY_NOOP=true`, and prevents the generic `ai:review-blocked` label from being applied. This avoids poisoning linked issues with unrecoverable labels when the workflow failure is transient (codex crash/timeout).

- **Updated stall recovery configuration**:
  - Added `STALL_THRESHOLD_REVIEW_BLOCKED_MINUTES` environment variable (default 120 min, matching `ai:done`)
  - Added `ai:review-blocked` recovery ladder: `["dispatch_rb_judge", "dispatch_rb_judge", "escalate_human"]`
  - Set `dispatch_rb_judge` action priority to 68 (between `resolve_merge_conflict` and `retrigger_validate`)

- **Updated standalone stall loop** to include `ai:review-blocked` in pipeline labels and recovery action handling, mirroring the managed-path implementation.

- **Updated documentation** in `agents.md` to explain the empty-editor-output gate and autonomous escape mechanism.

## Implementation Details

- **Linked PR lookup strategy**: Prefers `STALL_MANAGED_LINKED_PR_CACHE` (managed path) or `_STD_ITER_PR_NUM_CACHED` (standalone path) to avoid redundant API calls, falling back to `_issue_cross_ref_pr_number_last` only when necessary.

- **Duplicate-dispatch prevention**: Reuses existing `_CONFLICT_DISPATCH_TRACKER` file (same mechanism as conflict-dispatch guard) because both ultimately target `review_autofix.yml` and cancel-in-progress concurrency would otherwise kill one with the other.

- **Workflow dispatch ref**: Uses repo default branch (main) since the judge operates on PR metadata directly via `gh api`, not the PR's head ref.

- **Failure mode handling**: The empty-editor-output gate is narrowly scoped to only the case where both editor summary and committed files are absent, allowing other post-editor failures (push race, conflict resolver abort, auto-merge config error) to still flow through the label step as before.

https://claude.ai/code/session_01SmXyZ9SvxQfHkp7rGiAmaj