### PR TITLE
fix(setup_serena): pin context7-mcp to 2.1.8

### DIFF
--- a/scripts/setup_serena.sh
+++ b/scripts/setup_serena.sh
@@ -570,7 +570,7 @@ if [ "${CONTEXT7_DISABLED:-false}" != "true" ]; then
 
 [mcp_servers.context7]
 command = "npx"
-args = ["-y", "@upstash/context7-mcp@latest"]
+args = ["-y", "@upstash/context7-mcp@2.1.8"]
 required = false
 CONTEXT7_MCP_EOF
 	then


### PR DESCRIPTION
## Summary
- `scripts/setup_serena.sh` registered Context7 MCP via `@upstash/context7-mcp@latest`. The `@latest` tag pulled `2.2.1` (published 2026-04-27, ~10h before the failed run) whose handshake fails inside Codex (`mcp: context7 failed: MCP client for context7 failed to start: ... connection closed: initialize response`).
- After the failed handshake, Codex still includes a partially-constructed tool entry for context7 in its API request. OpenRouter's Azure provider then rejects the call with HTTP 400 — `7.type: Invalid input: expected "function"; 7.function: Invalid input: expected object, received undefined` — and Codex exits 1 on every retry, killing `implement.yml` after 5 attempts.
- Pin to `@2.1.8` (2026-04-13), the most recent stable release predating the regression, to restore a known-good handshake.

## Test plan
- [ ] Re-run an `implement.yml` workflow on a representative issue and confirm `mcp: context7 ready` appears (no handshake failure)
- [ ] Confirm Codex completes at least attempt 1 without the OpenRouter `tools[7]` 400 error
- [ ] Verify `CONTEXT7_DISABLED=true` still short-circuits the block (no regression to existing toggle)

Source: [job-logs.txt analysis](https://productionresultssa17.blob.core.windows.net/actions-results/064be7fd-1778-4304-83ce-f35fb7d63694/workflow-job-run-3eb3296b-657a-5de1-a6a5-e9e31646c4ae/logs/job/job-logs.txt) — `##[error]Codex implement failed after 5 attempts.` on issue #2738 implement run.

https://claude.ai/code/session_01N6EciNGG2YeHTgFP5d4PxP

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6EciNGG2YeHTgFP5d4PxP)_