### PR TITLE
fix(ai_memory): guard _parse_keyword_response against null LLM content

### DIFF
--- a/scripts/ai_memory_lib.py
+++ b/scripts/ai_memory_lib.py
@@ -1087,8 +1087,10 @@ def _extract_keywords_plain(title: str, body: str) -> set[str]:
     return {t for t in tokens if t not in _KEYWORD_STOP_WORDS and len(t) > 2}
 
 
-def _parse_keyword_response(raw: str) -> list[str] | None:
+def _parse_keyword_response(raw: str | None) -> list[str] | None:
     """Parse LLM response expecting a JSON array of strings. Returns None on failure."""
+    if not raw:
+        return None
     raw = raw.strip()
     # Handle markdown code fences
     if raw.startswith("```"):


### PR DESCRIPTION
## Summary

Found while analyzing the orchestrate run `24946015210` job log.

In `scripts/ai_memory_lib.py::_parse_keyword_response`, the function unconditionally calls `raw.strip()`. When OpenRouter returns `"content": null` (rare, but observed), the caller's `.get("content", "")` yields `None`, and the unguarded `.strip()` raises `AttributeError`. That exception is **not** in the retry loop's except clause (`URLError, HTTPError, OSError, JSONDecodeError, KeyError, IndexError`), so it escapes, kills `memory_retrieve` entirely, and forces the orchestrator to run with no AI-memory context (fail-open).

Fix: add a `if not raw: return None` guard at the top of the function, preserving its documented `Returns None on failure` contract. Type hint widened to `str | None` to match observed reality.

## Log evidence

Job log lines 1184–1206:

```
File "scripts/ai_memory_lib.py", line 1174, in _extract_keywords_llm
    keywords = _parse_keyword_response(content)
File "scripts/ai_memory_lib.py", line 1092, in _parse_keyword_response
    raw = raw.strip()
AttributeError: 'NoneType' object has no attribute 'strip'
##[warning]memory retrieve failed (fail-open)
```

## Note on the run failure

The job itself was canceled by the `timeout-minutes: 60` budget on `.github/workflows/orchestrate.yml:30` after the Codex orchestration step ran for the full hour with `MODEL_EDITOR=openai/gpt-5.4` / `MODEL_REASONING_EFFORT=xhigh`. That is a **separate, environmental issue** — no code change here addresses it. Possible knobs (raise the timeout, lower reasoning effort, switch model, trim the prompt) are a config decision left to the operator.

## Test plan

- [x] Manual: `_parse_keyword_response(None) is None`, `_parse_keyword_response("") is None`, `_parse_keyword_response("   ") is None`, `_parse_keyword_response('["a","b"]') == ["a","b"]`, fenced-code-block input still parses.
- [ ] Verify next orchestrate run no longer logs the `AttributeError` traceback when the keyword model returns null content.

https://claude.ai/code/session_01Xr2Qev3PKNFXPZzS7SKR6T

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr2Qev3PKNFXPZzS7SKR6T)_