### PR TITLE
review_autofix: shallow-clone codex-agent + deepen-on-miss

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1765,13 +1765,28 @@ jobs:
           # the off chance a PR has accumulated >100 commits (e.g. a
           # long-running orchestrator integration PR) we deepen by a
           # bounded amount once before walking so the counts are not
-          # silently truncated.  No-op when the repo is already a full
-          # clone or the deepen fetch fails (fail-open: counts may be
-          # undercounted but the workflow proceeds).
+          # silently truncated.
+          #
+          # Explicit refspec on TARGET_BRANCH (the PR head ref): without
+          # one, `git fetch ... origin` would defer to the default
+          # `remote.origin.fetch = +refs/heads/*:refs/remotes/origin/*`
+          # and pull every remote branch, undoing the whole point of
+          # fetch-depth: 100.  The walks only need HEAD's first-parent
+          # history, which lives on TARGET_BRANCH.
+          #
+          # No-op when the repo is already a full clone, when
+          # TARGET_BRANCH is unset (Checkout PR head branch hit its
+          # validation early-exit), or when the deepen fetch fails
+          # (fail-open: counts may be undercounted but the workflow
+          # proceeds).
           if [ -f "$(git rev-parse --git-dir)/shallow" ]; then
-            echo "Shallow repository detected — deepening once (+200) so autofix/judge-fix walks see PR-unique history beyond the initial fetch-depth boundary."
-            if ! git fetch --no-tags --prune --deepen=200 origin 2>/dev/null; then
-              echo "::warning::git fetch --deepen=200 origin failed before autofix/judge-fix walks; walk counts may be undercounted on PRs with >100 commits."
+            if [ -n "${TARGET_BRANCH:-}" ]; then
+              echo "Shallow repository detected — deepening TARGET_BRANCH=${TARGET_BRANCH} once (+200) so autofix/judge-fix walks see PR-unique history beyond the initial fetch-depth boundary."
+              if ! git fetch --no-tags --prune --deepen=200 origin "refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}" 2>/dev/null; then
+                echo "::warning::git fetch --deepen=200 origin refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH} failed before autofix/judge-fix walks; walk counts may be undercounted on PRs with >100 commits."
+              fi
+            else
+              echo "::warning::TARGET_BRANCH unset (Checkout PR head branch likely early-exited); skipping pre-walk deepen safeguard. Walk counts may be undercounted on PRs with >100 commits."
             fi
           fi
 
@@ -1851,10 +1866,24 @@ jobs:
           # --unshallow as a last resort.  Fail-open: callers that need
           # the merge-base check `git rev-parse --verify origin/<base>`
           # themselves and degrade gracefully.
+          #
+          # Refspec discipline: every `git fetch` here passes explicit
+          # refspecs limited to BASE_BRANCH + (when known) TARGET_BRANCH.
+          # Without them, `git fetch ... origin` defers to the default
+          # `remote.origin.fetch = +refs/heads/*:refs/remotes/origin/*`
+          # and would pull every remote branch on each deepen call —
+          # undoing the fetch-depth: 100 budget this PR is trying to
+          # enforce.  Either side of the merge-base reaching its full
+          # ancestor is sufficient for git merge-base to resolve, so
+          # deepening just these two refs is enough.
           _ensure_merge_base_reachable() {
             local _remote_ref="$1"
             local _local_ref="${2:-HEAD}"
             local _iter=0
+            local -a _refspecs=("refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}")
+            if [ -n "${TARGET_BRANCH:-}" ]; then
+              _refspecs+=("refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}")
+            fi
             while [ "${_iter}" -lt 4 ]; do
               if [ ! -f "$(git rev-parse --git-dir)/shallow" ]; then
                 return 0
@@ -1863,16 +1892,16 @@ jobs:
                 return 0
               fi
               _iter=$((_iter + 1))
-              echo "merge-base ${_remote_ref}…${_local_ref} unreachable in shallow clone — deepening (attempt ${_iter}/4)."
-              if ! git fetch --no-tags --prune --deepen=200 origin 2>/dev/null; then
-                echo "::warning::git fetch --deepen=200 origin failed during deepen-on-miss; falling back to --unshallow."
-                git fetch --no-tags --prune --unshallow origin 2>/dev/null || true
+              echo "merge-base ${_remote_ref}…${_local_ref} unreachable in shallow clone — deepening (attempt ${_iter}/4) on refs: ${_refspecs[*]}."
+              if ! git fetch --no-tags --prune --deepen=200 origin "${_refspecs[@]}" 2>/dev/null; then
+                echo "::warning::git fetch --deepen=200 origin ${_refspecs[*]} failed during deepen-on-miss; falling back to --unshallow on the same refs."
+                git fetch --no-tags --prune --unshallow origin "${_refspecs[@]}" 2>/dev/null || true
                 return 0
               fi
             done
             if ! git merge-base "${_remote_ref}" "${_local_ref}" >/dev/null 2>&1; then
-              echo "::warning::merge-base ${_remote_ref}…${_local_ref} still unreachable after 4 deepen attempts; trying final --unshallow."
-              git fetch --no-tags --prune --unshallow origin 2>/dev/null || true
+              echo "::warning::merge-base ${_remote_ref}…${_local_ref} still unreachable after 4 deepen attempts; trying final --unshallow on refs: ${_refspecs[*]}."
+              git fetch --no-tags --prune --unshallow origin "${_refspecs[@]}" 2>/dev/null || true
             fi
           }
 
@@ -2920,23 +2949,37 @@ jobs:
           # iteratively, falling back to --unshallow as a last resort.
           # Fail-open: if the deepen path fails, the merge precheck below
           # will still run and its existing error handling will catch it.
+          #
+          # Refspec discipline: every `git fetch` here passes explicit
+          # refspecs limited to BASE_BRANCH + (when known) TARGET_BRANCH.
+          # Without them, `git fetch ... origin` defers to the default
+          # `remote.origin.fetch = +refs/heads/*:refs/remotes/origin/*`
+          # and would pull every remote branch on each deepen call —
+          # undoing the fetch-depth: 100 budget this PR is trying to
+          # enforce.  Either side of the merge-base reaching its full
+          # ancestor is sufficient for git merge-base to resolve, so
+          # deepening just these two refs is enough.
           if [ -f "$(git rev-parse --git-dir)/shallow" ]; then
+            _merge_base_refspecs=("refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}")
+            if [ -n "${TARGET_BRANCH:-}" ]; then
+              _merge_base_refspecs+=("refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}")
+            fi
             _merge_base_deepen_iter=0
             while [ "${_merge_base_deepen_iter}" -lt 4 ]; do
               if git merge-base "origin/${BASE_BRANCH}" HEAD >/dev/null 2>&1; then
                 break
               fi
               _merge_base_deepen_iter=$((_merge_base_deepen_iter + 1))
-              echo "merge-base origin/${BASE_BRANCH}…HEAD unreachable in shallow clone — deepening (attempt ${_merge_base_deepen_iter}/4)."
-              if ! git fetch --no-tags --prune --deepen=200 origin 2>/dev/null; then
-                echo "::warning::git fetch --deepen=200 origin failed during merge-base deepen-on-miss; falling back to --unshallow."
-                git fetch --no-tags --prune --unshallow origin 2>/dev/null || true
+              echo "merge-base origin/${BASE_BRANCH}…HEAD unreachable in shallow clone — deepening (attempt ${_merge_base_deepen_iter}/4) on refs: ${_merge_base_refspecs[*]}."
+              if ! git fetch --no-tags --prune --deepen=200 origin "${_merge_base_refspecs[@]}" 2>/dev/null; then
+                echo "::warning::git fetch --deepen=200 origin ${_merge_base_refspecs[*]} failed during merge-base deepen-on-miss; falling back to --unshallow on the same refs."
+                git fetch --no-tags --prune --unshallow origin "${_merge_base_refspecs[@]}" 2>/dev/null || true
                 break
               fi
             done
             if ! git merge-base "origin/${BASE_BRANCH}" HEAD >/dev/null 2>&1; then
-              echo "::warning::merge-base origin/${BASE_BRANCH}…HEAD still unreachable after deepen attempts; trying final --unshallow."
-              git fetch --no-tags --prune --unshallow origin 2>/dev/null || true
+              echo "::warning::merge-base origin/${BASE_BRANCH}…HEAD still unreachable after deepen attempts; trying final --unshallow on refs: ${_merge_base_refspecs[*]}."
+              git fetch --no-tags --prune --unshallow origin "${_merge_base_refspecs[@]}" 2>/dev/null || true
             fi
           fi
 

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -618,7 +618,19 @@ jobs:
           # preventing the entire workflow — including conflict resolution
           # — from running.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 0
+          # Shallow clone to bound disk/memory cost on history-heavy
+          # consumer repos.  fetch-depth: 0 (full clone with all branches +
+          # tags) was the dominant cause of "runner died mid-step" on
+          # large repos: the parallel reviewer fan-out in `Run reviewer
+          # models` running on top of a multi-GB clone exhausts the
+          # ubuntu-latest runner's RAM/disk.  Depth 100 covers every
+          # in-job git walk by a wide margin (autofix walk ≤ 3, judge-fix
+          # walk ≤ PR-unique history, HEAD~1 diffs, recent-commits-20).
+          # Steps that need history beyond depth 100 (the merge precheck
+          # and the `origin/<base>...HEAD` diff fallback) deepen on demand
+          # below — see "Generate diff context" and "Detect merge
+          # conflicts".
+          fetch-depth: 100
           token: ${{ secrets.GH_PAT }}
 
       - name: Configure git auth for memory helper clones
@@ -1745,6 +1757,24 @@ jobs:
           # → default-branch merge.
           effective_max_iterations="${MAX_AUTOFIX_ITERATIONS}"
 
+          # Pre-walk shallow safeguard: the codex-agent's "Checkout repo"
+          # step uses fetch-depth: 100 to cap clone size on history-heavy
+          # consumer repos.  Both the [ai-autofix] walk below and the
+          # [judge-fix] walk further down expect to see all PR-unique
+          # history.  Depth 100 is enough for any realistic PR, but on
+          # the off chance a PR has accumulated >100 commits (e.g. a
+          # long-running orchestrator integration PR) we deepen by a
+          # bounded amount once before walking so the counts are not
+          # silently truncated.  No-op when the repo is already a full
+          # clone or the deepen fetch fails (fail-open: counts may be
+          # undercounted but the workflow proceeds).
+          if [ -f "$(git rev-parse --git-dir)/shallow" ]; then
+            echo "Shallow repository detected — deepening once (+200) so autofix/judge-fix walks see PR-unique history beyond the initial fetch-depth boundary."
+            if ! git fetch --no-tags --prune --deepen=200 origin 2>/dev/null; then
+              echo "::warning::git fetch --deepen=200 origin failed before autofix/judge-fix walks; walk counts may be undercounted on PRs with >100 commits."
+            fi
+          fi
+
           # Count consecutive [ai-autofix] commits from HEAD backwards.
           autofix_count=0
           while true; do
@@ -1812,6 +1842,40 @@ jobs:
           echo "Generating reviewer diff context"
           bash "${SUPPORT_SCRIPTS_DIR}/git_ref_health_check.sh" repair
 
+          # Helper: ensure the merge-base between HEAD and origin/<base>
+          # is reachable in the local (possibly shallow) clone.
+          # `git diff origin/<base>...HEAD` and the merge precheck both
+          # need this merge-base; on a shallow clone (codex-agent uses
+          # fetch-depth: 100) it may sit below the boundary for long-
+          # running PRs.  Deepens iteratively, falling back to
+          # --unshallow as a last resort.  Fail-open: callers that need
+          # the merge-base check `git rev-parse --verify origin/<base>`
+          # themselves and degrade gracefully.
+          _ensure_merge_base_reachable() {
+            local _remote_ref="$1"
+            local _local_ref="${2:-HEAD}"
+            local _iter=0
+            while [ "${_iter}" -lt 4 ]; do
+              if [ ! -f "$(git rev-parse --git-dir)/shallow" ]; then
+                return 0
+              fi
+              if git merge-base "${_remote_ref}" "${_local_ref}" >/dev/null 2>&1; then
+                return 0
+              fi
+              _iter=$((_iter + 1))
+              echo "merge-base ${_remote_ref}…${_local_ref} unreachable in shallow clone — deepening (attempt ${_iter}/4)."
+              if ! git fetch --no-tags --prune --deepen=200 origin 2>/dev/null; then
+                echo "::warning::git fetch --deepen=200 origin failed during deepen-on-miss; falling back to --unshallow."
+                git fetch --no-tags --prune --unshallow origin 2>/dev/null || true
+                return 0
+              fi
+            done
+            if ! git merge-base "${_remote_ref}" "${_local_ref}" >/dev/null 2>&1; then
+              echo "::warning::merge-base ${_remote_ref}…${_local_ref} still unreachable after 4 deepen attempts; trying final --unshallow."
+              git fetch --no-tags --prune --unshallow origin 2>/dev/null || true
+            fi
+          }
+
           PR_DIFF_ATTEMPTED_PATHS="${PR_DIFF_ATTEMPTED_PATHS:-gh_pr_diff:${PR_DIFF_FILE}}"
           if [ ! -s "${PR_DIFF_FILE}" ]; then
             echo "Primary gh pr diff output is empty. Attempting git fallback diff generation."
@@ -1820,6 +1884,7 @@ jobs:
               echo "Warning: git fetch origin ${BASE_BRANCH} failed in fallback path; fallback git diff requires an existing origin/${BASE_BRANCH} ref."
             fi
             if git rev-parse --verify "origin/${BASE_BRANCH}" >/dev/null 2>&1; then
+              _ensure_merge_base_reachable "origin/${BASE_BRANCH}" "HEAD"
               git diff "origin/${BASE_BRANCH}...HEAD" > "${PR_DIFF_FILE}" || true
             else
               echo "Warning: origin/${BASE_BRANCH} is unavailable in fallback path; skipping fallback git diff generation."
@@ -1855,6 +1920,7 @@ jobs:
           fi
 
           if git rev-parse --verify "origin/${BASE_BRANCH}" >/dev/null 2>&1; then
+            _ensure_merge_base_reachable "origin/${BASE_BRANCH}" "HEAD"
             git diff --name-only "origin/${BASE_BRANCH}...HEAD" > "${PR_CHANGED_FILES_FILE}" || true
           else
             echo "Warning: origin/${BASE_BRANCH} is unavailable; writing empty changed-files list."
@@ -2840,6 +2906,39 @@ jobs:
           done
           bash "${SUPPORT_SCRIPTS_DIR}/git_ref_health_check.sh" repair
           git fetch --no-tags --prune origin "refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}"
+
+          # Ensure the merge-base between HEAD and origin/<base> is reachable
+          # in the local clone before invoking `git merge --no-commit` below.
+          # The codex-agent's "Checkout repo" step uses fetch-depth: 100 to
+          # bound clone size on history-heavy consumer repos.  On long-running
+          # PRs (e.g. orchestrator integration branches that have lived through
+          # many base-branch advances) the merge-base may sit deeper than the
+          # shallow boundary.  Without this guard, `git merge origin/<base>`
+          # would fail with "refusing to merge unrelated histories" — which
+          # the existing handler below would surface as a (misleading)
+          # force-push / orphan-root error requiring manual repair.  Deepen
+          # iteratively, falling back to --unshallow as a last resort.
+          # Fail-open: if the deepen path fails, the merge precheck below
+          # will still run and its existing error handling will catch it.
+          if [ -f "$(git rev-parse --git-dir)/shallow" ]; then
+            _merge_base_deepen_iter=0
+            while [ "${_merge_base_deepen_iter}" -lt 4 ]; do
+              if git merge-base "origin/${BASE_BRANCH}" HEAD >/dev/null 2>&1; then
+                break
+              fi
+              _merge_base_deepen_iter=$((_merge_base_deepen_iter + 1))
+              echo "merge-base origin/${BASE_BRANCH}…HEAD unreachable in shallow clone — deepening (attempt ${_merge_base_deepen_iter}/4)."
+              if ! git fetch --no-tags --prune --deepen=200 origin 2>/dev/null; then
+                echo "::warning::git fetch --deepen=200 origin failed during merge-base deepen-on-miss; falling back to --unshallow."
+                git fetch --no-tags --prune --unshallow origin 2>/dev/null || true
+                break
+              fi
+            done
+            if ! git merge-base "origin/${BASE_BRANCH}" HEAD >/dev/null 2>&1; then
+              echo "::warning::merge-base origin/${BASE_BRANCH}…HEAD still unreachable after deepen attempts; trying final --unshallow."
+              git fetch --no-tags --prune --unshallow origin 2>/dev/null || true
+            fi
+          fi
 
           # Ensure committer identity is available — git merge (even with
           # --no-commit) requires it when recording a merge result.  Earlier


### PR DESCRIPTION
## Summary

The `codex-agent` job's `Checkout repo` step used `fetch-depth: 0` (full clone with every branch + tag), which on history-heavy consumer repos left the `ubuntu-latest` runner so resource-pressured that the parallel reviewer fan-out in `Run reviewer models` was killing the runner mid-step. The user-visible signature is the GitHub Actions "phantom in_progress" pattern: job marked failed, step stuck on the spinner, log inaccessible because GitHub never received the step-end event.

This PR switches the codex-agent checkout to `fetch-depth: 100` and adds bounded **deepen-on-miss** safeguards at the three call sites that may legitimately need history past the boundary on long-running PRs.

## Why this happened in only one consumer repo

That repo is large (long history, many branches). `fetch-depth: 0` fetches all of them, so disk + RAM pressure scales with repo size. Combined with the parallel reviewer fan-out (one `codex` process per model, each with its own `reviewer_codex_home`) at xhigh reasoning, the runner ran out of headroom right at the entry into PASS 2 — exactly where the screenshot logs cut off.

## What changed

- **`.github/workflows/review_autofix.yml`** — `codex-agent` job only:
  - `Checkout repo`: `fetch-depth: 0` → `fetch-depth: 100` (~L621–633).
  - `Count autofix iterations`: one-time `+200` deepen safeguard before the `[ai-autofix]` and `[judge-fix]` walks (~L1755–1775). Cheap when the repo is already a full clone.
  - `Generate diff context`: inline `_ensure_merge_base_reachable` helper called before both `git diff origin/<base>...HEAD` (PR diff fallback) and `git diff --name-only origin/<base>...HEAD` (changed-files) (~L1849–1923).
  - `Detect merge conflicts`: deepen-on-miss loop right after the existing base-branch fetch, before `git merge --no-commit --no-ff origin/<base>` (~L2910–2940). Without this, a long-running PR whose merge-base sits below the shallow boundary would otherwise hit the existing "refusing to merge unrelated histories" handler and surface a misleading force-push / orphan-root error.

All deepen paths are bounded (≤ 4 attempts of `--deepen=200`, then `--unshallow` as last resort) and **fail open** (warning + continue), so a transient fetch issue cannot brick the workflow.

## Audit (why depth 100 is sufficient)

Every history-touching git op reachable from `codex-agent` (workflow + sourced scripts) was audited:

| Site | Min depth | Notes |
|---|---|---|
| `[ai-autofix]` walk | bounded by `MAX_AUTOFIX_ITERATIONS` (3) | covered by depth 100 |
| `[judge-fix]` walk | PR-unique history | covered by depth 100 + one-time `+200` safeguard |
| `HEAD~1` diffs | 2 | covered |
| `git log --oneline -n 20` | 20 | covered |
| `origin/<base>...HEAD` diff/changed-files | merge-base reachable | now uses `_ensure_merge_base_reachable` |
| `git merge --no-commit origin/<base>` (merge precheck) | merge-base reachable | now uses deepen-on-miss loop |
| `check_external_branch_advance.sh` `merge-base --is-ancestor` / `rev-list LOCAL..REMOTE` | small window between INITIAL_HEAD_SHA and current tip during one run | covered |
| `review_apply_fixes.sh` `HEAD~N` walk | ≤ 3 | covered |

No env vars added. No operator-visible contract changes. Depth-1 checkouts of the workflow-source repo (`.codex-workflow-src`, `.codex-workflow-src-main`) are untouched.

## Test plan

- [ ] Trigger `review_autofix` on the large consumer repo where the 51-min phantom failure was reproducing — confirm the runner survives the parallel reviewer fan-out.
- [ ] Trigger `review_autofix` on a smaller consumer repo where it currently passes — confirm no regression.
- [ ] Trigger on a long-running PR (>100 commits since branching off base) — confirm the deepen-on-miss loop fires (look for `merge-base … unreachable in shallow clone — deepening (attempt N/4)` log lines) and the merge precheck still resolves correctly.
- [ ] Confirm `Generate diff context` produces non-empty `PR_DIFF_FILE` / `PR_CHANGED_FILES_FILE` on the same long-running PR.
- [ ] Confirm `judge_fix_count` / `autofix_count` retrigger-guard outputs match expected values on a PR that has accumulated a few `[ai-autofix]` / `[judge-fix]` commits.

https://claude.ai/code/session_01AjHDSShvn1cLghbRKZH1kx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjHDSShvn1cLghbRKZH1kx)_