### PR TITLE
fix(review_autofix): cancel in-flight run on new commit for claude/** branches

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -660,15 +660,33 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     concurrency:
-      # cancel-in-progress: false → new runs queue behind the running peer
-      # instead of cancelling it. If another run is already pending in this
-      # group, GitHub replaces that older pending run with the newest one.
-      # This keeps bursts near "current run + newest queued run" while
-      # avoiding the long trail of cancelled in-progress runs that
-      # cancel-in-progress: true caused. Hung runs are still bounded by the
-      # timeout-minutes above.
-      group: pr-autofix-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
-      cancel-in-progress: false
+      # Two cancellation regimes, keyed off needs.gate.outputs.claude_branch_review:
+      #
+      #   * Non-claude branches (regular PR autofix): cancel-in-progress=false.
+      #     New runs queue behind the running peer instead of cancelling it.
+      #     If another run is already pending in this group, GitHub replaces
+      #     that older pending run with the newest one. This keeps bursts
+      #     near "current run + newest queued run" while avoiding the long
+      #     trail of cancelled in-progress runs that cancel-in-progress=true
+      #     used to cause. Hung runs are bounded by the timeout-minutes above.
+      #
+      #   * claude/** branches (claude_branch_review mode): cancel-in-progress=true.
+      #     A claude/** branch is being actively edited by an operator, so a
+      #     new commit means the in-flight reviewer panel is reviewing stale
+      #     code and its consensus comment will land on a superseded SHA.
+      #     Cancel the prior run on every new push so the latest commit gets
+      #     a fresh review instead of waiting through a queued run that's
+      #     about to be redone anyway.
+      #
+      # Group key fallback to inputs.head_ref_override covers the no-PR
+      # claude-branch push path (review-claude-branch-push in
+      # internal-review.yml): PR_NUMBER is empty and inputs.pr_number is "",
+      # so without the head_ref_override fallback the group would collapse
+      # to github.run_id (unique per run) and cancel-in-progress could never
+      # match a prior run on the same branch. Using the branch name keeps
+      # the group stable across commits to the same claude/** branch.
+      group: pr-autofix-${{ github.event.pull_request.number || inputs.pr_number || inputs.head_ref_override || github.run_id }}
+      cancel-in-progress: ${{ needs.gate.outputs.claude_branch_review == 'true' }}
     if: ${{ needs.gate.outputs.should_run == 'true' }}
 
     env:


### PR DESCRIPTION
## Summary

- Switch `cancel-in-progress` on the `codex-agent` job to `true` when `needs.gate.outputs.claude_branch_review == 'true'`, so a new commit on a `claude/**` branch interrupts the in-flight reviewer panel instead of letting it finish on a stale SHA.
- Non-claude PR autofix runs keep the existing queue-don't-cancel policy (`cancel-in-progress: false`).
- Extend the concurrency group fallback chain to include `inputs.head_ref_override` so the no-PR claude push path (`review-claude-branch-push` in `internal-review.yml`) groups by branch name. Without this, that path would fall through to `github.run_id` (unique per run) and `cancel-in-progress` could never match a prior run on the same branch.

## Why

Claude branches are operator-driven — when a new commit lands, the operator wants the latest tree reviewed, not a queued review of a superseded SHA. The previous policy (queue and let each run finish) was designed for issue-driven autofix loops where every reviewer pass produces commit pressure, which doesn't apply here.

## Test plan

- [ ] Push two commits in quick succession to a `claude/**` branch with an open PR; confirm the first `codex-agent` run is cancelled and only the second's reviewer panel completes.
- [ ] Push two commits in quick succession to a `claude/**` branch with no open PR; confirm the same cancellation behavior under the no-PR path.
- [ ] Push two commits in quick succession to a non-claude PR; confirm the first run still completes and the second queues behind it (existing behavior preserved).

https://claude.ai/code/session_0177wJ7JJcFnBXYwc5p3xW2U

---
_Generated by [Claude Code](https://claude.ai/code/session_0177wJ7JJcFnBXYwc5p3xW2U)_