### PR TITLE
fix(validation-harness): propagate manifest env_overrides into node-hardhat-solidity runtime

### DIFF
--- a/scripts/templates/slot_manifest.schema.json
+++ b/scripts/templates/slot_manifest.schema.json
@@ -39,6 +39,10 @@
     },
     "env_overrides": {
       "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+      },
       "additionalProperties": {
         "type": "string"
       }

--- a/tests/test_render_validation_templates_node_hardhat_regressions.py
+++ b/tests/test_render_validation_templates_node_hardhat_regressions.py
@@ -194,6 +194,127 @@ def test_compose_dockerfile_path_tracks_output_root_name() -> None:
         assert "dockerfile: custom-output/Dockerfile.app" in compose_text
 
 
+def test_env_overrides_propagate_into_validate_env_and_compose() -> None:
+    with tempfile.TemporaryDirectory(prefix="render-validation-node-hardhat-") as td:
+        temp_root = Path(td)
+        manifest_path = temp_root / "validate.yml"
+        output_root = temp_root / "out"
+        payload = _manifest_payload()
+        payload["env_overrides"] = {
+            "CI": "true",
+            "HARDHAT_NETWORK": "hardhat",
+            "HARDHAT_TEST_CMD": "npx hardhat test",
+            "RPC_URL_ETHEREUM": "https://example.invalid/eth",
+        }
+        _write_yaml(manifest_path, payload)
+
+        result = _run_renderer(manifest_path, output_root)
+        assert result.returncode == 0, result.stderr
+
+        env_text = (output_root / "validate.env").read_text(encoding="utf-8")
+        assert 'CI="true"' in env_text, env_text
+        assert 'HARDHAT_NETWORK="hardhat"' in env_text, env_text
+        assert 'HARDHAT_TEST_CMD="npx hardhat test"' in env_text, env_text
+        assert 'RPC_URL_ETHEREUM="https://example.invalid/eth"' in env_text, env_text
+        for line in env_text.splitlines():
+            if not line.strip() or line.startswith("#"):
+                continue
+            assert '="' in line and line.endswith('"'), f"unquoted validate.env line: {line}"
+
+        compose_text = (output_root / "docker-compose.test.yml").read_text(encoding="utf-8")
+        # Manifest overrides must beat the compose host-shell fallbacks. When the
+        # manifest sets an override, the compose `environment:` block must carry
+        # the literal override value (not a `${VAR:-default}` interpolation that
+        # depends on the harness host shell).
+        assert 'HARDHAT_NETWORK: "hardhat"' in compose_text, compose_text
+        assert 'HARDHAT_TEST_CMD: "npx hardhat test"' in compose_text, compose_text
+        assert 'CI: "true"' in compose_text, compose_text
+        assert 'RPC_URL_ETHEREUM: "https://example.invalid/eth"' in compose_text, compose_text
+        # The manifest override must replace the host-shell fallback for the
+        # exact key it covers; any remaining `${HARDHAT_NETWORK:-...}` would
+        # silently revert the override at compose interpolation time.
+        assert "${HARDHAT_NETWORK:-localhost}" not in compose_text, compose_text
+        assert "${HARDHAT_TEST_CMD:-" not in compose_text, compose_text
+
+
+def test_env_overrides_default_compose_falls_back_to_host_shell_when_unset() -> None:
+    with tempfile.TemporaryDirectory(prefix="render-validation-node-hardhat-") as td:
+        temp_root = Path(td)
+        manifest_path = temp_root / "validate.yml"
+        output_root = temp_root / "out"
+        _write_yaml(manifest_path, _manifest_payload())
+
+        result = _run_renderer(manifest_path, output_root)
+        assert result.returncode == 0, result.stderr
+
+        compose_text = (output_root / "docker-compose.test.yml").read_text(encoding="utf-8")
+        # No env_overrides → preserve previous default behavior so existing
+        # consumer manifests render byte-compatibly.
+        assert 'HARDHAT_NETWORK: "${HARDHAT_NETWORK:-localhost}"' in compose_text, compose_text
+        assert 'HARDHAT_TEST_CMD: "${HARDHAT_TEST_CMD:-npx hardhat test --network localhost}"' in compose_text, compose_text
+
+
+def test_rpc_probe_is_skipped_for_in_process_hardhat_network() -> None:
+    with tempfile.TemporaryDirectory(prefix="render-validation-node-hardhat-") as td:
+        temp_root = Path(td)
+        manifest_path = temp_root / "validate.yml"
+        output_root = temp_root / "out"
+        payload = _manifest_payload()
+        payload["env_overrides"] = {
+            "HARDHAT_NETWORK": "hardhat",
+        }
+        _write_yaml(manifest_path, payload)
+
+        result = _run_renderer(manifest_path, output_root)
+        assert result.returncode == 0, result.stderr
+
+        rpc_probe = (output_root / "tests" / "25_rpc_probe.sh").read_text(encoding="utf-8")
+        assert "# SKIP manifest selects in-process Hardhat network" in rpc_probe, rpc_probe
+        # The skip path must not perform any Anvil RPC traffic.
+        assert "docker compose" not in rpc_probe, rpc_probe
+        assert "http://anvil" not in rpc_probe, rpc_probe
+
+
+def test_rpc_probe_runs_when_manifest_does_not_select_in_process_hardhat() -> None:
+    with tempfile.TemporaryDirectory(prefix="render-validation-node-hardhat-") as td:
+        temp_root = Path(td)
+        manifest_path = temp_root / "validate.yml"
+        output_root = temp_root / "out"
+        _write_yaml(manifest_path, _manifest_payload())
+
+        result = _run_renderer(manifest_path, output_root)
+        assert result.returncode == 0, result.stderr
+
+        rpc_probe = (output_root / "tests" / "25_rpc_probe.sh").read_text(encoding="utf-8")
+        assert "# SKIP manifest selects in-process Hardhat network" not in rpc_probe
+        assert "docker compose" in rpc_probe
+        # Failure diagnostics must surface curl exit/stderr so a regression of
+        # the "empty response" mode is actionable rather than opaque.
+        assert "##CURL_EXIT=" in rpc_probe
+        assert "curl exit" in rpc_probe
+
+
+def test_hardhat_test_runner_does_not_clobber_container_env_with_host_shell_value() -> None:
+    with tempfile.TemporaryDirectory(prefix="render-validation-node-hardhat-") as td:
+        temp_root = Path(td)
+        manifest_path = temp_root / "validate.yml"
+        output_root = temp_root / "out"
+        _write_yaml(manifest_path, _manifest_payload())
+
+        result = _run_renderer(manifest_path, output_root)
+        assert result.returncode == 0, result.stderr
+
+        runner_text = (output_root / "tests" / "30_hardhat_test.sh").read_text(encoding="utf-8")
+        # `docker compose exec -T -e HARDHAT_TEST_CMD=...` would re-export the
+        # harness host shell value into the container and silently override the
+        # manifest-driven container env. The runner must rely on the container
+        # env (set via env_file + compose environment) instead.
+        assert "-e HARDHAT_TEST_CMD" not in runner_text, runner_text
+        # Runner must source validate.env so failure diagnostics report the
+        # actual command that ran inside the container.
+        assert '"${ROOT_DIR}/validate.env"' in runner_text, runner_text
+
+
 def main() -> int:
     tests = [func for name, func in sorted(globals().items()) if name.startswith("test_")]
     failures = 0

--- a/tests/test_render_validation_templates_node_hardhat_regressions.py
+++ b/tests/test_render_validation_templates_node_hardhat_regressions.py
@@ -455,6 +455,32 @@ def test_rpc_probe_stderr_diagnostics_prefix_every_line() -> None:
         assert "printf '# stderr: %s\\n' \"${line}\"" in rpc_probe, rpc_probe
 
 
+def test_rpc_probe_does_not_clobber_container_env_with_host_shell_values() -> None:
+    with tempfile.TemporaryDirectory(prefix="render-validation-node-hardhat-") as td:
+        temp_root = Path(td)
+        manifest_path = temp_root / "validate.yml"
+        output_root = temp_root / "out"
+        _write_yaml(manifest_path, _manifest_payload())
+
+        result = _run_renderer(manifest_path, output_root)
+        assert result.returncode == 0, result.stderr
+
+        rpc_probe = (output_root / "tests" / "25_rpc_probe.sh").read_text(encoding="utf-8")
+        non_comment_lines = "\n".join(
+            line for line in rpc_probe.splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        # `docker compose exec -T -e RPC_URL=...` re-exports the harness host
+        # shell value (which falls back to a default) into the container and
+        # silently overrides the manifest-provided container env. The probe
+        # must rely on the container env (set via env_file + compose
+        # environment) for RPC_URL instead.
+        assert "-e RPC_URL" not in non_comment_lines, non_comment_lines
+        # The probe must source validate.env so APP_SERVICE / RPC_URL service
+        # selection and diagnostics reflect the manifest-provided values.
+        assert '"${ROOT_DIR}/validate.env"' in rpc_probe, rpc_probe
+
+
 def main() -> int:
     tests = [func for name, func in sorted(globals().items()) if name.startswith("test_")]
     failures = 0

--- a/tests/test_render_validation_templates_node_hardhat_regressions.py
+++ b/tests/test_render_validation_templates_node_hardhat_regressions.py
@@ -313,6 +313,146 @@ def test_hardhat_test_runner_does_not_clobber_container_env_with_host_shell_valu
         # Runner must source validate.env so failure diagnostics report the
         # actual command that ran inside the container.
         assert '"${ROOT_DIR}/validate.env"' in runner_text, runner_text
+        # `eval` was replaced with `sh -c "${cmd}"` to avoid double-expansion
+        # surprises; assert the eval form does not regress.
+        assert "eval " not in runner_text, runner_text
+
+
+def test_env_overrides_escape_shell_metacharacters_in_validate_env() -> None:
+    with tempfile.TemporaryDirectory(prefix="render-validation-node-hardhat-") as td:
+        temp_root = Path(td)
+        manifest_path = temp_root / "validate.yml"
+        output_root = temp_root / "out"
+        payload = _manifest_payload()
+        # validate.env is sourced by 30_hardhat_test.sh, so values containing
+        # shell metacharacters must be escaped to prevent host-side command
+        # substitution / variable expansion.
+        payload["env_overrides"] = {
+            "WITH_DOLLAR": "value with $HOME and ${PATH}",
+            "WITH_BACKTICK": "value with `whoami` substitution",
+            "WITH_QUOTE": 'value with "quoted" segment',
+            "WITH_BACKSLASH": "value with \\backslash",
+        }
+        _write_yaml(manifest_path, payload)
+
+        result = _run_renderer(manifest_path, output_root)
+        assert result.returncode == 0, result.stderr
+
+        env_text = (output_root / "validate.env").read_text(encoding="utf-8")
+        # `$` is escaped as `\$` so bash double-quoted sourcing keeps the literal.
+        assert r'WITH_DOLLAR="value with \$HOME and \${PATH}"' in env_text, env_text
+        # Backticks are escaped as `\`` to avoid command substitution on source.
+        assert r'WITH_BACKTICK="value with \`whoami\` substitution"' in env_text, env_text
+        # Embedded double-quotes are escaped.
+        assert r'WITH_QUOTE="value with \"quoted\" segment"' in env_text, env_text
+        # Backslashes are doubled so a single literal `\` round-trips.
+        assert r'WITH_BACKSLASH="value with \\backslash"' in env_text, env_text
+
+
+def test_env_overrides_escape_dollar_for_compose_interpolation() -> None:
+    with tempfile.TemporaryDirectory(prefix="render-validation-node-hardhat-") as td:
+        temp_root = Path(td)
+        manifest_path = temp_root / "validate.yml"
+        output_root = temp_root / "out"
+        payload = _manifest_payload()
+        # Docker Compose performs `${VAR}` interpolation on values in the
+        # `environment:` block; `$` must be escaped as `$$` so a manifest
+        # override that itself contains a `$` is preserved literally inside the
+        # container instead of being substituted from the harness host env.
+        payload["env_overrides"] = {
+            "HARDHAT_TEST_CMD": "npx hardhat test $@",
+            "HARDHAT_NETWORK": "fork-of-${UPSTREAM_NETWORK}",
+            "EXTRA_VAR": "literal-$value",
+        }
+        _write_yaml(manifest_path, payload)
+
+        result = _run_renderer(manifest_path, output_root)
+        assert result.returncode == 0, result.stderr
+
+        compose_text = (output_root / "docker-compose.test.yml").read_text(encoding="utf-8")
+        assert 'HARDHAT_TEST_CMD: "npx hardhat test $$@"' in compose_text, compose_text
+        assert 'HARDHAT_NETWORK: "fork-of-$${UPSTREAM_NETWORK}"' in compose_text, compose_text
+        assert 'EXTRA_VAR: "literal-$$value"' in compose_text, compose_text
+
+        # Compose YAML must still round-trip through PyYAML cleanly.
+        parsed = yaml.safe_load(compose_text)
+        assert parsed["services"]["app"]["environment"]["EXTRA_VAR"] == "literal-$$value"
+
+
+def test_app_service_and_rpc_url_env_overrides_take_effect_in_compose() -> None:
+    with tempfile.TemporaryDirectory(prefix="render-validation-node-hardhat-") as td:
+        temp_root = Path(td)
+        manifest_path = temp_root / "validate.yml"
+        output_root = temp_root / "out"
+        payload = _manifest_payload()
+        # Compose's `environment:` block beats `env_file`, so APP_SERVICE and
+        # RPC_URL overrides in validate.env alone would be silently ignored.
+        # The compose template must bake manifest overrides for these keys too.
+        payload["env_overrides"] = {
+            "APP_SERVICE": "custom-app",
+            "RPC_URL": "https://example.invalid/rpc",
+        }
+        _write_yaml(manifest_path, payload)
+
+        result = _run_renderer(manifest_path, output_root)
+        assert result.returncode == 0, result.stderr
+
+        compose_text = (output_root / "docker-compose.test.yml").read_text(encoding="utf-8")
+        assert 'APP_SERVICE: "custom-app"' in compose_text, compose_text
+        assert 'RPC_URL: "https://example.invalid/rpc"' in compose_text, compose_text
+        # Default fallbacks must be replaced when the manifest overrides them.
+        assert "${APP_SERVICE:-app}" not in compose_text, compose_text
+        assert "${RPC_URL:-http://anvil:" not in compose_text, compose_text
+
+
+def test_rpc_probe_inner_shell_captures_curl_exit_without_set_e() -> None:
+    with tempfile.TemporaryDirectory(prefix="render-validation-node-hardhat-") as td:
+        temp_root = Path(td)
+        manifest_path = temp_root / "validate.yml"
+        output_root = temp_root / "out"
+        _write_yaml(manifest_path, _manifest_payload())
+
+        result = _run_renderer(manifest_path, output_root)
+        assert result.returncode == 0, result.stderr
+
+        rpc_probe = (output_root / "tests" / "25_rpc_probe.sh").read_text(encoding="utf-8")
+        # Locate the inner `/bin/sh -c '...'` block and check it specifically;
+        # the outer harness script keeps `set -euo pipefail` at the top.
+        inner_marker = "/bin/sh -c '"
+        inner_start = rpc_probe.find(inner_marker)
+        assert inner_start != -1, rpc_probe
+        inner_block_end = rpc_probe.find("' >", inner_start)
+        assert inner_block_end != -1, rpc_probe
+        inner_block = rpc_probe[inner_start:inner_block_end]
+
+        # The inner shell must NOT use `set -e` — that would abort before
+        # `printf "##CURL_EXIT=..."` runs on curl failures, so the diagnostic
+        # marker would never be written.
+        assert "set -eu" not in inner_block, inner_block
+        assert "set +e" in inner_block, inner_block
+        # Inner shell must capture the curl exit code into a variable, emit it,
+        # then exit 0 so docker compose exec succeeds and the host script can
+        # parse the marker for diagnostics.
+        assert "curl_rc=$?" in inner_block, inner_block
+        assert '##CURL_EXIT=%s' in inner_block, inner_block
+        assert "exit 0" in inner_block, inner_block
+
+
+def test_rpc_probe_stderr_diagnostics_prefix_every_line() -> None:
+    with tempfile.TemporaryDirectory(prefix="render-validation-node-hardhat-") as td:
+        temp_root = Path(td)
+        manifest_path = temp_root / "validate.yml"
+        output_root = temp_root / "out"
+        _write_yaml(manifest_path, _manifest_payload())
+
+        result = _run_renderer(manifest_path, output_root)
+        assert result.returncode == 0, result.stderr
+
+        rpc_probe = (output_root / "tests" / "25_rpc_probe.sh").read_text(encoding="utf-8")
+        # A multi-line stderr must yield TAP-comment lines for every line, not
+        # just the first; loop over lines so consumers see consistent `# ` prefixes.
+        assert "while IFS= read -r line" in rpc_probe, rpc_probe
+        assert "printf '# stderr: %s\\n' \"${line}\"" in rpc_probe, rpc_probe
 
 
 def main() -> int:

--- a/tests/test_render_validation_templates_node_hardhat_regressions.py
+++ b/tests/test_render_validation_templates_node_hardhat_regressions.py
@@ -481,6 +481,90 @@ def test_rpc_probe_does_not_clobber_container_env_with_host_shell_values() -> No
         assert '"${ROOT_DIR}/validate.env"' in rpc_probe, rpc_probe
 
 
+def test_schema_rejects_env_overrides_keys_that_are_not_valid_env_var_names() -> None:
+    with tempfile.TemporaryDirectory(prefix="render-validation-node-hardhat-") as td:
+        temp_root = Path(td)
+        manifest_path = temp_root / "validate.yml"
+        output_root = temp_root / "out"
+        payload = _manifest_payload()
+        # A key like "FOO:BAR" or "WITH-DASH" is not a POSIX env-var name and
+        # would either break the rendered compose YAML or fail to export
+        # cleanly inside the container.
+        payload["env_overrides"] = {"FOO:BAR": "value"}
+        _write_yaml(manifest_path, payload)
+
+        result = _run_renderer(manifest_path, output_root)
+        assert result.returncode != 0, result.stdout
+        assert "Manifest validation failed" in result.stderr, result.stderr
+        assert "env_overrides" in result.stderr, result.stderr
+
+
+def test_env_overrides_escape_carriage_returns_and_newlines() -> None:
+    with tempfile.TemporaryDirectory(prefix="render-validation-node-hardhat-") as td:
+        temp_root = Path(td)
+        manifest_path = temp_root / "validate.yml"
+        output_root = temp_root / "out"
+        payload = _manifest_payload()
+        # A literal newline or CR in an override value would close the YAML
+        # double-quoted string mid-line and either silently truncate or break
+        # the rendered compose / validate.env file.
+        payload["env_overrides"] = {
+            "MULTI_LINE": "line1\nline2",
+            "WITH_CR": "alpha\rbeta",
+        }
+        _write_yaml(manifest_path, payload)
+
+        result = _run_renderer(manifest_path, output_root)
+        assert result.returncode == 0, result.stderr
+
+        compose_text = (output_root / "docker-compose.test.yml").read_text(encoding="utf-8")
+        # Newlines must be escaped so the YAML stays single-line and
+        # syntactically valid; the parsed value will round-trip as the
+        # 2-character escape sequence the consumer wrote.
+        assert 'MULTI_LINE: "line1\\nline2"' in compose_text, compose_text
+        assert 'WITH_CR: "alpha\\rbeta"' in compose_text, compose_text
+        # PyYAML must still parse the rendered compose cleanly. YAML's own
+        # `\n` escape inside double-quoted strings round-trips a literal `\n`
+        # in the source back to a real newline in the parsed value, so the
+        # consumer's original newline survives end-to-end without ever
+        # spanning multiple source lines.
+        parsed = yaml.safe_load(compose_text)
+        assert parsed["services"]["app"]["environment"]["MULTI_LINE"] == "line1\nline2"
+        assert parsed["services"]["app"]["environment"]["WITH_CR"] == "alpha\rbeta"
+
+        env_text = (output_root / "validate.env").read_text(encoding="utf-8")
+        # validate.env is sourced by bash; literal newlines would split the
+        # KEY="VALUE" assignment across lines and either fail or leak the rest
+        # of the file content into the value.
+        assert 'MULTI_LINE="line1\\nline2"' in env_text, env_text
+        assert 'WITH_CR="alpha\\rbeta"' in env_text, env_text
+
+
+def test_rpc_probe_skip_decision_trims_hardhat_network_whitespace() -> None:
+    with tempfile.TemporaryDirectory(prefix="render-validation-node-hardhat-") as td:
+        temp_root = Path(td)
+        manifest_path = temp_root / "validate.yml"
+        output_root = temp_root / "out"
+        payload = _manifest_payload()
+        # YAML block scalars / consumer typos commonly leave trailing
+        # whitespace; the skip decision must normalize before comparing so a
+        # value like "hardhat " still skips the in-process probe.
+        payload["env_overrides"] = {"HARDHAT_NETWORK": "  HARDHAT \t"}
+        _write_yaml(manifest_path, payload)
+
+        result = _run_renderer(manifest_path, output_root)
+        assert result.returncode == 0, result.stderr
+
+        rpc_probe = (output_root / "tests" / "25_rpc_probe.sh").read_text(encoding="utf-8")
+        assert "# SKIP manifest selects in-process Hardhat network" in rpc_probe, rpc_probe
+
+        compose_text = (output_root / "docker-compose.test.yml").read_text(encoding="utf-8")
+        # The compose-baked HARDHAT_NETWORK must also be the trimmed,
+        # normalized value so the container's hardhat config sees the canonical
+        # network name.
+        assert 'HARDHAT_NETWORK: "HARDHAT"' in compose_text, compose_text
+
+
 def main() -> int:
     tests = [func for name, func in sorted(globals().items()) if name.startswith("test_")]
     failures = 0

--- a/workflow-templates/validation-harness/node-hardhat-solidity/docker-compose.test.yml.j2
+++ b/workflow-templates/validation-harness/node-hardhat-solidity/docker-compose.test.yml.j2
@@ -1,7 +1,9 @@
 {%- set env_overrides = manifest.get('env_overrides', {}) or {} -%}
+{%- set _app_service_override = env_overrides.get('APP_SERVICE') -%}
+{%- set _rpc_url_override = env_overrides.get('RPC_URL') -%}
 {%- set _hardhat_network_override = env_overrides.get('HARDHAT_NETWORK') -%}
 {%- set _hardhat_test_cmd_override = env_overrides.get('HARDHAT_TEST_CMD') -%}
-{%- set _reserved_override_keys = ('HARDHAT_NETWORK', 'HARDHAT_TEST_CMD', 'APP_SERVICE', 'RPC_URL') -%}
+{%- set _reserved_override_keys = ('APP_SERVICE', 'RPC_URL', 'HARDHAT_NETWORK', 'HARDHAT_TEST_CMD') -%}
 services:
   anvil:
     image: ghcr.io/foundry-rs/foundry:v1.3.1
@@ -26,21 +28,29 @@ services:
     env_file:
       - validate.env
     environment:
+{%- if _app_service_override is not none %}
+      APP_SERVICE: "{{ _app_service_override | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$$') }}"
+{%- else %}
       APP_SERVICE: "${APP_SERVICE:-app}"
+{%- endif %}
+{%- if _rpc_url_override is not none %}
+      RPC_URL: "{{ _rpc_url_override | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$$') }}"
+{%- else %}
       RPC_URL: "${RPC_URL:-http://anvil:${ANVIL_PORT:-8545}}"
+{%- endif %}
 {%- if _hardhat_network_override is not none %}
-      HARDHAT_NETWORK: "{{ _hardhat_network_override | replace('\\', '\\\\') | replace('"', '\\"') }}"
+      HARDHAT_NETWORK: "{{ _hardhat_network_override | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$$') }}"
 {%- else %}
       HARDHAT_NETWORK: "${HARDHAT_NETWORK:-localhost}"
 {%- endif %}
 {%- if _hardhat_test_cmd_override is not none %}
-      HARDHAT_TEST_CMD: "{{ _hardhat_test_cmd_override | replace('\\', '\\\\') | replace('"', '\\"') }}"
+      HARDHAT_TEST_CMD: "{{ _hardhat_test_cmd_override | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$$') }}"
 {%- else %}
       HARDHAT_TEST_CMD: "${HARDHAT_TEST_CMD:-npx hardhat test --network localhost}"
 {%- endif %}
 {%- for key, value in env_overrides | dictsort %}
 {%- if key not in _reserved_override_keys %}
-      {{ key }}: "{{ value | replace('\\', '\\\\') | replace('"', '\\"') }}"
+      {{ key }}: "{{ value | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$$') }}"
 {%- endif %}
 {%- endfor %}
     depends_on:

--- a/workflow-templates/validation-harness/node-hardhat-solidity/docker-compose.test.yml.j2
+++ b/workflow-templates/validation-harness/node-hardhat-solidity/docker-compose.test.yml.j2
@@ -29,28 +29,28 @@ services:
       - validate.env
     environment:
 {%- if _app_service_override is not none %}
-      APP_SERVICE: "{{ _app_service_override | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$$') }}"
+      APP_SERVICE: "{{ _app_service_override | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$$') | replace('\r', '\\r') | replace('\n', '\\n') }}"
 {%- else %}
       APP_SERVICE: "${APP_SERVICE:-app}"
 {%- endif %}
 {%- if _rpc_url_override is not none %}
-      RPC_URL: "{{ _rpc_url_override | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$$') }}"
+      RPC_URL: "{{ _rpc_url_override | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$$') | replace('\r', '\\r') | replace('\n', '\\n') }}"
 {%- else %}
       RPC_URL: "${RPC_URL:-http://anvil:${ANVIL_PORT:-8545}}"
 {%- endif %}
 {%- if _hardhat_network_override is not none %}
-      HARDHAT_NETWORK: "{{ _hardhat_network_override | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$$') }}"
+      HARDHAT_NETWORK: "{{ _hardhat_network_override | string | trim | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$$') | replace('\r', '\\r') | replace('\n', '\\n') }}"
 {%- else %}
       HARDHAT_NETWORK: "${HARDHAT_NETWORK:-localhost}"
 {%- endif %}
 {%- if _hardhat_test_cmd_override is not none %}
-      HARDHAT_TEST_CMD: "{{ _hardhat_test_cmd_override | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$$') }}"
+      HARDHAT_TEST_CMD: "{{ _hardhat_test_cmd_override | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$$') | replace('\r', '\\r') | replace('\n', '\\n') }}"
 {%- else %}
       HARDHAT_TEST_CMD: "${HARDHAT_TEST_CMD:-npx hardhat test --network localhost}"
 {%- endif %}
 {%- for key, value in env_overrides | dictsort %}
 {%- if key not in _reserved_override_keys %}
-      {{ key }}: "{{ value | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$$') }}"
+      {{ key }}: "{{ value | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$$') | replace('\r', '\\r') | replace('\n', '\\n') }}"
 {%- endif %}
 {%- endfor %}
     depends_on:

--- a/workflow-templates/validation-harness/node-hardhat-solidity/docker-compose.test.yml.j2
+++ b/workflow-templates/validation-harness/node-hardhat-solidity/docker-compose.test.yml.j2
@@ -1,3 +1,7 @@
+{%- set env_overrides = manifest.get('env_overrides', {}) or {} -%}
+{%- set _hardhat_network_override = env_overrides.get('HARDHAT_NETWORK') -%}
+{%- set _hardhat_test_cmd_override = env_overrides.get('HARDHAT_TEST_CMD') -%}
+{%- set _reserved_override_keys = ('HARDHAT_NETWORK', 'HARDHAT_TEST_CMD', 'APP_SERVICE', 'RPC_URL') -%}
 services:
   anvil:
     image: ghcr.io/foundry-rs/foundry:v1.3.1
@@ -24,8 +28,21 @@ services:
     environment:
       APP_SERVICE: "${APP_SERVICE:-app}"
       RPC_URL: "${RPC_URL:-http://anvil:${ANVIL_PORT:-8545}}"
+{%- if _hardhat_network_override is not none %}
+      HARDHAT_NETWORK: "{{ _hardhat_network_override | replace('\\', '\\\\') | replace('"', '\\"') }}"
+{%- else %}
       HARDHAT_NETWORK: "${HARDHAT_NETWORK:-localhost}"
+{%- endif %}
+{%- if _hardhat_test_cmd_override is not none %}
+      HARDHAT_TEST_CMD: "{{ _hardhat_test_cmd_override | replace('\\', '\\\\') | replace('"', '\\"') }}"
+{%- else %}
       HARDHAT_TEST_CMD: "${HARDHAT_TEST_CMD:-npx hardhat test --network localhost}"
+{%- endif %}
+{%- for key, value in env_overrides | dictsort %}
+{%- if key not in _reserved_override_keys %}
+      {{ key }}: "{{ value | replace('\\', '\\\\') | replace('"', '\\"') }}"
+{%- endif %}
+{%- endfor %}
     depends_on:
       anvil:
         condition: service_healthy

--- a/workflow-templates/validation-harness/node-hardhat-solidity/tests/20_rpc_probe.sh.j2
+++ b/workflow-templates/validation-harness/node-hardhat-solidity/tests/20_rpc_probe.sh.j2
@@ -1,6 +1,16 @@
+{%- set env_overrides = manifest.get('env_overrides', {}) or {} -%}
+{%- set _hardhat_network = (env_overrides.get('HARDHAT_NETWORK') or '') | string | lower -%}
+{%- set _skip_probe = _hardhat_network == 'hardhat' -%}
 #!/usr/bin/env bash
 set -euo pipefail
 
+{% if _skip_probe -%}
+# Manifest env_overrides selected the in-process Hardhat network; the harness
+# does not depend on an external JSON-RPC endpoint, so the RPC probe is skipped.
+echo "1..1"
+echo "ok 1 - rpc probe eth_blockNumber returns non-empty string .result # SKIP manifest selects in-process Hardhat network (HARDHAT_NETWORK=hardhat)"
+exit 0
+{%- else -%}
 COMPOSE_FILE="${COMPOSE_FILE:-validation/docker-compose.test.yml}"
 APP_SERVICE="${APP_SERVICE:-app}"
 RPC_URL="${RPC_URL:-http://anvil:${ANVIL_PORT:-8545}}"
@@ -8,27 +18,61 @@ RPC_PAYLOAD='{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
 
 echo "1..1"
 
-RESP="$(docker compose -f "${COMPOSE_FILE}" exec -T \
+PROBE_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${PROBE_TMP_DIR}"' EXIT
+PROBE_OUT="${PROBE_TMP_DIR}/out"
+PROBE_ERR="${PROBE_TMP_DIR}/err"
+
+set +e
+docker compose -f "${COMPOSE_FILE}" exec -T \
 	-e RPC_URL="${RPC_URL}" \
 	-e RPC_PAYLOAD="${RPC_PAYLOAD}" \
-	"${APP_SERVICE}" /bin/sh -c 'curl -fsS --max-time 10 -H "Content-Type: application/json" --data "${RPC_PAYLOAD}" "${RPC_URL}" 2>/dev/null' || true)"
+	"${APP_SERVICE}" /bin/sh -c '
+		set -eu
+		curl -fsS --max-time 10 \
+			-H "Content-Type: application/json" \
+			--data "${RPC_PAYLOAD}" \
+			"${RPC_URL}"
+		printf "\n##CURL_EXIT=%s\n" "$?"
+	' >"${PROBE_OUT}" 2>"${PROBE_ERR}"
+DOCKER_EXEC_RC=$?
+set -e
+
+CURL_EXIT="$(awk -F= '/^##CURL_EXIT=/{print $2}' "${PROBE_OUT}" | tail -n 1)"
+RESP="$(sed '/^##CURL_EXIT=/d' "${PROBE_OUT}")"
+PROBE_ERR_TEXT="$(cat "${PROBE_ERR}" 2>/dev/null || true)"
+
+emit_failure_diagnostics() {
+	echo "# rpc probe target: ${RPC_URL}"
+	echo "# docker compose exec rc: ${DOCKER_EXEC_RC}"
+	if [ -n "${CURL_EXIT}" ]; then
+		echo "# curl exit: ${CURL_EXIT}"
+	fi
+	if [ -n "${PROBE_ERR_TEXT}" ]; then
+		printf '# stderr: %s\n' "${PROBE_ERR_TEXT}"
+	fi
+}
 
 if [ -z "${RESP}" ]; then
 	echo "not ok 1 - rpc probe eth_blockNumber returns non-empty string .result"
 	echo "# empty response from ${RPC_URL}"
+	emit_failure_diagnostics
 	exit 1
 fi
 
 if ! printf '%s' "${RESP}" | jq -e 'type == "object"' >/dev/null 2>&1; then
 	echo "not ok 1 - rpc probe eth_blockNumber returns non-empty string .result"
 	echo "# response is not a JSON object: ${RESP}"
+	emit_failure_diagnostics
 	exit 1
 fi
 
 if ! printf '%s' "${RESP}" | jq -e 'has("result") and (.result != null) and (.result | type == "string") and (.result | length > 0)' >/dev/null 2>&1; then
 	echo "not ok 1 - rpc probe eth_blockNumber returns non-empty string .result"
 	echo "# missing non-empty string .result field: ${RESP}"
+	emit_failure_diagnostics
 	exit 1
 fi
 
 echo "ok 1 - rpc probe eth_blockNumber returns non-empty string .result"
+{%- endif %}

--- a/workflow-templates/validation-harness/node-hardhat-solidity/tests/20_rpc_probe.sh.j2
+++ b/workflow-templates/validation-harness/node-hardhat-solidity/tests/20_rpc_probe.sh.j2
@@ -11,6 +11,19 @@ echo "1..1"
 echo "ok 1 - rpc probe eth_blockNumber returns non-empty string .result # SKIP manifest selects in-process Hardhat network (HARDHAT_NETWORK=hardhat)"
 exit 0
 {%- else -%}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Surface manifest-level env_overrides (APP_SERVICE, RPC_URL, ...) in the
+# harness host shell so service selection and diagnostics use the manifest
+# values instead of stale host-shell defaults.
+if [ -f "${ROOT_DIR}/validate.env" ]; then
+	set -a
+	# shellcheck disable=SC1091
+	. "${ROOT_DIR}/validate.env"
+	set +a
+fi
+
 COMPOSE_FILE="${COMPOSE_FILE:-validation/docker-compose.test.yml}"
 APP_SERVICE="${APP_SERVICE:-app}"
 RPC_URL="${RPC_URL:-http://anvil:${ANVIL_PORT:-8545}}"
@@ -24,8 +37,11 @@ PROBE_OUT="${PROBE_TMP_DIR}/out"
 PROBE_ERR="${PROBE_TMP_DIR}/err"
 
 set +e
+# The container env (compose env_file + environment) already carries the
+# manifest-provided RPC_URL; do not re-export it from the harness host shell
+# with `docker compose exec -e RPC_URL=...`, because that would silently
+# clobber the manifest override with the host-shell fallback.
 docker compose -f "${COMPOSE_FILE}" exec -T \
-	-e RPC_URL="${RPC_URL}" \
 	-e RPC_PAYLOAD="${RPC_PAYLOAD}" \
 	"${APP_SERVICE}" /bin/sh -c '
 		set -u

--- a/workflow-templates/validation-harness/node-hardhat-solidity/tests/20_rpc_probe.sh.j2
+++ b/workflow-templates/validation-harness/node-hardhat-solidity/tests/20_rpc_probe.sh.j2
@@ -1,5 +1,5 @@
 {%- set env_overrides = manifest.get('env_overrides', {}) or {} -%}
-{%- set _hardhat_network = (env_overrides.get('HARDHAT_NETWORK') or '') | string | lower -%}
+{%- set _hardhat_network = (env_overrides.get('HARDHAT_NETWORK') or '') | string | trim | lower -%}
 {%- set _skip_probe = _hardhat_network == 'hardhat' -%}
 #!/usr/bin/env bash
 set -euo pipefail

--- a/workflow-templates/validation-harness/node-hardhat-solidity/tests/20_rpc_probe.sh.j2
+++ b/workflow-templates/validation-harness/node-hardhat-solidity/tests/20_rpc_probe.sh.j2
@@ -28,12 +28,15 @@ docker compose -f "${COMPOSE_FILE}" exec -T \
 	-e RPC_URL="${RPC_URL}" \
 	-e RPC_PAYLOAD="${RPC_PAYLOAD}" \
 	"${APP_SERVICE}" /bin/sh -c '
-		set -eu
+		set -u
+		set +e
 		curl -fsS --max-time 10 \
 			-H "Content-Type: application/json" \
 			--data "${RPC_PAYLOAD}" \
 			"${RPC_URL}"
-		printf "\n##CURL_EXIT=%s\n" "$?"
+		curl_rc=$?
+		printf "\n##CURL_EXIT=%s\n" "${curl_rc}"
+		exit 0
 	' >"${PROBE_OUT}" 2>"${PROBE_ERR}"
 DOCKER_EXEC_RC=$?
 set -e
@@ -49,7 +52,9 @@ emit_failure_diagnostics() {
 		echo "# curl exit: ${CURL_EXIT}"
 	fi
 	if [ -n "${PROBE_ERR_TEXT}" ]; then
-		printf '# stderr: %s\n' "${PROBE_ERR_TEXT}"
+		printf '%s\n' "${PROBE_ERR_TEXT}" | while IFS= read -r line || [ -n "${line}" ]; do
+			printf '# stderr: %s\n' "${line}"
+		done
 	fi
 }
 

--- a/workflow-templates/validation-harness/node-hardhat-solidity/tests/30_hardhat_test.sh.j2
+++ b/workflow-templates/validation-harness/node-hardhat-solidity/tests/30_hardhat_test.sh.j2
@@ -32,7 +32,7 @@ set +e
 # host shell with docker compose exec's per-call env flag, because that would
 # silently clobber the manifest override with the host shell fallback.
 docker compose -f "${COMPOSE_FILE}" exec -T \
-	"${APP_SERVICE}" /bin/sh -c 'eval "${HARDHAT_TEST_CMD:-npx hardhat test --network localhost}"' >"${TEST_LOG}" 2>&1 &
+	"${APP_SERVICE}" /bin/sh -c 'cmd="${HARDHAT_TEST_CMD:-npx hardhat test --network localhost}"; exec /bin/sh -c "${cmd}"' >"${TEST_LOG}" 2>&1 &
 TEST_PID=$!
 
 (

--- a/workflow-templates/validation-harness/node-hardhat-solidity/tests/30_hardhat_test.sh.j2
+++ b/workflow-templates/validation-harness/node-hardhat-solidity/tests/30_hardhat_test.sh.j2
@@ -9,15 +9,30 @@ APP_SERVICE="${APP_SERVICE:-app}"
 mkdir -p "${LOG_DIR}"
 TEST_LOG="${LOG_DIR}/hardhat_test.log"
 
+# Surface manifest-level env_overrides (HARDHAT_TEST_CMD, HARDHAT_NETWORK, ...)
+# in the harness host shell so failure diagnostics report what actually ran
+# inside the container instead of a stale localhost fallback.
+if [ -f "${ROOT_DIR}/validate.env" ]; then
+	set -a
+	# shellcheck disable=SC1091
+	. "${ROOT_DIR}/validate.env"
+	set +a
+fi
+
 # shellcheck source=/dev/null
 . "${ROOT_DIR}/_lib/graceful_shutdown.sh"
 
 echo "1..1"
 
+REPORTED_HARDHAT_TEST_CMD="${HARDHAT_TEST_CMD:-npx hardhat test --network localhost}"
+
 set +e
+# The container env (set via compose env_file + environment) already carries
+# the manifest-provided HARDHAT_TEST_CMD; do not re-export it from the harness
+# host shell with docker compose exec's per-call env flag, because that would
+# silently clobber the manifest override with the host shell fallback.
 docker compose -f "${COMPOSE_FILE}" exec -T \
-	-e HARDHAT_TEST_CMD="${HARDHAT_TEST_CMD:-npx hardhat test --network localhost}" \
-	"${APP_SERVICE}" /bin/sh -c '${HARDHAT_TEST_CMD}' >"${TEST_LOG}" 2>&1 &
+	"${APP_SERVICE}" /bin/sh -c 'eval "${HARDHAT_TEST_CMD:-npx hardhat test --network localhost}"' >"${TEST_LOG}" 2>&1 &
 TEST_PID=$!
 
 (
@@ -35,7 +50,7 @@ set -e
 
 if [ "${TEST_STATUS}" -ne 0 ]; then
 	echo "not ok 1 - hardhat test suite"
-	echo "# hardhat command failed: ${HARDHAT_TEST_CMD:-npx hardhat test --network localhost}"
+	echo "# hardhat command failed: ${REPORTED_HARDHAT_TEST_CMD}"
 	echo "# log tail (${TAIL_LINES:-40} lines):"
 	tail -n "${TAIL_LINES:-40}" "${TEST_LOG}" 2>/dev/null || true
 	exit 1

--- a/workflow-templates/validation-harness/node-hardhat-solidity/validate.env.j2
+++ b/workflow-templates/validation-harness/node-hardhat-solidity/validate.env.j2
@@ -11,5 +11,5 @@ VALIDATION_TEST_USERNAME="validation-user"
 VALIDATION_TEST_PASSWORD="validation-password"
 VALIDATION_TEST_API_KEY="validation-api-key"
 {%- for key, value in env_overrides | dictsort %}
-{{ key }}="{{ value | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '\\$') | replace('`', '\\`') }}"
+{{ key }}="{{ value | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '\\$') | replace('`', '\\`') | replace('\r', '\\r') | replace('\n', '\\n') }}"
 {%- endfor %}

--- a/workflow-templates/validation-harness/node-hardhat-solidity/validate.env.j2
+++ b/workflow-templates/validation-harness/node-hardhat-solidity/validate.env.j2
@@ -1,3 +1,4 @@
+{%- set env_overrides = manifest.get('env_overrides', {}) or {} -%}
 APP_SERVICE="app"
 APP_URL=""
 ANVIL_PORT="{{ manifest.get('port', 8545) }}"
@@ -9,3 +10,6 @@ TAIL_LINES="60"
 VALIDATION_TEST_USERNAME="validation-user"
 VALIDATION_TEST_PASSWORD="validation-password"
 VALIDATION_TEST_API_KEY="validation-api-key"
+{%- for key, value in env_overrides | dictsort %}
+{{ key }}="{{ value | replace('\\', '\\\\') | replace('"', '\\"') }}"
+{%- endfor %}

--- a/workflow-templates/validation-harness/node-hardhat-solidity/validate.env.j2
+++ b/workflow-templates/validation-harness/node-hardhat-solidity/validate.env.j2
@@ -11,5 +11,5 @@ VALIDATION_TEST_USERNAME="validation-user"
 VALIDATION_TEST_PASSWORD="validation-password"
 VALIDATION_TEST_API_KEY="validation-api-key"
 {%- for key, value in env_overrides | dictsort %}
-{{ key }}="{{ value | replace('\\', '\\\\') | replace('"', '\\"') }}"
+{{ key }}="{{ value | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '\\$') | replace('`', '\\`') }}"
 {%- endfor %}


### PR DESCRIPTION
## Summary

The node-hardhat-solidity validation harness was ignoring `.ai/validate.yml` `env_overrides`. The rendered runtime files dropped `CI=true`, forced `npx hardhat test --network localhost`, and unconditionally fired an Anvil RPC probe — producing two failure modes in the consumer repo:

1. `30_hardhat_test.sh` failed inside the app container with `Missing required mainnet RPC URL environment variable: RPC_URL_ETHEREUM` because the consumer's `hardhat.config.ts` mainnet RPC guard never saw `CI=true` and the runner forced `--network localhost` instead of the manifest's `npx hardhat test` (in-process Hardhat).
2. `25_rpc_probe.sh` reported `empty response from http://anvil:8545` even though the manifest selected the in-process Hardhat network (no JSON-RPC dependency).

## Changes

- **`validate.env.j2`** — append every `env_overrides` key as a quoted `KEY="VALUE"` pair so the env file carries manifest values into the container.
- **`docker-compose.test.yml.j2`** — bake manifest overrides for `HARDHAT_NETWORK` and `HARDHAT_TEST_CMD` into the compose `environment:` block as literal values (no host-shell `${VAR:-default}` interpolation that silently reverts the override). Emit other overrides verbatim. Preserve the existing `${HARDHAT_NETWORK:-localhost}` and `${HARDHAT_TEST_CMD:-…}` fallbacks when the manifest has no overrides — backwards compatible.
- **`tests/20_rpc_probe.sh.j2`** (renders to `25_rpc_probe.sh`) — skip the probe with a TAP `# SKIP` directive when the manifest selects the in-process Hardhat network. Otherwise capture and surface the curl exit code and stderr so future "empty response" failures are actionable.
- **`tests/30_hardhat_test.sh.j2`** — source `validate.env` for diagnostic accuracy, and stop re-exporting `HARDHAT_TEST_CMD` via `docker compose exec -e ...` (which clobbered the manifest override with the harness host shell's localhost fallback).
- **Regression tests** covering env_overrides propagation, default-fallback preservation, RPC probe skip vs. run (with curl-exit/stderr diagnostics), and the no-host-clobber rule.

## Test plan

- [x] `python3 -m pytest tests/test_render_validation_templates.py tests/test_render_validation_templates_node_hardhat_regressions.py tests/test_render_validation_templates_repo_checks.py tests/test_validate_process_template_mode.py tests/test_validate_harness_rpc.py` (43 passed)
- [x] `python3 scripts/validation_lint.py <rendered_output>` against an override-bearing manifest (OK)
- [x] Verified rendered `docker-compose.test.yml` is valid YAML with literal override values; `25_rpc_probe.sh` SKIPs cleanly when `HARDHAT_NETWORK=hardhat`; default render (no overrides) preserves the historical `${HARDHAT_NETWORK:-localhost}` and `${HARDHAT_TEST_CMD:-npx hardhat test --network localhost}` fallbacks byte-compatibly.
- [ ] Re-run the consumer's validation pipeline against an `.ai/validate.yml` that sets `CI: "true"`, `HARDHAT_NETWORK: "hardhat"`, `HARDHAT_TEST_CMD: "npx hardhat test"` and confirm the rpc probe is skipped and `30_hardhat_test.sh` runs `npx hardhat test` with `CI=true`.

https://claude.ai/code/session_01AaD8VGchK6VbMeYjge7Zcr

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaD8VGchK6VbMeYjge7Zcr)_