### PR TITLE
fix(review_autofix): reclaim runner disk to stop codex-agent stalls

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -609,6 +609,34 @@ jobs:
 
     steps:
 
+      # Reclaim ~25–28 GB on ubuntu-latest before any checkout/Serena/LLM
+      # work runs.  The codex-agent job has historically died mid-step on
+      # asset-heavy consumer repos when the parallel reviewer fan-out, the
+      # Serena indexer, and an in-flight git clone all competed for the
+      # runner's default ~14 GB free disk.  Removing the unused
+      # tool-cache + Android/.NET/Haskell SDKs + Docker images + swap
+      # gives every downstream step a wide margin.
+      #
+      # Knobs deliberately left off:
+      #   * large-packages: apt removal is slow (~3–5 min) and not needed
+      #     once the SDK caches above are gone.
+      # Only enabled on codex-agent — the deterministic-skip-merge job
+      # has no checkout, no LLM, and no working tree, so the ~30 s spent
+      # here would be pure waste there.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
+
+      - name: Show disk usage (post free-disk-space)
+        run: df -h /
+
       - name: Checkout repo
         uses: actions/checkout@v5
         with:
@@ -631,7 +659,19 @@ jobs:
           # below — see "Generate diff context" and "Detect merge
           # conflicts".
           fetch-depth: 100
+          # Partial clone: skip historical blobs at clone time and lazy-
+          # fetch them only when a step actually reads file contents.  On
+          # asset-heavy consumer repos (large PNGs/binaries with many
+          # rewrites in history) this can drop the working clone by
+          # several GB without affecting the in-job git walks (autofix /
+          # judge-fix / HEAD~1 / recent-commits-20), which only need
+          # commits + trees.  HEAD's blobs are still materialised by the
+          # checkout itself, so reviewers see the working tree as usual.
+          filter: blob:none
           token: ${{ secrets.GH_PAT }}
+
+      - name: Show disk usage (post checkout)
+        run: df -h /
 
       - name: Configure git auth for memory helper clones
         env:
@@ -868,6 +908,9 @@ jobs:
             fi
           fi
 
+      - name: Show disk usage (post support-source staging)
+        run: df -h /
+
       - name: Validate PR number input
         run: |
           set -euo pipefail
@@ -1018,6 +1061,9 @@ jobs:
         run: |
           set -euo pipefail
           bash "${SUPPORT_SCRIPTS_DIR}/setup_serena.sh" --mode editing --context codex
+
+      - name: Show disk usage (post Serena setup)
+        run: df -h /
 
       - name: Pre-assemble static context (cacheable across runs)
         run: |
@@ -2174,6 +2220,10 @@ jobs:
             exit 1
           fi
           echo "Preflight check PASSED: all required files present."
+
+      - name: Show disk usage (pre LLM call)
+        if: steps.retrigger_guard.outputs.max_iterations_reached != 'true' && env.PR_CLOSED != 'true'
+        run: df -h /
 
       - name: Run reviewer models
         if: steps.retrigger_guard.outputs.max_iterations_reached != 'true' && env.PR_CLOSED != 'true'


### PR DESCRIPTION
## Summary

Targets the dominant cause of "runner died mid-step" stalls in `codex-agent` on asset-heavy consumer repos (the parallel reviewer fan-out + Serena indexer + in-flight git clone collectively exhaust the ubuntu-latest runner's ~14 GB free disk).

- **Add `jlumbroso/free-disk-space@v1.3.1` as the first step of `codex-agent`** — reclaims ~25–28 GB by removing unused tool-cache, Android/.NET/Haskell SDKs, Docker images, and swap. `large-packages` left off (slow apt removal, not needed once SDK caches are gone).
- **Add `filter: blob:none` to the main `Checkout repo`** (kept `fetch-depth: 100`). Drops historical blob bytes on repos with rewritten binary assets while leaving commit/tree walks intact; HEAD blobs still materialise so reviewers see the working tree as usual.
- **Add four `df -h /` checkpoints** (post free-disk-space, post checkout, post support-source staging, post Serena setup, pre LLM call) so the next failure narrows to a specific step instead of "the runner died." The pre-LLM checkpoint matches the gating predicate of `Run reviewer models`.

Restricted to `codex-agent` only — `deterministic-skip-merge` has no checkout, no LLM, and no working tree, so the ~30 s `free-disk-space` teardown there would be pure waste.

## Deliberately not changed (considered and rejected)

- **`fetch-depth` lowered**: `recent_commits.txt` needs ≥20, and the `[judge-fix]` undercount risk grows below the existing line-1785 deepen safeguard. With `blob:none`, any lower depth saves <100 MB net — not worth the increased reliance on opportunistic deepens.
- **`git gc` between iterations**: the job is a single pass per workflow run; no in-job iteration loop exists. Each PR push triggers a fresh runner.
- **Checkout consolidation**: `.codex-workflow-src*` are re-read from the merge-precheck step (lines 2915, 2924–2926, 3004, 3030) to re-stage scripts after `git clean -ffdx`, so the dirs must persist for the life of the job.

## Test plan

- [ ] Trigger `review_autofix.yml` against a known asset-heavy consumer PR; confirm `Free disk space` step succeeds and shows ~25–28 GB reclaimed.
- [ ] Confirm `Checkout repo` succeeds with `filter: blob:none` and that the in-job git walks (`autofix_count`, `judge_fix_count`, `HEAD~1` diff, `recent_commits.txt`) produce expected outputs.
- [ ] Verify the four `df -h /` lines appear in workflow logs at the documented checkpoints.
- [ ] Confirm `deterministic-skip-merge` job is unaffected (no `Free disk space` step there).
- [ ] Run on a long-lived PR (>100 commits past base) and confirm the existing merge-base deepen safeguards still resolve correctly against a partial clone.

https://claude.ai/code/session_011N6o6q3R9wczxJdo9PFSRD

---
_Generated by [Claude Code](https://claude.ai/code/session_011N6o6q3R9wczxJdo9PFSRD)_