### PR TITLE
fix: align validate-discover prompt with renderer family IDs and required slots

### DIFF
--- a/prompts/mode-validate-discover.txt
+++ b/prompts/mode-validate-discover.txt
@@ -20,8 +20,12 @@ Hard constraints:
 - Prefer concrete values found in the repo over guesses.
 - If uncertain, omit optional keys instead of inventing values.
 
-Expected YAML shape (subset is allowed):
-- `type`: `http-server` | `telegram-bot` | `worker` | `cli` | `library`
+Expected YAML shape (top-level `type` and `slots` are REQUIRED; everything else is optional):
+- `type` (REQUIRED): one of the renderer-supported template families — `python-mongo-flask` | `python-mongo-repo-checks` | `python-repo-checks` | `node-hardhat-solidity`. Pick the closest match for the repo; do not invent other values (the renderer rejects unknown families with `FamilyResolutionError`).
+- `slots` (REQUIRED, mapping):
+  - `project_name` (REQUIRED, non-empty string): short identifier used by rendered compose/test files (e.g. the repo or service slug).
+  - `canary_tools` (REQUIRED, non-empty list of strings): tools the canary test must verify are runnable inside the harness container (e.g. `["python", "pip"]` for Python repos, `["node", "npx"]` for Node repos).
+  - `tap_plan` (optional, positive integer): expected TAP test count when known.
 - `entry`: entrypoint path or command target
 - `port`: app port number (for network services)
 - `health_check`: health route/path when available


### PR DESCRIPTION
## Summary

- Replaces the stale `type` enum (`http-server | telegram-bot | worker | cli | library`) in `prompts/mode-validate-discover.txt` with the actual renderer-supported family IDs (`python-mongo-flask | python-mongo-repo-checks | python-repo-checks | node-hardhat-solidity`).
- Documents the schema-required top-level `slots` block (`project_name`, `canary_tools`, optional `tap_plan`) that the prompt previously omitted.

## Why

A `validate / validate` job for `shubhodeep1/tele-funtoken-msg-scoring` issue #2699 (run 24943782829) failed with `raw_status=harness_error` and `Template renderer execution failed (exit 14)`. The Codex VALIDATE-DISCOVER step materialized this `.ai/validate.yml`:

```yaml
type: worker
entry: python -B backend/flash_offer_worker.py
services: []
env_overrides: { ... }
custom_tests: [ ... ]
```

Two prompt-driven defects made it unrenderable:

1. `scripts/render_validation_templates.py` `FAMILY_REGISTRY` (lines 95-100) does not contain `worker`, so `resolve_family()` raises `FamilyResolutionError("Unknown manifest type 'worker'. Supported types: …")`. `agents.md:196` already calls this out: *"Hint-only types used in freehand examples (for example `http-server`) are not valid template-family IDs."*
2. `scripts/templates/slot_manifest.schema.json` requires top-level `["type","slots"]` plus `slots.project_name` and `slots.canary_tools`, none of which were mentioned in the prompt's "Expected YAML shape" block.

The model followed the prompt faithfully — the prompt was the contract drift.

## Test plan

- [ ] On the next `validate / validate` cycle for a consumer repo without a committed `.ai/validate.yml`, confirm Codex emits a `type:` from the four renderer families and a populated `slots:` block.
- [ ] Confirm `run_template_validation_harness_renderer` returns 0 (no exit 14 → `harness_error`) for the resulting manifest.
- [ ] Spot-check that `agents.md:196` and `README.md:1656` (which already document the correct family IDs) remain consistent — no doc drift introduced.

https://claude.ai/code/session_01CYbicFYYY7ojRKYih72Am1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYbicFYYY7ojRKYih72Am1)_