### PR TITLE
fix(models): drop unsupported input_modalities variants from catalog

### DIFF
--- a/scripts/codex_model_catalog.json
+++ b/scripts/codex_model_catalog.json
@@ -422,7 +422,7 @@
       "auto_compact_token_limit": 304000,
       "effective_context_window_percent": 95,
       "experimental_supported_tools": [],
-      "input_modalities": ["text", "image", "file"]
+      "input_modalities": ["text", "image"]
     },
     {
       "slug": "deepseek/deepseek-v4-pro",
@@ -482,7 +482,7 @@
       "auto_compact_token_limit": 720000,
       "effective_context_window_percent": 90,
       "experimental_supported_tools": [],
-      "input_modalities": ["text", "image", "video"]
+      "input_modalities": ["text", "image"]
     },
     {
       "slug": "x-ai/grok-4.1-fast",
@@ -512,7 +512,7 @@
       "auto_compact_token_limit": 1440000,
       "effective_context_window_percent": 90,
       "experimental_supported_tools": [],
-      "input_modalities": ["text", "image", "file"]
+      "input_modalities": ["text", "image"]
     }
   ]
 }

--- a/scripts/codex_model_catalog.json
+++ b/scripts/codex_model_catalog.json
@@ -457,7 +457,7 @@
     {
       "slug": "qwen/qwen3.6-plus",
       "display_name": "Qwen 3.6 Plus",
-      "description": "Alibaba Qwen 3.6 Plus - 1M context, multimodal (text/image/video), tool calling, ~half the price of qwen3-coder-plus ($0.325/$1.95 per M)",
+      "description": "Alibaba Qwen 3.6 Plus - 1M context, multimodal (text/image), tool calling, ~half the price of qwen3-coder-plus ($0.325/$1.95 per M)",
       "supported_reasoning_levels": [
         {"effort": "medium", "description": "Balanced reasoning"},
         {"effort": "high", "description": "Thorough reasoning"},
@@ -487,7 +487,7 @@
     {
       "slug": "x-ai/grok-4.1-fast",
       "display_name": "Grok 4.1 Fast",
-      "description": "xAI Grok 4.1 Fast - 2M context, multimodal (text/image/file), tool calling, very low cost ($0.20/$0.50 per M)",
+      "description": "xAI Grok 4.1 Fast - 2M context, multimodal (text/image), tool calling, very low cost ($0.20/$0.50 per M)",
       "supported_reasoning_levels": [
         {"effort": "medium", "description": "Balanced reasoning"},
         {"effort": "high", "description": "Thorough reasoning"},


### PR DESCRIPTION
## Summary

`scripts/codex_model_catalog.json` contained `input_modalities` values that codex-cli's deserializer rejects. The closed enum accepts only `text` and `image`; the recent reviewer-panel refresh (`b21ad76`) added `file` and `video`, which caused every codex-cli invocation to abort at startup with:

```
Error: failed to parse model_catalog_json path '.../scripts/codex_model_catalog.json' as JSON:
unknown variant `file`, expected `text` or `image` at line 425 column 50
```

This broke all 6 reviewers across both passes in `review_autofix.yml` (3 retries × 6 models × 2 passes = 36 identical exit-1 failures) and cascaded into "Editor produced no summary and no committed changes" / empty editor summary file. Observed end-to-end in PR #2731's job log.

## Changes

`scripts/codex_model_catalog.json` — removed unsupported variants from three model entries (commit `d098295`):

| Slug | Before | After |
|---|---|---|
| `openai/gpt-5.4-nano` | `["text", "image", "file"]` | `["text", "image"]` |
| `qwen/qwen3.6-plus` | `["text", "image", "video"]` | `["text", "image"]` |
| `x-ai/grok-4.1-fast` | `["text", "image", "file"]` | `["text", "image"]` |

(`z-ai/glm-5` was unaffected — its `input_modalities` was already `["text"]`.)

Aligned the prose descriptions for the two entries whose marketing text still advertised the removed variants (commit `639faf5`):

| Slug | Description before | Description after |
|---|---|---|
| `qwen/qwen3.6-plus` | `multimodal (text/image/video)` | `multimodal (text/image)` |
| `x-ai/grok-4.1-fast` | `multimodal (text/image/file)` | `multimodal (text/image)` |

(`openai/gpt-5.4-nano`'s description only said "multimodal" generically, so it didn't need updating.)

## Test plan

- [x] `python3 -c "import json; json.load(open('scripts/codex_model_catalog.json'))"` succeeds
- [x] All `input_modalities` arrays now contain only `text` and/or `image`
- [x] No prose description still references `text/image/file` or `text/image/video`
- [ ] Re-run `review_autofix.yml` on a test PR and confirm reviewers no longer fail at the catalog-parse step

---
_Generated by [Claude Code](https://claude.ai/code/session_01USsk1tv99xt82nGepd34vW)_