### PR TITLE
fix(review_autofix): require closing keyword for smoke-test issue lookup

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1757,10 +1757,17 @@ jobs:
             IS_SMOKE=true
           fi
 
-          # Check linked issue title (PR body often contains "issue #N" or issue URL)
+          # Check linked issue title. Only honour GitHub's closing-keyword
+          # pattern (Closes/Fixes/Resolves + #N or issue URL, case-insensitive)
+          # to avoid false-matching loose "issue #N" mentions inside log
+          # citations or backticked fragments quoted in the PR body — which
+          # would otherwise trigger phantom `gh api issues/<N>` 404s. The
+          # implement and orchestrator workflows both emit closing keywords
+          # when they create PRs, so this still resolves the linked issue
+          # for every auto-generated smoke-test PR.
           if [ "$IS_SMOKE" = "false" ]; then
-            ISSUE_NUM=$(echo "${PR_BODY}" | grep -oP '(?:issues/|issue\s*#)(\d+)' | head -1 | grep -oP '\d+' || true)
-            if [ -n "$ISSUE_NUM" ]; then
+            ISSUE_NUM=$(echo "${PR_BODY}" | grep -oiP '\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?):?\s+(?:https?://[^[:space:]]+/issues/|#)\K\d+' | head -1 || true)
+            if [ -n "${ISSUE_NUM:-}" ]; then
               ISSUE_TITLE=$(_safe_gh_jq "repos/${{ github.repository }}/issues/${ISSUE_NUM}" --jq '.title // ""' || echo "")
               if echo "${ISSUE_TITLE}" | grep -qi '\[E2E Smoke Test\]'; then
                 IS_SMOKE=true

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1769,7 +1769,7 @@ jobs:
           # cross-repo "Closes <other-repo>/issues/N" reference cannot route
           # an unrelated number into this repo's issues lookup.
           if [ "$IS_SMOKE" = "false" ]; then
-            ISSUE_NUM=$(echo "${PR_BODY}" | grep -oiPm1 '\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?):?\s+(?:https?://[^[:space:]]+/${{ github.repository }}/issues/|#)\K\d+' || true)
+            ISSUE_NUM=$(echo "${PR_BODY}" | grep -oiPm1 '\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?):?\s+(?:https?://[^[:space:]]+/${{ github.repository }}/issues/|#)\K\d+\b' || true)
             if [ -n "${ISSUE_NUM:-}" ]; then
               ISSUE_TITLE=$(_safe_gh_jq "repos/${{ github.repository }}/issues/${ISSUE_NUM}" --jq '.title // ""' || echo "")
               if echo "${ISSUE_TITLE}" | grep -qi '\[E2E Smoke Test\]'; then

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1765,8 +1765,11 @@ jobs:
           # implement and orchestrator workflows both emit closing keywords
           # when they create PRs, so this still resolves the linked issue
           # for every auto-generated smoke-test PR.
+          # The URL alternative is restricted to the current repository so a
+          # cross-repo "Closes <other-repo>/issues/N" reference cannot route
+          # an unrelated number into this repo's issues lookup.
           if [ "$IS_SMOKE" = "false" ]; then
-            ISSUE_NUM=$(echo "${PR_BODY}" | grep -oiP '\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?):?\s+(?:https?://[^[:space:]]+/issues/|#)\K\d+' | head -1 || true)
+            ISSUE_NUM=$(echo "${PR_BODY}" | grep -oiPm1 '\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?):?\s+(?:https?://[^[:space:]]+/${{ github.repository }}/issues/|#)\K\d+' || true)
             if [ -n "${ISSUE_NUM:-}" ]; then
               ISSUE_TITLE=$(_safe_gh_jq "repos/${{ github.repository }}/issues/${ISSUE_NUM}" --jq '.title // ""' || echo "")
               if echo "${ISSUE_TITLE}" | grep -qi '\[E2E Smoke Test\]'; then


### PR DESCRIPTION
## Summary

The "Detect smoke test and tune LLM settings" step's regex matched any `issue #N` mention in a PR body. PR #1705's body cites a prior failed run on issue #2738 inside a backticked source citation, which triggered a phantom `gh api repos/shubhodeep1/coding-workflows/issues/2738` 404 in the workflow log (job log line 3163 of run 25030408059).

Switch to GitHub's canonical closing-keyword pattern (case-insensitive `Closes` / `Fixes` / `Resolves` + optional colon + `#N` or full issue URL). The match rewrites with PCRE `\K` so `grep -o` returns only the digits.

The auto-generated PR creation paths in this repo all emit closing keywords (`implement.yml:2242` uses `Closes ${ISSUE_URL}`; `orchestrate_poll_process.sh:9691` uses `Closes #${rb_issue}`), so every smoke-test PR still resolves correctly. The same pattern is used elsewhere in the codebase to identify linked PRs (`orchestrate_poll_process.sh:1391`).

## Verification

Tested against representative inputs:

| Input | Old regex | New regex |
|---|---|---|
| ``Source: ... `##[error]Codex implement failed.` on issue #2738 implement run.`` | matches → 2738 (false positive, 404) | no match ✅ |
| `Automated implementation. Closes https://.../issues/4242` | matches → 4242 | matches → 4242 ✅ |
| `Closes #99` | matches → 99 | matches → 99 ✅ |
| `Fixes: #7` | matches → 7 | matches → 7 ✅ |
| `resolves #1234 and tidies up tests` | matches → 1234 | matches → 1234 ✅ |
| `see issue #2738 for context, no closing keyword` | matches → 2738 (false positive) | no match ✅ |
| `Closes #25528 (not 2552)` | matches → 25528 | matches → 25528 ✅ |

## Test plan

- [ ] Re-run `review_autofix` on a PR whose body cites another issue inside backticks — confirm no `gh: Not Found (HTTP 404)` line appears in the smoke-test detection step.
- [ ] Trigger a synthetic smoke-test PR with `Closes #N` pointing at an issue titled `[E2E Smoke Test] foo` — confirm the panel switches to the reduced 2-model set with `low` reasoning effort.

https://claude.ai/code/session_01N4w6JWHEoq85NMjKeWNJYS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ndru88aPjxZ7pe9xSczswr)_