### PR TITLE
post-codex: strip fences pre-validate, retry step lookup, dedupe+escalate defers

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -2553,14 +2553,24 @@ jobs:
             exit 0
           fi
 
-          RUN_JOBS_JSON="$(gh_retry _safe_gh_jq "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" || true)"
+          # Race window: when this step runs, the GitHub jobs API can
+          # briefly return all step conclusions as null/in_progress
+          # before the failing step is finalised. Retry a few times so
+          # diagnose downstream gets a real step name instead of
+          # falling through to "unknown-step".
           FAILED_STEP_NAME=""
-          if [ -n "${RUN_JOBS_JSON}" ]; then
-            FAILED_STEP_NAME="$(printf '%s' "${RUN_JOBS_JSON}" | jq -r '[.jobs[].steps[] | select(.conclusion == "failure")] | first | .name // ""' 2>/dev/null || true)"
-            if [ -z "${FAILED_STEP_NAME}" ] && [ "${{ job.status }}" = "cancelled" ]; then
-              FAILED_STEP_NAME="$(printf '%s' "${RUN_JOBS_JSON}" | jq -r '[.jobs[].steps[] | select(.conclusion == "cancelled" or .status == "in_progress")] | first | .name // ""' 2>/dev/null || true)"
+          RUN_JOBS_JSON=""
+          for _attempt in 1 2 3; do
+            RUN_JOBS_JSON="$(gh_retry _safe_gh_jq "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" || true)"
+            if [ -n "${RUN_JOBS_JSON}" ]; then
+              FAILED_STEP_NAME="$(printf '%s' "${RUN_JOBS_JSON}" | jq -r '[.jobs[].steps[] | select(.conclusion == "failure")] | first | .name // ""' 2>/dev/null || true)"
+              if [ -z "${FAILED_STEP_NAME}" ] && [ "${{ job.status }}" = "cancelled" ]; then
+                FAILED_STEP_NAME="$(printf '%s' "${RUN_JOBS_JSON}" | jq -r '[.jobs[].steps[] | select(.conclusion == "cancelled" or .status == "in_progress")] | first | .name // ""' 2>/dev/null || true)"
+              fi
             fi
-          fi
+            [ -n "${FAILED_STEP_NAME}" ] && break
+            [ "${_attempt}" -lt 3 ] && sleep 4 || true
+          done
           echo "failed_step_name=${FAILED_STEP_NAME}" >> "$GITHUB_OUTPUT"
 
           CAPTURE_FILE="${RUNTIME_DIR}/post_codex_validation_errors.txt"

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1268,7 +1268,7 @@ jobs:
           done < <(git diff --name-only --diff-filter=ACMR -z HEAD)
           while IFS= read -r -d '' path; do
             printf '%s\n' "${path}" >> "${INITIAL_CHANGED_FILE}"
-          done < <(git ls-files --others --exclude-standard -z -- '*.py' '*.js' '*.sh' '*.yml' '*.yaml')
+          done < <(git ls-files --others --exclude-standard -z -- '*.py' '*.js' '*.sh' '*.yml' '*.yaml' '*.json')
           sort -u "${INITIAL_CHANGED_FILE}" -o "${INITIAL_CHANGED_FILE}" || true
 
           : > "${CAPTURED_FILES_FILE}"

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -2554,19 +2554,24 @@ jobs:
           fi
 
           # Race window: when this step runs, the GitHub jobs API can
-          # briefly return all step conclusions as null/in_progress
-          # before the failing step is finalised. Retry a few times so
-          # diagnose downstream gets a real step name instead of
-          # falling through to "unknown-step".
+          # briefly return valid JSON whose step conclusions are still
+          # null/in_progress before the failing step is finalised. In
+          # that case retry up to 3× so diagnose downstream gets a real
+          # step name instead of falling through to "unknown-step".
+          # Empty/invalid responses are treated as terminal — the API
+          # is not going to start returning valid JSON on retry, so we
+          # avoid burning extra calls and let the unknown-step
+          # fallback handle them.
           FAILED_STEP_NAME=""
           RUN_JOBS_JSON=""
           for _attempt in 1 2 3; do
             RUN_JOBS_JSON="$(gh_retry _safe_gh_jq "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" || true)"
-            if [ -n "${RUN_JOBS_JSON}" ]; then
-              FAILED_STEP_NAME="$(printf '%s' "${RUN_JOBS_JSON}" | jq -r '[.jobs[].steps[] | select(.conclusion == "failure")] | first | .name // ""' 2>/dev/null || true)"
-              if [ -z "${FAILED_STEP_NAME}" ] && [ "${{ job.status }}" = "cancelled" ]; then
-                FAILED_STEP_NAME="$(printf '%s' "${RUN_JOBS_JSON}" | jq -r '[.jobs[].steps[] | select(.conclusion == "cancelled" or .status == "in_progress")] | first | .name // ""' 2>/dev/null || true)"
-              fi
+            if ! printf '%s' "${RUN_JOBS_JSON}" | jq -e 'type == "object" and (.jobs | type == "array")' >/dev/null 2>&1; then
+              break
+            fi
+            FAILED_STEP_NAME="$(printf '%s' "${RUN_JOBS_JSON}" | jq -r '[.jobs[].steps[] | select(.conclusion == "failure")] | first | .name // ""' 2>/dev/null || true)"
+            if [ -z "${FAILED_STEP_NAME}" ] && [ "${{ job.status }}" = "cancelled" ]; then
+              FAILED_STEP_NAME="$(printf '%s' "${RUN_JOBS_JSON}" | jq -r '[.jobs[].steps[] | select(.conclusion == "cancelled" or .status == "in_progress")] | first | .name // ""' 2>/dev/null || true)"
             fi
             [ -n "${FAILED_STEP_NAME}" ] && break
             [ "${_attempt}" -lt 3 ] && sleep 4 || true

--- a/prompts/mode-implement.txt
+++ b/prompts/mode-implement.txt
@@ -77,6 +77,16 @@ Rules:
   lockfiles as an unrelated side effect — that violates the minimal-change
   rule.
 
+Data-file output discipline (MANDATORY when writing YAML or JSON):
+
+- When writing files under `db/contracts/` or any other YAML/JSON path,
+  emit raw YAML or raw JSON only. Never wrap the file body in markdown
+  code fences (` ``` ` or ` ```yaml ` / ` ```json `), and never include
+  language tags, fence markers, or surrounding prose in the file. The
+  file's first byte must be valid YAML/JSON, and its last byte must be
+  valid YAML/JSON — anything else is a syntax error that breaks the
+  post-Codex validation step.
+
 If clarification context is incomplete, apply the safest minimal interpretation and explicitly record assumptions in your output/log summary without asking interactive questions.
 
 {{SERENA_EFFICIENCY_BLOCK_READ_WRITE}}

--- a/scripts/implement_diagnose_post_codex_failure.sh
+++ b/scripts/implement_diagnose_post_codex_failure.sh
@@ -121,21 +121,31 @@ ensure_implement_fixup_labels() {
   fi
 }
 
-FAILED_STEP_JOBS_JSON="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" || true)"
-if [ -z "${FAILED_STEP_JOBS_JSON}" ]; then
-  FAILED_STEP_JOBS_JSON='{"jobs":[]}'
-fi
-FAILED_STEP_NAME="$(printf '%s' "${FAILED_STEP_JOBS_JSON}" | jq -r '
-  [.jobs[].steps[]
-    | select(
-        .conclusion == "failure"
-        or .conclusion == "cancelled"
-        or .conclusion == "timed_out"
-        or .conclusion == "action_required"
-      )
-  ]
-  | first
-  | .name // ""' 2>/dev/null || true)"
+# Race window: GitHub's jobs API may not yet have populated step
+# conclusions when this script runs immediately after a failure.
+# Retry a few times before falling back to "unknown-step" so the
+# diagnose prompt gets a real step name.
+FAILED_STEP_JOBS_JSON=""
+FAILED_STEP_NAME=""
+for _attempt in 1 2 3; do
+  FAILED_STEP_JOBS_JSON="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" || true)"
+  if [ -z "${FAILED_STEP_JOBS_JSON}" ]; then
+    FAILED_STEP_JOBS_JSON='{"jobs":[]}'
+  fi
+  FAILED_STEP_NAME="$(printf '%s' "${FAILED_STEP_JOBS_JSON}" | jq -r '
+    [.jobs[].steps[]
+      | select(
+          .conclusion == "failure"
+          or .conclusion == "cancelled"
+          or .conclusion == "timed_out"
+          or .conclusion == "action_required"
+        )
+    ]
+    | first
+    | .name // ""' 2>/dev/null || true)"
+  [ -n "${FAILED_STEP_NAME}" ] && break
+  [ "${_attempt}" -lt 3 ] && sleep 4 || true
+done
 if [ -z "${FAILED_STEP_NAME}" ]; then
   FAILED_STEP_NAME="unknown-step"
 fi

--- a/scripts/implement_diagnose_post_codex_failure.sh
+++ b/scripts/implement_diagnose_post_codex_failure.sh
@@ -121,16 +121,19 @@ ensure_implement_fixup_labels() {
   fi
 }
 
-# Race window: GitHub's jobs API may not yet have populated step
-# conclusions when this script runs immediately after a failure.
-# Retry a few times before falling back to "unknown-step" so the
-# diagnose prompt gets a real step name.
+# Race window: GitHub's jobs API may briefly return valid JSON whose
+# step conclusions are still null/in_progress immediately after a
+# failure. In that case retry up to 3× so diagnose gets a real step
+# name. Empty/invalid responses are treated as terminal — they will
+# not become parseable on retry, so we let the unknown-step fallback
+# handle them rather than burning extra API calls.
 FAILED_STEP_JOBS_JSON=""
 FAILED_STEP_NAME=""
 for _attempt in 1 2 3; do
   FAILED_STEP_JOBS_JSON="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" || true)"
-  if [ -z "${FAILED_STEP_JOBS_JSON}" ]; then
+  if ! printf '%s' "${FAILED_STEP_JOBS_JSON}" | jq -e 'type == "object" and (.jobs | type == "array")' >/dev/null 2>&1; then
     FAILED_STEP_JOBS_JSON='{"jobs":[]}'
+    break
   fi
   FAILED_STEP_NAME="$(printf '%s' "${FAILED_STEP_JOBS_JSON}" | jq -r '
     [.jobs[].steps[]

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -10042,11 +10042,15 @@ ${RB_FIX_DESC}
           IF_SHOULD_ESCALATE="true"
           IF_ESCALATED_FLAG="true"
         fi
-        jq --arg key "${if_issue}" --arg summary "${IF_DEFER_SIGNATURE}" --argjson count "${IF_DEFER_COUNT}" --argjson escalated "${IF_ESCALATED_FLAG}" '
+        if jq --arg key "${if_issue}" --arg summary "${IF_DEFER_SIGNATURE}" --argjson count "${IF_DEFER_COUNT}" --argjson escalated "${IF_ESCALATED_FLAG}" '
           .implementation_failed_defer_state //= {}
           | .implementation_failed_defer_state[$key] = {summary: $summary, count: $count, escalated: $escalated}
-        ' "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
-        IMPL_FAILED_STATE_CHANGED=true
+        ' "${STATE_FILE}" > "${STATE_FILE}.tmp"; then
+          mv "${STATE_FILE}.tmp" "${STATE_FILE}"
+          IMPL_FAILED_STATE_CHANGED=true
+        else
+          rm -f "${STATE_FILE}.tmp" 2>/dev/null || true
+        fi
 
         echo "  Deferring implementation-failed reissue for #${if_issue} (${IF_LOCAL_ID}): mode=${IF_MODE}; blockers=${IF_BLOCKERS_CSV}; statuses=${IF_BLOCKER_STATUS_SUMMARY}; reason=${IF_DEFER_REASON}; cycle=${IF_DEFER_COUNT}/${MAX_IMPL_FAILED_DEFER_CYCLES}; escalated=${IF_ESCALATED_FLAG}."
         if [ "${IF_SHOULD_ESCALATE}" = "true" ]; then
@@ -10078,11 +10082,15 @@ ${RB_FIX_DESC}
         IF_SHOULD_ESCALATE="true"
         IF_ESCALATED_FLAG="true"
       fi
-      jq --arg key "${if_issue}" --arg summary "${IF_DEFER_SIGNATURE}" --argjson count "${IF_DEFER_COUNT}" --argjson escalated "${IF_ESCALATED_FLAG}" '
+      if jq --arg key "${if_issue}" --arg summary "${IF_DEFER_SIGNATURE}" --argjson count "${IF_DEFER_COUNT}" --argjson escalated "${IF_ESCALATED_FLAG}" '
         .implementation_failed_defer_state //= {}
         | .implementation_failed_defer_state[$key] = {summary: $summary, count: $count, escalated: $escalated}
-      ' "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
-      IMPL_FAILED_STATE_CHANGED=true
+      ' "${STATE_FILE}" > "${STATE_FILE}.tmp"; then
+        mv "${STATE_FILE}.tmp" "${STATE_FILE}"
+        IMPL_FAILED_STATE_CHANGED=true
+      else
+        rm -f "${STATE_FILE}.tmp" 2>/dev/null || true
+      fi
 
       echo "  Deferring implementation-failed reissue for #${if_issue} (${IF_LOCAL_ID}): mode=${IF_MODE}; reason=${IF_DEFER_REASON}; cycle=${IF_DEFER_COUNT}/${MAX_IMPL_FAILED_DEFER_CYCLES}; escalated=${IF_ESCALATED_FLAG}."
       if [ "${IF_SHOULD_ESCALATE}" = "true" ]; then
@@ -10100,13 +10108,17 @@ ${RB_FIX_DESC}
     # Reissue path reached: clear any stale defer-state entry so a
     # later failure starts a fresh dedup/escalation window.
     if jq -e --arg key "${if_issue}" '(.implementation_failed_defer_state // {}) | has($key)' "${STATE_FILE}" >/dev/null 2>&1; then
-      jq --arg key "${if_issue}" '
+      if jq --arg key "${if_issue}" '
         if (.implementation_failed_defer_state | type) == "object"
           then .implementation_failed_defer_state |= del(.[$key])
           else .
         end
-      ' "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
-      IMPL_FAILED_STATE_CHANGED=true
+      ' "${STATE_FILE}" > "${STATE_FILE}.tmp"; then
+        mv "${STATE_FILE}.tmp" "${STATE_FILE}"
+        IMPL_FAILED_STATE_CHANGED=true
+      else
+        rm -f "${STATE_FILE}.tmp" 2>/dev/null || true
+      fi
     fi
 
     if [ "${IF_MODE}" = "no-op-implementation" ]; then

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -7023,6 +7023,16 @@ if ! [[ "${MAX_IMPL_NOOP_REISSUES}" =~ ^[1-9][0-9]*$ ]]; then
   MAX_IMPL_NOOP_REISSUES=2
 fi
 
+# Cap on consecutive poll cycles a post-Codex implementation-failed
+# reissue may stay deferred with the same blocker status before being
+# escalated to ai:needs-human. Prevents fallback-id-only blocker
+# issues (which carry no actionable contract) from indefinitely
+# parking the source issue while spamming WARNING notifications.
+MAX_IMPL_FAILED_DEFER_CYCLES="${MAX_IMPL_FAILED_DEFER_CYCLES:-5}"
+if ! [[ "${MAX_IMPL_FAILED_DEFER_CYCLES}" =~ ^[1-9][0-9]*$ ]]; then
+  MAX_IMPL_FAILED_DEFER_CYCLES=5
+fi
+
 # ---------------------------------------------------------------
 # Helper: extract (RECOMMENDED) answers from clarification comments
 # ---------------------------------------------------------------
@@ -10014,14 +10024,72 @@ ${RB_FIX_DESC}
 
       if [ "${IF_DEFER_REISSUE}" = "true" ]; then
         IF_BLOCKERS_CSV="$(echo "${IF_BLOCKERS_JSON}" | jq -r 'map("#" + tostring) | join(", ")')"
-        echo "  Deferring implementation-failed reissue for #${if_issue} (${IF_LOCAL_ID}): mode=${IF_MODE}; blockers=${IF_BLOCKERS_CSV}; statuses=${IF_BLOCKER_STATUS_SUMMARY}; reason=${IF_DEFER_REASON}."
-        tg_notify "Deferred implementation-failed reissue for #${if_issue} (${IF_LOCAL_ID})."$'\n'"Mode: ${IF_MODE}"$'\n'"Blockers: ${IF_BLOCKERS_CSV}"$'\n'"Statuses: ${IF_BLOCKER_STATUS_SUMMARY}"$'\n'"Reason: ${IF_DEFER_REASON}"$'\n'"Issue: $(_gh_url "issues/${if_issue}")" "WARNING"
+        IF_DEFER_SIGNATURE="${IF_BLOCKER_STATUS_SUMMARY}|${IF_DEFER_REASON}"
+        IF_PREV_SIGNATURE="$(jq -r --arg key "${if_issue}" '.implementation_failed_defer_state[$key].summary // ""' "${STATE_FILE}" 2>/dev/null || echo "")"
+        IF_PREV_COUNT="$(jq -r --arg key "${if_issue}" '.implementation_failed_defer_state[$key].count // 0' "${STATE_FILE}" 2>/dev/null || echo "0")"
+        [[ "${IF_PREV_COUNT}" =~ ^[0-9]+$ ]] || IF_PREV_COUNT=0
+        if [ "${IF_DEFER_SIGNATURE}" = "${IF_PREV_SIGNATURE}" ]; then
+          IF_DEFER_COUNT=$((IF_PREV_COUNT + 1))
+        else
+          IF_DEFER_COUNT=1
+        fi
+        jq --arg key "${if_issue}" --arg summary "${IF_DEFER_SIGNATURE}" --argjson count "${IF_DEFER_COUNT}" '
+          .implementation_failed_defer_state //= {}
+          | .implementation_failed_defer_state[$key] = {summary: $summary, count: $count}
+        ' "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
+        IMPL_FAILED_STATE_CHANGED=true
+
+        echo "  Deferring implementation-failed reissue for #${if_issue} (${IF_LOCAL_ID}): mode=${IF_MODE}; blockers=${IF_BLOCKERS_CSV}; statuses=${IF_BLOCKER_STATUS_SUMMARY}; reason=${IF_DEFER_REASON}; cycle=${IF_DEFER_COUNT}/${MAX_IMPL_FAILED_DEFER_CYCLES}."
+        if [ "${IF_DEFER_COUNT}" -ge "${MAX_IMPL_FAILED_DEFER_CYCLES}" ]; then
+          ensure_label_exists "ai:needs-human"
+          gh_retry gh issue edit "${if_issue}" --repo "${GITHUB_REPOSITORY}" --add-label "ai:needs-human" >/dev/null 2>&1 || true
+          gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${if_issue}/comments" \
+            -f body="$(printf '## Post-Codex implementation-failed deferral escalated\n\nThis source issue has been deferred for %s consecutive poll cycles with the same blocker status (%s). Blocker fix-ups [%s] are not advancing on their own — escalating to `ai:needs-human` for manual review. Reason: %s.' "${IF_DEFER_COUNT}" "${IF_BLOCKER_STATUS_SUMMARY}" "${IF_BLOCKERS_CSV}" "${IF_DEFER_REASON}")" >/dev/null 2>&1 || true
+          tg_notify "Implementation-failed reissue for #${if_issue} (${IF_LOCAL_ID}) escalated to ai:needs-human after ${IF_DEFER_COUNT} deferred cycles."$'\n'"Mode: ${IF_MODE}"$'\n'"Blockers: ${IF_BLOCKERS_CSV}"$'\n'"Statuses: ${IF_BLOCKER_STATUS_SUMMARY}"$'\n'"Reason: ${IF_DEFER_REASON}"$'\n'"Issue: $(_gh_url "issues/${if_issue}")" "CRITICAL"
+        elif [ "${IF_DEFER_SIGNATURE}" != "${IF_PREV_SIGNATURE}" ]; then
+          tg_notify "Deferred implementation-failed reissue for #${if_issue} (${IF_LOCAL_ID})."$'\n'"Mode: ${IF_MODE}"$'\n'"Blockers: ${IF_BLOCKERS_CSV}"$'\n'"Statuses: ${IF_BLOCKER_STATUS_SUMMARY}"$'\n'"Reason: ${IF_DEFER_REASON}"$'\n'"Cycle: ${IF_DEFER_COUNT}/${MAX_IMPL_FAILED_DEFER_CYCLES}"$'\n'"Issue: $(_gh_url "issues/${if_issue}")" "WARNING"
+        fi
         continue
       fi
     elif [ "${IF_MODE}" = "post-codex-validation" ] && [ "${IF_DEFER_REISSUE}" = "true" ]; then
-      echo "  Deferring implementation-failed reissue for #${if_issue} (${IF_LOCAL_ID}): mode=${IF_MODE}; reason=${IF_DEFER_REASON}."
-      tg_notify "Deferred implementation-failed reissue for #${if_issue} (${IF_LOCAL_ID})."$'\n'"Mode: ${IF_MODE}"$'\n'"Reason: ${IF_DEFER_REASON}"$'\n'"Issue: $(_gh_url "issues/${if_issue}")" "WARNING"
+      IF_DEFER_SIGNATURE="|${IF_DEFER_REASON}"
+      IF_PREV_SIGNATURE="$(jq -r --arg key "${if_issue}" '.implementation_failed_defer_state[$key].summary // ""' "${STATE_FILE}" 2>/dev/null || echo "")"
+      IF_PREV_COUNT="$(jq -r --arg key "${if_issue}" '.implementation_failed_defer_state[$key].count // 0' "${STATE_FILE}" 2>/dev/null || echo "0")"
+      [[ "${IF_PREV_COUNT}" =~ ^[0-9]+$ ]] || IF_PREV_COUNT=0
+      if [ "${IF_DEFER_SIGNATURE}" = "${IF_PREV_SIGNATURE}" ]; then
+        IF_DEFER_COUNT=$((IF_PREV_COUNT + 1))
+      else
+        IF_DEFER_COUNT=1
+      fi
+      jq --arg key "${if_issue}" --arg summary "${IF_DEFER_SIGNATURE}" --argjson count "${IF_DEFER_COUNT}" '
+        .implementation_failed_defer_state //= {}
+        | .implementation_failed_defer_state[$key] = {summary: $summary, count: $count}
+      ' "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
+      IMPL_FAILED_STATE_CHANGED=true
+
+      echo "  Deferring implementation-failed reissue for #${if_issue} (${IF_LOCAL_ID}): mode=${IF_MODE}; reason=${IF_DEFER_REASON}; cycle=${IF_DEFER_COUNT}/${MAX_IMPL_FAILED_DEFER_CYCLES}."
+      if [ "${IF_DEFER_COUNT}" -ge "${MAX_IMPL_FAILED_DEFER_CYCLES}" ]; then
+        ensure_label_exists "ai:needs-human"
+        gh_retry gh issue edit "${if_issue}" --repo "${GITHUB_REPOSITORY}" --add-label "ai:needs-human" >/dev/null 2>&1 || true
+        gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${if_issue}/comments" \
+          -f body="$(printf '## Post-Codex implementation-failed deferral escalated\n\nThis source issue has been deferred for %s consecutive poll cycles with the same reason (%s). Escalating to `ai:needs-human` for manual review.' "${IF_DEFER_COUNT}" "${IF_DEFER_REASON}")" >/dev/null 2>&1 || true
+        tg_notify "Implementation-failed reissue for #${if_issue} (${IF_LOCAL_ID}) escalated to ai:needs-human after ${IF_DEFER_COUNT} deferred cycles."$'\n'"Mode: ${IF_MODE}"$'\n'"Reason: ${IF_DEFER_REASON}"$'\n'"Issue: $(_gh_url "issues/${if_issue}")" "CRITICAL"
+      elif [ "${IF_DEFER_SIGNATURE}" != "${IF_PREV_SIGNATURE}" ]; then
+        tg_notify "Deferred implementation-failed reissue for #${if_issue} (${IF_LOCAL_ID})."$'\n'"Mode: ${IF_MODE}"$'\n'"Reason: ${IF_DEFER_REASON}"$'\n'"Cycle: ${IF_DEFER_COUNT}/${MAX_IMPL_FAILED_DEFER_CYCLES}"$'\n'"Issue: $(_gh_url "issues/${if_issue}")" "WARNING"
+      fi
       continue
+    fi
+
+    # Reissue path reached: clear any stale defer-state entry so a
+    # later failure starts a fresh dedup/escalation window.
+    if jq -e --arg key "${if_issue}" '(.implementation_failed_defer_state // {}) | has($key)' "${STATE_FILE}" >/dev/null 2>&1; then
+      jq --arg key "${if_issue}" '
+        if (.implementation_failed_defer_state | type) == "object"
+          then .implementation_failed_defer_state |= del(.[$key])
+          else .
+        end
+      ' "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
+      IMPL_FAILED_STATE_CHANGED=true
     fi
 
     if [ "${IF_MODE}" = "no-op-implementation" ]; then

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -10027,20 +10027,29 @@ ${RB_FIX_DESC}
         IF_DEFER_SIGNATURE="${IF_BLOCKER_STATUS_SUMMARY}|${IF_DEFER_REASON}"
         IF_PREV_SIGNATURE="$(jq -r --arg key "${if_issue}" '.implementation_failed_defer_state[$key].summary // ""' "${STATE_FILE}" 2>/dev/null || echo "")"
         IF_PREV_COUNT="$(jq -r --arg key "${if_issue}" '.implementation_failed_defer_state[$key].count // 0' "${STATE_FILE}" 2>/dev/null || echo "0")"
+        IF_PREV_ESCALATED="$(jq -r --arg key "${if_issue}" '.implementation_failed_defer_state[$key].escalated // false' "${STATE_FILE}" 2>/dev/null || echo "false")"
         [[ "${IF_PREV_COUNT}" =~ ^[0-9]+$ ]] || IF_PREV_COUNT=0
         if [ "${IF_DEFER_SIGNATURE}" = "${IF_PREV_SIGNATURE}" ]; then
           IF_DEFER_COUNT=$((IF_PREV_COUNT + 1))
+          IF_ESCALATED_FLAG="${IF_PREV_ESCALATED}"
         else
           IF_DEFER_COUNT=1
+          # Signature changed — fresh defer window, reset the escalation flag.
+          IF_ESCALATED_FLAG="false"
         fi
-        jq --arg key "${if_issue}" --arg summary "${IF_DEFER_SIGNATURE}" --argjson count "${IF_DEFER_COUNT}" '
+        IF_SHOULD_ESCALATE="false"
+        if [ "${IF_DEFER_COUNT}" -ge "${MAX_IMPL_FAILED_DEFER_CYCLES}" ] && [ "${IF_ESCALATED_FLAG}" != "true" ]; then
+          IF_SHOULD_ESCALATE="true"
+          IF_ESCALATED_FLAG="true"
+        fi
+        jq --arg key "${if_issue}" --arg summary "${IF_DEFER_SIGNATURE}" --argjson count "${IF_DEFER_COUNT}" --argjson escalated "${IF_ESCALATED_FLAG}" '
           .implementation_failed_defer_state //= {}
-          | .implementation_failed_defer_state[$key] = {summary: $summary, count: $count}
+          | .implementation_failed_defer_state[$key] = {summary: $summary, count: $count, escalated: $escalated}
         ' "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
         IMPL_FAILED_STATE_CHANGED=true
 
-        echo "  Deferring implementation-failed reissue for #${if_issue} (${IF_LOCAL_ID}): mode=${IF_MODE}; blockers=${IF_BLOCKERS_CSV}; statuses=${IF_BLOCKER_STATUS_SUMMARY}; reason=${IF_DEFER_REASON}; cycle=${IF_DEFER_COUNT}/${MAX_IMPL_FAILED_DEFER_CYCLES}."
-        if [ "${IF_DEFER_COUNT}" -ge "${MAX_IMPL_FAILED_DEFER_CYCLES}" ]; then
+        echo "  Deferring implementation-failed reissue for #${if_issue} (${IF_LOCAL_ID}): mode=${IF_MODE}; blockers=${IF_BLOCKERS_CSV}; statuses=${IF_BLOCKER_STATUS_SUMMARY}; reason=${IF_DEFER_REASON}; cycle=${IF_DEFER_COUNT}/${MAX_IMPL_FAILED_DEFER_CYCLES}; escalated=${IF_ESCALATED_FLAG}."
+        if [ "${IF_SHOULD_ESCALATE}" = "true" ]; then
           ensure_label_exists "ai:needs-human"
           gh_retry gh issue edit "${if_issue}" --repo "${GITHUB_REPOSITORY}" --add-label "ai:needs-human" >/dev/null 2>&1 || true
           gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${if_issue}/comments" \
@@ -10055,20 +10064,28 @@ ${RB_FIX_DESC}
       IF_DEFER_SIGNATURE="|${IF_DEFER_REASON}"
       IF_PREV_SIGNATURE="$(jq -r --arg key "${if_issue}" '.implementation_failed_defer_state[$key].summary // ""' "${STATE_FILE}" 2>/dev/null || echo "")"
       IF_PREV_COUNT="$(jq -r --arg key "${if_issue}" '.implementation_failed_defer_state[$key].count // 0' "${STATE_FILE}" 2>/dev/null || echo "0")"
+      IF_PREV_ESCALATED="$(jq -r --arg key "${if_issue}" '.implementation_failed_defer_state[$key].escalated // false' "${STATE_FILE}" 2>/dev/null || echo "false")"
       [[ "${IF_PREV_COUNT}" =~ ^[0-9]+$ ]] || IF_PREV_COUNT=0
       if [ "${IF_DEFER_SIGNATURE}" = "${IF_PREV_SIGNATURE}" ]; then
         IF_DEFER_COUNT=$((IF_PREV_COUNT + 1))
+        IF_ESCALATED_FLAG="${IF_PREV_ESCALATED}"
       else
         IF_DEFER_COUNT=1
+        IF_ESCALATED_FLAG="false"
       fi
-      jq --arg key "${if_issue}" --arg summary "${IF_DEFER_SIGNATURE}" --argjson count "${IF_DEFER_COUNT}" '
+      IF_SHOULD_ESCALATE="false"
+      if [ "${IF_DEFER_COUNT}" -ge "${MAX_IMPL_FAILED_DEFER_CYCLES}" ] && [ "${IF_ESCALATED_FLAG}" != "true" ]; then
+        IF_SHOULD_ESCALATE="true"
+        IF_ESCALATED_FLAG="true"
+      fi
+      jq --arg key "${if_issue}" --arg summary "${IF_DEFER_SIGNATURE}" --argjson count "${IF_DEFER_COUNT}" --argjson escalated "${IF_ESCALATED_FLAG}" '
         .implementation_failed_defer_state //= {}
-        | .implementation_failed_defer_state[$key] = {summary: $summary, count: $count}
+        | .implementation_failed_defer_state[$key] = {summary: $summary, count: $count, escalated: $escalated}
       ' "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
       IMPL_FAILED_STATE_CHANGED=true
 
-      echo "  Deferring implementation-failed reissue for #${if_issue} (${IF_LOCAL_ID}): mode=${IF_MODE}; reason=${IF_DEFER_REASON}; cycle=${IF_DEFER_COUNT}/${MAX_IMPL_FAILED_DEFER_CYCLES}."
-      if [ "${IF_DEFER_COUNT}" -ge "${MAX_IMPL_FAILED_DEFER_CYCLES}" ]; then
+      echo "  Deferring implementation-failed reissue for #${if_issue} (${IF_LOCAL_ID}): mode=${IF_MODE}; reason=${IF_DEFER_REASON}; cycle=${IF_DEFER_COUNT}/${MAX_IMPL_FAILED_DEFER_CYCLES}; escalated=${IF_ESCALATED_FLAG}."
+      if [ "${IF_SHOULD_ESCALATE}" = "true" ]; then
         ensure_label_exists "ai:needs-human"
         gh_retry gh issue edit "${if_issue}" --repo "${GITHUB_REPOSITORY}" --add-label "ai:needs-human" >/dev/null 2>&1 || true
         gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${if_issue}/comments" \

--- a/scripts/validate_changed_files_syntax.sh
+++ b/scripts/validate_changed_files_syntax.sh
@@ -124,7 +124,7 @@ while IFS= read -r -d '' f; do
   if [ -f "${f}" ] && { [ "${ALLOW_WORKFLOW_EDITS:-true}" = "true" ] || [[ "${f}" != .github/workflows/* ]]; }; then
     strip_full_file_fence "${f}"
     checker_stderr="$(mktemp)"
-    if ! python3 -c "import json, sys; json.load(open(sys.argv[1], 'rb'))" "${f}" 2>"${checker_stderr}"; then
+    if ! python3 -c "import json, sys; f=open(sys.argv[1], 'rb'); json.load(f); f.close()" "${f}" 2>"${checker_stderr}"; then
       echo "::error file=${f}::JSON syntax error in ${f}"
       cat "${checker_stderr}" >&2
       append_checker_error "${f}" "python3 json.load" "${checker_stderr}"

--- a/scripts/validate_changed_files_syntax.sh
+++ b/scripts/validate_changed_files_syntax.sh
@@ -69,8 +69,46 @@ while IFS= read -r -d '' f; do
   fi
 done < <({ git diff --name-only --diff-filter=ACMR -z HEAD -- '*.sh'; git ls-files --others --exclude-standard -z -- '*.sh'; })
 
+# Strip a fully-fence-wrapped LLM artifact in place: the *entire* file
+# is a single ```/``` block (optionally with a language tag like ```yaml).
+# Only fires when the first non-blank line opens a fence and the last
+# non-blank line is exactly ```. Files containing inline fenced blocks
+# inside multi-document YAML or string values are left untouched.
+strip_full_file_fence() {
+  local target="$1"
+  python3 - "${target}" <<'PY' || true
+import sys
+
+path = sys.argv[1]
+try:
+    with open(path, "r", encoding="utf-8") as handle:
+        raw = handle.read()
+except (OSError, UnicodeDecodeError):
+    sys.exit(0)
+
+lines = raw.splitlines()
+non_blank_idx = [i for i, line in enumerate(lines) if line.strip()]
+if len(non_blank_idx) < 2:
+    sys.exit(0)
+
+first, last = non_blank_idx[0], non_blank_idx[-1]
+opener = lines[first].strip()
+closer = lines[last].strip()
+if not opener.startswith("```") or closer != "```":
+    sys.exit(0)
+
+stripped = lines[first + 1 : last]
+trailing_nl = "\n" if raw.endswith("\n") else ""
+with open(path, "w", encoding="utf-8") as handle:
+    handle.write("\n".join(stripped))
+    if stripped:
+        handle.write(trailing_nl or "\n")
+PY
+}
+
 while IFS= read -r -d '' f; do
   if [ -f "${f}" ] && { [ "${ALLOW_WORKFLOW_EDITS:-true}" = "true" ] || [[ "${f}" != .github/workflows/* ]]; }; then
+    strip_full_file_fence "${f}"
     checker_stderr="$(mktemp)"
     if ! python3 -c "import yaml, sys; f=open(sys.argv[1], 'rb'); list(yaml.safe_load_all(f)); f.close()" "${f}" 2>"${checker_stderr}"; then
       echo "::error file=${f}::YAML syntax error in ${f}"
@@ -81,6 +119,20 @@ while IFS= read -r -d '' f; do
     rm -f "${checker_stderr}"
   fi
 done < <({ git diff --name-only --diff-filter=ACMR -z HEAD -- '*.yml' '*.yaml'; git ls-files --others --exclude-standard -z -- '*.yml' '*.yaml'; })
+
+while IFS= read -r -d '' f; do
+  if [ -f "${f}" ] && { [ "${ALLOW_WORKFLOW_EDITS:-true}" = "true" ] || [[ "${f}" != .github/workflows/* ]]; }; then
+    strip_full_file_fence "${f}"
+    checker_stderr="$(mktemp)"
+    if ! python3 -c "import json, sys; json.load(open(sys.argv[1], 'rb'))" "${f}" 2>"${checker_stderr}"; then
+      echo "::error file=${f}::JSON syntax error in ${f}"
+      cat "${checker_stderr}" >&2
+      append_checker_error "${f}" "python3 json.load" "${checker_stderr}"
+      ERRORS=$((ERRORS + 1))
+    fi
+    rm -f "${checker_stderr}"
+  fi
+done < <({ git diff --name-only --diff-filter=ACMR -z HEAD -- '*.json'; git ls-files --others --exclude-standard -z -- '*.json'; })
 
 if [ "${ERRORS}" -gt 0 ]; then
   echo "::error::${ERRORS} file(s) failed syntax validation."

--- a/scripts/validate_changed_files_syntax.sh
+++ b/scripts/validate_changed_files_syntax.sh
@@ -102,7 +102,7 @@ trailing_nl = "\n" if raw.endswith("\n") else ""
 with open(path, "w", encoding="utf-8") as handle:
     handle.write("\n".join(stripped))
     if stripped:
-        handle.write(trailing_nl or "\n")
+        handle.write(trailing_nl)
 PY
 }
 


### PR DESCRIPTION
## Summary

Four hardening fixes for the post-Codex implement pipeline, addressing the failure mode that produced #2738 and the WARNING noise in the orchestrator poller.

- **Fence-strip + prompt tightening (`scripts/validate_changed_files_syntax.sh`, `prompts/mode-implement.txt`).** YAML and JSON files committed by Codex now have a fully-fence-wrapped body stripped in place before parsing. The strip is conservative — it only fires when the *entire* file is one ```/``` block (first non-blank line opens a fence, last non-blank line is exactly ```), so files containing inline triple-backticks inside a string value are left untouched. JSON gets a parse pass next to the existing YAML one. `prompts/mode-implement.txt` gains an explicit "raw YAML/JSON only — no fences, no language tags" rule for files written under `db/contracts/` and any other data path.
- **Failed-step lookup retry (`.github/workflows/implement.yml` ~L2556, `scripts/implement_diagnose_post_codex_failure.sh` ~L124).** The single-shot `gh api .../jobs` lookup races against GitHub's job-finalisation, occasionally returning all step conclusions as null right after a failure. Both call sites now retry up to 3× with a 4 s sleep when the failed-conclusion step is empty, before falling back to `unknown-step`. Diagnose downstream gets a real step name.
- **Defer dedup + bounded escalation (`scripts/orchestrate_poll_process.sh` ~L9985).** Per-issue defer state is now persisted in `STATE_FILE` under `.implementation_failed_defer_state[<issue>] = {summary, count}`. Identical defers no longer emit a `WARNING` every poll cycle (only the first transition is announced). Once the same blocker status persists for `MAX_IMPL_FAILED_DEFER_CYCLES` (default `5`) cycles, the source issue is labelled `ai:needs-human`, a `CRITICAL` notification fires, and an explanatory comment is posted — preventing fallback-id-only blocker issues (which carry no actionable contract) from parking the source issue indefinitely. Defer state is cleared whenever the reissue path is taken so a subsequent failure starts a fresh window.

## Verification

- `bash -n` passed on every edited shell script; the workflow YAML round-trips through `yaml.safe_load_all`.
- Fence-strip behaviour exercised against four fixtures: a fence-wrapped YAML (stripped, parses), a YAML containing inline ``` inside a string value (untouched, parses), a fence-wrapped JSON (stripped, parses), a genuinely broken YAML (correctly reported as syntax error and captured into the diagnostics file).
- Defer-state jq logic exercised end-to-end against a synthetic state file: count increments only when the signature matches, resets to 1 on signature change, the `has($key)` guard suppresses a redundant write when no entry was ever created, and the cleanup path leaves `.implementation_failed_defer_state` as `{}` after delete.

## Out of scope

The "malformed tool schema in the diagnose call" item from the original brief was rejected on inspection — the diagnose path uses `codex exec` and never constructs an OpenRouter `tools` array, so there was nothing to fix there.

## Test plan

- [ ] Trigger a synthetic post-Codex YAML failure where the LLM emits a ```yaml … ``` wrapper. Validation should now pass after the in-place strip and the file should be committed without the fence.
- [ ] Force a deferred reissue (e.g. by leaving a fix-up issue open) for ≥ 5 poll cycles and confirm: only the first cycle posts a `WARNING`, intermediate cycles are silent, and cycle 5 promotes to `ai:needs-human` with a `CRITICAL` notification.
- [ ] Verify the failed-step retry actually exercises the `sleep 4` branch on at least one run where step finalisation lags (look for `failed_step_name=` in the output of the capture step — should rarely be empty now).

https://claude.ai/code/session_01H7joWe1p3bKK5uyCSMtt1a

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7joWe1p3bKK5uyCSMtt1a)_