### PR TITLE
fix(gh_helpers): fail fast on permanent gh CLI errors instead of retrying 5×

### DIFF
--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -32,6 +32,27 @@ _is_gh_rate_limit()
 }
 
 # ---------------------------------------------------------------
+# _is_gh_permanent_failure — detect deterministic, non-retryable
+# failures that no amount of retrying will fix.
+#
+# Matches:
+#   * label-edit idempotent cases:   'X' not found
+#     (gh prints this when --remove-label targets a label that is
+#     not on the issue; retrying just burns API budget.)
+#   * HTTP 404 Not Found             (resource doesn't exist)
+#   * HTTP 422 Unprocessable Entity  (validation / already-exists)
+#   * "Resource not accessible by integration"  (token scope)
+#
+# Returns 0 (true) if the text indicates such a failure.
+# Conservative on purpose — only matches conditions that retrying
+# cannot resolve.
+# ---------------------------------------------------------------
+_is_gh_permanent_failure()
+{
+	printf '%s' "$1" | grep -qiE "'[^']+' not found|HTTP 404|HTTP 422|Resource not accessible by integration"
+}
+
+# ---------------------------------------------------------------
 # _sleep_until_reset — compute wait from an epoch timestamp.
 #
 # Caps at 600 s, floors at 1 s, falls back to 30 s if the
@@ -360,6 +381,15 @@ gh_retry()
 		local stderr_content
 		stderr_content=$(cat "${stderr_file}" 2>/dev/null || true)
 
+		if _is_gh_permanent_failure "${stderr_content}"; then
+			echo "::warning::gh command failed with non-retryable error (attempt ${attempt}/${max_attempts}); not retrying: $*" >&2
+			if [ -n "${stderr_content}" ]; then
+				echo "::warning::  stderr: ${stderr_content}" >&2
+			fi
+			rm -f "${stderr_file}"
+			return 1
+		fi
+
 		if _is_gh_rate_limit "${stderr_content}"; then
 			echo "::warning::GitHub API rate limit hit (attempt ${attempt}/${max_attempts}), waiting for reset…" >&2
 			_gh_ratelimit_tg_alert
@@ -417,6 +447,15 @@ gh_retry_to_file()
 
 		local stderr_content
 		stderr_content=$(cat "${stderr_file}" 2>/dev/null || true)
+
+		if _is_gh_permanent_failure "${stderr_content}"; then
+			echo "::warning::gh command failed with non-retryable error (attempt ${attempt}/${max_attempts}); not retrying: $*" >&2
+			if [ -n "${stderr_content}" ]; then
+				echo "::warning::  stderr: ${stderr_content}" >&2
+			fi
+			rm -f "${stderr_file}"
+			return 1
+		fi
 
 		if _is_gh_rate_limit "${stderr_content}"; then
 			echo "::warning::GitHub API rate limit hit (attempt ${attempt}/${max_attempts}), waiting for reset…" >&2

--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -32,6 +32,27 @@ _is_gh_rate_limit()
 }
 
 # ---------------------------------------------------------------
+# _gh_actions_escape — escape a string for safe interpolation into
+# a GitHub Actions workflow command (e.g. ::warning::, ::error::).
+#
+# Per the workflow-command format, '%', CR, and LF must be encoded
+# so they cannot terminate the command line, break annotations, or
+# enable workflow-command injection from untrusted stderr.
+#
+#   %  → %25     (must be first to avoid double-encoding)
+#   \r → %0D
+#   \n → %0A
+# ---------------------------------------------------------------
+_gh_actions_escape()
+{
+	local s="$1"
+	s="${s//%/%25}"
+	s="${s//$'\r'/%0D}"
+	s="${s//$'\n'/%0A}"
+	printf '%s' "${s}"
+}
+
+# ---------------------------------------------------------------
 # _is_gh_permanent_failure — detect deterministic, non-retryable
 # failures that no amount of retrying will fix.
 #
@@ -49,7 +70,7 @@ _is_gh_rate_limit()
 # ---------------------------------------------------------------
 _is_gh_permanent_failure()
 {
-	printf '%s' "$1" | grep -qiE "'[^']+' not found|HTTP 404|HTTP 422|Resource not accessible by integration"
+	printf '%s' "$1" | grep -qiE "['\"][^'\"]+['\"] not found|gh: Not Found|HTTP 404|404 Not Found|status code 404|HTTP 422|Resource not accessible by integration"
 }
 
 # ---------------------------------------------------------------
@@ -384,7 +405,7 @@ gh_retry()
 		if _is_gh_permanent_failure "${stderr_content}"; then
 			echo "::warning::gh command failed with non-retryable error (attempt ${attempt}/${max_attempts}); not retrying: $*" >&2
 			if [ -n "${stderr_content}" ]; then
-				echo "::warning::  stderr: ${stderr_content}" >&2
+				echo "::warning::  stderr: $(_gh_actions_escape "${stderr_content}")" >&2
 			fi
 			rm -f "${stderr_file}"
 			return 1
@@ -401,7 +422,7 @@ gh_retry()
 			local wait_secs=$(( 2 ** (attempt - 1) ))
 			echo "::warning::gh command failed (attempt ${attempt}/${max_attempts}), retrying in ${wait_secs}s…" >&2
 			if [ -n "${stderr_content}" ]; then
-				echo "::warning::  stderr: ${stderr_content}" >&2
+				echo "::warning::  stderr: $(_gh_actions_escape "${stderr_content}")" >&2
 			fi
 			if [ "${attempt}" -lt "${max_attempts}" ]; then
 				sleep "${wait_secs}"
@@ -451,7 +472,7 @@ gh_retry_to_file()
 		if _is_gh_permanent_failure "${stderr_content}"; then
 			echo "::warning::gh command failed with non-retryable error (attempt ${attempt}/${max_attempts}); not retrying: $*" >&2
 			if [ -n "${stderr_content}" ]; then
-				echo "::warning::  stderr: ${stderr_content}" >&2
+				echo "::warning::  stderr: $(_gh_actions_escape "${stderr_content}")" >&2
 			fi
 			rm -f "${stderr_file}"
 			return 1
@@ -468,7 +489,7 @@ gh_retry_to_file()
 			local wait_secs=$(( 2 ** (attempt - 1) ))
 			echo "::warning::gh command failed (attempt ${attempt}/${max_attempts}), retrying in ${wait_secs}s…" >&2
 			if [ -n "${stderr_content}" ]; then
-				echo "::warning::  stderr: ${stderr_content}" >&2
+				echo "::warning::  stderr: $(_gh_actions_escape "${stderr_content}")" >&2
 			fi
 			if [ "${attempt}" -lt "${max_attempts}" ]; then
 				sleep "${wait_secs}"
@@ -570,7 +591,7 @@ gh_api_json_to_file()
 				local wait_secs=$(( 2 ** (attempt - 1) ))
 				echo "::warning::gh command failed (attempt ${attempt}/${max_attempts}), retrying in ${wait_secs}s…" >&2
 				if [ -n "${stderr_content}" ]; then
-					echo "::warning::  stderr: ${stderr_content}" >&2
+					echo "::warning::  stderr: $(_gh_actions_escape "${stderr_content}")" >&2
 				fi
 				sleep "${wait_secs}"
 			fi


### PR DESCRIPTION
## Summary

Triggered by analysis of orchestrate_poll run [24944823597](https://github.com/shubhodeep1/tele-funtoken-msg-scoring/actions/runs/24944823597) (job 4cfc9cc6-738e-5004-9ab0-b301775a99da), which logged:

```
##[warning]gh command failed (attempt 1/5), retrying in 1s…
##[warning]  stderr: failed to update .../issues/2699: 'ai:validate-failed' not found
... (attempts 2–5, ~31 s of waiting) ...
##[error]gh command failed after 5 attempts: gh issue edit 2699 ... --remove-label ai:validate-failed
```

The error `'ai:validate-failed' not found` is **permanent** — it means the label is already not on the issue, which is exactly the post-condition the caller (`scripts/orchestrate_poll_process.sh:3767`, `:3784`) wants. Retrying 5× wastes API budget and emits a misleading `::error::` annotation on an otherwise-green job.

### What changed
- New helper `_is_gh_permanent_failure()` in `scripts/gh_helpers.sh` that matches deterministic, non-retryable conditions:
  - `'X' not found` (label-edit idempotent case)
  - `HTTP 404`, `HTTP 422`
  - `Resource not accessible by integration`
- `gh_retry()` and `gh_retry_to_file()` now check this predicate **before** the rate-limit / transient-error path. On a match they fail fast on attempt 1 with a single `::warning::` and return 1, leaving caller's existing `|| true` semantics unchanged.
- Rate-limit and genuinely transient failures keep their existing 5-attempt exponential-backoff behaviour.

### Why
- Aligns with `CLAUDE.md` §15 (**GitHub API Call Hygiene** — rate limits are a shared resource, do not add wasted calls).
- Cuts 5 wasted API calls per occurrence down to 1.
- Quiets the run log: `::error::` → single `::warning::` for already-satisfied label removals (and any analogous 404/422 idempotent case).

### Scope
Centralised helper change. No call-site edits required — every existing `gh_retry … --remove-label …` (~30 sites across the repo) benefits automatically. No behaviour change for callers that already use `|| true`.

## Test plan
- [x] `bash -n scripts/gh_helpers.sh` — syntax OK.
- [x] Unit-level test of `_is_gh_permanent_failure` against the exact log-observed string (`'ai:validate-failed' not found`) plus 8 other positive/negative cases — all 9 pass.
- [ ] Next orchestrate_poll cycle on a tracking issue without `ai:validate-failed`: confirm log shows `::warning::gh command failed with non-retryable error (attempt 1/5); not retrying: …` instead of 5 retries + `::error::`.
- [ ] Confirm rate-limit handling is unaffected by inducing a 429 in a sandbox / staging run, or by reviewing the next run that hits one.

https://claude.ai/code/session_01TkZioUBbG31UJvkbjZhKsY

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkZioUBbG31UJvkbjZhKsY)_