### PR TITLE
validation-harness: emit TAP output from 10_family_marker.sh

### DIFF
--- a/tests/fixtures/validation_harness/python_mongo_flask/tests/10_family_marker.sh
+++ b/tests/fixtures/validation_harness/python_mongo_flask/tests/10_family_marker.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "python-mongo-flask family for demo-project"
+echo "1..1"
+echo "ok 1 - python-mongo-flask family for demo-project"

--- a/tests/fixtures/validation_harness/python_repo_checks/tests/10_family_marker.sh
+++ b/tests/fixtures/validation_harness/python_repo_checks/tests/10_family_marker.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "python-repo-checks family for demo-project"
+echo "1..1"
+echo "ok 1 - python-repo-checks family for demo-project"

--- a/workflow-templates/validation-harness/node-hardhat-solidity/tests/10_family_marker.sh.j2
+++ b/workflow-templates/validation-harness/node-hardhat-solidity/tests/10_family_marker.sh.j2
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "node-hardhat-solidity family for {{ slots.project_name }}"
+echo "1..1"
+echo "ok 1 - node-hardhat-solidity family for {{ slots.project_name }}"

--- a/workflow-templates/validation-harness/python-mongo-flask/tests/10_family_marker.sh.j2
+++ b/workflow-templates/validation-harness/python-mongo-flask/tests/10_family_marker.sh.j2
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "python-mongo-flask family for {{ slots.project_name }}"
+echo "1..1"
+echo "ok 1 - python-mongo-flask family for {{ slots.project_name }}"

--- a/workflow-templates/validation-harness/python-mongo-repo-checks/tests/10_family_marker.sh.j2
+++ b/workflow-templates/validation-harness/python-mongo-repo-checks/tests/10_family_marker.sh.j2
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "python-mongo-repo-checks family for {{ slots.project_name }}"
+echo "1..1"
+echo "ok 1 - python-mongo-repo-checks family for {{ slots.project_name }}"

--- a/workflow-templates/validation-harness/python-repo-checks/tests/10_family_marker.sh.j2
+++ b/workflow-templates/validation-harness/python-repo-checks/tests/10_family_marker.sh.j2
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "python-repo-checks family for {{ slots.project_name }}"
+echo "1..1"
+echo "ok 1 - python-repo-checks family for {{ slots.project_name }}"


### PR DESCRIPTION
## Summary

Fixes the `validate` job failure (`raw_status=harness_error`, exit 2) reproduced in run 24872491428, where the rendered `validation/tests/10_family_marker.sh` printed only `python-repo-checks family for coding-workflows` and was classified by `scripts/validate_driver.sh::run_single_test` as "test produced no TAP output".

## Root cause

- `workflow-templates/validation-harness/python-repo-checks/tests/10_family_marker.sh.j2` rendered to a single `echo` with no TAP plan and no `ok`/`not ok` lines, exit 0.
- `scripts/validate_driver.sh` (lines 779–784) hard-fails any exit-0 test that emits zero `ok` and zero `not ok` lines.
- `scripts/validate_process.sh` classifies this as `harness_error` (harness-owned file), and the fail-job step maps that to exit code 2.
- All four family-marker templates carry the identical latent bug; only `python-repo-checks` was exercised in the failing run.

## Changes

Templates (4 families):
- `workflow-templates/validation-harness/python-repo-checks/tests/10_family_marker.sh.j2`
- `workflow-templates/validation-harness/python-mongo-flask/tests/10_family_marker.sh.j2`
- `workflow-templates/validation-harness/python-mongo-repo-checks/tests/10_family_marker.sh.j2`
- `workflow-templates/validation-harness/node-hardhat-solidity/tests/10_family_marker.sh.j2`

Each now emits a 1-test TAP plan:
```sh
echo "1..1"
echo "ok 1 - <family> family for {{ slots.project_name }}"
```

Golden fixtures regenerated to match:
- `tests/fixtures/validation_harness/python_repo_checks/tests/10_family_marker.sh`
- `tests/fixtures/validation_harness/python_mongo_flask/tests/10_family_marker.sh`

The marker substring `"<family> family for <project>"` is preserved inside the `ok` line, so existing `assert "<family> family for demo-project" in family_text` substring assertions and the strict fixture golden-match tests all continue to pass without edits.

## Test plan

- [x] `python3 tests/test_family_python_repo_checks.py` — 2/2 PASS (includes `_assert_fixture_match`)
- [x] `python3 tests/test_family_python_mongo_flask.py` — 2/2 PASS (includes `_assert_fixture_match`)
- [x] `python3 tests/test_render_validation_templates.py` — 12/12 PASS (covers all 4 families; internally runs `scripts/validation_lint.py` against rendered output)
- [x] Rendered `10_family_marker.sh` manually executed; produces `1..1\nok 1 - …\n`, exit 0 — now satisfies `validate_driver.sh::run_single_test`.

https://claude.ai/code/session_01JqYTVYaP9PQgKuikArgJ2X

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqYTVYaP9PQgKuikArgJ2X)_