### PR TITLE
implement: salvage partial work when Codex is killed mid-attempt

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1103,6 +1103,17 @@ jobs:
                 echo "::warning::Codex returned empty output on attempt ${attempt}."
               fi
             else
+              # Watchdog kill (wall-time/idle) or other non-zero exit. Salvage
+              # any file changes Codex managed to write before being killed —
+              # otherwise long attempts that produce real partial work get
+              # discarded and the loop wastes its remaining budget restarting
+              # from scratch (see analyze-log run 24989488561).
+              codex_delta="$(git status --porcelain -uall | grep -vxFf "${CODEX_PRE_BASELINE}" || true)"
+              if [ -n "${codex_delta}" ]; then
+                echo "::warning::Codex exited with code $cmd_rc on attempt ${attempt} but produced file changes; salvaging partial work."
+                implement_succeeded=true
+                break
+              fi
               echo "::warning::Codex exited with code $cmd_rc on attempt ${attempt}."
             fi
             if [ "${attempt}" -lt "${max_attempts}" ]; then


### PR DESCRIPTION
## Summary

When the implement-loop watchdog kills Codex for wall-time/idle, the post-run handler took the `cmd_rc != 0` branch and retried without checking the worktree. Real `apply_patch`'d file changes were left orphaned on disk, and the eventual `exit 1` from the budget-skip dropped them entirely.

This change adds a salvage check: on non-zero exit, compare the Codex-attributable delta against `CODEX_PRE_BASELINE`; if non-empty, mark the attempt as a partial success and let the downstream commit/review/validate steps decide whether the work is complete.

## Motivating run

Run [`24989488561`](https://github.com/shubhodeep1/tele-funtoken-msg-scoring/actions/runs/24989488561) (issue #2732, "Make WOF spin crediting crash-safe with an outcome outbox and recovery worker") spent the full 180-min budget across 4 attempts:

| Attempt | Wall | Apply_patch calls | Outcome |
|---|---|---|---|
| 1 | 3300s | 0 | Killed — wall-time exceeded; retry |
| 2 | 3300s | 9 | Killed mid-`apply_patch`; retry — work orphaned |
| 3 | 3300s | 1 | Killed; retry — work orphaned |
| 4 | 609s (budget-capped) | 0 | Killed; retry |
| 5 | — | — | Skipped (33s left); `exit 1` |

~10 patches (the WOF outbox helpers — `_credit_wof_outcome_once`, the find-and-update on `wof_spin_outcomes`, etc.) sat on disk until the workflow step terminated. With this change, attempt 2 would have been salvaged and the partial implementation would have flowed into review.

## Notes

- This does **not** fix the underlying "task too big for 55-min × 3-attempt budget" sizing. That's an orchestrator-level concern (split issues into smaller scopes, raise `EDITOR_MAX_WALL`, etc.).
- `internal-implement.yml` is a thin `uses:` wrapper over `implement.yml@main`, so this change applies to both entry points.
- Behavior is unchanged when there are no salvageable file changes (current warning-and-retry path).

## Test plan

- [ ] CI green on this PR
- [ ] Next consumer-repo implement run that hits the watchdog kill emits the new "salvaging partial work" warning and the partial diff lands in the review step instead of being discarded
- [ ] No regression in success-no-op handling (uses a different branch and an explicit flag file)

https://claude.ai/code/session_016AY6fqEnaqvnZJZ3verd8s

---
_Generated by [Claude Code](https://claude.ai/code/session_016AY6fqEnaqvnZJZ3verd8s)_