### PR TITLE
workflow-templates: add review_rb_judge_dispatch.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,39 @@ jobs:
     secrets: inherit
 ```
 
+**`.github/workflows/review_rb_judge_dispatch.yml`** — Stall-recovery dispatch wrapper for `ai:review-blocked` PRs. Filename is load-bearing: the orchestrator poller dispatches it by exact name (`gh workflow run review_rb_judge_dispatch.yml`) when an issue stalls past `STALL_THRESHOLD_REVIEW_BLOCKED_MINUTES` with no active autofix run, so the `ai-*` prefix is intentionally omitted. Calls `review_autofix.yml` with `force_rb_judge=true`; the reviewer/editor/commit path is short-circuited and only `scripts/review_rb_judge.sh` runs (decides merge / fix / close-and-reissue). Auto-deployed by `ai-update-workflows.yml`; consumer repos that lack this wrapper will see the poller log `::warning::Could not dispatch review_rb_judge_dispatch.yml` and the `ai:review-blocked` phase will have no autonomous escape path.
+```yaml
+name: AI Review-Blocked Judge Dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to run the review-blocked judge against"
+        required: true
+        type: string
+      allow_workflow_edits:
+        description: "Allow AI/editor changes to .github/workflows files (default false for judge-only dispatch)"
+        required: false
+        default: false
+        type: boolean
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+jobs:
+  judge:
+    uses: shubhodeep1/coding-workflows/.github/workflows/review_autofix.yml@stable
+    with:
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_is_draft: false
+      pr_title: ""
+      pr_body: ""
+      pr_skip_ai: false
+      allow_workflow_edits: ${{ github.event.inputs.allow_workflow_edits == 'true' }}
+      force_rb_judge: true
+    secrets: inherit
+```
+
 **`.github/workflows/ai-memory-maintenance.yml`** — Monthly compaction and archival of AI memory
 ```yaml
 name: AI Memory Maintenance

--- a/workflow-templates/review_rb_judge_dispatch.yml
+++ b/workflow-templates/review_rb_judge_dispatch.yml
@@ -1,0 +1,56 @@
+# IMPORTANT: This file is managed by coding-workflows and may be overwritten
+# automatically when upstream templates change. To opt out of auto-updates,
+# set the ALLOW_WORKFLOW_EDITS repository variable to 'false'.
+#
+# Thin wrapper around review_autofix.yml that runs only the
+# review-blocked judge step (scripts/review_rb_judge.sh) against a given
+# open PR. Used by the orchestrator poller's standalone stall loop to
+# escape the ai:review-blocked phase once an issue has been stuck past
+# the per-phase stall threshold with no active autofix run. See
+# scripts/orchestrate_poll_process.sh (dispatch_rb_judge action) and
+# orchestrate_lib.py:STALL_RECOVERY_ACTIONS["ai:review-blocked"].
+#
+# Contract:
+#   - Expects an open PR at ${pr_number}.
+#   - Forwards force_rb_judge=true to review_autofix.yml, which makes
+#     retrigger_guard report max_iterations_reached=true immediately so
+#     the reviewer/editor/commit path is skipped and the rb_judge step
+#     fires directly.
+#   - Does NOT allow AI workflow edits (defaults to false) — the judge
+#     only decides merge/fix/close_and_reissue and should not be able to
+#     rewrite workflow YAML.
+#
+# This workflow is workflow_dispatch-only on purpose: it is not a
+# push/PR-event handler. The poller triggers it via `gh workflow run`.
+# The filename `review_rb_judge_dispatch.yml` is load-bearing: the
+# orchestrator poller dispatches by exact filename and there is no
+# override variable.
+name: AI Review-Blocked Judge Dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to run the review-blocked judge against"
+        required: true
+        type: string
+      allow_workflow_edits:
+        description: "Allow AI/editor changes to .github/workflows files (default false for judge-only dispatch)"
+        required: false
+        default: false
+        type: boolean
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+jobs:
+  judge:
+    uses: shubhodeep1/coding-workflows/.github/workflows/review_autofix.yml@stable
+    with:
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_is_draft: false
+      pr_title: ""
+      pr_body: ""
+      pr_skip_ai: false
+      allow_workflow_edits: ${{ github.event.inputs.allow_workflow_edits == 'true' }}
+      force_rb_judge: true
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Add `workflow-templates/review_rb_judge_dispatch.yml` so consumer repos auto-deploy the wrapper that the orchestrator poller dispatches by exact filename when an issue stalls past `STALL_THRESHOLD_REVIEW_BLOCKED_MINUTES`.
- Document the new wrapper in README's "Optional wrappers" section, including the rationale for the non-`ai-*` filename (the dispatch call in `scripts/orchestrate_poll_process.sh:7336` is hardcoded and has no override variable, unlike `VALIDATE_WORKFLOW_NAME`).

## Why

The internal repo had `.github/workflows/review_rb_judge_dispatch.yml`, but it was never mirrored under `workflow-templates/`. `ai-update-workflows.yml` only deploys files that exist in `workflow-templates/`, so consumer repos lacked this wrapper. When a PR stalled at `ai:review-blocked` past the per-phase threshold with no active autofix run, the poller's `gh workflow run review_rb_judge_dispatch.yml` call failed open with `::warning::Could not dispatch review_rb_judge_dispatch.yml` — the standalone judge had no autonomous escape path on consumer repos.

The new template is pinned to `@stable`, uses the consumer-facing name "AI Review-Blocked Judge Dispatch", and carries the standard auto-update header. The contract (filename, `force_rb_judge=true`, judge-only — no workflow edits, `workflow_dispatch`-only) is preserved verbatim from the internal wrapper.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('workflow-templates/review_rb_judge_dispatch.yml'))"` parses cleanly
- [x] `yamllint -c .yamllint.yml workflow-templates/` passes (matches the dogfood lint gate in `ci.yml`)
- [ ] After merge to `@stable`, verify a consumer repo's `ai-update-workflows` run creates `.github/workflows/review_rb_judge_dispatch.yml` and the next poll-tick `dispatch_rb_judge` action against a stuck `ai:review-blocked` PR succeeds (no `::warning::Could not dispatch` line)
- [ ] Confirm filename match: poller dispatches `review_rb_judge_dispatch.yml` by exact name; deployed file is `.github/workflows/review_rb_judge_dispatch.yml` (no rename)

https://claude.ai/code/session_01TK5bDicY79tYBkwZaUD3TN

---
_Generated by [Claude Code](https://claude.ai/code/session_01TK5bDicY79tYBkwZaUD3TN)_