### PR TITLE
fix(harness): drop sh -c wrapper around anvil in node-hardhat-solidity compose template

### DIFF
--- a/workflow-templates/validation-harness/node-hardhat-solidity/docker-compose.test.yml.j2
+++ b/workflow-templates/validation-harness/node-hardhat-solidity/docker-compose.test.yml.j2
@@ -3,7 +3,7 @@ services:
     image: ghcr.io/foundry-rs/foundry:v1.3.1
     init: true
     command: >-
-      sh -c "anvil --host 0.0.0.0 --port ${ANVIL_PORT:-8545}"
+      anvil --host 0.0.0.0 --port ${ANVIL_PORT:-8545}
     healthcheck:
       test:
         - "CMD-SHELL"


### PR DESCRIPTION
## Summary

- Removes the redundant `sh -c "..."` wrapper around `anvil` in `workflow-templates/validation-harness/node-hardhat-solidity/docker-compose.test.yml.j2`. The `ghcr.io/foundry-rs/foundry` image already invokes commands through its own shell entrypoint, so the wrapper resolved at runtime to `sh -c sh -c "anvil ..."` — the inner `sh` ran with `-c` and the anvil argument shifted into `$0`/`$1`, so `anvil` never executed and the container exited cleanly (`exit 0`), taking the dependent `app` service down via `dependency failed to start`.
- Aligns with the harness's own failure-summary recommendation in run id `24977955574` (consumer repo `shubhodeep1/fun-token-multi-chain`, tracking issue #185), which classified the run as `harness_error` at the `preflight_compose_up` step.

## Reproduction

Before this fix, the rendered `validation/docker-compose.test.yml` produced:
```
Container validation-anvil-1  Started
Container validation-anvil-1  Waiting
Container validation-anvil-1  Error
dependency failed to start: container validation-anvil-1 exited (0)
```

## Test plan

- [x] `pytest tests/test_render_validation_templates.py tests/test_render_validation_templates_node_hardhat_regressions.py` (19 passed locally)
- [ ] Re-run `ai-validate` on a `node-hardhat-solidity` consumer repo and confirm `preflight_compose_up` reaches the `app` service / `npm run compile && npm test` phase without anvil exiting early.
- [ ] Verify `validation-anvil-1` stays running and healthy under `docker compose -f validation/docker-compose.test.yml up anvil`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1RJBQiLgzPJmrvQhmBopQ)_