### PR TITLE
refactor(workflow-log-analysis): drop legacy OpenRouter path; add full-log artifact + 30d report purge

### DIFF
--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -489,25 +489,33 @@ jobs:
             echo "::warning::WORKFLOW_LOG_ANALYSIS_REPORT_RETENTION_DAYS must be a positive integer (got: ${retention_raw}); defaulting to 30."
             retention_raw=30
           fi
-          cutoff_date="$(date -u -d "${retention_raw} days ago" +%Y-%m-%d 2>/dev/null || date -u +%Y-%m-%d)"
+          # Fail-open: if cutoff computation fails, skip the purge entirely
+          # rather than fall back to today (which would delete every prior
+          # report). The previous fallback `|| date -u +%Y-%m-%d` was unsafe
+          # for that reason.
           purged_count=0
-          shopt -s nullglob
-          for old_report in analysis/workflow-optimization-*.md; do
-            [ "${old_report}" = "${REPORT_FILE}" ] && continue
-            filename="$(basename "${old_report}")"
-            # Match workflow-optimization-YYYY-MM-DD(-N).md and capture only
-            # the date stamp; greedy parameter expansion (e.g. ${s%%-[0-9]*})
-            # would chop the month/day off the date itself.
-            if [[ ! "${filename}" =~ ^workflow-optimization-([0-9]{4}-[0-9]{2}-[0-9]{2})(-[0-9]+)?\.md$ ]]; then
-              continue
-            fi
-            stamp="${BASH_REMATCH[1]}"
-            if [[ "${stamp}" < "${cutoff_date}" ]]; then
-              git rm -- "${old_report}" >/dev/null
-              purged_count=$((purged_count + 1))
-            fi
-          done
-          shopt -u nullglob
+          cutoff_date=""
+          if cutoff_date="$(date -u -d "${retention_raw} days ago" +%Y-%m-%d 2>/dev/null)" && [ -n "${cutoff_date}" ]; then
+            shopt -s nullglob
+            for old_report in analysis/workflow-optimization-*.md; do
+              [ "${old_report}" = "${REPORT_FILE}" ] && continue
+              filename="$(basename "${old_report}")"
+              # Match workflow-optimization-YYYY-MM-DD(-N).md and capture only
+              # the date stamp; greedy parameter expansion (e.g. ${s%%-[0-9]*})
+              # would chop the month/day off the date itself.
+              if [[ ! "${filename}" =~ ^workflow-optimization-([0-9]{4}-[0-9]{2}-[0-9]{2})(-[0-9]+)?\.md$ ]]; then
+                continue
+              fi
+              stamp="${BASH_REMATCH[1]}"
+              if [[ "${stamp}" < "${cutoff_date}" ]]; then
+                git rm -- "${old_report}" >/dev/null
+                purged_count=$((purged_count + 1))
+              fi
+            done
+            shopt -u nullglob
+          else
+            echo "::warning::Unable to compute report purge cutoff date for retention window (${retention_raw} days); skipping age-based purge to avoid accidental deletions."
+          fi
           if [ "${purged_count}" -gt 0 ]; then
             echo "INFO: purged ${purged_count} workflow-optimization report(s) older than ${cutoff_date}."
           fi

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -14,15 +14,10 @@ on:
         default: "7"
         type: string
       codex_mode:
-        description: Run Codex-first analysis path (set false to use legacy analyzer mode)
+        description: Deprecated no-op input retained for backward compatibility; the workflow always runs the Codex-first analysis path.
         required: false
         default: true
         type: boolean
-      batch_api_disabled:
-        description: Optional true/false override for analyzer batch API behavior in non-codex mode
-        required: false
-        default: ""
-        type: string
       repos_override:
         description: Optional comma-separated repositories (owner/repo)
         required: false
@@ -124,6 +119,7 @@ jobs:
           printf ' - %s\n' "${deduped[@]}"
 
       - name: Collect workflow logs
+        id: collect
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
           PYTHONDONTWRITEBYTECODE: "1"
@@ -134,8 +130,14 @@ jobs:
           LOOKBACK_DAYS="${{ github.event.inputs.lookback_days || '7' }}"
           mapfile -t REPOS < /tmp/workflow-analysis-repos.txt
 
+          LOG_OUTPUT_DIR="${RUNNER_TEMP:-/tmp}/workflow-log-output"
+          rm -rf "${LOG_OUTPUT_DIR}"
+          mkdir -p "${LOG_OUTPUT_DIR}"
+          echo "log_output_dir=${LOG_OUTPUT_DIR}" >> "$GITHUB_OUTPUT"
+
           COLLECT_ARGS=(
             --output workflow_log_report.json
+            --log-output-dir "${LOG_OUTPUT_DIR}"
           )
 
           if [ -n "${SINCE_INPUT//[[:space:]]/}" ]; then
@@ -156,6 +158,14 @@ jobs:
           name: workflow-log-report
           path: workflow_log_report.json
           if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload full workflow log directory artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: workflow-log-output
+          path: ${{ steps.collect.outputs.log_output_dir }}
+          if-no-files-found: warn
           retention-days: 7
 
   analyze-commit-notify:
@@ -180,7 +190,6 @@ jobs:
           python-version: "3.12"
 
       - name: Cache Codex CLI
-        if: ${{ inputs.codex_mode }}
         id: cache-codex
         uses: actions/cache@v5
         with:
@@ -188,7 +197,7 @@ jobs:
           key: codex-${{ vars.CODEX_VERSION || 'v0.114.0' }}
 
       - name: Install Codex CLI
-        if: ${{ inputs.codex_mode && steps.cache-codex.outputs.cache-hit != 'true' }}
+        if: steps.cache-codex.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
@@ -198,13 +207,12 @@ jobs:
           cp "${CODEX_BIN}" "${{ runner.tool_cache }}/codex/codex"
 
       - name: Restore Codex CLI from cache
-        if: ${{ inputs.codex_mode && steps.cache-codex.outputs.cache-hit == 'true' }}
+        if: steps.cache-codex.outputs.cache-hit == 'true'
         run: |
           set -euo pipefail
           npm install -g "${{ runner.tool_cache }}/codex/package" --include=optional --no-audit --no-fund
 
       - name: Create Codex config
-        if: ${{ inputs.codex_mode }}
         env:
           WORKFLOW_EDITOR_MODEL: ${{ vars.WORKFLOW_LOG_ANALYSIS_MODEL || 'openai/gpt-5.4' }}
         run: |
@@ -240,28 +248,27 @@ jobs:
           name: workflow-log-report
           path: .
 
+      - name: Download full workflow log directory artifact
+        id: download_log_output
+        uses: actions/download-artifact@v4
+        with:
+          name: workflow-log-output
+          path: ${{ runner.temp }}/workflow-log-output
+
       - name: Run workflow log analysis
         id: analyze
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          OPENROUTER_PROMPT_CACHE_DISABLED: ${{ vars.OPENROUTER_PROMPT_CACHE_DISABLED || 'false' }}
-          THINKING_LEVEL_ANALYSIS: ${{ vars.THINKING_LEVEL_ANALYSIS || 'xhigh' }}
           WORKFLOW_EDITOR_MODEL: ${{ vars.WORKFLOW_LOG_ANALYSIS_MODEL || 'openai/gpt-5.4' }}
-          BATCH_API_DISABLED: ${{ vars.BATCH_API_DISABLED || 'false' }}
-          BATCH_API_PROVIDER: ${{ vars.BATCH_API_PROVIDER || 'auto' }}
-          BATCH_API_POLL_TIMEOUT_HOURS: ${{ vars.BATCH_API_POLL_TIMEOUT_HOURS || '24' }}
           MAX_CODEX_ATTEMPTS: ${{ vars.MAX_CODEX_ATTEMPTS || '3' }}
           CODEX_RETRY_BACKOFF_BASE_SECS: ${{ vars.CODEX_RETRY_BACKOFF_BASE_SECS || '10' }}
           TRACKING_ISSUE: ${{ inputs.tracking_issue || '0' }}
+          RUN_LOGS_DIR: ${{ steps.download_log_output.outputs.download-path }}
           GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
           PYTHONDONTWRITEBYTECODE: "1"
         run: |
           set -euo pipefail
 
-          CODEX_MODE_INPUT="${{ inputs.codex_mode && 'true' || 'false' }}"
-          BATCH_API_DISABLED_INPUT="${{ github.event.inputs.batch_api_disabled || '' }}"
-          BATCH_ARTIFACT_NAME="workflow-log-analysis-batch-state"
-          BATCH_STATE_FILE="workflow_log_analysis_batch_state.json"
           TRACKING_ISSUE_RAW="${TRACKING_ISSUE:-0}"
           TRACKING_ISSUE_NUM=""
           if [[ "${TRACKING_ISSUE_RAW}" =~ ^[0-9]+$ ]] && [ "${TRACKING_ISSUE_RAW}" -gt 0 ]; then
@@ -357,193 +364,105 @@ jobs:
             exit "${codex_exit}"
           }
 
-          if [ "${CODEX_MODE_INPUT}" != "true" ]; then
-            if ARTIFACTS_JSON="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" 2>/dev/null)"; then
-              :
-            else
-              ARTIFACTS_JSON=''
-            fi
-            if [ -n "${ARTIFACTS_JSON}" ]; then
-              ARTIFACT_ID="$(printf '%s\n' "${ARTIFACTS_JSON}" | jq -rs --arg name "${BATCH_ARTIFACT_NAME}" --arg branch "${GITHUB_REF_NAME}" '[.[].artifacts[]?] | map(select(.name == $name and .expired == false and (((.workflow_run // {}) | .head_branch // "") == $branch))) | sort_by(.created_at) | last | .id // empty' 2>/dev/null || true)"
-              if [ -n "${ARTIFACT_ID}" ]; then
-                TMP_DIR="$(mktemp -d)"
-                if gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}/zip" > "${TMP_DIR}/batch-state.zip" 2>/dev/null; then
-                  if unzip -oq "${TMP_DIR}/batch-state.zip" -d "${TMP_DIR}" >/dev/null 2>&1 && [ -f "${TMP_DIR}/${BATCH_STATE_FILE}" ]; then
-                    cp "${TMP_DIR}/${BATCH_STATE_FILE}" "${BATCH_STATE_FILE}"
-                    echo "INFO: {\"event\":\"batch_poll\",\"status\":\"state_loaded\",\"artifact_id\":${ARTIFACT_ID}}"
-                  fi
-                fi
-                rm -rf "${TMP_DIR}"
-              fi
-            fi
-          fi
-
-          if [ -n "${BATCH_API_DISABLED_INPUT//[[:space:]]/}" ]; then
-            case "${BATCH_API_DISABLED_INPUT,,}" in
-              true|false)
-                BATCH_API_DISABLED="${BATCH_API_DISABLED_INPUT,,}"
-                ;;
-              *)
-                echo "::error::Invalid batch_api_disabled input '${BATCH_API_DISABLED_INPUT}'. Use true or false."
-                exit 1
-                ;;
-            esac
-          fi
-
-          ANALYZE_EXIT=0
-          REPORT_FILE=""
-          if [ "${CODEX_MODE_INPUT}" = "true" ]; then
-            REPORT_DATE="$(date -u +%F)"
-            REPORT_DIR="analysis"
-            REPORT_BASE="${REPORT_DIR}/workflow-optimization-${REPORT_DATE}"
-            REPORT_FILE="${REPORT_BASE}.md"
-            if [ -f "${REPORT_FILE}" ]; then
-              REPORT_SUFFIX=2
-              while [ -f "${REPORT_BASE}-${REPORT_SUFFIX}.md" ]; do
-                REPORT_SUFFIX=$((REPORT_SUFFIX + 1))
-              done
-              REPORT_FILE="${REPORT_BASE}-${REPORT_SUFFIX}.md"
-            fi
-
-            ANALYSIS_CONTEXT_FILE=""
-            set +e
-            ANALYSIS_CONTEXT_FILE="$(python3 scripts/analyze_workflow_logs.py --input workflow_log_report.json --output "${REPORT_FILE}" --codex-mode)"
-            ANALYZE_EXIT=$?
-            set -e
-
-            if [ "${ANALYZE_EXIT}" -ne 0 ]; then
-              failure_summary="Analyzer failed to prepare Codex context with exit code ${ANALYZE_EXIT}."
-              echo "::error::${failure_summary}"
-              handle_log_analysis_codex_failure "analysis_prepare_context" "analyzer_failed" "1" "${ANALYZE_EXIT}" "${failure_summary}"
-            fi
-            if [ -z "${ANALYSIS_CONTEXT_FILE}" ] || [ ! -f "${ANALYSIS_CONTEXT_FILE}" ]; then
-              failure_summary="Analyzer did not produce a valid Codex context file path."
-              echo "::error::${failure_summary}"
-              handle_log_analysis_codex_failure "analysis_prepare_context" "missing_context_artifact" "1" 1 "${failure_summary}"
-            fi
-
-            CODEX_PROMPT_FILE="$(mktemp)"
-            {
-              bash scripts/render_prompt.sh prompts/mode-workflow-analysis.txt
-              echo
-              echo "=== ANALYSIS CONTEXT ==="
-              cat "${ANALYSIS_CONTEXT_FILE}"
-            } > "${CODEX_PROMPT_FILE}"
-
-            max_attempts="${MAX_CODEX_ATTEMPTS}"
-            if ! [[ "${max_attempts}" =~ ^[0-9]+$ ]] || [ "${max_attempts}" -lt 1 ]; then
-              echo "::warning::MAX_CODEX_ATTEMPTS must be a positive integer (got: ${max_attempts}); defaulting to 3."
-              max_attempts="3"
-            fi
-            codex_failure_mode=""
-            analyze_attempts_used=0
-            for attempt in $(seq 1 "${max_attempts}"); do
-              analyze_attempts_used="${attempt}"
-              set +e
-              codex exec --model "${WORKFLOW_EDITOR_MODEL}" --full-auto < "${CODEX_PROMPT_FILE}" > "${REPORT_FILE}" 2> >(tee -a /tmp/workflow-analysis-codex.log >&2)
-              ANALYZE_EXIT=$?
-              set -e
-              if [ "${ANALYZE_EXIT}" -eq 0 ] && grep -q '[^[:space:]]' "${REPORT_FILE}"; then
-                codex_failure_mode=""
-                break
-              fi
-              if [ "${ANALYZE_EXIT}" -ne 0 ]; then
-                codex_failure_mode="codex_rc_nonzero"
-              else
-                codex_failure_mode="codex_empty_output"
-              fi
-              if [ "${attempt}" -lt "${max_attempts}" ]; then
-                sleep_secs=$((CODEX_RETRY_BACKOFF_BASE_SECS * (2 ** (attempt - 1))))
-                sleep "${sleep_secs}"
-              else
-                if [ "${codex_failure_mode}" = "codex_empty_output" ]; then
-                  failure_summary="Workflow log analysis Codex pass returned empty output after ${max_attempts} attempts."
-                  echo "::error::${failure_summary}"
-                  handle_log_analysis_codex_failure "analysis_codex_pass" "codex_empty_output" "${analyze_attempts_used}" 0 "${failure_summary}"
-                fi
-                failure_summary="Workflow log analysis Codex pass failed after ${max_attempts} attempts with exit code ${ANALYZE_EXIT}."
-                echo "::error::${failure_summary}"
-                handle_log_analysis_codex_failure "analysis_codex_pass" "codex_rc_nonzero" "${analyze_attempts_used}" "${ANALYZE_EXIT}" "${failure_summary}"
-              fi
+          REPORT_DATE="$(date -u +%F)"
+          REPORT_DIR="analysis"
+          REPORT_BASE="${REPORT_DIR}/workflow-optimization-${REPORT_DATE}"
+          REPORT_FILE="${REPORT_BASE}.md"
+          if [ -f "${REPORT_FILE}" ]; then
+            REPORT_SUFFIX=2
+            while [ -f "${REPORT_BASE}-${REPORT_SUFFIX}.md" ]; do
+              REPORT_SUFFIX=$((REPORT_SUFFIX + 1))
             done
-
-            echo "report_file=${REPORT_FILE}" >> "$GITHUB_OUTPUT"
-            echo "analysis_status=completed" >> "$GITHUB_OUTPUT"
-            exit 0
+            REPORT_FILE="${REPORT_BASE}-${REPORT_SUFFIX}.md"
           fi
 
-          cmd=(python3 scripts/analyze_workflow_logs.py --input workflow_log_report.json --batch-state-file "${BATCH_STATE_FILE}")
-          if [ -n "${THINKING_LEVEL_ANALYSIS}" ]; then
-            cmd+=(--thinking-level "${THINKING_LEVEL_ANALYSIS}")
-          fi
-          LEGACY_PROMPT_TOKEN_BUDGET="${{ vars.WORKFLOW_LOG_ANALYSIS_LEGACY_PROMPT_TOKEN_BUDGET || '24000' }}"
-          if [[ ! "${LEGACY_PROMPT_TOKEN_BUDGET}" =~ ^[0-9]+$ ]]; then
-            echo "::error::Invalid WORKFLOW_LOG_ANALYSIS_LEGACY_PROMPT_TOKEN_BUDGET='${LEGACY_PROMPT_TOKEN_BUDGET}'. Use a non-negative integer."
-            exit 1
-          fi
-          cmd+=(--prompt-token-budget "${LEGACY_PROMPT_TOKEN_BUDGET}")
-          case "${WORKFLOW_EDITOR_MODEL:-}" in
-            *gemini*) cmd+=(--max-output-tokens 60000) ;;
-          esac
-
+          ANALYSIS_CONTEXT_FILE=""
+          ANALYZE_EXIT=0
           set +e
-          REPORT_FILE="$("${cmd[@]}")"
+          ANALYSIS_CONTEXT_FILE="$(python3 scripts/analyze_workflow_logs.py --input workflow_log_report.json --output "${REPORT_FILE}" --codex-mode)"
           ANALYZE_EXIT=$?
           set -e
 
-          if [ "${ANALYZE_EXIT}" -eq 0 ]; then
-            if [ -z "${REPORT_FILE}" ] || [ ! -f "${REPORT_FILE}" ]; then
-              echo "::error::Analyzer did not produce a valid report file path."
-              exit 1
-            fi
-            echo "report_file=${REPORT_FILE}" >> "$GITHUB_OUTPUT"
-            echo "analysis_status=completed" >> "$GITHUB_OUTPUT"
-            if [ -f "${BATCH_STATE_FILE}" ]; then
-              echo "batch_state_file=${BATCH_STATE_FILE}" >> "$GITHUB_OUTPUT"
-            fi
-            exit 0
+          if [ "${ANALYZE_EXIT}" -ne 0 ]; then
+            failure_summary="Analyzer failed to prepare Codex context with exit code ${ANALYZE_EXIT}."
+            echo "::error::${failure_summary}"
+            handle_log_analysis_codex_failure "analysis_prepare_context" "analyzer_failed" "1" "${ANALYZE_EXIT}" "${failure_summary}"
+          fi
+          if [ -z "${ANALYSIS_CONTEXT_FILE}" ] || [ ! -f "${ANALYSIS_CONTEXT_FILE}" ]; then
+            failure_summary="Analyzer did not produce a valid Codex context file path."
+            echo "::error::${failure_summary}"
+            handle_log_analysis_codex_failure "analysis_prepare_context" "missing_context_artifact" "1" 1 "${failure_summary}"
           fi
 
-          if [ "${ANALYZE_EXIT}" -eq 3 ]; then
-            if [ ! -f "${BATCH_STATE_FILE}" ]; then
-              echo "::error::Analyzer exited pending but did not produce batch state file."
-              exit 1
+          # Verify the full-log directory artifact arrived before assembling
+          # the prompt; without it Codex would fall back to the analysis
+          # context's quick-index views and miss the untruncated step logs
+          # that motivate the workflow-log-output artifact.
+          if [ -z "${RUN_LOGS_DIR:-}" ] || [ ! -d "${RUN_LOGS_DIR}" ]; then
+            echo "::warning::workflow-log-output artifact not present at '${RUN_LOGS_DIR:-<unset>}'; Codex will only see analysis_context.json."
+            RUN_LOGS_DIR=""
+          fi
+
+          CODEX_PROMPT_FILE="$(mktemp)"
+          {
+            bash scripts/render_prompt.sh prompts/mode-workflow-analysis.txt
+            echo
+            echo "=== ANALYSIS CONTEXT ==="
+            cat "${ANALYSIS_CONTEXT_FILE}"
+            if [ -n "${RUN_LOGS_DIR}" ]; then
+              echo
+              echo "=== FULL RUN LOGS DIRECTORY ==="
+              echo "Run-logs directory: ${RUN_LOGS_DIR}"
+              echo "Layout: summary.json (top-level metrics), errors/ (full logs of failed runs), slow/ (full logs of longest runs by repo+family), recent/ (full logs of most recent runs)."
+              echo "Each run subdirectory contains metadata.json plus untruncated step-NNN-<step>.log files. Read summary.json first, then drill into errors/, slow/, recent/ for evidence."
             fi
-            echo "analysis_status=pending" >> "$GITHUB_OUTPUT"
-            echo "batch_state_file=${BATCH_STATE_FILE}" >> "$GITHUB_OUTPUT"
-            echo "INFO: {\"event\":\"batch_poll\",\"status\":\"pending\"}"
-            exit 0
-          fi
+          } > "${CODEX_PROMPT_FILE}"
 
-          failure_summary="Workflow log analyzer failed with exit code ${ANALYZE_EXIT}."
-          echo "::error::${failure_summary}"
-          if [ -n "${TRACKING_ISSUE_NUM}" ]; then
-            emit_log_analysis_phase_failure "analysis_prepare" "analyzer_failed" "1" "${failure_summary}"
-            gh label create "ai:log-analysis-failed" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --color "e11d48" \
-              --description "Workflow log analysis failed" >/dev/null 2>&1 || true
-            gh issue edit "${TRACKING_ISSUE_NUM}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --add-label "ai:log-analysis-failed" >/dev/null 2>&1 || \
-              echo "::warning::Failed to apply ai:log-analysis-failed to #${TRACKING_ISSUE_NUM}."
-          else
-            echo "::warning::Workflow log analyzer failed without tracking issue context; skipping ai:log-analysis-failed label and AI_PHASE_FAILURE_V1 marker."
+          max_attempts="${MAX_CODEX_ATTEMPTS}"
+          if ! [[ "${max_attempts}" =~ ^[0-9]+$ ]] || [ "${max_attempts}" -lt 1 ]; then
+            echo "::warning::MAX_CODEX_ATTEMPTS must be a positive integer (got: ${max_attempts}); defaulting to 3."
+            max_attempts="3"
           fi
-          exit "${ANALYZE_EXIT}"
+          codex_failure_mode=""
+          analyze_attempts_used=0
+          for attempt in $(seq 1 "${max_attempts}"); do
+            analyze_attempts_used="${attempt}"
+            set +e
+            codex exec --model "${WORKFLOW_EDITOR_MODEL}" --full-auto < "${CODEX_PROMPT_FILE}" > "${REPORT_FILE}" 2> >(tee -a /tmp/workflow-analysis-codex.log >&2)
+            ANALYZE_EXIT=$?
+            set -e
+            if [ "${ANALYZE_EXIT}" -eq 0 ] && grep -q '[^[:space:]]' "${REPORT_FILE}"; then
+              codex_failure_mode=""
+              break
+            fi
+            if [ "${ANALYZE_EXIT}" -ne 0 ]; then
+              codex_failure_mode="codex_rc_nonzero"
+            else
+              codex_failure_mode="codex_empty_output"
+            fi
+            if [ "${attempt}" -lt "${max_attempts}" ]; then
+              sleep_secs=$((CODEX_RETRY_BACKOFF_BASE_SECS * (2 ** (attempt - 1))))
+              sleep "${sleep_secs}"
+            else
+              if [ "${codex_failure_mode}" = "codex_empty_output" ]; then
+                failure_summary="Workflow log analysis Codex pass returned empty output after ${max_attempts} attempts."
+                echo "::error::${failure_summary}"
+                handle_log_analysis_codex_failure "analysis_codex_pass" "codex_empty_output" "${analyze_attempts_used}" 0 "${failure_summary}"
+              fi
+              failure_summary="Workflow log analysis Codex pass failed after ${max_attempts} attempts with exit code ${ANALYZE_EXIT}."
+              echo "::error::${failure_summary}"
+              handle_log_analysis_codex_failure "analysis_codex_pass" "codex_rc_nonzero" "${analyze_attempts_used}" "${ANALYZE_EXIT}" "${failure_summary}"
+            fi
+          done
 
-      - name: Upload batch state artifact
-        if: steps.analyze.outputs.batch_state_file != ''
-        uses: actions/upload-artifact@v6
-        with:
-          name: workflow-log-analysis-batch-state
-          path: ${{ steps.analyze.outputs.batch_state_file }}
-          if-no-files-found: error
-          retention-days: 7
+          echo "report_file=${REPORT_FILE}" >> "$GITHUB_OUTPUT"
+          echo "analysis_status=completed" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push report
         id: commit_report
         if: steps.analyze.outputs.analysis_status == 'completed'
+        env:
+          REPORT_RETENTION_DAYS: ${{ vars.WORKFLOW_LOG_ANALYSIS_REPORT_RETENTION_DAYS || '30' }}
         run: |
           set -euo pipefail
 
@@ -557,6 +476,36 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Age-based purge: delete analysis/workflow-optimization-<date>(-N).md
+          # files whose date stamp in the filename is older than the retention
+          # window. Filename dates are authoritative — mtime would reset on
+          # every checkout. The just-written REPORT_FILE is excluded.
+          retention_raw="${REPORT_RETENTION_DAYS:-30}"
+          if ! [[ "${retention_raw}" =~ ^[0-9]+$ ]] || [ "${retention_raw}" -lt 1 ]; then
+            echo "::warning::WORKFLOW_LOG_ANALYSIS_REPORT_RETENTION_DAYS must be a positive integer (got: ${retention_raw}); defaulting to 30."
+            retention_raw=30
+          fi
+          cutoff_date="$(date -u -d "${retention_raw} days ago" +%Y-%m-%d 2>/dev/null || date -u +%Y-%m-%d)"
+          purged_count=0
+          shopt -s nullglob
+          for old_report in analysis/workflow-optimization-*.md; do
+            [ "${old_report}" = "${REPORT_FILE}" ] && continue
+            stamp="$(basename "${old_report}" .md)"
+            stamp="${stamp#workflow-optimization-}"
+            stamp="${stamp%%-[0-9]*}"
+            if [[ ! "${stamp}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+              continue
+            fi
+            if [[ "${stamp}" < "${cutoff_date}" ]]; then
+              git rm -- "${old_report}" >/dev/null
+              purged_count=$((purged_count + 1))
+            fi
+          done
+          shopt -u nullglob
+          if [ "${purged_count}" -gt 0 ]; then
+            echo "INFO: purged ${purged_count} workflow-optimization report(s) older than ${cutoff_date}."
+          fi
+
           git add "${REPORT_FILE}"
           if git diff --cached --quiet; then
             echo "No report changes to commit."
@@ -564,7 +513,12 @@ jobs:
             exit 0
           fi
 
-          git commit -m "chore: add workflow log analysis report"
+          if [ "${purged_count}" -gt 0 ]; then
+            commit_msg="chore: add workflow log analysis report (purged ${purged_count} older than ${retention_raw}d)"
+          else
+            commit_msg="chore: add workflow log analysis report"
+          fi
+          git commit -m "${commit_msg}"
           git pull --rebase origin "${TARGET_BRANCH}"
           git push origin "HEAD:${TARGET_BRANCH}"
 
@@ -598,14 +552,7 @@ jobs:
             REPORT_URL="${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/${REPORT_FILE}"
           fi
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          if [ "${ANALYSIS_STATUS}" = "pending" ]; then
-            MSG="Workflow log analysis submitted async batch for ${{ github.repository }}"
-            MSG+=$'\n'
-            MSG+="Report: pending (rerun this workflow manually to continue polling)"
-            MSG+=$'\n'
-            MSG+="Run: ${RUN_URL}"
-            ALERT_LEVEL="DEBUG"
-          elif [ "${ANALYSIS_STATUS}" = "completed" ]; then
+          if [ "${ANALYSIS_STATUS}" = "completed" ]; then
             SUMMARY_LINE="Analysis report generated."
             if [ -n "${REPORT_FILE}" ] && [ -f "${REPORT_FILE}" ]; then
               SUMMARY_LINE="$(grep -m1 -E '^- |^[0-9]+\. ' "${REPORT_FILE}" || true)"
@@ -632,7 +579,7 @@ jobs:
 
   deep-audit:
     needs: analyze-commit-notify
-    if: success() && needs.analyze-commit-notify.outputs.analysis_status == 'completed' && inputs.codex_mode
+    if: success() && needs.analyze-commit-notify.outputs.analysis_status == 'completed'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
@@ -723,7 +670,6 @@ jobs:
         id: audit
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          OPENROUTER_PROMPT_CACHE_DISABLED: ${{ vars.OPENROUTER_PROMPT_CACHE_DISABLED || 'false' }}
           WORKFLOW_EDITOR_MODEL: ${{ vars.WORKFLOW_LOG_ANALYSIS_MODEL || 'openai/gpt-5.4' }}
           MAX_CODEX_ATTEMPTS: ${{ vars.MAX_CODEX_ATTEMPTS || '3' }}
           CODEX_RETRY_BACKOFF_BASE_SECS: ${{ vars.CODEX_RETRY_BACKOFF_BASE_SECS || '10' }}
@@ -949,7 +895,7 @@ jobs:
 
   api-redundancy:
     needs: [analyze-commit-notify, deep-audit]
-    if: success() && needs.deep-audit.outputs.audit_status == 'completed' && inputs.codex_mode
+    if: success() && needs.deep-audit.outputs.audit_status == 'completed'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
@@ -1040,7 +986,6 @@ jobs:
         id: api_redundancy
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          OPENROUTER_PROMPT_CACHE_DISABLED: ${{ vars.OPENROUTER_PROMPT_CACHE_DISABLED || 'false' }}
           WORKFLOW_EDITOR_MODEL: ${{ vars.WORKFLOW_LOG_ANALYSIS_MODEL || 'openai/gpt-5.4' }}
           MAX_CODEX_ATTEMPTS: ${{ vars.MAX_CODEX_ATTEMPTS || '3' }}
           CODEX_RETRY_BACKOFF_BASE_SECS: ${{ vars.CODEX_RETRY_BACKOFF_BASE_SECS || '10' }}

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -250,6 +250,10 @@ jobs:
 
       - name: Download full workflow log directory artifact
         id: download_log_output
+        # Fail-open contract: a missing/expired workflow-log-output artifact
+        # must NOT fail the analyze job. The downstream Codex prompt assembly
+        # falls back to analysis_context.json only and emits a ::warning::.
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: workflow-log-output
@@ -490,12 +494,14 @@ jobs:
           shopt -s nullglob
           for old_report in analysis/workflow-optimization-*.md; do
             [ "${old_report}" = "${REPORT_FILE}" ] && continue
-            stamp="$(basename "${old_report}" .md)"
-            stamp="${stamp#workflow-optimization-}"
-            stamp="${stamp%%-[0-9]*}"
-            if [[ ! "${stamp}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            filename="$(basename "${old_report}")"
+            # Match workflow-optimization-YYYY-MM-DD(-N).md and capture only
+            # the date stamp; greedy parameter expansion (e.g. ${s%%-[0-9]*})
+            # would chop the month/day off the date itself.
+            if [[ ! "${filename}" =~ ^workflow-optimization-([0-9]{4}-[0-9]{2}-[0-9]{2})(-[0-9]+)?\.md$ ]]; then
               continue
             fi
+            stamp="${BASH_REMATCH[1]}"
             if [[ "${stamp}" < "${cutoff_date}" ]]; then
               git rm -- "${old_report}" >/dev/null
               purged_count=$((purged_count + 1))

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `SERENA_DISABLED` | No | `false` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, validate | Disable the Serena MCP server |
 | `CONTEXT7_DISABLED` | No | `false` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, orchestrate_clarify_respond, validate | Disable the optional Context7 MCP server |
 | `GIT_MCP_DISABLED` | No | `false` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, orchestrate_clarify_respond, validate | Disable the optional Git MCP server setup (preloaded diff artifacts remain the fallback). |
-| `OPENROUTER_PROMPT_CACHE_DISABLED` | No | `false` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, orchestrate_clarify_respond, validate, workflow-log-analysis | Kill switch for OpenRouter prompt-cache instrumentation. `false` enables cache-friendly prompt ordering and cache telemetry logging; `true` disables explicit cache breakpoints and related instrumentation. |
+| `OPENROUTER_PROMPT_CACHE_DISABLED` | No | `false` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, orchestrate_clarify_respond, validate | Kill switch for OpenRouter prompt-cache instrumentation. `false` enables cache-friendly prompt ordering and cache telemetry logging; `true` disables explicit cache breakpoints and related instrumentation. (No longer consumed by `workflow-log-analysis`, which is Codex-only.) |
 | `WORKFLOW_ORCHESTRATE_MODEL` | No | (falls back to `WORKFLOW_EDITOR_MODEL`) | orchestrate, orchestrate_poll | Model override for orchestrator decomposer and judge |
 | `ORCHESTRATE_POLL_INTERVAL` | No | `30` | orchestrate | Reserved poll interval setting (current poll cadence is controlled by the poller wrapper cron schedule) |
 | `ORCHESTRATE_SHORTCIRCUIT_MAX_CHARS` | No | `1200` | _(deprecated — no longer consumed)_ | Formerly controlled the pre-LLM short-circuit. Removed in #1163; every orchestrator run now goes through full decomposition. |
@@ -144,9 +144,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `MAX_POST_CODEX_REPAIR_ATTEMPTS` | No | `1` | implement | Maximum in-job post-Codex syntax-repair attempts after `Validate syntax of changed files` fails. Must be a non-negative integer (`0` disables in-job repair); invalid values fallback to `1`. The repair loop runs only for syntax-validator failures, enforces an allow-list scope guard, and then falls back to the existing diagnose/fix-up path when attempts are exhausted. |
 | `BULK_DELETE_THRESHOLD` | No | `3` | implement | Maximum number of file deletions allowed in a single AI implementation commit before the destructive-commit guard blocks it. Set higher for legitimate large refactors, or bypass on a per-run basis via `ALLOW_BULK_DELETE=true`. See "Destructive-commit guard" below. |
 | `ALLOW_BULK_DELETE` | No | `false` | implement | When `true`, the destructive-commit guard ignores the `BULK_DELETE_THRESHOLD` rejection path. Canonical workflow-source file deletions are still blocked unless `ALLOW_WORKFLOW_EDITS=true`. Use for legitimate large refactors approved by a human. |
-| `BATCH_API_DISABLED` | No | `false` | workflow-log-analysis, memory_maintenance | Kill switch for async batch mode. When `true`, workflow log analysis always uses synchronous inference. Memory maintenance emits compatibility/no-op batch logs only. |
-| `BATCH_API_PROVIDER` | No | `auto` | workflow-log-analysis, memory_maintenance | Batch provider routing hint for OpenRouter Responses API capability checks/submission (`auto`, `openai`, `anthropic`). Unsupported hints fall back to sync with structured warnings. |
-| `BATCH_API_POLL_TIMEOUT_HOURS` | No | `24` | workflow-log-analysis, memory_maintenance | Maximum pending batch age before workflow-log-analysis falls back to synchronous generation. |
+| `WORKFLOW_LOG_ANALYSIS_REPORT_RETENTION_DAYS` | No | `30` | workflow-log-analysis | Age (in days) above which dated `analysis/workflow-optimization-<date>.md` reports are git-removed in the same commit as a new report. Filename date stamps are authoritative; the just-written report is always preserved. Invalid values fail open to `30` with a warning. |
 
 **Thinking levels** — control the model's reasoning effort per phase. Valid values: `xhigh`, `high`, `medium`, `low`. All phases default to `xhigh` (maximum reasoning depth). No cycle-based downgrades are applied — every phase uses the configured reasoning effort for all cycles. **E2E smoke test exception:** when an issue or PR title contains `[E2E Smoke Test]`, all phases force `low` reasoning to keep smoke runs cheap and fast.
 
@@ -156,7 +154,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `THINKING_LEVEL_CLARIFY_ORCHESTRATOR` | `xhigh` | clarify | Reasoning effort used only when clarify runs Codex for `ai:orchestrator-managed` issues on forced human `/reclarify` |
 | `THINKING_LEVEL_PLAN` | `xhigh` | plan | Reasoning effort for the planning phase |
 | `THINKING_LEVEL_IMPLEMENT` | `xhigh` | implement | Reasoning effort for the implementation phase |
-| `THINKING_LEVEL_ANALYSIS` | `xhigh` | workflow-log-analysis | Reasoning effort for the workflow log analysis report generation. |
+| `THINKING_LEVEL_ANALYSIS` | `xhigh` | workflow-log-analysis | Reasoning effort for the deep-audit and API-redundancy Codex passes (passed via Codex `model_reasoning_effort`). |
 | `THINKING_LEVEL_REVIEWER` | `xhigh` | review_autofix | Reasoning effort for the reviewer models (bug detection) |
 | `THINKING_LEVEL_EDITOR` | `xhigh` | review_autofix | Reasoning effort for the editor model (applying fixes) |
 | `THINKING_LEVEL_REVIEW_BLOCKED_JUDGE` | `xhigh` | review_autofix | Reasoning effort for the review-blocked judge (non-orchestrator PRs) |
@@ -840,17 +838,19 @@ Triggers:
 |---|---|---|
 | `since` | `""` | Optional ISO-8601 timestamp. When set, collector runs with `scripts/collect_workflow_logs.py --since <timestamp>`. |
 | `lookback_days` | `"7"` | Days of workflow runs to collect when `since` is empty. Passed to `scripts/collect_workflow_logs.py --lookback-days`. |
-| `codex_mode` | `true` | Codex-first analysis mode. When `true`, workflow runs analyzer preprocessing (`--codex-mode`) and then `codex exec` in the same run. When `false`, workflow uses the legacy analyzer inference/batch path (including deferred polling via batch-state artifact). |
-| `batch_api_disabled` | `""` | Optional `true`/`false` override for analyzer batch API behavior in non-codex mode only. Non-empty values are validated in all runs; invalid values fail the workflow before mode branching. Empty keeps `BATCH_API_DISABLED` env default. |
+| `codex_mode` | `true` | Deprecated no-op input retained for backward compatibility with existing callers. The workflow always runs the Codex-first analysis path; the value is ignored. |
 | `repos_override` | `""` | Optional comma-separated `owner/repo` list. Each item is validated with `^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`; invalid values fail the run. |
 | `tracking_issue` | `"0"` | Optional tracking issue number used for terminal Codex/analyzer failure labeling (`ai:log-analysis-failed`) and `AI_PHASE_FAILURE_V1` marker comments. `0`/empty keeps fail-open warning behavior without issue mutation. |
 
-Mode behavior:
+Pipeline behavior (Codex-only):
 
-- `codex_mode=true` (default): analyzer writes `analysis_context.json` (`--codex-mode`) and Codex generates the markdown report directly. Codex attempts are bounded by `MAX_CODEX_ATTEMPTS` (default `3`) with exponential backoff base `CODEX_RETRY_BACKOFF_BASE_SECS` (default `10`).
-- `codex_mode=false`: workflow restores latest non-expired `workflow-log-analysis-batch-state` artifact when available, runs analyzer in legacy mode, and may return pending (`exit 3`) until a later manual rerun completes polling.
-- `batch_api_disabled` input is validated whenever a non-empty value is provided, but only affects analyzer behavior in `codex_mode=false` runs.
-- Terminal Codex/analyzer failures are issue-context aware: when `tracking_issue` is set to a positive integer the workflow emits `AI_PHASE_FAILURE_V1` and applies `ai:log-analysis-failed`; otherwise it emits a fail-open warning and exits without issue mutation.
+1. **Collector** writes `workflow_log_report.json` (run metrics + 4 KB per-step `log_excerpts`) and a categorised full-log directory under `${RUNNER_TEMP}/workflow-log-output/` (`summary.json` + `errors/`/`slow/`/`recent/` trees with untruncated step logs).
+2. **Artifacts:** `workflow-log-report` and `workflow-log-output` (both retention 7 days).
+3. **Analyzer (`--codex-mode`)** consumes `workflow_log_report.json` and writes `analysis/analysis_context.json` (aggregates + capped quick-index lists). It does NOT call any LLM.
+4. **Codex pass** receives the rendered prompt + `analysis_context.json` + the on-disk path of the downloaded `workflow-log-output` artifact, then writes `analysis/workflow-optimization-<UTC-date>.md`. Codex attempts are bounded by `MAX_CODEX_ATTEMPTS` (default `3`) with exponential backoff base `CODEX_RETRY_BACKOFF_BASE_SECS` (default `10`).
+5. **Commit step** age-purges any sibling `analysis/workflow-optimization-*.md` whose filename date stamp is older than `WORKFLOW_LOG_ANALYSIS_REPORT_RETENTION_DAYS` (default `30`) in the same commit as the new report.
+
+Failure surfacing: terminal Codex/analyzer failures are issue-context aware — when `tracking_issue` is set to a positive integer the workflow emits `AI_PHASE_FAILURE_V1` and applies `ai:log-analysis-failed`; otherwise it emits a fail-open warning and exits without issue mutation.
 
 Repository selection behavior:
 
@@ -861,7 +861,7 @@ Repository selection behavior:
 ### Auth and configuration
 
 - `GH_PAT` is preferred for GitHub API/push operations, with `github.token` fallback in workflow steps.
-- `OPENROUTER_API_KEY` is required for `scripts/analyze_workflow_logs.py`.
+- `OPENROUTER_API_KEY` is required for the Codex passes (consumed via Codex CLI's `env_key` setting in `~/.codex/config.toml`).
 - Telegram notification is optional. If either `TG_BOT_SECRET` or `TG_ADMIN_CHAT_ID` is missing, notification is skipped.
 
 ### Collector input/output contract
@@ -906,34 +906,30 @@ Generated JSON report (`workflow_log_report.json`) includes:
 
 Analyzer script: [`scripts/analyze_workflow_logs.py`](scripts/analyze_workflow_logs.py)
 
-- Codex-first workflow path (`codex_mode=true`):
-  1. `python3 scripts/analyze_workflow_logs.py --input workflow_log_report.json --output <report.md> --codex-mode` (writes `analysis_context.json` and prints its path)
-  2. `codex exec --model <WORKFLOW_EDITOR_MODEL> --full-auto` with `prompts/mode-workflow-analysis.txt` + generated analysis context, writing the final markdown report file.
-- Legacy workflow path (`codex_mode=false`): `python3 scripts/analyze_workflow_logs.py --input workflow_log_report.json --batch-state-file workflow_log_analysis_batch_state.json`
-- `--max-output-tokens` default is `100000`. The workflow auto-caps this to `60000` when the resolved `WORKFLOW_EDITOR_MODEL` contains `gemini` (Gemini 2.5 Pro's max output is 65536).
-- Model resolution for this workflow only: the `Run workflow log analysis` step defaults `WORKFLOW_EDITOR_MODEL` to `openai/gpt-5.4` and allows override via repo variable `WORKFLOW_LOG_ANALYSIS_MODEL`. This override is scoped to this workflow and does not affect the global `WORKFLOW_EDITOR_MODEL` used by `clarify`/`plan`/`implement`/`review_autofix`/`validate`/`orchestrate`.
+The analyzer is now a context-prep stage only — it loads the collector report, computes aggregates, and writes `analysis_context.json`. The Codex pass that follows reads that JSON plus the `workflow-log-output` artifact directory directly. There is no inference call inside the Python script.
+
+- CLI used by the workflow: `python3 scripts/analyze_workflow_logs.py --input workflow_log_report.json --output <report.md> --codex-mode` (the `--codex-mode` flag is a no-op alias retained for backward compatibility; output is always `<output-dir>/analysis_context.json` and the path is printed on stdout).
 - `load_input_data` accepts either:
-  - `--input` with a collector report (`runs` list; `runs[].log_excerpts` are flattened into `deep_dive_logs` as `{name: <repo>/<run_id>/<step_name>, excerpt}`), a combined bundle object (`run_metrics`, `summary_stats`, optional `deep_dive_logs`), or a JSON array of run metrics
-  - `--data-dir` containing `workflow_log_report.json` or `run_metrics.json` + `summary_stats.json` (optionally `run_logs/`)
+  - `--input` with a collector report (`runs` list), a combined bundle object (`run_metrics`, `summary_stats`), or a JSON array of run metrics.
+  - `--data-dir` containing `workflow_log_report.json` or `run_metrics.json` + `summary_stats.json`.
+- `prepare_analysis_context` produces the JSON payload Codex consumes. Quick-index caps:
+  - `failing_runs`, `slow_runs`, `recent_runs`: each capped at `RUN_LIST_CAP = 100` normalized rows.
+  - `errors`: capped at `ERRORS_CAP = 250`.
+  - `deep_dive_logs` is intentionally **NOT** present — full untruncated logs live in the `workflow-log-output` artifact.
 - Output path behavior from `resolve_dated_output_path`:
-  - default: `analysis/workflow-optimization-YYYY-MM-DD.md`
+  - default: `analysis/workflow-optimization-YYYY-MM-DD.md` (used to derive the sibling `analysis_context.json` path).
   - same-day collisions: `analysis/workflow-optimization-YYYY-MM-DD-2.md`, `-3.md`, etc.
-- `main` prints the final report path on stdout and exits non-zero on API/write/input errors.
-- Batch mode uses OpenRouter Responses API with deferred polling and state file support:
-  - `--batch-mode` (`auto|submit|poll|sync`)
-  - `--batch-state-file` path for persisted batch metadata
-  - `--batch-provider` (`auto|openai|anthropic`) provider hint
-  - `--batch-api-disabled` kill switch
-  - `--batch-poll-timeout-hours` timeout before sync fallback
-- Analyzer exits with code `3` when batch remains pending; workflow treats this as success and defers completion to future runs.
+- Model resolution for the Codex passes only: the workflow defaults `WORKFLOW_EDITOR_MODEL` to `openai/gpt-5.4` and allows override via repo variable `WORKFLOW_LOG_ANALYSIS_MODEL`. This override is scoped to this workflow and does not affect the global `WORKFLOW_EDITOR_MODEL`.
+- `main` prints the analysis-context path on stdout and exits non-zero on input/write errors only.
 
 ### Workflow outputs
 
-- Artifact upload: `workflow-log-report` containing `workflow_log_report.json` (retention 7 days).
-- Repository commit: generated markdown report is committed/pushed to `${{ github.ref_name }}`.
-- No-op behavior: if the report file has no diff, commit/push is skipped (`No report changes to commit.`).
-- Telegram summary: when configured, sends either a pending-batch message or a completion message with report URL and workflow run URL.
-- Deferred artifact contract (non-codex mode): pending batch metadata is uploaded as artifact `workflow-log-analysis-batch-state` containing `workflow_log_analysis_batch_state.json`; later manual dispatch runs fetch latest non-expired artifact and continue polling.
+- Artifacts (retention 7 days):
+  - `workflow-log-report` — `workflow_log_report.json` (aggregated metrics + 4 KB per-step `log_excerpts` quick-index).
+  - `workflow-log-output` — categorised full-log directory (`summary.json` + `errors/`/`slow/`/`recent/` trees with untruncated step logs).
+- Repository commit: generated markdown report `analysis/workflow-optimization-<date>.md` is committed/pushed to `${{ github.ref_name }}`. The commit step also `git rm`s reports older than `WORKFLOW_LOG_ANALYSIS_REPORT_RETENTION_DAYS` (default `30`) in the same commit.
+- No-op behavior: if the report file has no diff after Codex runs, commit/push is skipped (`No report changes to commit.`); purges still apply only when there is a new report to commit alongside them.
+- Telegram summary: when configured, sends a completion message with report URL and workflow run URL, or a CRITICAL failure message when the analysis status is unknown/failed.
 - Structured logs are emitted for batch decisions and lifecycle (`batch_submit`, `batch_poll`, `batch_complete`, `batch_fallback`).
 - `memory_maintenance.yml` remains functionally unchanged (no LLM path in current repo) and now emits structured `batch_noop` compatibility logging with batch env values.
 - Low-data windows are valid: the analyzer still writes a report when input data is sparse.
@@ -1030,9 +1026,7 @@ Analyzer script: [`scripts/analyze_workflow_logs.py`](scripts/analyze_workflow_l
 | `EDITOR_MAX_WALL` | `3300` | Max wall-clock seconds per editor attempt; auto-capped to remaining job budget |
 | `EDITOR_MIN_ATTEMPT_SECS` | `300` | Minimum job budget (seconds) required to start an editor attempt |
 | `REVIEW_PR_STATE_POLL_INTERVAL_SECS` | `10` | Sleep interval (seconds) for the reviewer watchdog loop in `scripts/review_run_reviewers.sh`; GitHub PR-state API checks run every 9 polls (default ~90s); must be integer `10..3600`, else warn (`rate_limit_audit_fallback`) and fall back to `10` |
-| `BATCH_API_DISABLED` | `false` | Kill switch for async batch mode in workflow-log-analysis (`true` forces sync fallback) |
-| `BATCH_API_PROVIDER` | `auto` | Batch provider hint (`auto`, `openai`, `anthropic`) for OpenRouter responses routing checks |
-| `BATCH_API_POLL_TIMEOUT_HOURS` | `24` | Maximum pending batch age before synchronous fallback |
+| `WORKFLOW_LOG_ANALYSIS_REPORT_RETENTION_DAYS` | `30` | Age (days) above which sibling `analysis/workflow-optimization-<date>.md` reports are git-removed in the same commit as a new report. Filename date is authoritative; the new report is always preserved. |
 | `TOOL_CALL_BUDGET_ORCHESTRATE` | `40` | Tool call budget for decomposer |
 | `TOOL_CALL_BUDGET_JUDGE` | `60` | Tool call budget for judge (needs deep repo inspection) |
 | `TOKEN_WARN_THRESHOLD_ORCHESTRATE` | `200000` | Token warning threshold for orchestration |

--- a/README.md
+++ b/README.md
@@ -908,7 +908,7 @@ Analyzer script: [`scripts/analyze_workflow_logs.py`](scripts/analyze_workflow_l
 
 The analyzer is now a context-prep stage only — it loads the collector report, computes aggregates, and writes `analysis_context.json`. The Codex pass that follows reads that JSON plus the `workflow-log-output` artifact directory directly. There is no inference call inside the Python script.
 
-- CLI used by the workflow: `python3 scripts/analyze_workflow_logs.py --input workflow_log_report.json --output <report.md> --codex-mode` (the `--codex-mode` flag is a no-op alias retained for backward compatibility; output is always `<output-dir>/analysis_context.json` and the path is printed on stdout).
+- CLI used by the workflow: `python3 scripts/analyze_workflow_logs.py --input workflow_log_report.json --output <report.md> --codex-mode` (the `--codex-mode` flag is a no-op alias retained for backward compatibility; `analysis_context.json` is written alongside the resolved output path, so with `--output <report.md>` it lands at `dirname(<report.md>)/analysis_context.json` — `--output` overrides `--output-dir` for this purpose. The path is printed on stdout).
 - `load_input_data` accepts either:
   - `--input` with a collector report (`runs` list), a combined bundle object (`run_metrics`, `summary_stats`), or a JSON array of run metrics.
   - `--data-dir` containing `workflow_log_report.json` or `run_metrics.json` + `summary_stats.json`.

--- a/README.md
+++ b/README.md
@@ -928,11 +928,9 @@ The analyzer is now a context-prep stage only — it loads the collector report,
   - `workflow-log-report` — `workflow_log_report.json` (aggregated metrics + 4 KB per-step `log_excerpts` quick-index).
   - `workflow-log-output` — categorised full-log directory (`summary.json` + `errors/`/`slow/`/`recent/` trees with untruncated step logs).
 - Repository commit: generated markdown report `analysis/workflow-optimization-<date>.md` is committed/pushed to `${{ github.ref_name }}`. The commit step also `git rm`s reports older than `WORKFLOW_LOG_ANALYSIS_REPORT_RETENTION_DAYS` (default `30`) in the same commit.
-- No-op behavior: if the report file has no diff after Codex runs, commit/push is skipped (`No report changes to commit.`); purges still apply only when there is a new report to commit alongside them.
+- No-op behavior: if neither the generated report nor any staged purge deletions produce a diff after Codex runs, commit/push is skipped (`No report changes to commit.`). Because old-report purges are staged before the diff check, they may still be committed even when the newly generated report content is unchanged.
 - Telegram summary: when configured, sends a completion message with report URL and workflow run URL, or a CRITICAL failure message when the analysis status is unknown/failed.
-- Structured logs are emitted for batch decisions and lifecycle (`batch_submit`, `batch_poll`, `batch_complete`, `batch_fallback`).
-- `memory_maintenance.yml` remains functionally unchanged (no LLM path in current repo) and now emits structured `batch_noop` compatibility logging with batch env values.
-- Low-data windows are valid: the analyzer still writes a report when input data is sparse.
+- Low-data windows are valid: the analyzer still writes a context payload (and Codex still produces a report) when input data is sparse — `prepare_analysis_context` flags `insufficient_data: true` and supplies `analysis_guidance` so the model frames the response as a collection-gap notice rather than fabricating findings.
 
 ## Required Secrets
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `BULK_DELETE_THRESHOLD` | No | `3` | implement | Maximum number of file deletions allowed in a single AI implementation commit before the destructive-commit guard blocks it. Set higher for legitimate large refactors, or bypass on a per-run basis via `ALLOW_BULK_DELETE=true`. See "Destructive-commit guard" below. |
 | `ALLOW_BULK_DELETE` | No | `false` | implement | When `true`, the destructive-commit guard ignores the `BULK_DELETE_THRESHOLD` rejection path. Canonical workflow-source file deletions are still blocked unless `ALLOW_WORKFLOW_EDITS=true`. Use for legitimate large refactors approved by a human. |
 | `WORKFLOW_LOG_ANALYSIS_REPORT_RETENTION_DAYS` | No | `30` | workflow-log-analysis | Age (in days) above which dated `analysis/workflow-optimization-<date>.md` reports are git-removed in the same commit as a new report. Filename date stamps are authoritative; the just-written report is always preserved. Invalid values fail open to `30` with a warning. |
+| `BATCH_API_DISABLED` | No | `false` | memory_maintenance | Deprecated compatibility variable. The active workflow-log-analysis batch path was removed (the workflow is now Codex-only). `memory_maintenance.yml` still reads this var and echoes it in a single `batch_noop` log line so external log scrapers that grep for `batch_*` events keep working; the value does not change any current behaviour. |
+| `BATCH_API_PROVIDER` | No | `auto` | memory_maintenance | Deprecated compatibility variable. Same status as `BATCH_API_DISABLED` — only surfaced in `memory_maintenance.yml`'s `batch_noop` log line for backward-compatible telemetry. |
+| `BATCH_API_POLL_TIMEOUT_HOURS` | No | `24` | memory_maintenance | Deprecated compatibility variable. Same status as `BATCH_API_DISABLED` — only surfaced in `memory_maintenance.yml`'s `batch_noop` log line for backward-compatible telemetry. |
 
 **Thinking levels** — control the model's reasoning effort per phase. Valid values: `xhigh`, `high`, `medium`, `low`. All phases default to `xhigh` (maximum reasoning depth). No cycle-based downgrades are applied — every phase uses the configured reasoning effort for all cycles. **E2E smoke test exception:** when an issue or PR title contains `[E2E Smoke Test]`, all phases force `low` reasoning to keep smoke runs cheap and fast.
 
@@ -1025,6 +1028,9 @@ The analyzer is now a context-prep stage only — it loads the collector report,
 | `EDITOR_MIN_ATTEMPT_SECS` | `300` | Minimum job budget (seconds) required to start an editor attempt |
 | `REVIEW_PR_STATE_POLL_INTERVAL_SECS` | `10` | Sleep interval (seconds) for the reviewer watchdog loop in `scripts/review_run_reviewers.sh`; GitHub PR-state API checks run every 9 polls (default ~90s); must be integer `10..3600`, else warn (`rate_limit_audit_fallback`) and fall back to `10` |
 | `WORKFLOW_LOG_ANALYSIS_REPORT_RETENTION_DAYS` | `30` | Age (days) above which sibling `analysis/workflow-optimization-<date>.md` reports are git-removed in the same commit as a new report. Filename date is authoritative; the new report is always preserved. |
+| `BATCH_API_DISABLED` | `false` | _(deprecated compat)_ Active batch path removed; only echoed in `memory_maintenance.yml`'s `batch_noop` telemetry line for log-scraper backward compatibility |
+| `BATCH_API_PROVIDER` | `auto` | _(deprecated compat)_ Same status as `BATCH_API_DISABLED` — surfaced only in `memory_maintenance.yml` `batch_noop` log line |
+| `BATCH_API_POLL_TIMEOUT_HOURS` | `24` | _(deprecated compat)_ Same status as `BATCH_API_DISABLED` — surfaced only in `memory_maintenance.yml` `batch_noop` log line |
 | `TOOL_CALL_BUDGET_ORCHESTRATE` | `40` | Tool call budget for decomposer |
 | `TOOL_CALL_BUDGET_JUDGE` | `60` | Tool call budget for judge (needs deep repo inspection) |
 | `TOKEN_WARN_THRESHOLD_ORCHESTRATE` | `200000` | Token warning threshold for orchestration |

--- a/agents.md
+++ b/agents.md
@@ -156,7 +156,7 @@ All code is production-bound. Verify: logic correctness, error paths, race condi
      existing bullets here cause merge conflicts. -->
 - Always provide defaults for new env vars unless explicitly told otherwise.
 - Preserve all existing env var names.
-- Batch controls in this repo: removed. The legacy `BATCH_API_DISABLED` / `BATCH_API_PROVIDER` / `BATCH_API_POLL_TIMEOUT_HOURS` repo vars and the `workflow_log_analysis_batch_state.json` artifact contract were dropped when the workflow-log-analysis pipeline was simplified to Codex-only. No replacement is needed; `memory_maintenance.yml` no longer relies on these knobs either.
+- Batch controls in this repo: removed as functional controls. The legacy `BATCH_API_DISABLED` / `BATCH_API_PROVIDER` / `BATCH_API_POLL_TIMEOUT_HOURS` repo vars and the `workflow_log_analysis_batch_state.json` artifact contract were dropped when the workflow-log-analysis pipeline was simplified to Codex-only. `memory_maintenance.yml` still reads the three vars and echoes them in a single `batch_noop` log line — this is compatibility-only telemetry so log scrapers that grep for `batch_*` events keep working; the values do not influence any actual batch behaviour and there is no replacement to set.
 - Orchestrator clean-wave control: `ENABLE_CLEAN_WAVE_JUDGE_SKIP` (default `true`) skips judge invocation on clean completed waves (no failures, not stuck, project not complete) and advances wave mechanically.
 - Integration-sync conflict knobs (see also section 18 below):
   - `INTEGRATION_CONFLICT_MAX_RETRIES` (default `3`) — global resolver-retry budget for non-orchestrator integration branches.

--- a/agents.md
+++ b/agents.md
@@ -156,7 +156,7 @@ All code is production-bound. Verify: logic correctness, error paths, race condi
      existing bullets here cause merge conflicts. -->
 - Always provide defaults for new env vars unless explicitly told otherwise.
 - Preserve all existing env var names.
-- Batch controls in this repo: `BATCH_API_DISABLED` (default `false`), `BATCH_API_PROVIDER` (default `auto`), `BATCH_API_POLL_TIMEOUT_HOURS` (default `24`).
+- Batch controls in this repo: removed. The legacy `BATCH_API_DISABLED` / `BATCH_API_PROVIDER` / `BATCH_API_POLL_TIMEOUT_HOURS` repo vars and the `workflow_log_analysis_batch_state.json` artifact contract were dropped when the workflow-log-analysis pipeline was simplified to Codex-only. No replacement is needed; `memory_maintenance.yml` no longer relies on these knobs either.
 - Orchestrator clean-wave control: `ENABLE_CLEAN_WAVE_JUDGE_SKIP` (default `true`) skips judge invocation on clean completed waves (no failures, not stuck, project not complete) and advances wave mechanically.
 - Integration-sync conflict knobs (see also section 18 below):
   - `INTEGRATION_CONFLICT_MAX_RETRIES` (default `3`) — global resolver-retry budget for non-orchestrator integration branches.
@@ -319,17 +319,17 @@ After changes: original intent preserved, behavior unchanged unless approved, ba
 
 ---
 
-## 13. Workflow Log Analysis Batch Operations
+## 13. Workflow Log Analysis Operations
 
-- `workflow-log-analysis.yml` uses artifact-backed deferred polling with `workflow-log-analysis-batch-state` (`workflow_log_analysis_batch_state.json`).
-- Pending batch analyzer exits with code `3` to signal deferred completion; workflow must treat this as non-failure.
-- On unsupported provider/model, capability probe errors, poll timeout, or batch terminal errors, analyzer must emit structured `batch_fallback` warnings and run synchronous analysis.
-- `memory_maintenance.yml` currently has no LLM path; keep compaction behavior unchanged and emit `batch_noop` compatibility logging only.
+- `workflow-log-analysis.yml` runs a Codex-only analysis pipeline. The legacy OpenRouter sync/batch path, the `workflow-log-analysis-batch-state` artifact, the `BATCH_API_DISABLED` / `BATCH_API_PROVIDER` / `BATCH_API_POLL_TIMEOUT_HOURS` repo vars, the `WORKFLOW_LOG_ANALYSIS_LEGACY_PROMPT_TOKEN_BUDGET` repo var, and the `batch_api_disabled` workflow input have all been removed. The `codex_mode` workflow input and the analyzer `--codex-mode` CLI flag remain accepted for backward compatibility but are no-ops — the workflow always runs the Codex path.
+- `memory_maintenance.yml` currently has no LLM path; keep compaction behavior unchanged.
 - The collector (`scripts/collect_workflow_logs.py`) collects **all** workflow families (no static filter). `workflow_families` in the report is derived from observed runs.
 - The collector randomly samples ~7% of successful runs for log analysis (`--success-sample-rate`, default `0.07`) using a deterministic seed. Sampled runs are tagged with `_success_sampled: true`.
+- The collector also writes a categorised full-log directory under `--log-output-dir` (set to `${RUNNER_TEMP}/workflow-log-output` by the workflow). Layout: `summary.json` plus `errors/`, `slow/`, `recent/` subtrees, each `<repo>/<family>/<run_id>/{metadata.json, step-NNN-<step>.log}`. Step logs are untruncated (the 4 KB `LOG_EXCERPT_MAX_CHARS` cap only applies to the inline `log_excerpts` quick-index in `workflow_log_report.json`).
+- The full-log directory is uploaded as a separate artifact `workflow-log-output` (retention 7 days). The analyze job downloads it and splices its path into the Codex prompt next to `=== ANALYSIS CONTEXT ===` so Codex can read untruncated logs directly. Missing artifact is treated as fail-open (`::warning::` plus quick-index-only analysis).
+- `analysis_context.json` is the quick-index Codex receives alongside the run-logs directory. It contains aggregates, per-repo / per-workflow-family breakdowns, and capped lists `failing_runs` / `slow_runs` / `recent_runs` (each up to `RUN_LIST_CAP=100` normalized rows) plus `errors` (up to `ERRORS_CAP=250`). It intentionally does **not** include `deep_dive_logs` — Codex pulls that detail from the `workflow-log-output` artifact.
 - AI memory operations emit `AI_MEMORY_TELEMETRY: {JSON}` lines (stderr from `ai_memory.py`; `memory_helpers.sh` uses stdout unless stdout must remain machine-readable, then telemetry is sent to stderr). The analysis prompt instructs the LLM to produce an **AI Memory Health** section from these lines.
-- `workflow-log-analysis.yml` remains `workflow_dispatch`-only and has dual execution paths: `codex_mode=true` (default) runs analyzer preprocessing (`--codex-mode`) plus `codex exec`, while `codex_mode=false` uses the legacy analyzer/batch path.
-- `batch_api_disabled` input is validated whenever a non-empty value is provided, but only overrides analyzer batch behavior for `codex_mode=false`; codex-mode runs do not use the batch path.
+- Dated optimization reports are committed to the trigger branch as `analysis/workflow-optimization-<UTC-date>.md`. The commit step purges any `analysis/workflow-optimization-*.md` whose filename date stamp is older than `WORKFLOW_LOG_ANALYSIS_REPORT_RETENTION_DAYS` (default `30`). Filename dates are authoritative — `mtime` is not consulted because checkouts reset it. The just-written report is always preserved. Invalid retention values fail open to `30` with a `::warning::`.
 
 ## 13a. Workflow Log Analysis And Improvement Workflow
 

--- a/scripts/analyze_workflow_logs.py
+++ b/scripts/analyze_workflow_logs.py
@@ -3,8 +3,11 @@
 
 Reads `workflow_log_report.json` produced by `scripts/collect_workflow_logs.py`,
 computes per-repo / per-workflow-family aggregates plus capped quick-index
-lists of failing/slow/recent runs, and writes the result to
-`<output-dir>/analysis_context.json`. The Codex pass in
+lists of failing/slow/recent runs, and writes `analysis_context.json` beside
+the resolved output markdown path: when `--output <report.md>` is provided,
+the JSON lands at `dirname(<report.md>)/analysis_context.json`; otherwise the
+markdown path is derived from `--output-dir` (default `analysis/`) and the
+JSON sits in that directory. The Codex pass in
 `.github/workflows/workflow-log-analysis.yml` then consumes that JSON as a
 quick index; full untruncated logs are read by Codex directly from the
 `workflow-log-output` artifact (see `--log-output-dir` in the collector).

--- a/scripts/analyze_workflow_logs.py
+++ b/scripts/analyze_workflow_logs.py
@@ -384,7 +384,10 @@ def resolve_dated_output_path(
 def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
 	path.parent.mkdir(parents=True, exist_ok=True)
 	tmp_path = path.with_suffix(path.suffix + ".tmp")
-	tmp_path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+	tmp_path.write_text(
+		json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+		encoding="utf-8",
+	)
 	tmp_path.replace(path)
 
 

--- a/scripts/analyze_workflow_logs.py
+++ b/scripts/analyze_workflow_logs.py
@@ -1,51 +1,32 @@
 #!/usr/bin/env python3
-"""Generate dated workflow optimization reports from workflow telemetry."""
+"""Prepare aggregated workflow telemetry context for the Codex analysis pass.
+
+Reads `workflow_log_report.json` produced by `scripts/collect_workflow_logs.py`,
+computes per-repo / per-workflow-family aggregates plus capped quick-index
+lists of failing/slow/recent runs, and writes the result to
+`<output-dir>/analysis_context.json`. The Codex pass in
+`.github/workflows/workflow-log-analysis.yml` then consumes that JSON as a
+quick index; full untruncated logs are read by Codex directly from the
+`workflow-log-output` artifact (see `--log-output-dir` in the collector).
+"""
 
 from __future__ import annotations
 
 import argparse
-import copy
 import json
-import os
-import re
-import subprocess
 import sys
-import tempfile
-import urllib.error
-import urllib.parse
-import urllib.request
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
-try:
-	from openrouter_prompt_cache import (
-		add_ephemeral_cache_breakpoint,
-		format_usage_value,
-		is_cache_disabled,
-		normalize_usage,
-		should_retry_without_breakpoint,
-	)
-except ModuleNotFoundError:
-	from scripts.openrouter_prompt_cache import (
-		add_ephemeral_cache_breakpoint,
-		format_usage_value,
-		is_cache_disabled,
-		normalize_usage,
-		should_retry_without_breakpoint,
-	)
-
-DEFAULT_MODEL = "openai/gpt-5.3-codex"
-DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-DEFAULT_PROMPT_FILE = "prompts/mode-workflow-analysis.txt"
 DEFAULT_OUTPUT_DIR = "analysis"
 DEFAULT_INPUT_FILE = "workflow_log_report.json"
-DEFAULT_BATCH_PROVIDER = "auto"
-DEFAULT_BATCH_POLL_TIMEOUT_HOURS = 24
-DEFAULT_BATCH_API_DISABLED = "false"
-DEFAULT_BATCH_STATE_SCHEMA_VERSION = "workflow_log_analysis_batch_state.v1"
-PENDING_BATCH_STATUSES = {"pending", "submitted", "queued", "in_progress"}
-SERENA_PLACEHOLDER_PATTERN = re.compile(r"\{\{SERENA_EFFICIENCY_BLOCK_[A-Z_]+\}\}")
+
+# Quick-index list caps. Codex reads the full per-run logs from the
+# workflow-log-output artifact, so these only need to be wide enough to give
+# the model a per-run summary index.
+RUN_LIST_CAP = 100
+ERRORS_CAP = 250
 
 
 def _parse_iso8601(value: str | None) -> datetime | None:
@@ -83,14 +64,6 @@ def _percentile(values: list[int], pct: int) -> float:
 	return float(sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight)
 
 
-def _estimate_tokens(payload: Any) -> int:
-	if isinstance(payload, str):
-		text = payload
-	else:
-		text = json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True)
-	return max(1, len(text) // 4)
-
-
 def _load_json_file(path: Path) -> Any:
 	try:
 		return json.loads(path.read_text(encoding="utf-8"))
@@ -104,54 +77,9 @@ def _load_json_file(path: Path) -> Any:
 		raise ValueError(f"invalid JSON in {path}: {exc}") from exc
 
 
-def _collect_deep_dive_logs(run_logs_dir: Path) -> list[dict[str, str]]:
-	if not run_logs_dir.exists() or not run_logs_dir.is_dir():
-		return []
-	entries: list[dict[str, str]] = []
-	for log_file in sorted(path for path in run_logs_dir.iterdir() if path.is_file()):
-		try:
-			with log_file.open("r", encoding="utf-8", errors="replace") as handle:
-				excerpt = handle.read(4000)
-		except OSError:
-			continue
-		entries.append(
-			{
-				"name": log_file.name,
-				"excerpt": excerpt,
-			}
-		)
-	return entries
-
-
-def _collect_deep_dive_logs_from_runs(runs: list[dict[str, Any]]) -> list[dict[str, str]]:
-	entries: list[dict[str, str]] = []
-	for run in runs:
-		repository = str(run.get("repository") or "").strip()
-		run_id = _to_int(run.get("run_id"), 0)
-		if not repository or run_id <= 0:
-			continue
-		log_excerpts = run.get("log_excerpts")
-		if not isinstance(log_excerpts, list):
-			continue
-		for item in log_excerpts:
-			if not isinstance(item, dict):
-				continue
-			step_name = item.get("step_name")
-			excerpt = item.get("excerpt")
-			if not isinstance(step_name, str) or not isinstance(excerpt, str):
-				continue
-			entries.append(
-				{
-					"name": f"{repository}/{run_id}/{step_name}",
-					"excerpt": excerpt,
-				}
-			)
-	return entries
-
-
 def build_parser() -> argparse.ArgumentParser:
 	parser = argparse.ArgumentParser(
-		description="Analyze workflow log telemetry with OpenRouter and write a dated markdown report."
+		description="Prepare workflow telemetry context for the Codex log analysis pass."
 	)
 	input_group = parser.add_mutually_exclusive_group(required=False)
 	input_group.add_argument(
@@ -171,89 +99,15 @@ def build_parser() -> argparse.ArgumentParser:
 	output_group.add_argument(
 		"--output-dir",
 		default=DEFAULT_OUTPUT_DIR,
-		help="Output directory for generated dated markdown reports.",
+		help="Output directory used to derive the analysis_context.json sibling path.",
 	)
-	parser.add_argument(
-		"--prompt-file",
-		default=DEFAULT_PROMPT_FILE,
-		help="Path to system prompt template.",
-	)
-	parser.add_argument(
-		"--model",
-		default=os.getenv("WORKFLOW_EDITOR_MODEL", DEFAULT_MODEL),
-		help="OpenRouter model ID.",
-	)
-	parser.add_argument(
-		"--thinking-level",
-		choices=["xhigh", "high", "medium", "low"],
-		default="xhigh",
-		help="Reasoning effort for the OpenRouter request.",
-	)
-	parser.add_argument(
-		"--max-prompt-tokens",
-		"--prompt-token-budget",
-		dest="prompt_token_budget",
-		type=int,
-		default=0,
-		help="Approximate max prompt tokens before deterministic truncation (0 = no truncation).",
-	)
-	parser.add_argument(
-		"--max-output-tokens",
-		type=int,
-		default=100000,
-		help="Max completion tokens for the analysis report.",
-	)
-	parser.add_argument(
-		"--temperature",
-		type=float,
-		default=0.0,
-		help="Sampling temperature for the chat completion.",
-	)
-	parser.add_argument(
-		"--openrouter-base-url",
-		default=DEFAULT_OPENROUTER_BASE_URL,
-		help="Base URL for OpenRouter API.",
-	)
-	parser.add_argument(
-		"--request-timeout-seconds",
-		type=int,
-		default=90,
-		help="HTTP timeout in seconds for OpenRouter request.",
-	)
-	parser.add_argument(
-		"--batch-mode",
-		choices=["auto", "submit", "poll", "sync"],
-		default="auto",
-		help="Batch flow mode: auto submit/poll, forced submit, forced poll, or sync only.",
-	)
-	parser.add_argument(
-		"--batch-state-file",
-		default="",
-		help="Path to persisted batch state JSON for deferred polling.",
-	)
-	parser.add_argument(
-		"--batch-provider",
-		default=os.getenv("BATCH_API_PROVIDER", DEFAULT_BATCH_PROVIDER),
-		help="Batch provider routing hint.",
-	)
-	parser.add_argument(
-		"--batch-api-disabled",
-		default=os.getenv("BATCH_API_DISABLED", DEFAULT_BATCH_API_DISABLED),
-		help="Disable batch API path when set to true.",
-	)
-	parser.add_argument(
-		"--batch-poll-timeout-hours",
-		type=int,
-		default=_to_int(
-			os.getenv("BATCH_API_POLL_TIMEOUT_HOURS", str(DEFAULT_BATCH_POLL_TIMEOUT_HOURS)),
-			DEFAULT_BATCH_POLL_TIMEOUT_HOURS,
-		),
-		help="Maximum age of pending batch job before sync fallback.",
-	)
+	# `--codex-mode` is retained as a no-op alias for backward compatibility
+	# with callers that still pass it; the analyzer always emits
+	# `analysis_context.json` for the Codex pass to consume.
 	parser.add_argument(
 		"--codex-mode",
 		action="store_true",
-		help="Skip inference and write preprocessed analysis_context.json for Codex handoff.",
+		help="Deprecated no-op flag; analyzer always emits analysis_context.json.",
 	)
 	return parser
 
@@ -263,7 +117,6 @@ def load_input_data(args: argparse.Namespace) -> dict[str, Any]:
 	collector_report: dict[str, Any] | None = None
 	run_metrics: list[dict[str, Any]] | None = None
 	summary_stats: dict[str, Any] | None = None
-	deep_dive_logs: list[dict[str, str]] = []
 
 	if args.input:
 		payload_path = Path(args.input)
@@ -271,7 +124,6 @@ def load_input_data(args: argparse.Namespace) -> dict[str, Any]:
 		source_files.append(str(payload_path))
 		if isinstance(raw, dict) and isinstance(raw.get("runs"), list):
 			collector_report = raw
-			deep_dive_logs = _collect_deep_dive_logs_from_runs(raw.get("runs") or [])
 		elif isinstance(raw, dict):
 			run_metrics_value = raw.get("run_metrics")
 			if isinstance(run_metrics_value, list):
@@ -279,15 +131,6 @@ def load_input_data(args: argparse.Namespace) -> dict[str, Any]:
 			summary_value = raw.get("summary_stats")
 			if isinstance(summary_value, dict):
 				summary_stats = summary_value
-			run_logs_value = raw.get("deep_dive_logs")
-			if isinstance(run_logs_value, list):
-				deep_dive_logs = [
-					item
-					for item in run_logs_value
-					if isinstance(item, dict)
-					and isinstance(item.get("name"), str)
-					and isinstance(item.get("excerpt"), str)
-				]
 		elif isinstance(raw, list):
 			run_metrics = [item for item in raw if isinstance(item, dict)]
 		else:
@@ -303,8 +146,6 @@ def load_input_data(args: argparse.Namespace) -> dict[str, Any]:
 			if not isinstance(raw_collector, dict):
 				raise ValueError(f"expected JSON object in {collector_path}")
 			collector_report = raw_collector
-			if isinstance(raw_collector.get("runs"), list):
-				deep_dive_logs = _collect_deep_dive_logs_from_runs(raw_collector.get("runs") or [])
 			source_files.append(str(collector_path))
 
 		run_metrics_path = data_dir / "run_metrics.json"
@@ -323,12 +164,6 @@ def load_input_data(args: argparse.Namespace) -> dict[str, Any]:
 			summary_stats = raw_summary
 			source_files.append(str(summary_path))
 
-		run_logs_dir = data_dir / "run_logs"
-		run_logs = _collect_deep_dive_logs(run_logs_dir)
-		if run_logs:
-			deep_dive_logs.extend(run_logs)
-			source_files.append(str(run_logs_dir))
-
 	if collector_report is None and run_metrics is None and summary_stats is None:
 		raise ValueError(
 			"no input data found; provide --input or --data-dir with workflow_log_report.json "
@@ -340,7 +175,6 @@ def load_input_data(args: argparse.Namespace) -> dict[str, Any]:
 		"collector_report": collector_report,
 		"run_metrics": run_metrics,
 		"summary_stats": summary_stats,
-		"deep_dive_logs": deep_dive_logs,
 	}
 
 
@@ -500,17 +334,20 @@ def prepare_analysis_context(input_data: dict[str, Any]) -> dict[str, Any]:
 	total_runs = _to_int(summary.get("total_runs"), len(runs))
 	insufficient_data = total_runs <= 0
 
+	# `deep_dive_logs` is intentionally omitted from this payload — full
+	# untruncated step logs are exported by the collector under
+	# `--log-output-dir` and shipped via the `workflow-log-output` artifact
+	# for Codex to read directly.
 	return {
 		"source_files": input_data.get("source_files") or [],
 		"scope": scope,
 		"summary": summary,
 		"per_repo": per_repo,
 		"per_workflow_family": per_workflow_family,
-		"failing_runs": failing_runs[:25],
-		"slow_runs": slow_runs[:25],
-		"recent_runs": recent_runs[:25],
-		"errors": errors[:100],
-		"deep_dive_logs": input_data.get("deep_dive_logs") or [],
+		"failing_runs": failing_runs[:RUN_LIST_CAP],
+		"slow_runs": slow_runs[:RUN_LIST_CAP],
+		"recent_runs": recent_runs[:RUN_LIST_CAP],
+		"errors": errors[:ERRORS_CAP],
 		"insufficient_data": insufficient_data,
 		"analysis_guidance": (
 			"No workflow runs were available in the selected window. "
@@ -519,540 +356,6 @@ def prepare_analysis_context(input_data: dict[str, Any]) -> dict[str, Any]:
 			else ""
 		),
 	}
-
-
-def truncate_to_budget(context: dict[str, Any], prompt_token_budget: int) -> dict[str, Any]:
-	removed = {
-		"deep_dive_logs": 0,
-		"recent_runs": 0,
-		"slow_runs": 0,
-		"failing_runs": 0,
-		"errors": 0,
-		"per_repo": 0,
-		"per_workflow_family": 0,
-	}
-
-	if prompt_token_budget <= 0:
-		trimmed = dict(context)
-		trimmed["truncation"] = {
-			"estimated_tokens": _estimate_tokens(trimmed),
-			"prompt_token_budget": prompt_token_budget,
-			"removed": removed,
-		}
-		return trimmed
-
-	trimmed = copy.deepcopy(context)
-
-	def estimate() -> int:
-		return _estimate_tokens(trimmed)
-
-	def trim_list_field(field_name: str) -> None:
-		nonlocal trimmed
-		while estimate() > prompt_token_budget and isinstance(trimmed.get(field_name), list) and trimmed[field_name]:
-			trimmed[field_name].pop()
-			removed[field_name] += 1
-
-	for field in ("deep_dive_logs", "recent_runs", "slow_runs", "failing_runs", "errors"):
-		trim_list_field(field)
-
-	for field in ("per_repo", "per_workflow_family"):
-		field_dict = trimmed.get(field)
-		if not isinstance(field_dict, dict) or not field_dict:
-			continue
-		ordered_keys = sorted(
-			field_dict.keys(),
-			key=lambda key: (_to_int((field_dict.get(key) if isinstance(field_dict.get(key), dict) else {}).get("total_runs"), 0), key),
-		)
-		for key in ordered_keys:
-			if estimate() <= prompt_token_budget:
-				break
-			del field_dict[key]
-			removed[field] += 1
-
-	trimmed["truncation"] = {
-		"estimated_tokens": estimate(),
-		"prompt_token_budget": prompt_token_budget,
-		"removed": removed,
-		"budget_exceeded": estimate() > prompt_token_budget,
-	}
-	return trimmed
-
-
-def build_prompt_messages(prompt_template: str, analysis_context: dict[str, Any]) -> list[dict[str, str]]:
-	context_json = json.dumps(analysis_context, ensure_ascii=True, indent=2, sort_keys=True)
-	user_content = (
-		"Analyze the workflow telemetry payload and produce a markdown optimization report.\n"
-		"If `insufficient_data` is true, explicitly state that the data window is insufficient and "
-		"provide concrete next collection steps.\n\n"
-		"Telemetry payload:\n"
-		"```json\n"
-		f"{context_json}\n"
-		"```\n"
-	)
-	return [
-		{"role": "system", "content": prompt_template.strip()},
-		{"role": "user", "content": user_content},
-	]
-
-
-def _extract_content_value(content: Any) -> str:
-	if isinstance(content, str):
-		return content
-	if isinstance(content, list):
-		parts: list[str] = []
-		for item in content:
-			if isinstance(item, str):
-				parts.append(item)
-			elif isinstance(item, dict):
-				text_value = item.get("text")
-				if isinstance(text_value, str):
-					parts.append(text_value)
-		return "\n".join(part for part in parts if part)
-	return ""
-
-
-def _is_truthy(value: Any) -> bool:
-	if isinstance(value, bool):
-		return value
-	normalized = str(value or "").strip().lower()
-	return normalized in {"1", "true", "yes", "on"}
-
-
-def _normalize_batch_provider(value: str | None) -> str:
-	normalized = str(value or "").strip().lower()
-	if normalized in {"openai", "anthropic"}:
-		return normalized
-	return "auto"
-
-
-def _batch_log(event: str, *, severity: str = "INFO", **fields: Any) -> None:
-	payload: dict[str, Any] = {"event": event}
-	payload.update(fields)
-	message = json.dumps(payload, ensure_ascii=True, sort_keys=True)
-	normalized_severity = severity.upper()
-	if normalized_severity == "WARNING":
-		print(f"::warning::{message}", file=sys.stderr)
-	elif normalized_severity == "ERROR":
-		print(f"::error::{message}", file=sys.stderr)
-	print(f"{normalized_severity}: {message}", file=sys.stderr)
-
-
-def _openrouter_request_json(
-	*,
-	api_key: str,
-	base_url: str,
-	path: str,
-	request_timeout_seconds: int,
-	method: str,
-	payload: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-	request_data = None
-	headers = {
-		"Authorization": f"Bearer {api_key}",
-	}
-	if payload is not None:
-		request_data = json.dumps(payload).encode("utf-8")
-		headers["Content-Type"] = "application/json"
-	request = urllib.request.Request(
-		f"{base_url.rstrip('/')}/{path.lstrip('/')}",
-		data=request_data,
-		headers=headers,
-		method=method,
-	)
-	try:
-		with urllib.request.urlopen(request, timeout=request_timeout_seconds) as response:
-			response_text = response.read().decode("utf-8")
-	except urllib.error.HTTPError as exc:
-		try:
-			error_text = exc.read().decode("utf-8", errors="replace")
-		except Exception:  # noqa: BLE001
-			error_text = ""
-		raise RuntimeError(f"OpenRouter request failed (HTTP {exc.code}): {error_text or exc.reason}") from exc
-	except (urllib.error.URLError, OSError, TimeoutError) as exc:
-		raise RuntimeError(f"OpenRouter request failed: {exc}") from exc
-
-	try:
-		response_payload = json.loads(response_text)
-	except json.JSONDecodeError as exc:
-		raise RuntimeError(f"OpenRouter returned invalid JSON: {exc}") from exc
-
-	if not isinstance(response_payload, dict):
-		raise RuntimeError("OpenRouter returned non-object JSON response")
-	return response_payload
-
-
-def _extract_endpoint_entries(payload: dict[str, Any]) -> list[dict[str, Any]]:
-	entries: list[dict[str, Any]] = []
-	for key in ("data", "endpoints"):
-		value = payload.get(key)
-		if isinstance(value, list):
-			for item in value:
-				if isinstance(item, dict):
-					entries.append(item)
-		if isinstance(value, dict):
-			for subvalue in value.values():
-				if isinstance(subvalue, dict):
-					entries.append(subvalue)
-	if isinstance(payload.get("result"), list):
-		for item in payload["result"]:
-			if isinstance(item, dict):
-				entries.append(item)
-	return entries
-
-
-def _entry_supports_background(entry: dict[str, Any]) -> bool:
-	if _is_truthy(entry.get("supports_background")) or _is_truthy(entry.get("background")):
-		return True
-	for key in ("parameters", "supported_parameters", "params"):
-		value = entry.get(key)
-		if isinstance(value, list):
-			for param in value:
-				if isinstance(param, str) and param.strip().lower() == "background":
-					return True
-				if isinstance(param, dict):
-					name = str(param.get("name") or "").strip().lower()
-					if name == "background":
-						return True
-	return False
-
-
-def _entry_matches_responses(entry: dict[str, Any]) -> bool:
-	for key in ("endpoint", "name", "path", "type", "id"):
-		value = str(entry.get(key) or "").strip().lower()
-		if "responses" in value:
-			return True
-		if "chat/completions" in value:
-			return False
-	return False
-
-
-def _entry_supports_provider(entry: dict[str, Any], provider_hint: str) -> bool:
-	if provider_hint == "auto":
-		return True
-	for key in ("provider", "providers", "supported_providers"):
-		value = entry.get(key)
-		if isinstance(value, str):
-			if provider_hint == value.strip().lower():
-				return True
-		if isinstance(value, list):
-			for item in value:
-				if isinstance(item, str) and provider_hint == item.strip().lower():
-					return True
-				if isinstance(item, dict):
-					name = str(item.get("name") or item.get("slug") or "").strip().lower()
-					if provider_hint == name:
-						return True
-	return False
-
-
-def _batch_capability_decision(
-	*,
-	api_key: str,
-	model: str,
-	base_url: str,
-	request_timeout_seconds: int,
-	provider_hint: str,
-) -> tuple[str, str]:
-	if "/" not in model:
-		return "unsupported", "model_id_missing_author"
-	author, slug = model.split("/", 1)
-	if not author.strip() or not slug.strip():
-		return "unsupported", "model_id_missing_author"
-	path = f"models/{urllib.parse.quote(author, safe='')}/{urllib.parse.quote(slug, safe='')}/endpoints"
-	try:
-		payload = _openrouter_request_json(
-			api_key=api_key,
-			base_url=base_url,
-			path=path,
-			request_timeout_seconds=request_timeout_seconds,
-			method="GET",
-		)
-	except RuntimeError as exc:
-		return "unknown", f"capability_probe_failed:{exc}"
-
-	entries = _extract_endpoint_entries(payload)
-	if not entries:
-		return "unknown", "capability_schema_unknown"
-
-	response_entries = [entry for entry in entries if _entry_matches_responses(entry)]
-	if not response_entries:
-		return "unsupported", "responses_endpoint_missing"
-
-	provider_compatible: list[dict[str, Any]] = []
-	for entry in response_entries:
-		if _entry_supports_provider(entry, provider_hint):
-			provider_compatible.append(entry)
-	if provider_hint != "auto" and not provider_compatible:
-		return "unsupported", "provider_not_supported"
-
-	background_compatible = [entry for entry in provider_compatible or response_entries if _entry_supports_background(entry)]
-	if not background_compatible:
-		return "unsupported", "background_param_not_supported"
-	return "supported", "batch_supported"
-
-
-def _build_batch_state(
-	*,
-	batch_id: str,
-	status: str,
-	provider_hint: str,
-	model: str,
-	poll_timeout_hours: int,
-	submitted_at: str,
-	last_polled_at: str | None = None,
-	fallback_reason: str | None = None,
-) -> dict[str, Any]:
-	source_run_id = str(os.getenv("GITHUB_RUN_ID", "")).strip()
-	state: dict[str, Any] = {
-		"schema_version": DEFAULT_BATCH_STATE_SCHEMA_VERSION,
-		"batch_id": batch_id,
-		"status": status,
-		"submitted_at": submitted_at,
-		"provider_hint": provider_hint,
-		"model": model,
-		"poll_timeout_hours": poll_timeout_hours,
-		"source_workflow": str(os.getenv("GITHUB_WORKFLOW", "workflow-log-analysis") or "workflow-log-analysis"),
-		"source_run_id": source_run_id,
-	}
-	if last_polled_at:
-		state["last_polled_at"] = last_polled_at
-	if fallback_reason:
-		state["fallback_reason"] = fallback_reason
-	return state
-
-
-def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
-	path.parent.mkdir(parents=True, exist_ok=True)
-	with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as tmp:
-		json.dump(payload, tmp, ensure_ascii=True, indent=2, sort_keys=True)
-		tmp.write("\n")
-		tmp_path = Path(tmp.name)
-	tmp_path.replace(path)
-
-
-def _load_batch_state(path: Path) -> dict[str, Any] | None:
-	if not path.exists() or not path.is_file():
-		return None
-	try:
-		raw = _load_json_file(path)
-	except ValueError:
-		return None
-	if not isinstance(raw, dict):
-		return None
-	batch_id = str(raw.get("batch_id") or "").strip()
-	status = str(raw.get("status") or "").strip().lower()
-	if not batch_id or not status:
-		return None
-	raw["batch_id"] = batch_id
-	raw["status"] = status
-	return raw
-
-
-def _extract_response_text(payload: dict[str, Any]) -> str:
-	text_fields = [
-		payload.get("output_text"),
-		(payload.get("response") or {}).get("output_text") if isinstance(payload.get("response"), dict) else None,
-	]
-	for candidate in text_fields:
-		if isinstance(candidate, str) and candidate.strip():
-			return candidate
-
-	output = payload.get("output")
-	if isinstance(output, list):
-		parts: list[str] = []
-		for item in output:
-			if not isinstance(item, dict):
-				continue
-			content = item.get("content")
-			if isinstance(content, list):
-				for block in content:
-					if not isinstance(block, dict):
-						continue
-					text_value = block.get("text")
-					if isinstance(text_value, str) and text_value:
-						parts.append(text_value)
-		if parts:
-			return "\n".join(parts)
-
-	choices = payload.get("choices")
-	if isinstance(choices, list) and choices:
-		first_choice = choices[0] if isinstance(choices[0], dict) else {}
-		message = first_choice.get("message") if isinstance(first_choice.get("message"), dict) else {}
-		content = _extract_content_value(message.get("content"))
-		if content.strip():
-			return content
-
-	return ""
-
-
-def submit_openrouter_batch(
-	*,
-	api_key: str,
-	model: str,
-	messages: list[dict[str, str]],
-	temperature: float,
-	max_tokens: int,
-	base_url: str,
-	request_timeout_seconds: int,
-	thinking_level: str | None,
-	provider_hint: str,
-) -> tuple[str, str]:
-	input_items: list[dict[str, Any]] = []
-	for message in messages:
-		role = str(message.get("role") or "user").strip() or "user"
-		content_text = str(message.get("content") or "")
-		input_items.append(
-			{
-				"role": role,
-				"content": [{"type": "input_text", "text": content_text}],
-			}
-		)
-
-	payload: dict[str, Any] = {
-		"model": model,
-		"input": input_items,
-		"background": True,
-		"temperature": temperature,
-		"max_output_tokens": max_tokens,
-	}
-	normalized_thinking_level = ""
-	if thinking_level is not None:
-		normalized_thinking_level = str(thinking_level).strip()
-	if normalized_thinking_level:
-		payload["reasoning"] = normalized_thinking_level
-	if provider_hint in {"openai", "anthropic"}:
-		payload["provider"] = {"order": [provider_hint]}
-
-	response_payload = _openrouter_request_json(
-		api_key=api_key,
-		base_url=base_url,
-		path="responses",
-		request_timeout_seconds=request_timeout_seconds,
-		method="POST",
-		payload=payload,
-	)
-	batch_id = str(response_payload.get("id") or "").strip()
-	if not batch_id:
-		raise RuntimeError("OpenRouter batch submit response missing id")
-	status = str(response_payload.get("status") or "submitted").strip().lower() or "submitted"
-	return batch_id, status
-
-
-def poll_openrouter_batch(
-	*,
-	api_key: str,
-	base_url: str,
-	batch_id: str,
-	request_timeout_seconds: int,
-) -> tuple[str, str, dict[str, Any], str, dict[str, Any] | None]:
-	response_payload = _openrouter_request_json(
-		api_key=api_key,
-		base_url=base_url,
-		path=f"responses/{urllib.parse.quote(batch_id, safe='')}",
-		request_timeout_seconds=request_timeout_seconds,
-		method="GET",
-	)
-	status = str(response_payload.get("status") or "unknown").strip().lower() or "unknown"
-	content = _extract_response_text(response_payload).rstrip()
-	usage_value = response_payload.get("usage")
-	usage = usage_value if isinstance(usage_value, dict) else None
-	batch_status = str(response_payload.get("status") or "unknown").strip().lower() or "unknown"
-	return status, batch_status, response_payload, content, usage
-
-
-def call_openrouter(
-	*,
-	api_key: str,
-	model: str,
-	messages: list[dict[str, str]],
-	temperature: float,
-	max_tokens: int,
-	base_url: str,
-	request_timeout_seconds: int,
-	thinking_level: str | None = None,
-) -> tuple[str, dict[str, Any] | None]:
-	base_messages = [dict(message) for message in messages]
-	messages_with_breakpoint, breakpoint_enabled = add_ephemeral_cache_breakpoint(
-		base_messages,
-		model_id=model,
-	)
-	request_messages = messages_with_breakpoint
-	had_cache_fallback_retry = False
-
-	def build_payload(payload_messages: list[dict[str, Any]]) -> dict[str, Any]:
-		payload_data = {
-			"model": model,
-			"messages": payload_messages,
-			"temperature": temperature,
-			"max_tokens": max_tokens,
-		}
-		normalized_thinking_level = ""
-		if thinking_level is not None:
-			normalized_thinking_level = str(thinking_level).strip()
-		if normalized_thinking_level:
-			payload_data["reasoning"] = normalized_thinking_level
-		return payload_data
-
-	response_text = ""
-	while True:
-		payload = build_payload(request_messages)
-		request_body = json.dumps(payload).encode("utf-8")
-		request = urllib.request.Request(
-			f"{base_url.rstrip('/')}/chat/completions",
-			data=request_body,
-			headers={
-				"Content-Type": "application/json",
-				"Authorization": f"Bearer {api_key}",
-			},
-			method="POST",
-		)
-
-		try:
-			with urllib.request.urlopen(request, timeout=request_timeout_seconds) as response:
-				response_text = response.read().decode("utf-8")
-			break
-		except urllib.error.HTTPError as exc:
-			try:
-				error_text = exc.read().decode("utf-8", errors="replace")
-			except Exception:  # noqa: BLE001
-				error_text = ""
-			if (
-				breakpoint_enabled
-				and not had_cache_fallback_retry
-				and should_retry_without_breakpoint(exc.code, error_text)
-			):
-				had_cache_fallback_retry = True
-				request_messages = base_messages
-				continue
-			raise RuntimeError(
-				f"OpenRouter request failed (HTTP {exc.code}): {error_text or exc.reason}"
-			) from exc
-		except (urllib.error.URLError, OSError, TimeoutError) as exc:
-			raise RuntimeError(f"OpenRouter request failed: {exc}") from exc
-
-	try:
-		response_payload = json.loads(response_text)
-	except json.JSONDecodeError as exc:
-		raise RuntimeError(f"OpenRouter returned invalid JSON: {exc}") from exc
-
-	if not isinstance(response_payload, dict):
-		raise RuntimeError("OpenRouter returned non-object JSON response")
-
-	choices = response_payload.get("choices")
-	if not isinstance(choices, list) or not choices:
-		raise RuntimeError("OpenRouter response did not include choices")
-	first_choice = choices[0] if isinstance(choices[0], dict) else {}
-	message = first_choice.get("message") if isinstance(first_choice.get("message"), dict) else {}
-	content = _extract_content_value(message.get("content"))
-	if not content.strip():
-		raise RuntimeError("OpenRouter response did not include message content")
-
-	usage_value = response_payload.get("usage")
-	usage = normalize_usage(usage_value) if isinstance(usage_value, dict) else None
-	if usage is not None:
-		usage["cache_breakpoint_enabled"] = breakpoint_enabled and not is_cache_disabled()
-		usage["cache_breakpoint_fallback_retry"] = had_cache_fallback_retry
-	return content.rstrip() + "\n", usage
 
 
 def resolve_dated_output_path(
@@ -1078,71 +381,16 @@ def resolve_dated_output_path(
 		suffix += 1
 
 
-def write_report_atomic(path: Path, content: str) -> None:
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
 	path.parent.mkdir(parents=True, exist_ok=True)
-	with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as tmp:
-		tmp.write(content)
-		tmp_path = Path(tmp.name)
+	tmp_path = path.with_suffix(path.suffix + ".tmp")
+	tmp_path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
 	tmp_path.replace(path)
-
-
-def load_prompt_template(path: Path) -> str:
-	prompt_path = path.resolve()
-	try:
-		template = prompt_path.read_text(encoding="utf-8")
-	except (OSError, UnicodeDecodeError) as exc:
-		raise RuntimeError(f"unable to read prompt file {path}: {exc}") from exc
-	if not SERENA_PLACEHOLDER_PATTERN.search(template):
-		return template
-
-	render_script = Path(__file__).resolve().with_name("render_prompt.sh")
-	if not render_script.is_file():
-		raise RuntimeError(
-			f"prompt contains Serena placeholders but renderer not found at expected location: {render_script}"
-		)
-
-	# scripts/render_prompt.sh is expected at <repo_root>/scripts/render_prompt.sh.
-	repo_root = render_script.parent.parent
-	try:
-		result = subprocess.run(
-			["bash", str(render_script), str(prompt_path)],
-			check=True,
-			capture_output=True,
-			text=True,
-			cwd=repo_root,
-		)
-	except OSError as exc:
-		raise RuntimeError(f"unable to execute prompt renderer for {path}: {exc}") from exc
-	except subprocess.CalledProcessError as exc:
-		stderr = (exc.stderr or "").strip()
-		detail = f": {stderr}" if stderr else ""
-		raise RuntimeError(f"unable to render prompt file {path}{detail}") from exc
-	return result.stdout
 
 
 def main(argv: list[str] | None = None) -> int:
 	parser = build_parser()
 	args = parser.parse_args(argv)
-
-	if args.prompt_token_budget < 0:
-		print("ERROR: --prompt-token-budget must be >= 0", file=sys.stderr)
-		return 2
-	if args.max_output_tokens <= 0:
-		print("ERROR: --max-output-tokens must be > 0", file=sys.stderr)
-		return 2
-	if args.request_timeout_seconds <= 0:
-		print("ERROR: --request-timeout-seconds must be > 0", file=sys.stderr)
-		return 2
-	if args.batch_poll_timeout_hours <= 0:
-		print("ERROR: --batch-poll-timeout-hours must be > 0", file=sys.stderr)
-		return 2
-
-	api_key = ""
-	if not args.codex_mode:
-		api_key = os.getenv("OPENROUTER_API_KEY", "").strip()
-		if not api_key:
-			print("ERROR: OPENROUTER_API_KEY is required", file=sys.stderr)
-			return 2
 
 	try:
 		input_data = load_input_data(args)
@@ -1152,285 +400,16 @@ def main(argv: list[str] | None = None) -> int:
 
 	analysis_context = prepare_analysis_context(input_data)
 
-	if args.codex_mode:
-		context_output_base = resolve_dated_output_path(args.output, args.output_dir)
-		context_path = context_output_base.parent / "analysis_context.json"
-		try:
-			_write_json_atomic(context_path, analysis_context)
-		except OSError as exc:
-			print(f"ERROR: failed to write analysis context {context_path}: {exc}", file=sys.stderr)
-			return 1
-		print(str(context_path))
-		return 0
-
-	prompt_path = Path(args.prompt_file)
+	context_output_base = resolve_dated_output_path(args.output, args.output_dir)
+	context_path = context_output_base.parent / "analysis_context.json"
 	try:
-		prompt_template = load_prompt_template(prompt_path)
-	except RuntimeError as exc:
-		print(f"ERROR: {exc}", file=sys.stderr)
-		return 2
+		_write_json_atomic(context_path, analysis_context)
+	except OSError as exc:
+		print(f"ERROR: failed to write analysis context {context_path}: {exc}", file=sys.stderr)
+		return 1
 
-	trimmed_context = truncate_to_budget(analysis_context, args.prompt_token_budget)
-	messages = build_prompt_messages(prompt_template, trimmed_context)
-
-	model = str(args.model or DEFAULT_MODEL)
-	provider_hint = _normalize_batch_provider(args.batch_provider)
-	batch_disabled = _is_truthy(args.batch_api_disabled)
-	batch_mode = str(args.batch_mode or "auto").strip().lower() or "auto"
-	state_path = Path(str(args.batch_state_file or "").strip()) if str(args.batch_state_file or "").strip() else None
-	state = _load_batch_state(state_path) if state_path is not None else None
-	now = datetime.now(timezone.utc)
-
-	def run_sync(reason: str) -> int:
-		state_for_fallback = _load_batch_state(state_path) if state_path is not None else None
-		state_for_fallback_status = str((state_for_fallback or {}).get("status") or "").strip().lower()
-		if state_path is not None and state_for_fallback is not None and state_for_fallback_status in PENDING_BATCH_STATUSES:
-			fallback_batch_id = str(state_for_fallback.get("batch_id") or "").strip()
-			if fallback_batch_id:
-				fallback_state = _build_batch_state(
-					batch_id=fallback_batch_id,
-					status="fallback_sync",
-					provider_hint=provider_hint,
-					model=model,
-					poll_timeout_hours=int(args.batch_poll_timeout_hours),
-					submitted_at=str(state_for_fallback.get("submitted_at") or now.isoformat()),
-					last_polled_at=now.isoformat(),
-					fallback_reason=reason,
-				)
-				try:
-					_write_json_atomic(state_path, fallback_state)
-				except OSError as exc:
-					_batch_log(
-						"batch_fallback",
-						severity="WARNING",
-						reason=f"fallback_state_write_failed:{exc}",
-						provider=provider_hint,
-						model=model,
-						batch_id=fallback_batch_id,
-					)
-
-		_batch_log(
-			"batch_fallback",
-			severity="WARNING",
-			reason=reason,
-			provider=provider_hint,
-			model=model,
-		)
-		try:
-			report_markdown, usage = call_openrouter(
-				api_key=api_key,
-				model=model,
-				messages=messages,
-				temperature=float(args.temperature),
-				max_tokens=args.max_output_tokens,
-				base_url=args.openrouter_base_url,
-				request_timeout_seconds=args.request_timeout_seconds,
-				thinking_level=args.thinking_level,
-			)
-		except RuntimeError as exc:
-			print(f"ERROR: {exc}", file=sys.stderr)
-			return 1
-
-		output_path = resolve_dated_output_path(args.output, args.output_dir)
-		try:
-			write_report_atomic(output_path, report_markdown)
-		except OSError as exc:
-			print(f"ERROR: failed to write report {output_path}: {exc}", file=sys.stderr)
-			return 1
-
-		if usage is not None:
-			prompt_tokens = _to_int(usage.get("prompt_tokens"), 0)
-			completion_tokens = _to_int(usage.get("completion_tokens"), 0)
-			total_tokens = _to_int(usage.get("total_tokens"), 0)
-			cache_creation_tokens = usage.get("cache_creation_input_tokens")
-			cache_read_tokens = usage.get("cache_read_input_tokens")
-			cache_breakpoint_enabled = usage.get("cache_breakpoint_enabled")
-			cache_breakpoint_retry = usage.get("cache_breakpoint_fallback_retry")
-			cache_enabled = "false" if is_cache_disabled() else "true"
-			print(
-				"INFO: openrouter usage "
-				f"phase=workflow_log_analysis model={model} "
-				f"cache_enabled={cache_enabled} "
-				f"cache_breakpoint_enabled={str(bool(cache_breakpoint_enabled)).lower()} "
-				f"cache_breakpoint_fallback_retry={str(bool(cache_breakpoint_retry)).lower()} "
-				f"prompt_tokens={prompt_tokens} completion_tokens={completion_tokens} total_tokens={total_tokens} "
-				f"cache_creation_input_tokens={format_usage_value(cache_creation_tokens)} "
-				f"cache_read_input_tokens={format_usage_value(cache_read_tokens)}",
-				file=sys.stderr,
-			)
-		print(str(output_path))
-		return 0
-
-	if batch_mode == "sync":
-		return run_sync("batch_mode_sync")
-
-	if batch_disabled:
-		return run_sync("batch_api_disabled")
-
-	state_status = str((state or {}).get("status") or "").strip().lower()
-	has_pending_state = state is not None and state_status in PENDING_BATCH_STATUSES
-
-	if batch_mode in {"auto", "poll"} and has_pending_state:
-		batch_id = str(state.get("batch_id") or "").strip()
-		submitted_at = _parse_iso8601(str(state.get("submitted_at") or ""))
-		if batch_id:
-			if submitted_at is not None:
-				timeout_at = submitted_at + timedelta(hours=int(args.batch_poll_timeout_hours))
-				if now >= timeout_at:
-					return run_sync("batch_poll_timeout")
-			else:
-				_batch_log(
-					"batch_poll",
-					severity="WARNING",
-					status="submitted_at_invalid",
-					batch_id=batch_id,
-					provider=provider_hint,
-					model=model,
-				)
-			try:
-				status, batch_status, _response_payload, report_content, usage = poll_openrouter_batch(
-					api_key=api_key,
-					base_url=args.openrouter_base_url,
-					batch_id=batch_id,
-					request_timeout_seconds=args.request_timeout_seconds,
-				)
-			except RuntimeError as exc:
-				_batch_log(
-					"batch_fallback",
-					severity="WARNING",
-					reason=f"batch_poll_error:{exc}",
-					provider=provider_hint,
-					model=model,
-					batch_id=batch_id,
-				)
-				return run_sync("batch_poll_error")
-
-			_batch_log(
-				"batch_poll",
-				status=status,
-				batch_status=batch_status,
-				batch_id=batch_id,
-				provider=provider_hint,
-				model=model,
-			)
-
-			if status in {"completed"}:
-				if not report_content.strip():
-					return run_sync("batch_completed_without_content")
-				output_path = resolve_dated_output_path(args.output, args.output_dir)
-				try:
-					write_report_atomic(output_path, report_content.rstrip() + "\n")
-				except OSError as exc:
-					print(f"ERROR: failed to write report {output_path}: {exc}", file=sys.stderr)
-					return 1
-				if state_path is not None:
-					completed_state = _build_batch_state(
-						batch_id=batch_id,
-						status="completed",
-						provider_hint=provider_hint,
-						model=model,
-						poll_timeout_hours=int(args.batch_poll_timeout_hours),
-						submitted_at=str(state.get("submitted_at") or now.isoformat()),
-						last_polled_at=now.isoformat(),
-					)
-					_write_json_atomic(state_path, completed_state)
-				_batch_log(
-					"batch_complete",
-					batch_id=batch_id,
-					provider=provider_hint,
-					model=model,
-				)
-				if usage is not None:
-					prompt_tokens = _to_int(usage.get("prompt_tokens"), 0)
-					completion_tokens = _to_int(usage.get("completion_tokens"), 0)
-					total_tokens = _to_int(usage.get("total_tokens"), 0)
-					print(
-						f"INFO: openrouter usage prompt_tokens={prompt_tokens} completion_tokens={completion_tokens} total_tokens={total_tokens}",
-						file=sys.stderr,
-					)
-				print(str(output_path))
-				return 0
-
-			if status in PENDING_BATCH_STATUSES:
-				if state_path is not None:
-					pending_state = _build_batch_state(
-						batch_id=batch_id,
-						status=batch_status,
-						provider_hint=provider_hint,
-						model=model,
-						poll_timeout_hours=int(args.batch_poll_timeout_hours),
-						submitted_at=str(state.get("submitted_at") or now.isoformat()),
-						last_polled_at=now.isoformat(),
-					)
-					_write_json_atomic(state_path, pending_state)
-				_batch_log(
-					"batch_poll",
-					status="pending",
-					batch_id=batch_id,
-					provider=provider_hint,
-					model=model,
-				)
-				return 3
-
-			if status in {"incomplete", "failed", "cancelled"}:
-				return run_sync(f"batch_status_{status}")
-
-			return run_sync(f"batch_unknown_status_{status}")
-
-	if batch_mode == "poll":
-		return run_sync("batch_poll_requested_without_state")
-
-	if batch_mode in {"auto", "submit"}:
-		capability, reason = _batch_capability_decision(
-			api_key=api_key,
-			model=model,
-			base_url=args.openrouter_base_url,
-			request_timeout_seconds=args.request_timeout_seconds,
-			provider_hint=provider_hint,
-		)
-		if capability == "unsupported":
-			return run_sync(reason)
-		if capability == "unknown" and batch_mode == "auto":
-			return run_sync(reason)
-		try:
-			batch_id, batch_status = submit_openrouter_batch(
-				api_key=api_key,
-				model=model,
-				messages=messages,
-				temperature=float(args.temperature),
-				max_tokens=args.max_output_tokens,
-				base_url=args.openrouter_base_url,
-				request_timeout_seconds=args.request_timeout_seconds,
-				thinking_level=args.thinking_level,
-				provider_hint=provider_hint,
-			)
-		except RuntimeError as exc:
-			if batch_mode == "submit":
-				print(f"ERROR: {exc}", file=sys.stderr)
-				return 1
-			return run_sync(f"batch_submit_error:{exc}")
-
-		submitted_at_iso = now.isoformat()
-		if state_path is not None:
-			state_payload = _build_batch_state(
-				batch_id=batch_id,
-				status=batch_status,
-				provider_hint=provider_hint,
-				model=model,
-				poll_timeout_hours=int(args.batch_poll_timeout_hours),
-				submitted_at=submitted_at_iso,
-			)
-			_write_json_atomic(state_path, state_payload)
-		_batch_log(
-			"batch_submit",
-			batch_id=batch_id,
-			status=batch_status,
-			provider=provider_hint,
-			model=model,
-		)
-		return 3
-
-	return run_sync("batch_mode_unhandled")
+	print(str(context_path))
+	return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_analyze_workflow_logs.py
+++ b/tests/test_analyze_workflow_logs.py
@@ -273,3 +273,22 @@ def test_aggregate_runs_by_key_computes_failure_rate_and_durations():
 	assert abs(out["a"]["failure_rate"] - 0.5) < 1e-9
 	assert out["a"]["avg_duration_seconds"] == 75.0
 	assert out["b"]["failure_rate"] == 1.0
+
+
+# ---------- script-mode entry point ---------------------------------------
+# CI's "Workflow log analyzer coverage gate" invokes this file directly:
+#   python3 -m coverage run tests/test_analyze_workflow_logs.py
+# Several of the tests above rely on pytest fixtures (`capsys`, `pytest.raises`),
+# so a plain `python3 <file>` invocation that walks module-level functions
+# would silently skip those tests and starve the coverage gate. Delegate to
+# `pytest.main()` so the same process runs every test and coverage.py keeps
+# tracking lines through the import.
+
+
+def main() -> int:
+	exit_code = pytest.main(["-x", "--tb=short", "--no-header", __file__])
+	return int(exit_code)
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_analyze_workflow_logs.py
+++ b/tests/test_analyze_workflow_logs.py
@@ -9,18 +9,28 @@ sync/batch pathway has been removed. These tests cover:
     `deep_dive_logs` field intentionally excluded
   * resolve_dated_output_path collision handling
   * main() writes analysis_context.json and prints its path
+
+The file is runnable two ways:
+  * via pytest (for local dev): `python3 -m pytest tests/test_analyze_workflow_logs.py`
+  * as a plain script (for CI's coverage gate at `.github/workflows/ci.yml:199`):
+    `python3 -m coverage run tests/test_analyze_workflow_logs.py`
+
+CI installs `yamllint coverage pyyaml jsonschema jinja2` only — no pytest —
+so the script-mode entry point at the bottom must NOT depend on pytest.
+That's why the test bodies use plain `try/except`/`io.StringIO` instead
+of `pytest.raises`/`capsys` fixtures.
 """
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import json
 import sys
 import tempfile
 from datetime import date
 from pathlib import Path
-
-import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -38,6 +48,24 @@ spec.loader.exec_module(analyzer)
 def _write_json(path: Path, payload: object) -> None:
 	path.parent.mkdir(parents=True, exist_ok=True)
 	path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+@contextlib.contextmanager
+def _capture_std():
+	"""Replacement for pytest's capsys fixture; works without pytest installed."""
+	out = io.StringIO()
+	err = io.StringIO()
+	with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+		yield out, err
+
+
+def _assert_raises(exc_type: type[BaseException], func, *args, **kwargs) -> BaseException:
+	"""Replacement for pytest.raises; returns the raised exception for further checks."""
+	try:
+		func(*args, **kwargs)
+	except exc_type as exc:
+		return exc
+	raise AssertionError(f"expected {exc_type.__name__} but no exception was raised")
 
 
 # ---------- argparse surface ------------------------------------------------
@@ -63,10 +91,11 @@ def test_build_parser_accepts_input_and_output():
 
 def test_build_parser_rejects_legacy_batch_flags():
 	parser = analyzer.build_parser()
-	with pytest.raises(SystemExit):
-		parser.parse_args(["--prompt-token-budget", "24000"])
-	with pytest.raises(SystemExit):
-		parser.parse_args(["--batch-mode", "auto"])
+	# argparse calls sys.exit(2) with stderr noise on unknown args; suppress
+	# the noise so the script-mode test runner output stays clean.
+	with _capture_std():
+		_assert_raises(SystemExit, parser.parse_args, ["--prompt-token-budget", "24000"])
+		_assert_raises(SystemExit, parser.parse_args, ["--batch-mode", "auto"])
 
 
 # ---------- load_input_data ------------------------------------------------
@@ -78,8 +107,7 @@ def test_load_input_data_rejects_malformed_json_input():
 		path = tmp.name
 	try:
 		args = analyzer.build_parser().parse_args(["--input", path])
-		with pytest.raises(ValueError):
-			analyzer.load_input_data(args)
+		_assert_raises(ValueError, analyzer.load_input_data, args)
 	finally:
 		Path(path).unlink(missing_ok=True)
 
@@ -106,8 +134,7 @@ def test_load_input_data_collector_report_round_trips_runs():
 def test_load_input_data_errors_when_no_data_present():
 	with tempfile.TemporaryDirectory(prefix="analyze-empty-") as td:
 		args = analyzer.build_parser().parse_args(["--data-dir", td])
-		with pytest.raises(ValueError):
-			analyzer.load_input_data(args)
+		_assert_raises(ValueError, analyzer.load_input_data, args)
 
 
 # ---------- prepare_analysis_context ---------------------------------------
@@ -219,7 +246,7 @@ def test_resolve_dated_output_path_uses_explicit_output_when_provided():
 # ---------- main() ---------------------------------------------------------
 
 
-def test_main_writes_analysis_context_and_prints_path(capsys):
+def test_main_writes_analysis_context_and_prints_path():
 	report = {
 		"runs": _make_runs(2, conclusion="failure"),
 		"summary": {"total_runs": 2},
@@ -232,18 +259,18 @@ def test_main_writes_analysis_context_and_prints_path(capsys):
 		_write_json(input_path, report)
 		output_md = td_path / "analysis" / "workflow-optimization-2099-12-31.md"
 
-		exit_code = analyzer.main(
-			[
-				"--input",
-				str(input_path),
-				"--output",
-				str(output_md),
-				"--codex-mode",
-			]
-		)
+		with _capture_std() as (out, _err):
+			exit_code = analyzer.main(
+				[
+					"--input",
+					str(input_path),
+					"--output",
+					str(output_md),
+					"--codex-mode",
+				]
+			)
 		assert exit_code == 0
-		captured = capsys.readouterr()
-		printed_path = Path(captured.out.strip())
+		printed_path = Path(out.getvalue().strip())
 		assert printed_path == output_md.parent / "analysis_context.json"
 		assert printed_path.exists()
 		payload = json.loads(printed_path.read_text(encoding="utf-8"))
@@ -251,11 +278,11 @@ def test_main_writes_analysis_context_and_prints_path(capsys):
 		assert len(payload["failing_runs"]) == 2
 
 
-def test_main_returns_2_when_input_missing(capsys):
-	exit_code = analyzer.main(["--input", "/nonexistent/does-not-exist.json"])
+def test_main_returns_2_when_input_missing():
+	with _capture_std() as (_out, err):
+		exit_code = analyzer.main(["--input", "/nonexistent/does-not-exist.json"])
 	assert exit_code == 2
-	captured = capsys.readouterr()
-	assert "ERROR" in captured.err
+	assert "ERROR" in err.getvalue()
 
 
 # ---------- aggregations ---------------------------------------------------
@@ -278,16 +305,32 @@ def test_aggregate_runs_by_key_computes_failure_rate_and_durations():
 # ---------- script-mode entry point ---------------------------------------
 # CI's "Workflow log analyzer coverage gate" invokes this file directly:
 #   python3 -m coverage run tests/test_analyze_workflow_logs.py
-# Several of the tests above rely on pytest fixtures (`capsys`, `pytest.raises`),
-# so a plain `python3 <file>` invocation that walks module-level functions
-# would silently skip those tests and starve the coverage gate. Delegate to
-# `pytest.main()` so the same process runs every test and coverage.py keeps
-# tracking lines through the import.
+# CI does NOT install pytest, so this entry point must run all tests
+# in-process without any pytest dependency. It walks `test_*` callables
+# in module globals and calls each one; assertion failures abort with a
+# non-zero exit so the coverage gate fails loudly on regressions.
 
 
 def main() -> int:
-	exit_code = pytest.main(["-x", "--tb=short", "--no-header", __file__])
-	return int(exit_code)
+	test_funcs = sorted(
+		(name, obj)
+		for name, obj in globals().items()
+		if name.startswith("test_") and callable(obj)
+	)
+	failures: list[tuple[str, BaseException]] = []
+	for name, func in test_funcs:
+		try:
+			func()
+		except BaseException as exc:  # noqa: BLE001 — script runner aggregates everything
+			failures.append((name, exc))
+			print(f"FAIL: {name}: {exc!r}", file=sys.stderr)
+		else:
+			print(f"PASS: {name}")
+	if failures:
+		print(f"\n{len(failures)} of {len(test_funcs)} tests failed.", file=sys.stderr)
+		return 1
+	print(f"\n{len(test_funcs)} tests passed.")
+	return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_analyze_workflow_logs.py
+++ b/tests/test_analyze_workflow_logs.py
@@ -1,18 +1,26 @@
 #!/usr/bin/env python3
-"""Tests for scripts/analyze_workflow_logs.py."""
+"""Tests for scripts/analyze_workflow_logs.py.
+
+The analyzer now does context preparation only — the legacy OpenRouter
+sync/batch pathway has been removed. These tests cover:
+  * argparse surface (including the deprecated --codex-mode no-op alias)
+  * load_input_data validation
+  * prepare_analysis_context: caps lifted to 100/250 and the
+    `deep_dive_logs` field intentionally excluded
+  * resolve_dated_output_path collision handling
+  * main() writes analysis_context.json and prints its path
+"""
 
 from __future__ import annotations
 
 import importlib.util
-import io
 import json
-import os
-import tempfile
-import urllib.error
-import contextlib
-from datetime import date, datetime, timezone
-from pathlib import Path
 import sys
+import tempfile
+from datetime import date
+from pathlib import Path
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -32,6 +40,160 @@ def _write_json(path: Path, payload: object) -> None:
 	path.write_text(json.dumps(payload), encoding="utf-8")
 
 
+# ---------- argparse surface ------------------------------------------------
+
+
+def test_build_parser_codex_mode_default_false():
+	args = analyzer.build_parser().parse_args([])
+	assert args.codex_mode is False
+
+
+def test_build_parser_accepts_codex_mode_flag():
+	args = analyzer.build_parser().parse_args(["--codex-mode"])
+	assert args.codex_mode is True
+
+
+def test_build_parser_accepts_input_and_output():
+	args = analyzer.build_parser().parse_args(
+		["--input", "in.json", "--output", "out.md"]
+	)
+	assert args.input == "in.json"
+	assert args.output == "out.md"
+
+
+def test_build_parser_rejects_legacy_batch_flags():
+	parser = analyzer.build_parser()
+	with pytest.raises(SystemExit):
+		parser.parse_args(["--prompt-token-budget", "24000"])
+	with pytest.raises(SystemExit):
+		parser.parse_args(["--batch-mode", "auto"])
+
+
+# ---------- load_input_data ------------------------------------------------
+
+
+def test_load_input_data_rejects_malformed_json_input():
+	with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as tmp:
+		tmp.write("{not-json")
+		path = tmp.name
+	try:
+		args = analyzer.build_parser().parse_args(["--input", path])
+		with pytest.raises(ValueError):
+			analyzer.load_input_data(args)
+	finally:
+		Path(path).unlink(missing_ok=True)
+
+
+def test_load_input_data_collector_report_round_trips_runs():
+	report = {
+		"runs": [
+			{"repository": "o/r", "run_id": 1, "conclusion": "failure", "duration_seconds": 90},
+			{"repository": "o/r", "run_id": 2, "conclusion": "success", "duration_seconds": 30},
+		],
+		"summary": {"total_runs": 2},
+		"errors": [],
+		"scope": {"repositories": ["o/r"]},
+	}
+	with tempfile.TemporaryDirectory(prefix="analyze-input-") as td:
+		path = Path(td) / "workflow_log_report.json"
+		_write_json(path, report)
+		args = analyzer.build_parser().parse_args(["--input", str(path)])
+		loaded = analyzer.load_input_data(args)
+	assert loaded["collector_report"] == report
+	assert "deep_dive_logs" not in loaded
+
+
+def test_load_input_data_errors_when_no_data_present():
+	with tempfile.TemporaryDirectory(prefix="analyze-empty-") as td:
+		args = analyzer.build_parser().parse_args(["--data-dir", td])
+		with pytest.raises(ValueError):
+			analyzer.load_input_data(args)
+
+
+# ---------- prepare_analysis_context ---------------------------------------
+
+
+def _make_runs(count: int, *, conclusion: str, base_id: int = 0) -> list[dict]:
+	return [
+		{
+			"repository": "o/r",
+			"run_id": base_id + i,
+			"workflow_name": "ci",
+			"workflow_family": "ci",
+			"conclusion": conclusion,
+			"duration_seconds": 10 * (i + 1),
+			"run_attempt": 1,
+			"retries": 0,
+			"created_at": f"2026-04-{(i % 28) + 1:02d}T00:00:00Z",
+		}
+		for i in range(count)
+	]
+
+
+def test_prepare_analysis_context_lifts_caps_to_100_and_drops_deep_dive_logs():
+	# 150 failing + 200 successful, plus excerpts attached to inputs to confirm
+	# they are NOT propagated into the output context (Q8: B).
+	failing = _make_runs(150, conclusion="failure", base_id=0)
+	for run in failing:
+		run["log_excerpts"] = [{"step_name": "step1", "excerpt": "boom"}]
+	successful = _make_runs(200, conclusion="success", base_id=1000)
+	report = {
+		"runs": failing + successful,
+		"errors": [{"repository": "o/r", "scope": "logs", "message": f"err-{i}"} for i in range(400)],
+	}
+	input_data = {
+		"source_files": ["x.json"],
+		"collector_report": report,
+		"run_metrics": None,
+		"summary_stats": None,
+	}
+
+	ctx = analyzer.prepare_analysis_context(input_data)
+
+	assert "deep_dive_logs" not in ctx
+	assert len(ctx["failing_runs"]) == analyzer.RUN_LIST_CAP == 100
+	assert len(ctx["slow_runs"]) == analyzer.RUN_LIST_CAP == 100
+	assert len(ctx["recent_runs"]) == analyzer.RUN_LIST_CAP == 100
+	assert len(ctx["errors"]) == analyzer.ERRORS_CAP == 250
+	# Each row in the lists is a normalized view, never the raw row, so
+	# log_excerpts must not have leaked through.
+	assert all("log_excerpts" not in run for run in ctx["failing_runs"])
+
+
+def test_prepare_analysis_context_marks_insufficient_data_when_empty():
+	ctx = analyzer.prepare_analysis_context(
+		{
+			"source_files": [],
+			"collector_report": {"runs": [], "summary": {"total_runs": 0}, "errors": []},
+			"run_metrics": None,
+			"summary_stats": None,
+		}
+	)
+	assert ctx["insufficient_data"] is True
+	assert "insufficient" in ctx["analysis_guidance"].lower()
+
+
+def test_prepare_analysis_context_failing_runs_sorted_by_duration():
+	runs = [
+		{"repository": "o/r", "run_id": 1, "conclusion": "failure", "duration_seconds": 10},
+		{"repository": "o/r", "run_id": 2, "conclusion": "failure", "duration_seconds": 500},
+		{"repository": "o/r", "run_id": 3, "conclusion": "success", "duration_seconds": 600},
+	]
+	ctx = analyzer.prepare_analysis_context(
+		{
+			"source_files": [],
+			"collector_report": {"runs": runs, "summary": {}, "errors": []},
+			"run_metrics": None,
+			"summary_stats": None,
+		}
+	)
+	assert [r["run_id"] for r in ctx["failing_runs"]] == [2, 1]
+	assert [r["run_id"] for r in ctx["slow_runs"][:1]] == [3]
+
+
+# ---------- resolve_dated_output_path --------------------------------------
+
+
 def test_resolve_dated_output_path_with_suffix_collision():
 	with tempfile.TemporaryDirectory(prefix="analyze-output-") as td:
 		output_dir = Path(td)
@@ -45,1073 +207,69 @@ def test_resolve_dated_output_path_with_suffix_collision():
 		assert resolved == output_dir / "workflow-optimization-2026-04-11-3.md"
 
 
-def test_truncate_to_budget_drops_deep_dive_before_recent_runs():
-	context = {
-		"summary": {"total_runs": 10},
-		"deep_dive_logs": [{"name": "a.log", "excerpt": "x" * 4000} for _ in range(2)],
-		"recent_runs": [{"run_id": i, "detail": "y" * 2000} for i in range(2)],
-		"slow_runs": [{"run_id": 1}],
-		"failing_runs": [{"run_id": 2}],
-		"errors": [{"message": "z"}],
-		"per_repo": {"owner/repo": {"total_runs": 10}},
-		"per_workflow_family": {"plan": {"total_runs": 5}},
-	}
-	budget = analyzer._estimate_tokens({
-		"summary": context["summary"],
-		"recent_runs": context["recent_runs"],
-		"slow_runs": context["slow_runs"],
-		"failing_runs": context["failing_runs"],
-		"errors": context["errors"],
-		"per_repo": context["per_repo"],
-		"per_workflow_family": context["per_workflow_family"],
-	}) + 64
-	trimmed = analyzer.truncate_to_budget(context, budget)
-	assert trimmed["deep_dive_logs"] == []
-	assert trimmed["recent_runs"] == context["recent_runs"]
-	assert trimmed["truncation"]["removed"]["deep_dive_logs"] == 2
-	assert trimmed["truncation"]["removed"]["recent_runs"] == 0
+def test_resolve_dated_output_path_uses_explicit_output_when_provided():
+	resolved = analyzer.resolve_dated_output_path(
+		"/tmp/explicit.md",
+		"/ignored",
+		today=date(2026, 4, 11),
+	)
+	assert resolved == Path("/tmp/explicit.md")
 
 
-def test_truncate_to_budget_zero_budget_preserves_fields():
-	context = {
+# ---------- main() ---------------------------------------------------------
+
+
+def test_main_writes_analysis_context_and_prints_path(capsys):
+	report = {
+		"runs": _make_runs(2, conclusion="failure"),
 		"summary": {"total_runs": 2},
-		"deep_dive_logs": [{"name": "a.log", "excerpt": "x" * 1000}],
-		"recent_runs": [{"run_id": 1, "detail": "y" * 200}],
-		"slow_runs": [{"run_id": 2}],
-		"failing_runs": [],
 		"errors": [],
-		"per_repo": {"owner/repo": {"total_runs": 2}},
-		"per_workflow_family": {"plan": {"total_runs": 2}},
+		"scope": {"repositories": ["o/r"]},
 	}
-	trimmed = analyzer.truncate_to_budget(context, 0)
-	assert trimmed["deep_dive_logs"] == context["deep_dive_logs"]
-	assert trimmed["recent_runs"] == context["recent_runs"]
-	assert trimmed["truncation"]["prompt_token_budget"] == 0
-	assert trimmed["truncation"]["removed"]["deep_dive_logs"] == 0
-	assert "truncation" not in context
-
-
-def test_build_parser_thinking_level_defaults_to_xhigh():
-	args = analyzer.build_parser().parse_args([])
-	assert args.thinking_level == "xhigh"
-	assert args.prompt_token_budget == 0
-	assert args.codex_mode is False
-
-
-def test_build_parser_accepts_zero_prompt_token_budget():
-	args = analyzer.build_parser().parse_args(["--prompt-token-budget", "0"])
-	assert args.prompt_token_budget == 0
-
-
-def test_build_parser_accepts_explicit_thinking_level():
-	args = analyzer.build_parser().parse_args(["--thinking-level", "high"])
-	assert args.thinking_level == "high"
-
-
-def test_build_parser_batch_defaults_from_env():
-	original_provider = os.environ.get("BATCH_API_PROVIDER")
-	original_disabled = os.environ.get("BATCH_API_DISABLED")
-	original_timeout = os.environ.get("BATCH_API_POLL_TIMEOUT_HOURS")
-	try:
-		os.environ["BATCH_API_PROVIDER"] = "anthropic"
-		os.environ["BATCH_API_DISABLED"] = "true"
-		os.environ["BATCH_API_POLL_TIMEOUT_HOURS"] = "36"
-		args = analyzer.build_parser().parse_args([])
-	finally:
-		if original_provider is None:
-			os.environ.pop("BATCH_API_PROVIDER", None)
-		else:
-			os.environ["BATCH_API_PROVIDER"] = original_provider
-		if original_disabled is None:
-			os.environ.pop("BATCH_API_DISABLED", None)
-		else:
-			os.environ["BATCH_API_DISABLED"] = original_disabled
-		if original_timeout is None:
-			os.environ.pop("BATCH_API_POLL_TIMEOUT_HOURS", None)
-		else:
-			os.environ["BATCH_API_POLL_TIMEOUT_HOURS"] = original_timeout
-
-	assert args.batch_provider == "anthropic"
-	assert args.batch_api_disabled == "true"
-	assert args.batch_poll_timeout_hours == 36
-
-
-def test_call_openrouter_builds_payload_and_parses_response():
-	captured = {"url": "", "payload": {}, "headers": []}
-	orig_urlopen = analyzer.urllib.request.urlopen
-	old_cache_disabled = os.environ.get("OPENROUTER_PROMPT_CACHE_DISABLED")
-	os.environ["OPENROUTER_PROMPT_CACHE_DISABLED"] = "false"
-
-	class FakeResponse:
-		def __init__(self, body: str):
-			self._body = body
-
-		def __enter__(self):
-			return self
-
-		def __exit__(self, exc_type, exc, tb):
-			return False
-
-		def read(self) -> bytes:
-			return self._body.encode("utf-8")
-
-	def fake_urlopen(request, timeout=0):
-		captured["url"] = request.full_url
-		captured["payload"] = json.loads(request.data.decode("utf-8"))
-		captured["headers"] = request.header_items()
-		assert timeout == 17
-		return FakeResponse(
-			json.dumps(
-				{
-					"choices": [{"message": {"content": "# report"}}],
-					"usage": {
-						"prompt_tokens": 11,
-						"completion_tokens": 22,
-						"total_tokens": 33,
-						"prompt_tokens_details": {"cache_write_tokens": 7, "cached_tokens": 5},
-					},
-				}
-			)
-		)
-
-	analyzer.urllib.request.urlopen = fake_urlopen
-	try:
-		content, usage = analyzer.call_openrouter(
-			api_key="test-key",
-			model="openai/gpt-5.3-codex",
-			messages=[{"role": "user", "content": "hello"}],
-			temperature=0.0,
-			max_tokens=123,
-			base_url="https://openrouter.ai/api/v1",
-			request_timeout_seconds=17,
-			thinking_level="high",
-		)
-	finally:
-		analyzer.urllib.request.urlopen = orig_urlopen
-		if old_cache_disabled is None:
-			os.environ.pop("OPENROUTER_PROMPT_CACHE_DISABLED", None)
-		else:
-			os.environ["OPENROUTER_PROMPT_CACHE_DISABLED"] = old_cache_disabled
-
-	assert content == "# report\n"
-	assert usage == {
-		"prompt_tokens": 11,
-		"completion_tokens": 22,
-		"total_tokens": 33,
-		"cache_creation_input_tokens": 7,
-		"cache_read_input_tokens": 5,
-		"cache_breakpoint_enabled": True,
-		"cache_breakpoint_fallback_retry": False,
-	}
-	assert captured["url"] == "https://openrouter.ai/api/v1/chat/completions"
-	assert captured["payload"]["model"] == "openai/gpt-5.3-codex"
-	assert captured["payload"]["max_tokens"] == 123
-	assert captured["payload"]["reasoning"] == "high"
-	assert captured["payload"]["messages"][0]["cache_control"] == {"type": "ephemeral"}
-	assert any(k.lower() == "authorization" and v == "Bearer test-key" for k, v in captured["headers"])
-
-def test_call_openrouter_omits_reasoning_when_thinking_level_empty_or_none():
-	orig_urlopen = analyzer.urllib.request.urlopen
-	old_cache_disabled = os.environ.get("OPENROUTER_PROMPT_CACHE_DISABLED")
-	os.environ["OPENROUTER_PROMPT_CACHE_DISABLED"] = "false"
-
-	class FakeResponse:
-		def __init__(self, body: str):
-			self._body = body
-
-		def __enter__(self):
-			return self
-
-		def __exit__(self, exc_type, exc, tb):
-			return False
-
-		def read(self) -> bytes:
-			return self._body.encode("utf-8")
-
-	def run_case(thinking_level):
-		captured_payload: dict[str, object] = {}
-
-		def fake_urlopen(request, timeout=0):
-			del timeout
-			captured_payload.clear()
-			captured_payload.update(json.loads(request.data.decode("utf-8")))
-			return FakeResponse(json.dumps({"choices": [{"message": {"content": "# ok"}}]}))
-
-		analyzer.urllib.request.urlopen = fake_urlopen
-		content, usage = analyzer.call_openrouter(
-			api_key="test-key",
-			model="openai/gpt-5.3-codex",
-			messages=[{"role": "user", "content": "hello"}],
-			temperature=0.0,
-			max_tokens=123,
-			base_url="https://openrouter.ai/api/v1",
-			request_timeout_seconds=17,
-			thinking_level=thinking_level,
-		)
-		assert content == "# ok\n"
-		assert usage is None
-		assert "reasoning" not in captured_payload
-		assert captured_payload["messages"][0]["cache_control"] == {"type": "ephemeral"}
-
-	try:
-		run_case("")
-		run_case("   ")
-		run_case(None)
-	finally:
-		analyzer.urllib.request.urlopen = orig_urlopen
-		if old_cache_disabled is None:
-			os.environ.pop("OPENROUTER_PROMPT_CACHE_DISABLED", None)
-		else:
-			os.environ["OPENROUTER_PROMPT_CACHE_DISABLED"] = old_cache_disabled
-
-def test_call_openrouter_http_error_is_reported():
-	orig_urlopen = analyzer.urllib.request.urlopen
-
-	def fake_urlopen(request, timeout=0):
-		raise urllib.error.HTTPError(
-			url=request.full_url,
-			code=429,
-			msg="Too Many Requests",
-			hdrs=None,
-			fp=io.BytesIO(b'{"error":"rate_limited"}'),
-		)
-
-	analyzer.urllib.request.urlopen = fake_urlopen
-	try:
-		try:
-			analyzer.call_openrouter(
-				api_key="test-key",
-				model="model",
-				messages=[{"role": "user", "content": "hello"}],
-				temperature=0.0,
-				max_tokens=64,
-				base_url="https://openrouter.ai/api/v1",
-				request_timeout_seconds=10,
-			)
-			raise AssertionError("expected RuntimeError")
-		except RuntimeError as exc:
-			assert "HTTP 429" in str(exc)
-	finally:
-		analyzer.urllib.request.urlopen = orig_urlopen
-
-
-def test_call_openrouter_skips_breakpoint_for_gemini_models():
-	captured_payload: dict[str, object] = {}
-	orig_urlopen = analyzer.urllib.request.urlopen
-	old_cache_disabled = os.environ.get("OPENROUTER_PROMPT_CACHE_DISABLED")
-	os.environ["OPENROUTER_PROMPT_CACHE_DISABLED"] = "false"
-
-	class FakeResponse:
-		def __init__(self, body: str):
-			self._body = body
-
-		def __enter__(self):
-			return self
-
-		def __exit__(self, exc_type, exc, tb):
-			return False
-
-		def read(self) -> bytes:
-			return self._body.encode("utf-8")
-
-	def fake_urlopen(request, timeout=0):
-		del timeout
-		captured_payload.clear()
-		captured_payload.update(json.loads(request.data.decode("utf-8")))
-		return FakeResponse(json.dumps({"choices": [{"message": {"content": "# ok"}}]}))
-
-	analyzer.urllib.request.urlopen = fake_urlopen
-	try:
-		content, usage = analyzer.call_openrouter(
-			api_key="test-key",
-			model="google/gemini-2.5-pro",
-			messages=[{"role": "user", "content": "hello"}],
-			temperature=0.0,
-			max_tokens=123,
-			base_url="https://openrouter.ai/api/v1",
-			request_timeout_seconds=17,
-		)
-	finally:
-		analyzer.urllib.request.urlopen = orig_urlopen
-		if old_cache_disabled is None:
-			os.environ.pop("OPENROUTER_PROMPT_CACHE_DISABLED", None)
-		else:
-			os.environ["OPENROUTER_PROMPT_CACHE_DISABLED"] = old_cache_disabled
-
-	assert content == "# ok\n"
-	assert usage is None
-	assert "cache_control" not in captured_payload["messages"][0]
-
-
-def test_call_openrouter_disables_breakpoint_when_cache_switch_enabled():
-	captured_payload: dict[str, object] = {}
-	orig_urlopen = analyzer.urllib.request.urlopen
-	old_cache_disabled = os.environ.get("OPENROUTER_PROMPT_CACHE_DISABLED")
-	os.environ["OPENROUTER_PROMPT_CACHE_DISABLED"] = "true"
-
-	class FakeResponse:
-		def __init__(self, body: str):
-			self._body = body
-
-		def __enter__(self):
-			return self
-
-		def __exit__(self, exc_type, exc, tb):
-			return False
-
-		def read(self) -> bytes:
-			return self._body.encode("utf-8")
-
-	def fake_urlopen(request, timeout=0):
-		del timeout
-		captured_payload.clear()
-		captured_payload.update(json.loads(request.data.decode("utf-8")))
-		return FakeResponse(json.dumps({"choices": [{"message": {"content": "# ok"}}], "usage": {"prompt_tokens": 3}}))
-
-	analyzer.urllib.request.urlopen = fake_urlopen
-	try:
-		content, usage = analyzer.call_openrouter(
-			api_key="test-key",
-			model="openai/gpt-5.3-codex",
-			messages=[{"role": "user", "content": "hello"}],
-			temperature=0.0,
-			max_tokens=123,
-			base_url="https://openrouter.ai/api/v1",
-			request_timeout_seconds=17,
-		)
-	finally:
-		analyzer.urllib.request.urlopen = orig_urlopen
-		if old_cache_disabled is None:
-			os.environ.pop("OPENROUTER_PROMPT_CACHE_DISABLED", None)
-		else:
-			os.environ["OPENROUTER_PROMPT_CACHE_DISABLED"] = old_cache_disabled
-
-	assert content == "# ok\n"
-	assert usage is not None
-	assert usage["cache_breakpoint_enabled"] is False
-	assert "cache_control" not in captured_payload["messages"][0]
-
-
-def test_call_openrouter_retries_without_breakpoint_on_cache_control_error():
-	payloads: list[dict[str, object]] = []
-	orig_urlopen = analyzer.urllib.request.urlopen
-	old_cache_disabled = os.environ.get("OPENROUTER_PROMPT_CACHE_DISABLED")
-	os.environ["OPENROUTER_PROMPT_CACHE_DISABLED"] = "false"
-
-	class FakeResponse:
-		def __init__(self, body: str):
-			self._body = body
-
-		def __enter__(self):
-			return self
-
-		def __exit__(self, exc_type, exc, tb):
-			return False
-
-		def read(self) -> bytes:
-			return self._body.encode("utf-8")
-
-	def fake_urlopen(request, timeout=0):
-		del timeout
-		payload = json.loads(request.data.decode("utf-8"))
-		payloads.append(payload)
-		if len(payloads) == 1:
-			raise urllib.error.HTTPError(
-				url=request.full_url,
-				code=422,
-				msg="Unprocessable Entity",
-				hdrs=None,
-				fp=io.BytesIO(b'{"error":"cache_control is not supported"}'),
-			)
-		return FakeResponse(
-			json.dumps(
-				{
-					"choices": [{"message": {"content": "# ok"}}],
-					"usage": {
-						"prompt_tokens": 8,
-						"completion_tokens": 4,
-						"total_tokens": 12,
-						"cache_creation_input_tokens": 2,
-						"cache_read_input_tokens": 1,
-					},
-				}
-			)
-		)
-
-	analyzer.urllib.request.urlopen = fake_urlopen
-	try:
-		content, usage = analyzer.call_openrouter(
-			api_key="test-key",
-			model="openai/gpt-5.3-codex",
-			messages=[{"role": "user", "content": "hello"}],
-			temperature=0.0,
-			max_tokens=64,
-			base_url="https://openrouter.ai/api/v1",
-			request_timeout_seconds=10,
-		)
-	finally:
-		analyzer.urllib.request.urlopen = orig_urlopen
-		if old_cache_disabled is None:
-			os.environ.pop("OPENROUTER_PROMPT_CACHE_DISABLED", None)
-		else:
-			os.environ["OPENROUTER_PROMPT_CACHE_DISABLED"] = old_cache_disabled
-
-	assert content == "# ok\n"
-	assert len(payloads) == 2
-	assert payloads[0]["messages"][0]["cache_control"] == {"type": "ephemeral"}
-	assert "cache_control" not in payloads[1]["messages"][0]
-	assert usage is not None
-	assert usage["cache_creation_input_tokens"] == 2
-	assert usage["cache_read_input_tokens"] == 1
-	assert usage["cache_breakpoint_enabled"] is True
-	assert usage["cache_breakpoint_fallback_retry"] is True
-
-
-def test_batch_capability_decision_supported_with_provider_hint():
-	orig_request_json = analyzer._openrouter_request_json
-
-	def fake_request_json(**kwargs):
-		del kwargs
-		return {
-			"data": [
-				{
-					"endpoint": "/api/v1/responses",
-					"supported_parameters": ["background"],
-					"supported_providers": ["openai", "anthropic"],
-				}
-			]
-		}
-
-	analyzer._openrouter_request_json = fake_request_json
-	try:
-		status, reason = analyzer._batch_capability_decision(
-			api_key="k",
-			model="openai/gpt-5.3-codex",
-			base_url="https://openrouter.ai/api/v1",
-			request_timeout_seconds=10,
-			provider_hint="anthropic",
-		)
-	finally:
-		analyzer._openrouter_request_json = orig_request_json
-
-	assert status == "supported"
-	assert reason == "batch_supported"
-
-
-def test_batch_capability_decision_unsupported_provider():
-	orig_request_json = analyzer._openrouter_request_json
-
-	def fake_request_json(**kwargs):
-		del kwargs
-		return {
-			"data": [
-				{
-					"endpoint": "/api/v1/responses",
-					"supported_parameters": ["background"],
-					"supported_providers": ["openai"],
-				}
-			]
-		}
-
-	analyzer._openrouter_request_json = fake_request_json
-	try:
-		status, reason = analyzer._batch_capability_decision(
-			api_key="k",
-			model="openai/gpt-5.3-codex",
-			base_url="https://openrouter.ai/api/v1",
-			request_timeout_seconds=10,
-			provider_hint="anthropic",
-		)
-	finally:
-		analyzer._openrouter_request_json = orig_request_json
-
-	assert status == "unsupported"
-	assert reason == "provider_not_supported"
-
-
-def test_submit_openrouter_batch_builds_background_payload():
-	captured: dict[str, object] = {}
-	orig_request_json = analyzer._openrouter_request_json
-
-	def fake_request_json(**kwargs):
-		captured.update(kwargs)
-		return {"id": "resp_123", "status": "queued"}
-
-	analyzer._openrouter_request_json = fake_request_json
-	try:
-		batch_id, status = analyzer.submit_openrouter_batch(
-			api_key="test-key",
-			model="openai/gpt-5.3-codex",
-			messages=[{"role": "user", "content": "hello"}],
-			temperature=0.0,
-			max_tokens=128,
-			base_url="https://openrouter.ai/api/v1",
-			request_timeout_seconds=30,
-			thinking_level="high",
-			provider_hint="openai",
-		)
-	finally:
-		analyzer._openrouter_request_json = orig_request_json
-
-	payload = captured.get("payload")
-	assert isinstance(payload, dict)
-	assert payload["background"] is True
-	assert payload["provider"]["order"] == ["openai"]
-	assert payload["reasoning"] == "high"
-	assert batch_id == "resp_123"
-	assert status == "queued"
-
-
-def test_poll_openrouter_batch_reports_pending_status():
-	orig_request_json = analyzer._openrouter_request_json
-
-	def fake_request_json(**kwargs):
-		del kwargs
-		return {"id": "resp_123", "status": "in_progress"}
-
-	analyzer._openrouter_request_json = fake_request_json
-	try:
-		status, batch_status, payload, content, usage = analyzer.poll_openrouter_batch(
-			api_key="test-key",
-			base_url="https://openrouter.ai/api/v1",
-			batch_id="resp_123",
-			request_timeout_seconds=30,
-		)
-	finally:
-		analyzer._openrouter_request_json = orig_request_json
-
-	assert status == "in_progress"
-	assert batch_status == "in_progress"
-	assert isinstance(payload, dict)
-	assert content == ""
-	assert usage is None
-
-
-def test_main_batch_submit_writes_state_and_returns_pending():
-	with tempfile.TemporaryDirectory(prefix="analyze-main-batch-submit-") as td:
-		tmp = Path(td)
-		data_dir = tmp / "data"
-		state_file = tmp / "batch-state.json"
-		prompt_file = tmp / "prompt.txt"
-		_write_json(
-			data_dir / "workflow_log_report.json",
-			{
-				"schema_version": "workflow_log_collector.v1",
-				"scope": {"repositories": ["owner/repo"], "workflow_families": ["plan"]},
-				"runs": [
-					{
-						"repository": "owner/repo",
-						"run_id": 101,
-						"workflow_name": "AI Plan",
-						"workflow_family": "plan",
-						"conclusion": "success",
-						"duration_seconds": 42,
-						"created_at": "2026-04-11T10:00:00Z",
-					}
-				],
-				"summary": {"total_runs": 1},
-				"errors": [],
-			},
-		)
-		prompt_file.write_text("You are a test analyzer.", encoding="utf-8")
-
-		orig_submit = analyzer.submit_openrouter_batch
-		orig_capability = analyzer._batch_capability_decision
-
-		def fake_submit(**kwargs):
-			del kwargs
-			return "resp_pending", "queued"
-
-		def fake_capability(**kwargs):
-			del kwargs
-			return "supported", "batch_supported"
-
-		analyzer.submit_openrouter_batch = fake_submit
-		analyzer._batch_capability_decision = fake_capability
-
-		original_key = os.environ.get("OPENROUTER_API_KEY")
-		try:
-			os.environ["OPENROUTER_API_KEY"] = "k"
-			exit_code = analyzer.main(
-				[
-					"--data-dir",
-					str(data_dir),
-					"--prompt-file",
-					str(prompt_file),
-					"--batch-mode",
-					"submit",
-					"--batch-state-file",
-					str(state_file),
-				]
-			)
-		finally:
-			if original_key is None:
-				os.environ.pop("OPENROUTER_API_KEY", None)
-			else:
-				os.environ["OPENROUTER_API_KEY"] = original_key
-			analyzer.submit_openrouter_batch = orig_submit
-			analyzer._batch_capability_decision = orig_capability
-
-		assert exit_code == 3
-		state_payload = json.loads(state_file.read_text(encoding="utf-8"))
-		assert state_payload["batch_id"] == "resp_pending"
-		assert state_payload["status"] == "queued"
-
-
-def test_main_batch_poll_completes_and_writes_report():
-	with tempfile.TemporaryDirectory(prefix="analyze-main-batch-poll-") as td:
-		tmp = Path(td)
-		data_dir = tmp / "data"
-		output_dir = tmp / "analysis"
-		state_file = tmp / "batch-state.json"
-		prompt_file = tmp / "prompt.txt"
-		_write_json(
-			data_dir / "workflow_log_report.json",
-			{
-				"schema_version": "workflow_log_collector.v1",
-				"scope": {"repositories": ["owner/repo"], "workflow_families": ["plan"]},
-				"runs": [
-					{
-						"repository": "owner/repo",
-						"run_id": 101,
-						"workflow_name": "AI Plan",
-						"workflow_family": "plan",
-						"conclusion": "success",
-						"duration_seconds": 42,
-						"created_at": "2026-04-11T10:00:00Z",
-					}
-				],
-				"summary": {"total_runs": 1},
-				"errors": [],
-			},
-		)
-		prompt_file.write_text("You are a test analyzer.", encoding="utf-8")
-		state_file.write_text(
-			json.dumps(
-				{
-					"schema_version": analyzer.DEFAULT_BATCH_STATE_SCHEMA_VERSION,
-					"batch_id": "resp_pending",
-					"status": "queued",
-					"submitted_at": datetime.now(timezone.utc).isoformat(),
-					"provider_hint": "auto",
-					"model": "openai/gpt-5.3-codex",
-					"poll_timeout_hours": 24,
-					"source_workflow": "Workflow Log Analysis",
-					"source_run_id": "1",
-				}
-			),
-			encoding="utf-8",
-		)
-
-		orig_poll = analyzer.poll_openrouter_batch
-		orig_resolve_dated_output_path = analyzer.resolve_dated_output_path
-
-		def fake_poll(**kwargs):
-			del kwargs
-			return (
-				"completed",
-				"completed",
-				{"id": "resp_pending", "status": "completed"},
-				"## Executive Summary\n- async-ok\n",
-				{"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
-			)
-
-		def fake_resolve(output_path, out_dir, *, today=None):
-			del output_path, today
-			assert out_dir == str(output_dir)
-			return output_dir / "workflow-optimization-2026-04-11.md"
-
-		analyzer.poll_openrouter_batch = fake_poll
-		analyzer.resolve_dated_output_path = fake_resolve
-
-		original_key = os.environ.get("OPENROUTER_API_KEY")
-		try:
-			os.environ["OPENROUTER_API_KEY"] = "k"
-			exit_code = analyzer.main(
-				[
-					"--data-dir",
-					str(data_dir),
-					"--output-dir",
-					str(output_dir),
-					"--prompt-file",
-					str(prompt_file),
-					"--batch-mode",
-					"poll",
-					"--batch-state-file",
-					str(state_file),
-				]
-			)
-		finally:
-			if original_key is None:
-				os.environ.pop("OPENROUTER_API_KEY", None)
-			else:
-				os.environ["OPENROUTER_API_KEY"] = original_key
-			analyzer.poll_openrouter_batch = orig_poll
-			analyzer.resolve_dated_output_path = orig_resolve_dated_output_path
-
-		assert exit_code == 0
-		report_path = output_dir / "workflow-optimization-2026-04-11.md"
-		assert report_path.exists()
-		assert "async-ok" in report_path.read_text(encoding="utf-8")
-
-
-def test_main_batch_poll_timeout_falls_back_to_sync():
-	with tempfile.TemporaryDirectory(prefix="analyze-main-batch-timeout-") as td:
-		tmp = Path(td)
-		data_dir = tmp / "data"
-		output_dir = tmp / "analysis"
-		state_file = tmp / "batch-state.json"
-		prompt_file = tmp / "prompt.txt"
-		_write_json(
-			data_dir / "workflow_log_report.json",
-			{
-				"schema_version": "workflow_log_collector.v1",
-				"scope": {"repositories": ["owner/repo"], "workflow_families": ["plan"]},
-				"runs": [
-					{
-						"repository": "owner/repo",
-						"run_id": 101,
-						"workflow_name": "AI Plan",
-						"workflow_family": "plan",
-						"conclusion": "success",
-						"duration_seconds": 42,
-						"created_at": "2026-04-11T10:00:00Z",
-					}
-				],
-				"summary": {"total_runs": 1},
-				"errors": [],
-			},
-		)
-		prompt_file.write_text("You are a test analyzer.", encoding="utf-8")
-		state_file.write_text(
-			json.dumps(
-				{
-					"schema_version": analyzer.DEFAULT_BATCH_STATE_SCHEMA_VERSION,
-					"batch_id": "resp_pending",
-					"status": "queued",
-					"submitted_at": "2000-01-01T00:00:00+00:00",
-					"provider_hint": "auto",
-					"model": "openai/gpt-5.3-codex",
-					"poll_timeout_hours": 24,
-					"source_workflow": "Workflow Log Analysis",
-					"source_run_id": "1",
-				}
-			),
-			encoding="utf-8",
-		)
-
-		orig_call_openrouter = analyzer.call_openrouter
-		orig_resolve_dated_output_path = analyzer.resolve_dated_output_path
-		orig_poll = analyzer.poll_openrouter_batch
-
-		def fake_call_openrouter(**kwargs):
-			del kwargs
-			return "## Executive Summary\n- sync-fallback\n", None
-
-		def fake_resolve(output_path, out_dir, *, today=None):
-			del output_path, today
-			assert out_dir == str(output_dir)
-			return output_dir / "workflow-optimization-2026-04-11.md"
-
-		def fake_poll(**kwargs):
-			raise AssertionError("poll should not be called when timeout already exceeded")
-
-		analyzer.call_openrouter = fake_call_openrouter
-		analyzer.resolve_dated_output_path = fake_resolve
-		analyzer.poll_openrouter_batch = fake_poll
-
-		original_key = os.environ.get("OPENROUTER_API_KEY")
-		try:
-			os.environ["OPENROUTER_API_KEY"] = "k"
-			exit_code = analyzer.main(
-				[
-					"--data-dir",
-					str(data_dir),
-					"--output-dir",
-					str(output_dir),
-					"--prompt-file",
-					str(prompt_file),
-					"--batch-mode",
-					"poll",
-					"--batch-state-file",
-					str(state_file),
-				]
-			)
-		finally:
-			if original_key is None:
-				os.environ.pop("OPENROUTER_API_KEY", None)
-			else:
-				os.environ["OPENROUTER_API_KEY"] = original_key
-			analyzer.call_openrouter = orig_call_openrouter
-			analyzer.resolve_dated_output_path = orig_resolve_dated_output_path
-			analyzer.poll_openrouter_batch = orig_poll
-
-		assert exit_code == 0
-		report_path = output_dir / "workflow-optimization-2026-04-11.md"
-		assert report_path.exists()
-		assert "sync-fallback" in report_path.read_text(encoding="utf-8")
-		updated_state = json.loads(state_file.read_text(encoding="utf-8"))
-		assert updated_state["status"] == "fallback_sync"
-		assert updated_state["fallback_reason"] == "batch_poll_timeout"
-
-
-def test_load_input_data_rejects_malformed_json_input():
-	with tempfile.TemporaryDirectory(prefix="analyze-input-") as td:
-		input_file = Path(td) / "bad.json"
-		input_file.write_text("{bad", encoding="utf-8")
-		args = analyzer.build_parser().parse_args(["--input", str(input_file)])
-		try:
-			analyzer.load_input_data(args)
-			raise AssertionError("expected ValueError")
-		except ValueError as exc:
-			assert "invalid JSON" in str(exc)
-
-
-def test_load_input_data_collects_deep_dive_logs_from_collector_runs():
-	with tempfile.TemporaryDirectory(prefix="analyze-input-runs-") as td:
-		input_file = Path(td) / "collector.json"
-		_write_json(
-			input_file,
-			{
-				"schema_version": "workflow_log_collector.v1",
-				"runs": [
-					{
-						"repository": "owner/repo",
-						"run_id": 55,
-						"log_excerpts": [
-							{"step_name": "build", "excerpt": "line1"},
-							{"step_name": "test", "excerpt": "line2"},
-						],
-					}
-				],
-			},
-		)
-		args = analyzer.build_parser().parse_args(["--input", str(input_file)])
-		loaded = analyzer.load_input_data(args)
-		assert loaded["deep_dive_logs"] == [
-			{"name": "owner/repo/55/build", "excerpt": "line1"},
-			{"name": "owner/repo/55/test", "excerpt": "line2"},
-		]
-
-
-def test_build_parser_max_output_tokens_default_100000():
-	args = analyzer.build_parser().parse_args([])
-	assert args.max_output_tokens == 100000
-
-
-def test_load_prompt_template_returns_content_without_placeholders():
-	with tempfile.TemporaryDirectory(prefix="analyze-prompt-raw-") as td:
-		prompt_file = Path(td) / "prompt.txt"
-		prompt_file.write_text("You are a test analyzer.", encoding="utf-8")
-		rendered = analyzer.load_prompt_template(prompt_file)
-		assert rendered == "You are a test analyzer."
-
-
-def test_load_prompt_template_renders_serena_placeholder():
-	with tempfile.TemporaryDirectory(prefix="analyze-prompt-render-") as td:
-		prompt_file = Path(td) / "prompt.txt"
-		prompt_file.write_text("Before\n{{SERENA_EFFICIENCY_BLOCK_READ_ONLY}}\nAfter\n", encoding="utf-8")
-		rendered = analyzer.load_prompt_template(prompt_file)
-		assert "SERENA MCP EFFICIENCY (MANDATORY):" in rendered
-		assert "{{SERENA_EFFICIENCY_BLOCK_READ_ONLY}}" not in rendered
-
-
-def test_load_prompt_template_errors_on_unresolved_placeholder():
-	with tempfile.TemporaryDirectory(prefix="analyze-prompt-error-") as td:
-		prompt_file = Path(td) / "prompt.txt"
-		prompt_file.write_text("{{SERENA_EFFICIENCY_BLOCK_UNKNOWN}}\n", encoding="utf-8")
-		try:
-			analyzer.load_prompt_template(prompt_file)
-			raise AssertionError("expected RuntimeError")
-		except RuntimeError as exc:
-			assert "unable to render prompt file" in str(exc)
-
-
-def test_main_missing_openrouter_api_key_returns_2():
-	original = os.environ.get("OPENROUTER_API_KEY")
-	try:
-		if "OPENROUTER_API_KEY" in os.environ:
-			del os.environ["OPENROUTER_API_KEY"]
-		exit_code = analyzer.main([])
-	finally:
-		if original is None:
-			os.environ.pop("OPENROUTER_API_KEY", None)
-		else:
-			os.environ["OPENROUTER_API_KEY"] = original
-	assert exit_code == 2
-
-
-def test_main_codex_mode_writes_context_and_skips_inference_calls():
-	with tempfile.TemporaryDirectory(prefix="analyze-main-codex-") as td:
-		tmp = Path(td)
-		data_dir = tmp / "data"
-		output_dir = tmp / "analysis"
-		_write_json(
-			data_dir / "workflow_log_report.json",
-			{
-				"schema_version": "workflow_log_collector.v1",
-				"scope": {"repositories": ["owner/repo"], "workflow_families": ["plan"]},
-				"runs": [
-					{
-						"repository": "owner/repo",
-						"run_id": 101,
-						"workflow_name": "AI Plan",
-						"workflow_family": "plan",
-						"conclusion": "success",
-						"duration_seconds": 42,
-						"created_at": "2026-04-11T10:00:00Z",
-					}
-				],
-				"summary": {"total_runs": 1},
-				"errors": [],
-			},
-		)
-
-		orig_call_openrouter = analyzer.call_openrouter
-		orig_submit_openrouter_batch = analyzer.submit_openrouter_batch
-		orig_poll_openrouter_batch = analyzer.poll_openrouter_batch
-		orig_batch_capability_decision = analyzer._batch_capability_decision
-
-		def fail_if_called(**kwargs):
-			del kwargs
-			raise AssertionError("inference path should not run in codex mode")
-
-		analyzer.call_openrouter = fail_if_called
-		analyzer.submit_openrouter_batch = fail_if_called
-		analyzer.poll_openrouter_batch = fail_if_called
-		analyzer._batch_capability_decision = fail_if_called
-
-		stdout = io.StringIO()
-		original_key = os.environ.get("OPENROUTER_API_KEY")
-		try:
-			if "OPENROUTER_API_KEY" in os.environ:
-				del os.environ["OPENROUTER_API_KEY"]
-			with contextlib.redirect_stdout(stdout):
-				exit_code = analyzer.main(
-					[
-						"--data-dir",
-						str(data_dir),
-						"--output",
-						str(output_dir / "report.md"),
-						"--codex-mode",
-					]
-				)
-		finally:
-			if original_key is None:
-				os.environ.pop("OPENROUTER_API_KEY", None)
-			else:
-				os.environ["OPENROUTER_API_KEY"] = original_key
-			analyzer.call_openrouter = orig_call_openrouter
-			analyzer.submit_openrouter_batch = orig_submit_openrouter_batch
-			analyzer.poll_openrouter_batch = orig_poll_openrouter_batch
-			analyzer._batch_capability_decision = orig_batch_capability_decision
-
-		assert exit_code == 0
-		context_path = output_dir / "analysis_context.json"
-		assert stdout.getvalue().strip() == str(context_path)
-		assert context_path.exists()
-		payload = json.loads(context_path.read_text(encoding="utf-8"))
-		assert payload["summary"]["total_runs"] == 1
-		assert "truncation" not in payload
-
-
-def test_main_generates_dated_report_using_stubs():
 	with tempfile.TemporaryDirectory(prefix="analyze-main-") as td:
-		tmp = Path(td)
-		data_dir = tmp / "data"
-		output_dir = tmp / "analysis"
-		prompt_file = tmp / "prompt.txt"
-		_write_json(
-			data_dir / "workflow_log_report.json",
-			{
-				"schema_version": "workflow_log_collector.v1",
-				"scope": {"repositories": ["owner/repo"], "workflow_families": ["plan"]},
-				"runs": [
-					{
-						"repository": "owner/repo",
-						"run_id": 101,
-						"workflow_name": "AI Plan",
-						"workflow_family": "plan",
-						"conclusion": "success",
-						"duration_seconds": 42,
-						"created_at": "2026-04-11T10:00:00Z",
-					}
-				],
-				"summary": {"total_runs": 1},
-				"errors": [],
-			},
+		td_path = Path(td)
+		input_path = td_path / "workflow_log_report.json"
+		_write_json(input_path, report)
+		output_md = td_path / "analysis" / "workflow-optimization-2099-12-31.md"
+
+		exit_code = analyzer.main(
+			[
+				"--input",
+				str(input_path),
+				"--output",
+				str(output_md),
+				"--codex-mode",
+			]
 		)
-		prompt_file.write_text("You are a test analyzer.", encoding="utf-8")
-
-		orig_call_openrouter = analyzer.call_openrouter
-		orig_resolve_dated_output_path = analyzer.resolve_dated_output_path
-
-		def fake_call_openrouter(**kwargs):
-			assert kwargs["model"] == "unit-test-model"
-			assert kwargs["max_tokens"] == 200
-			return "## Executive Summary\n- ok\n", {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}
-
-		def fake_resolve_dated_output_path(output_path, out_dir, *, today=None):
-			assert output_path is None
-			assert out_dir == str(output_dir)
-			return output_dir / "workflow-optimization-2026-04-11.md"
-
-		analyzer.call_openrouter = fake_call_openrouter
-		analyzer.resolve_dated_output_path = fake_resolve_dated_output_path
-
-		original_key = os.environ.get("OPENROUTER_API_KEY")
-		try:
-			os.environ["OPENROUTER_API_KEY"] = "k"
-			exit_code = analyzer.main(
-				[
-					"--data-dir",
-					str(data_dir),
-					"--output-dir",
-					str(output_dir),
-					"--prompt-file",
-					str(prompt_file),
-					"--model",
-					"unit-test-model",
-					"--max-output-tokens",
-					"200",
-				]
-			)
-		finally:
-			if original_key is None:
-				os.environ.pop("OPENROUTER_API_KEY", None)
-			else:
-				os.environ["OPENROUTER_API_KEY"] = original_key
-			analyzer.call_openrouter = orig_call_openrouter
-			analyzer.resolve_dated_output_path = orig_resolve_dated_output_path
-
 		assert exit_code == 0
-		report_path = output_dir / "workflow-optimization-2026-04-11.md"
-		assert report_path.exists()
-		assert "## Executive Summary" in report_path.read_text(encoding="utf-8")
+		captured = capsys.readouterr()
+		printed_path = Path(captured.out.strip())
+		assert printed_path == output_md.parent / "analysis_context.json"
+		assert printed_path.exists()
+		payload = json.loads(printed_path.read_text(encoding="utf-8"))
+		assert "deep_dive_logs" not in payload
+		assert len(payload["failing_runs"]) == 2
 
 
-# ---------------------------------------------------------------------------
-# Runner
-# ---------------------------------------------------------------------------
+def test_main_returns_2_when_input_missing(capsys):
+	exit_code = analyzer.main(["--input", "/nonexistent/does-not-exist.json"])
+	assert exit_code == 2
+	captured = capsys.readouterr()
+	assert "ERROR" in captured.err
 
 
-def main() -> int:
-	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
-	passed = 0
-	failed = 0
-	for func in test_funcs:
-		name = func.__name__
-		try:
-			func()
-			print(f"  PASS  {name}")
-			passed += 1
-		except Exception as exc:  # noqa: BLE001
-			print(f"  FAIL  {name}: {exc}")
-			failed += 1
-
-	print(f"\n{passed} passed, {failed} failed, {passed + failed} total")
-	return 1 if failed > 0 else 0
+# ---------- aggregations ---------------------------------------------------
 
 
-if __name__ == "__main__":
-	raise SystemExit(main())
+def test_aggregate_runs_by_key_computes_failure_rate_and_durations():
+	runs = [
+		{"repository": "a", "conclusion": "failure", "duration_seconds": 100},
+		{"repository": "a", "conclusion": "success", "duration_seconds": 50},
+		{"repository": "b", "conclusion": "failure", "duration_seconds": 200},
+	]
+	out = analyzer._aggregate_runs_by_key(runs, "repository")
+	assert out["a"]["total_runs"] == 2
+	assert out["a"]["failure_count"] == 1
+	assert abs(out["a"]["failure_rate"] - 0.5) < 1e-9
+	assert out["a"]["avg_duration_seconds"] == 75.0
+	assert out["b"]["failure_rate"] == 1.0


### PR DESCRIPTION
## Summary

Simplifies `workflow-log-analysis.yml` to be Codex-only, ships a new `workflow-log-output` artifact with full untruncated step logs so Codex can analyse DEBUG-level evidence directly, and adds an age-based purge so dated reports stop accumulating unboundedly. Net diff **+428 / −2352** lines.

## Changes

### Legacy removal (Q1: B / Q2: B / Q3: A / Q4: A)
- `codex_mode` workflow input and analyzer `--codex-mode` CLI flag are kept as **no-op aliases** for backward compatibility — they're accepted but ignored, and the workflow always runs the Codex-first path.
- Removed: `batch_api_disabled` workflow input; `BATCH_API_DISABLED` / `BATCH_API_PROVIDER` / `BATCH_API_POLL_TIMEOUT_HOURS` / `WORKFLOW_LOG_ANALYSIS_LEGACY_PROMPT_TOKEN_BUDGET` / `OPENROUTER_PROMPT_CACHE_DISABLED` env vars in this workflow; the legacy artifact-restore block; the `Upload batch state artifact` step; the `&& inputs.codex_mode` gate on `deep-audit` and `api-redundancy`; ~1100 lines of OpenRouter sync/batch/state code in `scripts/analyze_workflow_logs.py`.
- The analyzer now does **context preparation only** — it reads `workflow_log_report.json`, computes aggregates, writes `analysis_context.json`. No LLM call inside Python.
- Tests: deleted all OpenRouter/batch tests; rewrote to cover argparse no-op alias, `prepare_analysis_context` caps, and `main()` exit codes. **42/42 tests pass locally.**

### Full-log artifact (Q5: C / Q6: A / Q7: A / Q8: B)
- Collector step now passes `--log-output-dir ${RUNNER_TEMP}/workflow-log-output` so the existing categorised exporter writes `summary.json` + `errors/` / `slow/` / `recent/` trees containing **untruncated** step logs.
- New artifact `workflow-log-output` (retention 7 days) carries that directory across jobs.
- Analyze job downloads it and splices `=== FULL RUN LOGS DIRECTORY === \n Run-logs directory: <path>` into the Codex prompt next to the existing `=== ANALYSIS CONTEXT ===` block. The `mode-workflow-analysis.txt` prompt already instructs Codex to read `summary.json` first, then drill into `errors/` / `slow/` / `recent/`. Missing artifact fails open with a `::warning::`.
- Quick-index changes in `analysis_context.json`:
  - `deep_dive_logs` removed (full logs live on disk now).
  - `failing_runs` / `slow_runs` / `recent_runs` caps lifted to **100** (was 25).
  - `errors` cap lifted to **250** (was 100).

### Report purge (Q9: C — 30 days)
- Commit step age-purges `analysis/workflow-optimization-<date>(-N).md` whose **filename** date stamp is older than `WORKFLOW_LOG_ANALYSIS_REPORT_RETENTION_DAYS` (default `30`) in the same commit as the new report.
- Filename date is authoritative (mtime would reset on every checkout). The just-written report is always preserved. Invalid retention values fail open to `30` with a `::warning::`.

### Docs
- `agents.md` §13 rewritten to describe the Codex-only pipeline, the new artifact, the quick-index caps, and the retention behaviour. Old §6 batch-controls bullet replaced with a removal note.
- `README.md` updated: dropped the `BATCH_API_*` rows from the env-var table, added `WORKFLOW_LOG_ANALYSIS_REPORT_RETENTION_DAYS`, rewrote the `Workflow Log Analysis` section to describe the 5-step Codex-only pipeline, removed legacy mode-behavior bullets and the legacy analyzer-input contract block.

## Test plan

- [x] `python3 -m pytest tests/test_analyze_workflow_logs.py tests/test_collect_workflow_logs.py tests/test_workflow_log_analysis_failure_contract.py tests/test_ai_memory_workflow_log_analysis_cache.py` — 42 passed
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/workflow-log-analysis.yml'))"` — valid
- [x] `python3 -c "import scripts.analyze_workflow_logs as a; a.build_parser().parse_args(['--codex-mode', '--input', '/dev/null'])"` — no-op alias accepted
- [ ] Manual `workflow_dispatch` of `Workflow Log Analysis` in this repo to confirm `workflow-log-output` artifact uploads and Codex consumes it (exercise on next ad-hoc run).
- [ ] Confirm the 30-day purge step is a no-op today (only one report exists: `workflow-optimization-2026-04-21.md` is < 30 days old as of 2026-04-27).

## Backward compatibility

- `codex_mode` workflow input still accepted (ignored). `comprehensive-test-and-release.yml` already passes `codex_mode=true`; unchanged.
- `--codex-mode` analyzer flag still accepted (ignored).
- Removed env vars (`BATCH_API_DISABLED`, etc.) — Q3:A is a deliberate breaking change for any repo configuring them; behaviour change is benign because the legacy code path that consumed them is also gone.

https://claude.ai/code/session_0146A3rtdzXVo2VoBuBTpMve

---
_Generated by [Claude Code](https://claude.ai/code/session_0146A3rtdzXVo2VoBuBTpMve)_