### PR TITLE
review_autofix: align summariser reasoning default with docs (xhigh → medium)

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -78,7 +78,7 @@ env:
   # call that emits a consolidated ledger. Hard-fails the workflow on repeat
   # failure — job-level "Telegram failure" step surfaces the incident.
   XPOLL_SUMMARISER_MODEL: ${{ vars.XPOLL_SUMMARISER_MODEL || 'openai/gpt-5.4-mini' }}
-  XPOLL_SUMMARISER_REASONING: ${{ vars.XPOLL_SUMMARISER_REASONING || 'xhigh' }}
+  XPOLL_SUMMARISER_REASONING: ${{ vars.XPOLL_SUMMARISER_REASONING || 'medium' }}
   XPOLL_SUMMARISER_LINES_PER_REVIEWER: ${{ vars.XPOLL_SUMMARISER_LINES_PER_REVIEWER || '160' }}
   XPOLL_SUMMARISER_CALL_TIMEOUT_SECS: ${{ vars.XPOLL_SUMMARISER_CALL_TIMEOUT_SECS || '2400' }}
   XPOLL_SUMMARISER_MAX_INPUT_LINES: ${{ vars.XPOLL_SUMMARISER_MAX_INPUT_LINES || '3000' }}


### PR DESCRIPTION
## Summary
- `.github/workflows/review_autofix.yml:81` was injecting `XPOLL_SUMMARISER_REASONING=xhigh` as the workflow-level fallback, overriding the script's documented `medium` default and contradicting `README.md:71`, `agents.md:182`, and the header of `scripts/summarize_reviewer_consensus.sh`.
- Change the workflow fallback from `'xhigh'` to `'medium'` so the effective default matches the docs. `xhigh` (or any other value) remains opt-in via the `XPOLL_SUMMARISER_REASONING` repo/org variable.

## Rationale
The summariser task is cross-reviewer dedup of already-written reviewer outputs (extracting `flagged_by: [slug, ...]` and per-reviewer sections). The README explicitly notes this "does not require maximum reasoning depth", and `xhigh` on a `gpt-5.4-mini` model adds latency on the critical path (pass-1 → pass-2 → editor) without a corresponding quality lift.

## Files changed
- `.github/workflows/review_autofix.yml:81` — fallback `'xhigh'` → `'medium'` (single-line change).

## Test plan
- [ ] Confirm next `review_autofix` run logs `summariser (...): ... reasoning=medium` when no repo/org `XPOLL_SUMMARISER_REASONING` variable is set.
- [ ] Confirm setting `XPOLL_SUMMARISER_REASONING=xhigh` at the repo/org variable level still overrides to `xhigh` (opt-in path preserved).

https://claude.ai/code/session_01EPQwc3kyM1QCDDT9AzqrE1

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPQwc3kyM1QCDDT9AzqrE1)_