### PR TITLE
orchestrator: add single-repo invariant to mode-orchestrate prompt

### DIFF
--- a/prompts/mode-orchestrate.txt
+++ b/prompts/mode-orchestrate.txt
@@ -47,9 +47,13 @@ Single-repo invariant (NON-NEGOTIABLE — violations produce unimplementable iss
 - DO NOT generate sub-issues whose acceptance criteria require committing
   files into, opening PRs against, or running CI in repositories other than
   this one.
-- DO NOT generate sub-issues whose runtime path depends on private cross-
-  repo fetches or `GH_PAT`-authenticated clones of other repos as part of
-  the implementation work itself.
+- DO NOT generate sub-issues that require creating, modifying, or otherwise
+  depending for completion on direct changes in other repositories. Also do
+  not depend on unspecified, implicitly discovered, or nonexistent external
+  repos. Read-only fetches/clones of explicitly identified `<owner>/<repo>`
+  targets at explicit refs are allowed only when the implementation and
+  acceptance criteria remain entirely in this repo and the behavior can be
+  validated with deterministic in-tree/offline coverage.
 - Mentions of other repositories for context are fine when the WORK happens
   in this repo. Examples that ARE in scope: editing
   `.github/ai/consumer_repos.json` (which lists external dispatch targets),

--- a/prompts/mode-orchestrate.txt
+++ b/prompts/mode-orchestrate.txt
@@ -34,6 +34,37 @@ Rules:
 - Do not propose issues that duplicate existing functionality.
 - Do not write code. Only produce the decomposition JSON.
 
+Single-repo invariant (NON-NEGOTIABLE — violations produce unimplementable issues):
+
+- All orchestrator-generated sub-issues MUST complete entirely within this
+  repository. The downstream planner checks out only this repo's working
+  tree; the integration branch and integration PR live here. There is no
+  mechanism for an orchestrator-generated issue to produce commits, runs,
+  or releases in any other repository.
+- DO NOT generate sub-issues that require creating new external repositories
+  (e.g. "create a `<owner>/<name>` fixture repo and commit X there").
+- DO NOT generate sub-issues whose acceptance criteria require committing
+  files into, opening PRs against, or running CI in repositories other than
+  this one.
+- DO NOT generate sub-issues whose runtime path depends on private cross-
+  repo fetches or `GH_PAT`-authenticated clones of other repos as part of
+  the implementation work itself.
+- Mentions of other repositories for context are fine when the WORK happens
+  in this repo. Examples that ARE in scope: editing
+  `.github/ai/consumer_repos.json` (which lists external dispatch targets),
+  documenting cross-repo behavior in `README.md`/`agents.md`, adjusting a
+  workflow that emits `repository_dispatch` to consumers. Examples that are
+  NOT in scope: pushing commits into one of those consumer repos, seeding
+  a new fixture repo with files, adding a git submodule that points at an
+  external repo.
+- If the source spec implies cross-repo work — new fixture repos, external
+  submodules, "create a separate repo and commit X there" — re-scope to an
+  in-tree alternative (e.g. `tests/fixtures/...`, `examples/...`,
+  `scripts/...`, `workflow-templates/...`) before generating the issue. If
+  no in-tree alternative exists, OMIT the sub-issue and surface the gap as
+  a note in `project_summary` or as a follow-up comment on the tracking
+  issue, rather than filing an unimplementable sub-issue.
+
 File partitioning rules (MANDATORY — prevents merge conflicts between parallel
 sibling issues within the same wave):
 

--- a/prompts/mode-orchestrate.txt
+++ b/prompts/mode-orchestrate.txt
@@ -63,8 +63,8 @@ Single-repo invariant (NON-NEGOTIABLE — violations produce unimplementable iss
   in-tree alternative (e.g. `tests/fixtures/...`, `examples/...`,
   `scripts/...`, `workflow-templates/...`) before generating the issue. If
   no in-tree alternative exists, OMIT the sub-issue and surface the gap as
-  a note in `project_summary` or as a follow-up comment on the tracking
-  issue, rather than filing an unimplementable sub-issue.
+  a note in `project_summary`, rather than filing an unimplementable
+  sub-issue.
 
 File partitioning rules (MANDATORY — prevents merge conflicts between parallel
 sibling issues within the same wave):

--- a/prompts/mode-orchestrate.txt
+++ b/prompts/mode-orchestrate.txt
@@ -38,9 +38,10 @@ Single-repo invariant (NON-NEGOTIABLE — violations produce unimplementable iss
 
 - All orchestrator-generated sub-issues MUST complete entirely within this
   repository. The downstream planner checks out only this repo's working
-  tree; the integration branch and integration PR live here. There is no
-  mechanism for an orchestrator-generated issue to produce commits, runs,
-  or releases in any other repository.
+  tree; the integration branch and integration PR live here. Sub-issues
+  must not require creating commits, opening PRs, publishing releases, or
+  making any other direct changes in other repositories to be considered
+  complete.
 - DO NOT generate sub-issues that require creating new external repositories
   (e.g. "create a `<owner>/<name>` fixture repo and commit X there").
 - DO NOT generate sub-issues whose acceptance criteria require committing


### PR DESCRIPTION
## Summary

- Adds a `Single-repo invariant (NON-NEGOTIABLE)` section to `prompts/mode-orchestrate.txt` instructing the orchestrator LLM not to generate sub-issues that require work outside this repository.
- Targets the failure pattern observed in issue #1609 / tracking #1608 (M6 nightly self-test): the orchestrator generated a sub-issue prescribing two new external fixture repos (`coding-workflows-test-python-mongo`, `coding-workflows-test-node-hardhat`) which do not exist. The planner correctly emitted `BLOCKED: fixture repo owner/repo slugs, refs, and manifest paths are not specified` because per `CLAUDE.md` §0/§12 it cannot unilaterally re-scope.
- The downstream planner is structurally single-repo (checks out only this repo's tree, integration branch + PR live here), so any sub-issue whose acceptance criteria require cross-repo writes is unimplementable by construction. The new invariant makes that constraint explicit at the orchestrator prompt layer.

## What's in scope vs. out of scope

The new section explicitly distinguishes:
- **In scope** (allowed): editing `.github/ai/consumer_repos.json`, documenting cross-repo behavior, adjusting workflows that emit `repository_dispatch` — i.e. the WORK happens in this repo even though it MENTIONS other repos.
- **Out of scope** (rejected): pushing commits into consumer repos, seeding new fixture repos, adding submodules pointing at external repos.

## What this does NOT do

- No code changes — prompt-only. Soft enforcement at the orchestrator LLM layer.
- No deterministic gate in `orchestrate_lib.py` yet — that was discussed and intentionally deferred. We monitor whether the prompt rule alone catches the pattern; if it doesn't, a `validate_single_repo_scope()` check in `validate_decomposition()` is the natural next step.
- Does not retroactively rewrite existing BLOCKED issues; #1609 still needs the in-flight `/answer` (already posted) to land.

## Test plan

- [ ] Next orchestrator run (`orchestrate.yml` workflow_dispatch or scheduled) on a spec that historically would have implied cross-repo work emits a decomposition that re-scopes to in-tree alternatives instead.
- [ ] Existing orchestrator-generated issues that legitimately mention other repos for context (e.g. M5 refresh-runner work touching `consumer_repos.json`) are NOT incorrectly suppressed.
- [ ] Spot-check the next 2-3 orchestrator runs to confirm the prompt directive lands before deciding whether to add the deterministic gate.

https://claude.ai/code/session_019yiYGGrdT74fYgJjw59ucC

---
_Generated by [Claude Code](https://claude.ai/code/session_019yiYGGrdT74fYgJjw59ucC)_