### PR TITLE
fix(prompts): namespace MCP tool refs to mcp__&lt;server&gt;__&lt;tool&gt; for codex v0.125

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -657,7 +657,8 @@ jobs:
           - Batch shell searches with && or ;.
           - When searching for multiple terms (e.g., game names, route patterns), batch
             into ONE shell rg call with alternation (rg 'term1|term2|term3') rather than
-            making separate Serena mcp__serena__find_file or mcp__serena__search_for_pattern calls per term.
+            making separate Serena MCP calls to mcp__serena__find_file or
+            mcp__serena__search_for_pattern for each term.
           - After a Serena search returns empty results, do NOT retry with a slightly
             different regex. Switch to shell rg with broader patterns instead.
           - Do NOT map the full implementation surface. Only inspect code to the extent

--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -629,18 +629,18 @@ jobs:
 
           SERENA MCP EFFICIENCY (MANDATORY):
           {{SERENA_EFFICIENCY_BLOCK_READ_ONLY}}
-          - LARGE FILES (>5000 lines): Skip get_symbols_overview entirely — it will
+          - LARGE FILES (>5000 lines): Skip mcp__serena__get_symbols_overview entirely — it will
             exceed character limits and waste a tool call. Use shell rg with | head -n N
-            first to locate relevant functions, then use find_symbol or targeted sed reads.
+            first to locate relevant functions, then use mcp__serena__find_symbol or targeted sed reads.
           - Serena search responses are truncated at ~29,000 characters. If
-            get_symbols_overview is truncated, retry ONCE with max_answer_chars=29000
-            before falling back to shell. Do NOT retry search_for_pattern — narrow
+            mcp__serena__get_symbols_overview is truncated, retry ONCE with max_answer_chars=29000
+            before falling back to shell. Do NOT retry mcp__serena__search_for_pattern — narrow
             scope instead. Never fall back to shell grep/rg with the same patterns.
-          - NARROW SEARCH SCOPE: When using search_for_pattern, target a specific
+          - NARROW SEARCH SCOPE: When using mcp__serena__search_for_pattern, target a specific
             directory or file — never search the entire repo with a broad pattern.
-            Bad:  search_for_pattern("crash", "ft.games", "**/*.{py,html,js}")
-            Good: search_for_pattern("animateCrash|riseFrameId", "ft.games/static/crash.js")
-            If you need to locate files first, use find_file with a specific mask.
+            Bad:  mcp__serena__search_for_pattern("crash", "ft.games", "**/*.{py,html,js}")
+            Good: mcp__serena__search_for_pattern("animateCrash|riseFrameId", "ft.games/static/crash.js")
+            If you need to locate files first, use mcp__serena__find_file with a specific mask.
 
           EFFICIENCY RULES (MANDATORY — reduces token waste):
           - Read ONLY the specific lines/symbols you need. Do NOT read entire files or
@@ -648,7 +648,7 @@ jobs:
             ranges (e.g. sed -n '10,30p') instead of full-file reads.
           - Never read the same file region twice. Plan your reads upfront. When reading
             multiple nearby ranges, merge them into ONE wider range instead of separate calls.
-          - Prefer Serena MCP tools (get_symbols_overview, find_symbol) over raw file reads
+          - Prefer Serena MCP tools (mcp__serena__get_symbols_overview, mcp__serena__find_symbol) over raw file reads
             when available — they return only relevant symbols with far fewer tokens.
           - When a Serena search hits its character limit, do NOT fall back to shell grep/rg
             with the same patterns. Refine the Serena query or narrow the scope instead.
@@ -657,7 +657,7 @@ jobs:
           - Batch shell searches with && or ;.
           - When searching for multiple terms (e.g., game names, route patterns), batch
             into ONE shell rg call with alternation (rg 'term1|term2|term3') rather than
-            making separate Serena find_file or search_for_pattern calls per term.
+            making separate Serena mcp__serena__find_file or mcp__serena__search_for_pattern calls per term.
           - After a Serena search returns empty results, do NOT retry with a slightly
             different regex. Switch to shell rg with broader patterns instead.
           - Do NOT map the full implementation surface. Only inspect code to the extent
@@ -671,21 +671,21 @@ jobs:
 
           EFFICIENT TOOL CALL EXAMPLES (study before starting):
           WASTEFUL (burns budget on broad, overlapping queries):
-            1. search_for_pattern("user", "src")  ← broad term on broad directory, huge result
-            2. search_for_pattern("@app.route('/foo')", "app.py")  ← too-literal regex, misses dynamic routes
+            1. mcp__serena__search_for_pattern("user", "src")  ← broad term on broad directory, huge result
+            2. mcp__serena__search_for_pattern("@app.route('/foo')", "app.py")  ← too-literal regex, misses dynamic routes
             3. Same search retried with a slightly different regex  ← overlapping retry wastes a call
-            4. list_dir on directories unrelated to the issue  ← unnecessary exploration
+            4. mcp__serena__list_dir on directories unrelated to the issue  ← unnecessary exploration
             5. shell: sed -n '1,200p' some_file  ← reading 200 lines when 20-30 would suffice
             6. Searching db/schema/contract files for a pure UI/frontend issue  ← wrong scope
             7. sed -n '100,200p' f then sed -n '180,250p' f  ← overlapping ranges; use sed -n '100,250p' once
-            8. 4× find_file("*term1*"), find_file("*term2*")…  ← use one rg 'term1|term2|…' call instead
+            8. 4× mcp__serena__find_file("*term1*"), mcp__serena__find_file("*term2*")…  ← use one rg 'term1|term2|…' call instead
           EFFICIENT (targeted, batched, minimal):
-            1. activate_project → get_symbols_overview("src/main_module.py")  ← see all functions at once
-            2. find_symbol("handle_request", "src/main_module.py")  ← jump to exact function
+            1. mcp__serena__activate_project → mcp__serena__get_symbols_overview("src/main_module.py")  ← see all functions at once
+            2. mcp__serena__find_symbol("handle_request", "src/main_module.py")  ← jump to exact function
             3. shell: sed -n '120,140p' src/main_module.py  ← read only the 20 lines you need
-            4. search_for_pattern("EDGE_CONFIG|rate_limit|payout", "src/main_module.py")  ← one query, specific terms
+            4. mcp__serena__search_for_pattern("EDGE_CONFIG|rate_limit|payout", "src/main_module.py")  ← one query, specific terms
             5. shell: rg -l 'ClassName' src/ && sed -n '50,70p' src/found_file.py  ← batched with &&
-          Rule of thumb: 1 activate + 1 get_symbols_overview + 2-3 find_symbol/search
+          Rule of thumb: 1 mcp__serena__activate_project + 1 mcp__serena__get_symbols_overview + 2-3 mcp__serena__find_symbol/mcp__serena__search_for_pattern
           calls should cover most clarification needs. If you're past 10 tool calls,
           you are likely over-exploring.
 
@@ -714,7 +714,7 @@ jobs:
           3. Ask only essential questions needed for implementation.
           4. Use repo documentation only; no external web searches.
           5. If external APIs/services are likely required, review their official API docs and identify the expected endpoints and parameters so planning can include concrete call details for an offline editor.
-          6. Use Serena MCP tools (get_symbols_overview, find_symbol) when available to explore
+          6. Use Serena MCP tools (mcp__serena__get_symbols_overview, mcp__serena__find_symbol) when available to explore
              the codebase efficiently. This helps you understand code structure with fewer tokens.
              If Serena tools are unavailable, fall back to normal file reads.
           7. Flag any factual conflicts between the issue description and the codebase

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -862,7 +862,7 @@ jobs:
             request large ranges speculatively. Use Serena symbol tools or targeted line
             ranges (e.g. sed -n '10,30p') instead of full-file reads.
           - Never read the same file region twice. Plan your reads upfront.
-          - Prefer Serena MCP tools (get_symbols_overview, find_symbol) over raw file reads
+          - Prefer Serena MCP tools (mcp__serena__get_symbols_overview, mcp__serena__find_symbol) over raw file reads
             when available — they return only relevant symbols with far fewer tokens.
           - When a Serena search hits its character limit, do NOT fall back to shell grep/rg
             with the same patterns. Refine the Serena query or narrow the scope instead.

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -810,10 +810,10 @@ jobs:
 
           SERENA MCP EFFICIENCY (MANDATORY):
           {{SERENA_EFFICIENCY_BLOCK_READ_ONLY}}
-          - For large files (>5000 lines), use get_symbols_overview with depth=0 first to
-            get a high-level map, then drill into specific symbols with find_symbol.
+          - For large files (>5000 lines), use mcp__serena__get_symbols_overview with depth=0 first to
+            get a high-level map, then drill into specific symbols with mcp__serena__find_symbol.
             Do NOT use depth=1+ on very large files — it will exceed character limits.
-          - When search_for_pattern returns "answer is too long", NARROW the query (target
+          - When mcp__serena__search_for_pattern returns "answer is too long", NARROW the query (target
             a single function/class name or a specific subdirectory). Do NOT retry the same
             broad pattern or fall back to shell grep/rg with equivalent patterns.
 
@@ -838,7 +838,7 @@ jobs:
             request large ranges speculatively. Use Serena symbol tools or targeted line
             ranges (e.g. sed -n '10,30p') instead of full-file reads.
           - Never read the same file region twice. Plan your reads upfront.
-          - Prefer Serena MCP tools (get_symbols_overview, find_symbol) over raw file reads
+          - Prefer Serena MCP tools (mcp__serena__get_symbols_overview, mcp__serena__find_symbol) over raw file reads
             when available — they return only relevant symbols with far fewer tokens.
           - When a Serena search hits its character limit, do NOT fall back to shell grep/rg
             with the same patterns. Refine the Serena query or narrow the scope instead.

--- a/agents.md
+++ b/agents.md
@@ -23,7 +23,7 @@ Reduce token usage by using Serena's LSP-backed semantic tools instead of full-f
 Rules:
 - ALWAYS use Serena semantic tools over full-file reads.
 - NEVER read an entire file if symbol tools suffice.
-- NEVER rewrite an entire file if `replace_symbol_body` or `insert_after_symbol` can do it.
+- NEVER rewrite an entire file if `mcp__serena__replace_symbol_body` or `mcp__serena__insert_after_symbol` can do it.
 
 ### Reading code (use INSTEAD of cat/read):
 - `mcp__serena__get_symbols_overview` — file structure (classes, functions, exports)
@@ -33,14 +33,14 @@ Rules:
 
 ### Editing code (use INSTEAD of full-file writes):
 - `mcp__serena__replace_symbol_body` — replace a function/class body
-- `mcp__serena__insert_after_symbol` / `insert_before_symbol` — add code around a symbol
+- `mcp__serena__insert_after_symbol` / `mcp__serena__insert_before_symbol` — add code around a symbol
 - `mcp__serena__rename_symbol` — rename across codebase (LSP refactor)
 
 ### Workflow:
-1. `get_symbols_overview` → understand file structure
-2. `find_symbol` → drill into specific functions
-3. `find_referencing_symbols` → understand change impact
-4. Edit with `replace_symbol_body` / `insert_after_symbol` — NOT full-file rewrites
+1. `mcp__serena__get_symbols_overview` → understand file structure
+2. `mcp__serena__find_symbol` → drill into specific functions
+3. `mcp__serena__find_referencing_symbols` → understand change impact
+4. Edit with `mcp__serena__replace_symbol_body` / `mcp__serena__insert_after_symbol` — NOT full-file rewrites
 
 ### Search result limits:
 - Serena results may truncate at ~29k chars. Do NOT re-run via shell grep. Instead narrow the query or split into targeted lookups.

--- a/codex_system_instructions.md
+++ b/codex_system_instructions.md
@@ -23,7 +23,7 @@ Reduce token usage by using Serena's LSP-backed semantic tools instead of full-f
 Rules:
 - ALWAYS use Serena semantic tools over full-file reads.
 - NEVER read an entire file if symbol tools suffice.
-- NEVER rewrite an entire file if `replace_symbol_body` or `insert_after_symbol` can do it.
+- NEVER rewrite an entire file if `mcp__serena__replace_symbol_body` or `mcp__serena__insert_after_symbol` can do it.
 
 ### Reading code (use INSTEAD of cat/read):
 - `mcp__serena__get_symbols_overview` — file structure (classes, functions, exports)
@@ -33,14 +33,14 @@ Rules:
 
 ### Editing code (use INSTEAD of full-file writes):
 - `mcp__serena__replace_symbol_body` — replace a function/class body
-- `mcp__serena__insert_after_symbol` / `insert_before_symbol` — add code around a symbol
+- `mcp__serena__insert_after_symbol` / `mcp__serena__insert_before_symbol` — add code around a symbol
 - `mcp__serena__rename_symbol` — rename across codebase (LSP refactor)
 
 ### Workflow:
-1. `get_symbols_overview` → understand file structure
-2. `find_symbol` → drill into specific functions
-3. `find_referencing_symbols` → understand change impact
-4. Edit with `replace_symbol_body` / `insert_after_symbol` — NOT full-file rewrites
+1. `mcp__serena__get_symbols_overview` → understand file structure
+2. `mcp__serena__find_symbol` → drill into specific functions
+3. `mcp__serena__find_referencing_symbols` → understand change impact
+4. Edit with `mcp__serena__replace_symbol_body` / `mcp__serena__insert_after_symbol` — NOT full-file rewrites
 
 ### Search result limits:
 - Serena results may truncate at ~29k chars. Do NOT re-run via shell grep. Instead narrow the query or split into targeted lookups.
@@ -64,7 +64,7 @@ Rules:
 Use Git MCP in review/edit flows to fetch scoped, on-demand git context when available.
 
 Rules:
-- Prefer targeted Git MCP queries (`git_status`, `git_diff`, `git_show`, `git_log`, `git_branch`) over broad git context dumps.
+- Prefer targeted Git MCP queries (`mcp__git__git_status`, `mcp__git__git_diff`, `mcp__git__git_show`, `mcp__git__git_log`, `mcp__git__git_branch`) over broad git context dumps.
 - Keep Git MCP usage read-oriented in review/edit flows.
 - Keep existing preloaded diff/context artifacts as fallback when Git MCP is unavailable or disabled.
 - If Git MCP is unavailable or errors, continue with the existing fallback artifacts.

--- a/prompts/serena-efficiency-block.txt
+++ b/prompts/serena-efficiency-block.txt
@@ -1,21 +1,21 @@
 [READ_ONLY]
 SERENA MCP EFFICIENCY (MANDATORY):
-- Do NOT call onboarding, initial_instructions, or check_onboarding_performed.
-- Skip straight to activate_project and then use tools directly.
-- Prefer get_symbols_overview and find_symbol over raw file reads.
-- Use find_referencing_symbols for impact analysis when needed.
-- Use search_for_pattern instead of shell grep/rg when Serena is available.
-- In review/edit flows, prefer targeted Git MCP fetches (`git_status`, `git_diff`, `git_show`, `git_log`, `git_branch`) when Git MCP is available.
+- Do NOT call mcp__serena__onboarding, mcp__serena__initial_instructions, or mcp__serena__check_onboarding_performed.
+- Skip straight to mcp__serena__activate_project and then use tools directly.
+- Prefer mcp__serena__get_symbols_overview and mcp__serena__find_symbol over raw file reads.
+- Use mcp__serena__find_referencing_symbols for impact analysis when needed.
+- Use mcp__serena__search_for_pattern instead of shell grep/rg when Serena is available.
+- In review/edit flows, prefer targeted Git MCP fetches (`mcp__git__git_status`, `mcp__git__git_diff`, `mcp__git__git_show`, `mcp__git__git_log`, `mcp__git__git_branch`) when Git MCP is available.
 - Keep existing preloaded diff/context artifacts as fallback when Git MCP is unavailable.
 - Never read the same file region twice. Plan reads upfront.
 - If Serena tools are unavailable or error, fall back to normal file operations.
 
 [READ_WRITE]
 SERENA MCP EFFICIENCY (MANDATORY):
-- Call activate_project exactly once, then do NOT call onboarding, initial_instructions, or check_onboarding_performed.
-- Prefer Serena read tools (get_symbols_overview, find_symbol, find_referencing_symbols, search_for_pattern) over full-file reads.
-- Prefer Serena edit tools (replace_symbol_body, insert_after_symbol, insert_before_symbol, rename_symbol) over full-file rewrites.
-- In review/edit flows, prefer targeted Git MCP fetches (`git_status`, `git_diff`, `git_show`, `git_log`, `git_branch`) when Git MCP is available.
+- Call mcp__serena__activate_project exactly once, then do NOT call mcp__serena__onboarding, mcp__serena__initial_instructions, or mcp__serena__check_onboarding_performed.
+- Prefer Serena read tools (mcp__serena__get_symbols_overview, mcp__serena__find_symbol, mcp__serena__find_referencing_symbols, mcp__serena__search_for_pattern) over full-file reads.
+- Prefer Serena edit tools (mcp__serena__replace_symbol_body, mcp__serena__insert_after_symbol, mcp__serena__insert_before_symbol, mcp__serena__rename_symbol) over full-file rewrites.
+- In review/edit flows, prefer targeted Git MCP fetches (`mcp__git__git_status`, `mcp__git__git_diff`, `mcp__git__git_show`, `mcp__git__git_log`, `mcp__git__git_branch`) when Git MCP is available.
 - Keep existing preloaded diff/context artifacts as fallback when Git MCP is unavailable.
 - Never read the same file region twice.
 - If Serena tools are unavailable or error, fall back to normal file operations.


### PR DESCRIPTION
## Summary

- Codex v0.125's tool router enforces exact-match on registered (namespaced) MCP tool names; v0.114 was lenient and resolved bare names against the MCP-registered set.
- Every implement run on v0.125 has been failing with `codex_core::tools::router: error=unsupported call: activate_project` because prompts instructed the model to call bare `activate_project` etc., which the router does not recognize. After 5 retries each implement run exited 1 with no branch / no PR.
- Confirmed via the `e2e-smoke-test` failure on issue #1710 → implement run **25034870641** (every Codex attempt 1-5 hit the same router rejection).
- Fix: namespace every MCP tool reference in prompts/canonical instruction docs to `mcp__<server>__<tool>`. Pure prompt-text change — no logic, config, transport, or pin-site edits.

## What changed

| File | Why |
|---|---|
| `prompts/serena-efficiency-block.txt` | Primary site — fetched + injected into every codex run (clarify, plan, implement, review, autofix). Both `[READ_ONLY]` and `[READ_WRITE]` blocks updated for Serena + Git MCP. |
| `codex_system_instructions.md` | Workflow steps (lines 26, 40-43) and Git MCP rule (line 67). Already used `mcp__serena__` for read tools; now consistent throughout. |
| `agents.md` | Mirror of `codex_system_instructions.md` per CLAUDE.md §6. Same edits on the same lines. |
| `.github/workflows/clarify.yml` | Inline "Run clarify" prompt heredoc (lines 632, 634, 636-637, 639-643, 651, 660, 674-688, 717). |
| `.github/workflows/plan.yml` | Inline "Run plan" prompt (lines 813-816, 841). |
| `.github/workflows/implement.yml` | Inline prompt nudge (line 865). |

`scripts/setup_serena.sh`, all 15 codex pin sites, `serena_efficiency_report.py`, `generate_symbol_diff_summary.py`, `analyze_workflow_logs.py`, and tests are deliberately untouched — they don't reference bare MCP tool names in a way that codex's router consumes (verified via grep).

## Backward compatibility

- v0.114 will still work after this change (its lenient router accepts the namespaced form too — same form was already used in `codex_system_instructions.md:29-37` and ran on v0.114 without error).
- `serena_efficiency_report.py:38-40` regex `(?:mcp__serena__|serena[./])(\w+)` already matches the namespaced form. Counts and savings calculations stay correct.
- Consumer repos pull these files at runtime via `.codex-workflow-src` checkout, so they pick up the change automatically. Repos pinning an older `vars.CODEX_VERSION` keep working.

## Test plan

- [ ] Re-run `test-and-mark-stable.yml` `e2e-smoke-test` after merge. Pass = canary PR is created on issue → smoke test green.
- [ ] If the same `unsupported call: ...` error reappears with a *different* (non-namespaced) tool name, that name reveals codex's actual registration format and the diff is trivial to refine on a follow-up.
- [ ] Spot-check the next clarify, plan, and review runs to confirm the model emits the namespaced form (visible in `codex_log.txt` artifacts).
- [ ] Watch for any new `Codex returned output but produced no file changes` warnings on the next 1-2 real implement runs.

## Diagnosis trail

- `e2e-smoke-test` run 25034760491 → issue #1710 → implement run 25034870641 → 5 attempts × `error=unsupported call: activate_project` → `Codex implement failed after 5 attempts` → no branch pushed, no PR.
- Setup logs confirm Serena MCP loaded fine ("Serena MCP server validated successfully", `MCP section present: 1`); the failure is purely per-call routing.
- Pre-bump (v0.114) the same prompts worked, so the regression is the v0.114 → v0.125 codex bump in PR #1704 (commit 157c519) tightening MCP routing.

https://claude.ai/code/session_018apRjeuWLTj81EW4QusLB2

---
_Generated by [Claude Code](https://claude.ai/code/session_018apRjeuWLTj81EW4QusLB2)_