### PR TITLE
review_autofix: suffix codex-agent check name with (claude-branch-review) on claude/** PRs

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -657,6 +657,15 @@ jobs:
 
   codex-agent:
     needs: gate
+    # Display name surfaces the gate's claude_branch_review decision in the
+    # GitHub Checks UI. When the head ref is claude/**, the gate flips into
+    # review-only mode (reviewer panel + summariser + PR comment; no
+    # editor/commit/push/judge/auto-merge tail) — the suffix below makes
+    # that mode obvious from the check name without having to open the gate
+    # job logs. Job ID stays "codex-agent" so cross-references in
+    # internal-review.yml / status checks / required-checks rules don't
+    # break.
+    name: ${{ needs.gate.outputs.claude_branch_review == 'true' && 'codex-agent (claude-branch-review)' || 'codex-agent' }}
     runs-on: ubuntu-latest
     timeout-minutes: 180
     concurrency:


### PR DESCRIPTION
## Summary

Make the `claude/**` review-only mode visible from the GitHub Checks UI by suffixing the `codex-agent` check name with `(claude-branch-review)` when the gate flagged that mode.

Today, on a `claude/**` PR, the gate (`review_autofix.yml:247-255`) detects the head ref and exports `CLAUDE_BRANCH_REVIEW_MODE=true` to `codex-agent`, which then runs the reviewer panel + summariser + `post_review_comment.sh` and skips the editor/commit/push/judge/auto-merge tail. But the check displayed as `review / codex-agent` — identical to a regular PR autofix run — so it looked like the non-claude flow was firing. The suffix makes the routing decision evident without opening the gate job log.

## Why this looked confusing on PR #1703

A `claude/**` push fires both event paths in `internal-review.yml`:

1. `push: claude/**` → `resolve-claude-branch-pr` → `review-claude-branch-push`
2. `pull_request:synchronize` → `review` → `review_autofix.yml@main`

When a PR exists, `resolve-claude-branch-pr` emits `proceed=false` and `review-claude-branch-push` skips (to avoid double-firing); the `pull_request` path handles the review through the regular `review` job, with the gate inside `review_autofix.yml` flipping it into review-only mode. The displayed check stayed `review / codex-agent`, hiding the mode flip.

## Implementation

* `name: ${{ needs.gate.outputs.claude_branch_review == 'true' && 'codex-agent (claude-branch-review)' || 'codex-agent' }}` on the `codex-agent` job.
* Job ID stays `codex-agent` so `internal-review.yml`, agents.md, README, required-status-check rules, and historical log references continue to resolve.
* On non-claude branches the displayed name is byte-identical to before (`codex-agent`), so any branch protection / required-checks rule keyed on `review / codex-agent` is unaffected for the regular PR flow.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/review_autofix.yml'))"` — file parses.
- [ ] On the next push to a `claude/**` branch with an open PR, verify the displayed check is `review / codex-agent (claude-branch-review)`.
- [ ] On the next push to a non-claude branch, verify the displayed check is unchanged: `review / codex-agent`.

https://claude.ai/code/session_01SReZCLFviU31DieZx2xL9K

---
_Generated by [Claude Code](https://claude.ai/code/session_01SReZCLFviU31DieZx2xL9K)_