### PR TITLE
fix: validation-refresh git auth + orchestrate_poll FD-3 regression

### DIFF
--- a/.github/workflows/validation-refresh.yml
+++ b/.github/workflows/validation-refresh.yml
@@ -57,6 +57,10 @@ jobs:
             exit 1
           fi
 
+          # Wire git to use the gh credential helper so raw `git fetch`/`ls-remote`
+          # calls inside cloned consumer repos authenticate with GH_TOKEN.
+          gh auth setup-git
+
           RUNTIME_DIR="${RUNNER_TEMP}/validation-refresh-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           mkdir -p "${RUNTIME_DIR}"
           SUMMARY_JSON="${RUNTIME_DIR}/summary.json"

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -2236,11 +2236,18 @@ ensure_integration_conflict_state_fields() {
 
 normalize_judge_justification_for_fingerprint() {
   local raw_text="${1-}"
-  printf '%s' "${raw_text}" | python3 /dev/fd/3 3<<'PY'
+  # Pass input via env var, not stdin: the GHA Ubuntu 24.04 runner's
+  # `bash -e {0}` shell closes the heredoc-bound FD 3 before exec'ing
+  # python3, so the previous `python3 /dev/fd/3 3<<'PY'` form failed
+  # with "can't open file '/dev/fd/3': [Errno 2]" and turned every
+  # poller invocation that touched judge fingerprints into a non-zero
+  # exit. Reading the text from RAW_TEXT and the script from stdin
+  # (`python3 -`) sidesteps the FD-3 dance entirely.
+  RAW_TEXT="${raw_text}" python3 - <<'PY'
+import os
 import re
-import sys
 
-text = sys.stdin.read()
+text = os.environ.get("RAW_TEXT", "")
 if not text:
     print("")
     raise SystemExit(0)


### PR DESCRIPTION
## Summary

Two unrelated production bugs caught while investigating an analyze-log run; both surface on shared CI infrastructure, so they're bundled here at the maintainer's request (Q1:A in PR thread).

### 1. `validation-refresh.yml` — git auth missing for cross-repo work

- Validation-refresh run [24975155859](https://github.com/shubhodeep1/coding-workflows/actions/runs/24975155859) errored on **10 of 11** consumer repos with `fatal: could not read Username for 'https://github.com': No such device or address` (exit 128).
- Root cause: `scripts/validation_refresh_runner.py` clones each consumer repo via `gh repo clone` (authenticated by `GH_TOKEN`) and then runs raw `git ls-remote` / `git fetch` / `git checkout` inside it. Those raw git calls have no credential helper installed, so git tries to prompt and dies on the non-TTY runner. The only repo that didn't fail was `shubhodeep1/coding-workflows` itself — `actions/checkout@v5` had already configured `http.https://github.com/.extraheader` for its working tree.
- Fix: call `gh auth setup-git` once at the start of the `Run validation refresh` step. That registers `gh` as the git credential helper for the rest of the job, so subsequent raw git calls authenticate with the same `GH_TOKEN`.
- Single workflow line, no Python edits.

### 2. `orchestrate_poll_process.sh` — broken `python3 /dev/fd/3` idiom

- 14 consistent FAILs in `tests/test_orchestrate_poll_process.py` (`test_clean_wave_skip_*`, `test_judge_repeat_fingerprint_*`, `test_in_progress_judge_*`, `test_missing_labels_*`, `test_wave_judge_*`) all share the same stderr line:

  ```
  /opt/hostedtoolcache/Python/3.12.13/x64/bin/python3:
    can't open file '/dev/fd/3': [Errno 2] No such file or directory
  ```

- Root cause: `normalize_judge_justification_for_fingerprint` (introduced in PR #1679, commit `1b48022`) uses `printf … | python3 /dev/fd/3 3<<'PY' … PY` — i.e. data on stdin, script source on FD 3. On the GHA Ubuntu 24.04 runner under the default `shell: /usr/bin/bash -e {0}` the heredoc-bound FD 3 is closed before `python3` execs, so `python3` cannot reopen `/dev/fd/3` and exits ENOENT. Every poller invocation that reaches the fingerprint normaliser exits non-zero, turning the lint job red on every PR opened against `main` since `1b48022`.
- Fix: swap to the portable idiom — pass the text via env var `RAW_TEXT` (not subject to FD propagation quirks) and read the script body from stdin via `python3 -`. Same output for the same inputs; verified by smoke-testing the function on a representative justification (timestamp, `Judge cycle N`, `path:lineno` stripping) and on empty input.

## Files changed

- `.github/workflows/validation-refresh.yml` — 4 lines added inside the existing `Run validation refresh` step (1-line comment + `gh auth setup-git`).
- `scripts/orchestrate_poll_process.sh` — `normalize_judge_justification_for_fingerprint` (lines 2237-2260): replace `python3 /dev/fd/3 3<<'PY'` with `RAW_TEXT="${raw_text}" python3 - <<'PY'`, and `text = sys.stdin.read()` with `text = os.environ.get("RAW_TEXT", "")`.

No env-var/contract/behavioural changes. Everything else in both files is byte-identical.

## Test plan

- [ ] Lint job on this PR passes (the 14 `test_orchestrate_poll_process.py` failures should disappear).
- [ ] Manual `workflow_dispatch` of `Validation Refresh` against this branch — confirm none of the 10 previously-failing repos report `checkout_failed(exit=128)` in `summary.json`, and `coding-workflows` itself still reports `skipped` / `no_changes_detected`.
- [ ] Local sanity check (bash + shellcheck): `bash -n scripts/orchestrate_poll_process.sh` and `shellcheck --severity=error scripts/orchestrate_poll_process.sh` — both clean.
- [ ] Manual smoke test:
      ```
      normalize_judge_justification_for_fingerprint \
        "Judge cycle 3 reported error at 2026-04-27T05:02:48Z in scripts/foo.sh:42"
      → "reported error at in scripts/foo.sh"
      normalize_judge_justification_for_fingerprint ""
      → ""
      ```

https://claude.ai/code/session_01UxeEwQ2perUfL2yqUSAjSF