### PR TITLE
fix(models,codex): add openai/gpt-5.4-mini to catalog; bump codex pin v0.114.0 → v0.125.0

### DIFF
--- a/.github/actions/setup-runtime/action.yml
+++ b/.github/actions/setup-runtime/action.yml
@@ -5,7 +5,7 @@ inputs:
   codex_version:
     description: Pinned Codex CLI version.
     required: false
-    default: v0.114.0
+    default: v0.125.0
   node_version:
     description: Node.js version used for Codex CLI.
     required: false

--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Install Codex CLI
         run: |
           set -euo pipefail
-          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
+          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.125.0' }}"
           npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
 
       - name: Resolve workflow support ref

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -68,7 +68,7 @@ jobs:
         if: env.SKIP_IMPLEMENT != 'true'
         run: |
           set -euo pipefail
-          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
+          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.125.0' }}"
           npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
 
       - name: Install uv for Serena

--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
+          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.125.0' }}"
           npm install -g "@openai/codex@${CODEX_VERSION}" --include=optional --no-audit --no-fund
 
           missing_tools=()

--- a/.github/workflows/orchestrate_clarify_respond.yml
+++ b/.github/workflows/orchestrate_clarify_respond.yml
@@ -184,7 +184,7 @@ jobs:
         if: steps.check_orchestrator.outputs.is_orchestrator == 'true'
         run: |
           set -euo pipefail
-          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
+          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.125.0' }}"
           npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
 
       - name: Resolve workflow support ref

--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -154,7 +154,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
+          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.125.0' }}"
           npm install -g "@openai/codex@${CODEX_VERSION}" --include=optional --no-audit --no-fund
 
           missing_tools=()

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -43,7 +43,7 @@ jobs:
       OPENROUTER_PROMPT_CACHE_DISABLED: ${{ vars.OPENROUTER_PROMPT_CACHE_DISABLED || 'false' }}
       AUTO_IMPLEMENT_ON_CLEAR_PLAN: ${{ vars.AUTO_IMPLEMENT_ON_CLEAR_PLAN || 'true' }}
       PLAN_FAILURE_CONTEXT: "Planning run did not complete."
-      CODEX_VERSION: ${{ vars.CODEX_VERSION || 'v0.114.0' }}
+      CODEX_VERSION: ${{ vars.CODEX_VERSION || 'v0.125.0' }}
       PROCESSED_ANSWER_CLAIMED: "false"
       PROCESSED_ANSWER_COMPLETED: "false"
 
@@ -53,7 +53,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ runner.tool_cache }}/codex
-          key: codex-${{ vars.CODEX_VERSION || 'v0.114.0' }}
+          key: codex-${{ vars.CODEX_VERSION || 'v0.125.0' }}
 
       - name: Install Codex CLI
         if: steps.cache-codex.outputs.cache-hit != 'true'

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1027,7 +1027,7 @@ jobs:
       - name: Install dependencies
         run: |
           set -euo pipefail
-          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
+          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.125.0' }}"
           npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
           sudo apt-get update
           sudo apt-get install -y jq curl python3

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -176,7 +176,7 @@ jobs:
       report_file: ${{ steps.analyze.outputs.report_file }}
       analysis_status: ${{ steps.analyze.outputs.analysis_status }}
     env:
-      CODEX_VERSION: ${{ vars.CODEX_VERSION || 'v0.114.0' }}
+      CODEX_VERSION: ${{ vars.CODEX_VERSION || 'v0.125.0' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -194,7 +194,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ runner.tool_cache }}/codex
-          key: codex-${{ vars.CODEX_VERSION || 'v0.114.0' }}
+          key: codex-${{ vars.CODEX_VERSION || 'v0.125.0' }}
 
       - name: Install Codex CLI
         if: steps.cache-codex.outputs.cache-hit != 'true'
@@ -599,7 +599,7 @@ jobs:
     outputs:
       audit_status: ${{ steps.audit.outputs.audit_status }}
     env:
-      CODEX_VERSION: ${{ vars.CODEX_VERSION || 'v0.114.0' }}
+      CODEX_VERSION: ${{ vars.CODEX_VERSION || 'v0.125.0' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -617,7 +617,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ runner.tool_cache }}/codex
-          key: codex-${{ vars.CODEX_VERSION || 'v0.114.0' }}
+          key: codex-${{ vars.CODEX_VERSION || 'v0.125.0' }}
 
       - name: Install Codex CLI
         if: steps.cache-codex.outputs.cache-hit != 'true'
@@ -915,7 +915,7 @@ jobs:
     outputs:
       api_redundancy_status: ${{ steps.api_redundancy.outputs.api_redundancy_status }}
     env:
-      CODEX_VERSION: ${{ vars.CODEX_VERSION || 'v0.114.0' }}
+      CODEX_VERSION: ${{ vars.CODEX_VERSION || 'v0.125.0' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -933,7 +933,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ runner.tool_cache }}/codex
-          key: codex-${{ vars.CODEX_VERSION || 'v0.114.0' }}
+          key: codex-${{ vars.CODEX_VERSION || 'v0.125.0' }}
 
       - name: Install Codex CLI
         if: steps.cache-codex.outputs.cache-hit != 'true'

--- a/prompts/mode-validate-diagnose.txt
+++ b/prompts/mode-validate-diagnose.txt
@@ -1,5 +1,5 @@
 You are executing the VALIDATE-DIAGNOSE phase of the AI development pipeline.
-You are Codex v0.114.0 running in unattended CI mode.
+You are Codex v0.125.0 running in unattended CI mode.
 
 All context is inlined directly into the prompt for efficiency:
 - System instructions, AI pipeline spec, agents.md, and README.md appear above.

--- a/prompts/mode-validate-discover.txt
+++ b/prompts/mode-validate-discover.txt
@@ -1,5 +1,5 @@
 You are executing the VALIDATE-DISCOVER phase of the AI development pipeline.
-You are Codex v0.114.0 running in unattended CI mode.
+You are Codex v0.125.0 running in unattended CI mode.
 
 All context is inlined directly into the prompt for efficiency:
 - System instructions, AI pipeline spec, agents.md, and README.md appear above.

--- a/prompts/mode-validate-fix-harness.txt
+++ b/prompts/mode-validate-fix-harness.txt
@@ -1,5 +1,5 @@
 You are executing the VALIDATE-FIX-HARNESS phase of the AI development pipeline.
-You are Codex v0.114.0 running in unattended CI mode.
+You are Codex v0.125.0 running in unattended CI mode.
 
 All context is inlined directly into the prompt for efficiency:
 - System instructions, AI pipeline spec, agents.md, and README.md appear above.

--- a/prompts/mode-validate-generate.txt
+++ b/prompts/mode-validate-generate.txt
@@ -1,5 +1,5 @@
 You are executing the VALIDATE-GENERATE phase of the AI development pipeline.
-You are Codex v0.114.0 running in unattended CI mode.
+You are Codex v0.125.0 running in unattended CI mode.
 
 All context is inlined directly into the prompt for efficiency:
 - System instructions, AI pipeline spec, agents.md, and README.md appear above.

--- a/prompts/mode-validate-self-heal.txt
+++ b/prompts/mode-validate-self-heal.txt
@@ -1,5 +1,5 @@
 You are executing the VALIDATE-SELF-HEAL phase of the AI development pipeline.
-You are Codex v0.114.0 running in unattended CI mode.
+You are Codex v0.125.0 running in unattended CI mode.
 
 All context is inlined directly into the prompt for efficiency:
 - System instructions, AI pipeline spec, agents.md, and README.md appear above.

--- a/scripts/codex_model_catalog.json
+++ b/scripts/codex_model_catalog.json
@@ -425,6 +425,37 @@
       "input_modalities": ["text", "image"]
     },
     {
+      "slug": "openai/gpt-5.4-mini",
+      "display_name": "GPT-5.4 Mini",
+      "description": "OpenAI GPT-5.4 Mini - 400K context, multimodal (text/image), reasoning + tool use, mid-tier pricing ($0.75/$4.50 per M)",
+      "supported_reasoning_levels": [
+        {"effort": "low", "description": "Fast with minimal reasoning"},
+        {"effort": "medium", "description": "Balanced reasoning"},
+        {"effort": "high", "description": "Thorough reasoning"},
+        {"effort": "xhigh", "description": "Maximum reasoning depth"}
+      ],
+      "shell_type": "shell_command",
+      "visibility": "list",
+      "supported_in_api": true,
+      "priority": 4,
+      "upgrade": null,
+      "base_instructions": "You are a senior software engineer acting as an AI code reviewer and editor. You have access to shell commands for reading files and exploring the repository. Use them to understand the codebase before making changes. Be precise, minimal, and correct.",
+      "model_messages": null,
+      "supports_reasoning_summaries": true,
+      "default_reasoning_summary": "auto",
+      "support_verbosity": false,
+      "default_verbosity": null,
+      "apply_patch_tool_type": "freeform",
+      "truncation_policy": {"mode": "tokens", "limit": 400000},
+      "supports_parallel_tool_calls": true,
+      "supports_image_detail_original": false,
+      "context_window": 400000,
+      "auto_compact_token_limit": 304000,
+      "effective_context_window_percent": 95,
+      "experimental_supported_tools": [],
+      "input_modalities": ["text", "image"]
+    },
+    {
       "slug": "deepseek/deepseek-v4-pro",
       "display_name": "DeepSeek V4 Pro",
       "description": "DeepSeek V4 Pro - 1M context, text-only, tool calling, near-trivial cached-input pricing ($0.435/$0.87 per M)",


### PR DESCRIPTION
## Summary

- **Adds `openai/gpt-5.4-mini` to `scripts/codex_model_catalog.json`** — the slug exists on OpenRouter (verified at https://openrouter.ai/openai/gpt-5.4-mini) but was never added to the catalog after `XPOLL_SUMMARISER_MODEL` was set to it in `review_autofix.yml`.
- **Bumps `CODEX_VERSION` default `v0.114.0` → `v0.125.0`** across all 9 workflows + 1 composite action (15 pin sites total); `vars.CODEX_VERSION` repo-var override path unchanged.

## Why

Two `review_autofix` runs against `claude/analyze-job-logs-*` branches failed identically (run IDs `25026882619` and `25027318001`). The job-killing error was:

```
##[error]summariser (pass1): all 10 attempts failed (last rc=1).
##[error]Process completed with exit code 1.
```

`scripts/summarize_reviewer_consensus.sh` invokes codex-cli with `--model openai/gpt-5.4-mini`. Each of the 10 retries failed in ~3-4 seconds — the deterministic fast-fail signature for an unknown model slug. The slug *does* exist on OpenRouter (400K ctx, $0.75/$4.50 per M, text+image, reasoning-enabled), it was just missing from the local catalog.

The 10-attempt exponential backoff (5→10→20→40→80→160→320→640→1280s) consumed ~47 min of wall-clock per run before hard-failing.

## Catalog entry shape

Mirrors `gpt-5.4-nano`:

| field | gpt-5.4-mini | gpt-5.4-nano (reference) |
|---|---|---|
| context_window | 400 000 | 400 000 |
| input/output ($/M) | 0.75 / 4.50 | 0.20 / 1.25 |
| input_modalities | text, image | text, image |
| reasoning levels | low/medium/high/xhigh | same |
| priority | 4 | 5 |
| truncation_policy | tokens, 400000 | tokens, 400000 |
| apply_patch_tool_type | freeform | freeform |
| supports_reasoning_summaries | true | true |

## Codex CLI bump (v0.114.0 → v0.125.0)

11 minor versions behind — current upstream is v0.125.0 (published 2026-04-24).

**Compatibility scan (developers.openai.com/codex/changelog + GitHub releases):**
- v0.122 — formalised root→subcommand flag inheritance. **Compatible** with our `codex --ask-for-approval never exec --model X --sandbox read-only` pattern (`scripts/review_rb_judge.sh:295`, `scripts/summarize_reviewer_consensus.sh:275`).
- v0.123 — `codex exec --json` now reports reasoning-token usage. **No-op** — we don't consume `--json`.
- v0.123 — plugin MCP loading accepts both `mcpServers` and top-level server maps in `.mcp.json`. **Compat-expand**, not break.
- v0.125 — config validation tightened (rejects conflicting `MultiAgentV2` thread limits, hides unsupported MCP bearer-token fields). **Not used** in our `config.toml`.

**Surface area scan:**
- All `codex exec` invocations across `scripts/` and `.github/workflows/` use stable flags only: `--model`, `--full-auto`, `--ask-for-approval`, `--sandbox`. None deprecated.
- `model_reasoning_effort` in `config.toml` (sed-patched in `summarize_reviewer_consensus.sh:222`) — schema unchanged.
- Serena MCP config (`scripts/setup_serena.sh`) — schema unchanged in this range.

**Pin sites updated (15):**
- `.github/actions/setup-runtime/action.yml:8` (composite action default)
- `.github/workflows/clarify.yml:158`
- `.github/workflows/implement.yml:71`
- `.github/workflows/orchestrate.yml:79`
- `.github/workflows/orchestrate_clarify_respond.yml:187`
- `.github/workflows/orchestrate_poll.yml:157`
- `.github/workflows/plan.yml:46,56`
- `.github/workflows/review_autofix.yml:1030`
- `.github/workflows/workflow-log-analysis.yml:179,197,602,620,918,936`

## Out of scope (deferred from log analysis)

- **3 reviewer slugs failed fast on the same run** (`deepseek/deepseek-v4-pro`, `qwen/qwen3.6-plus`, `x-ai/grok-4.1-fast`). All three are confirmed live on OpenRouter, so this looks transient/provider-side — no catalog change. Will re-evaluate if the next run still shows the same pattern.
- **`gh: Variable $number of type Int!` GraphQL spam** in the no-PR `claude-branch-review` path (`review_autofix.yml:1330-1335`) wastes ~28s per run on 5 retries of an empty `PR_NUMBER`. Workflow already fail-opens, so non-fatal. Deferred per Q1 selection (option A — only model catalog fix).

## Test plan

- [ ] CI passes on this PR (validates JSON catalog + workflow YAML schema).
- [ ] After merge, manually re-trigger `review_autofix` on a `claude/analyze-job-logs-*` branch and confirm the summariser pass-1 step now succeeds (instead of 10× rc=1 fast-failing).
- [ ] Confirm `npm install -g @openai/codex@v0.125.0 --include=optional` succeeds on the runner image used by `setup-runtime/action.yml`.
- [ ] Confirm Serena MCP startup (`scripts/setup_serena.sh`) and `codex exec --model openai/gpt-5.3-codex --full-auto` still work end-to-end on v0.125.0 in at least one `implement.yml` smoke run.

https://claude.ai/code/session_01PwQ8s5gTtNAFr28PXU9VZH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwQ8s5gTtNAFr28PXU9VZH)_