### PR TITLE
fix(issue_pr_status): split orchestrator skip rule; close managed children on integration-branch merge

### DIFF
--- a/.github/workflows/issue_pr_status.yml
+++ b/.github/workflows/issue_pr_status.yml
@@ -250,17 +250,39 @@ jobs:
           fi
           ensure_label_exists "${FINAL_LABEL}" "${REPOSITORY}"
 
-          # Identify orchestrator-managed issues — those carry the
-          # ai:orchestrator-tracking label or the "Managed by: AI
-          # Orchestrator" body marker. Their terminal phase label
-          # (ai:merged / ai:closed / ai:validation-failed / etc.) is
-          # owned exclusively by scripts/orchestrate_poll_process.sh,
-          # so this PR-close path must NOT relabel or auto-close
-          # them. Single batched GraphQL call (one API request,
-          # regardless of N) per CLAUDE.md §15. Fail-open with a
-          # per-issue REST fallback so a transient GraphQL failure
-          # cannot cause the bug it is trying to prevent.
-          ORCHESTRATED_ISSUES=""
+          # Classify each linked issue into one of three buckets so the
+          # label/close path applies the right policy:
+          #
+          #   1. TRACKING_ISSUES — orchestrator project tracking issues
+          #      (label `ai:orchestrator-tracking`). Their terminal phase
+          #      label and close lifecycle are owned exclusively by
+          #      scripts/orchestrate_poll_process.sh. SKIP entirely.
+          #      This is the regression guard for issue #1469: when a
+          #      child PR's body mentions a tracking issue, we must not
+          #      relabel or auto-close it.
+          #
+          #   2. MANAGED_ISSUES — orchestrator-managed child issues
+          #      (label `ai:orchestrator-managed` OR the
+          #      "Managed by: AI Orchestrator" body marker). These
+          #      always merge into orchestrator/project-N, never main,
+          #      so the default `PR_BASE_REF == main` close gate would
+          #      strand them. Apply FINAL_LABEL and close on PR merge
+          #      regardless of base ref. The orchestrator poller's
+          #      reconcile_managed_issue_labels and
+          #      close_merged_issues_sweep paths remain authoritative
+          #      backstops; this path is idempotent with them.
+          #
+          #   3. Standalone issues — neither tracking nor managed. Keep
+          #      the original `PR_BASE_REF == main` gate to preserve
+          #      the workflow's long-standing safety for non-orchestrator
+          #      flows.
+          #
+          # Single batched GraphQL call (one API request regardless of
+          # N) per CLAUDE.md §15. Fail-open with a per-issue REST
+          # fallback so a transient GraphQL failure cannot silently
+          # degrade detection.
+          TRACKING_ISSUES=""
+          MANAGED_ISSUES=""
           ORCH_ALIAS_FRAGMENT=""
           ORCH_IDX=0
           while IFS= read -r _orch_num; do
@@ -279,36 +301,50 @@ jobs:
               and (.data.repository? != null)
               and (([.data.repository | to_entries[] | .value | select(. != null)] | length) == $expected)
             ' >/dev/null 2>&1; then
-              if _orchestrated_issues="$(printf '%s' "${ORCH_RESP}" | jq -r '
+              _tracking_issues="$(printf '%s' "${ORCH_RESP}" | jq -r '
                 .data.repository | to_entries[] | .value | select(. != null) |
+                select(((.labels.nodes // []) | map(.name) | index("ai:orchestrator-tracking")) != null) |
+                .number
+              ' 2>/dev/null || echo '')"
+              _managed_issues="$(printf '%s' "${ORCH_RESP}" | jq -r '
+                .data.repository | to_entries[] | .value | select(. != null) |
+                select(((.labels.nodes // []) | map(.name) | index("ai:orchestrator-tracking")) == null) |
                 select(
-                  ((.labels.nodes // []) | map(.name) | index("ai:orchestrator-tracking")) != null
+                  ((.labels.nodes // []) | map(.name) | index("ai:orchestrator-managed")) != null
                   or
                   ((.body // "") | contains("Managed by: AI Orchestrator"))
                 ) | .number
-              ' 2>/dev/null)"; then
-                ORCHESTRATED_ISSUES="${_orchestrated_issues}"
-                ORCH_BATCH_FAILED=false
-              fi
+              ' 2>/dev/null || echo '')"
+              TRACKING_ISSUES="${_tracking_issues}"
+              MANAGED_ISSUES="${_managed_issues}"
+              ORCH_BATCH_FAILED=false
             fi
             if [ "${ORCH_BATCH_FAILED}" = true ]; then
               # GraphQL batch failed — fall back to per-issue REST detection
-              # so we never silently re-introduce the auto-label/close bug.
+              # so a transient failure cannot re-introduce the #1469 bug
+              # (tracking issue auto-closed) or strand a managed child.
               echo "::warning::Orchestrator-issue batch detection failed; falling back to per-issue REST."
               while IFS= read -r _orch_num; do
                 [ -n "${_orch_num}" ] || continue
                 [[ "${_orch_num}" =~ ^[0-9]+$ ]] || continue
                 _orch_meta="$(gh_retry gh api "repos/${REPOSITORY}/issues/${_orch_num}" --jq '{labels:[.labels[].name], body:(.body // "")}' 2>/dev/null || echo '')"
                 if [ -z "${_orch_meta}" ]; then
-                  echo "::warning::Orchestrator fallback lookup failed for issue #${_orch_num}; conservatively skipping label/close mutation for this issue."
-                  ORCHESTRATED_ISSUES+="${_orch_num}"$'\n'
+                  # Conservative fail-open: treat as tracking so we skip
+                  # the label/close mutation. Mis-classifying a managed
+                  # child as tracking only delays its close to the next
+                  # orchestrator poll cycle; mis-classifying a tracking
+                  # issue as managed would re-introduce #1469.
+                  echo "::warning::Orchestrator fallback lookup failed for issue #${_orch_num}; conservatively treating as tracking (skip)."
+                  TRACKING_ISSUES+="${_orch_num}"$'\n'
                   continue
                 fi
-                if printf '%s' "${_orch_meta}" | jq -e '
-                  ((.labels // []) | index("ai:orchestrator-tracking")) != null
+                if printf '%s' "${_orch_meta}" | jq -e '((.labels // []) | index("ai:orchestrator-tracking")) != null' >/dev/null 2>&1; then
+                  TRACKING_ISSUES+="${_orch_num}"$'\n'
+                elif printf '%s' "${_orch_meta}" | jq -e '
+                  ((.labels // []) | index("ai:orchestrator-managed")) != null
                   or ((.body // "") | contains("Managed by: AI Orchestrator"))
                 ' >/dev/null 2>&1; then
-                  ORCHESTRATED_ISSUES+="${_orch_num}"$'\n'
+                  MANAGED_ISSUES+="${_orch_num}"$'\n'
                 fi
               done <<< "${ISSUE_NUMBERS}"
             fi
@@ -317,16 +353,25 @@ jobs:
           while IFS= read -r issue_number; do
             [ -n "${issue_number}" ] || continue
 
-            if [ -n "${ORCHESTRATED_ISSUES}" ] && printf '%s\n' "${ORCHESTRATED_ISSUES}" | grep -qxF "${issue_number}"; then
-              echo "Skipping orchestrator-managed issue #${issue_number} — terminal phase label and close are owned by orchestrate_poll_process.sh; PR-close path must not mutate it."
+            if [ -n "${TRACKING_ISSUES}" ] && printf '%s\n' "${TRACKING_ISSUES}" | grep -qxF "${issue_number}"; then
+              echo "Skipping orchestrator-tracking issue #${issue_number} — terminal phase label and close are owned by orchestrate_poll_process.sh; PR-close path must not mutate it."
               continue
+            fi
+
+            is_managed_child=false
+            if [ -n "${MANAGED_ISSUES}" ] && printf '%s\n' "${MANAGED_ISSUES}" | grep -qxF "${issue_number}"; then
+              is_managed_child=true
             fi
 
             echo "Updating issue #${issue_number} with label ${FINAL_LABEL}"
             set_issue_phase_label_resilient "${issue_number}" "${FINAL_LABEL}" "${REPOSITORY}"
 
-            if [ "${PR_MERGED}" != "true" ] || [ "${PR_BASE_REF}" = "main" ]; then
-              echo "Closing issue #${issue_number} after PR #${PR_NUMBER} close event."
+            if [ "${PR_MERGED}" != "true" ] || [ "${PR_BASE_REF}" = "main" ] || [ "${is_managed_child}" = "true" ]; then
+              if [ "${is_managed_child}" = "true" ] && [ "${PR_MERGED}" = "true" ] && [ "${PR_BASE_REF}" != "main" ]; then
+                echo "Closing orchestrator-managed child issue #${issue_number} after PR #${PR_NUMBER} merged into ${PR_BASE_REF} (integration branch)."
+              else
+                echo "Closing issue #${issue_number} after PR #${PR_NUMBER} close event."
+              fi
               if ! gh_retry gh issue close "${issue_number}" -R "${REPOSITORY}"; then
                 echo "::warning::Failed to close issue #${issue_number}."
               fi

--- a/tests/test_issue_pr_status_payload_fallback_contract.py
+++ b/tests/test_issue_pr_status_payload_fallback_contract.py
@@ -71,36 +71,37 @@ def test_orchestrator_tracking_issues_are_skipped_in_label_close_loop() -> None:
 
 	When a PR's body mentions an orchestrator tracking issue (or one is
 	resolved via the regex fallback), this workflow must not relabel or
-	auto-close it. Terminal-phase ownership for orchestrator-managed
+	auto-close it. Terminal-phase ownership for orchestrator project
 	tracking issues belongs exclusively to scripts/orchestrate_poll_process.sh.
 
-	The Telegram alert step at the bottom of the workflow already had an
-	IS_ORCHESTRATED guard scanning the issue body for the
-	"Managed by: AI Orchestrator" marker, but the guard was not applied
-	to the label/close path above it. This test pins the new guard.
+	Tracking issues carry the `ai:orchestrator-tracking` label; the
+	classifier must skip them based on that label (the parent body does
+	NOT contain the "Managed by: AI Orchestrator" marker — that marker
+	identifies child issues, see orchestrate_poll_process.sh:8406).
 	"""
 	text = _workflow_text()
 
 	# The detection step builds an aliased GraphQL query that fetches both
 	# labels and body for every linked issue in a single API call.
 	assert "ORCH_ALIAS_FRAGMENT" in text, (
-		"Expected batched GraphQL detection of orchestrator-managed issues"
+		"Expected batched GraphQL detection of orchestrator-related issues"
 	)
 	assert ' i${ORCH_IDX}: issue(number: ${_orch_num}) { number labels(first: 50) { nodes { name } } body }' in text, (
 		"Expected aliased GraphQL fragment that fetches labels+body in one call"
 	)
 
-	# Detection must check both the orchestrator-tracking label and the
-	# body marker (either signal must be sufficient).
+	# Tracking detection MUST be by label only — the parent tracking body
+	# does not carry "Managed by: AI Orchestrator", so a body-based check
+	# would mis-classify children as tracking and re-introduce the
+	# stranded-child bug.
 	assert 'index("ai:orchestrator-tracking")' in text
-	assert 'contains("Managed by: AI Orchestrator")' in text
 
 	# GraphQL validity requires complete aliased-issue coverage; any missing/null
 	# alias entry must trigger REST fallback.
 	assert 'and (([.data.repository | to_entries[] | .value | select(. != null)] | length) == $expected)' in text
 
 	# Fail-open contract: GraphQL failure must fall back to per-issue REST,
-	# not silently degrade to the buggy "label everything" behavior.
+	# not silently degrade detection.
 	assert "Orchestrator-issue batch detection failed; falling back to per-issue REST" in text, (
 		"GraphQL failure path must use per-issue REST fallback so a transient "
 		"GraphQL error cannot re-introduce the auto-label bug."
@@ -109,20 +110,20 @@ def test_orchestrator_tracking_issues_are_skipped_in_label_close_loop() -> None:
 		"Per-issue REST fallback lookup must remain wired in the GraphQL-failure path."
 	)
 
-	# Loop guard: the label/close loop must consult ORCHESTRATED_ISSUES
+	# Loop guard: the label/close loop must consult TRACKING_ISSUES
 	# and continue (skip) before touching the label or issue state.
 	assert (
-		'if [ -n "${ORCHESTRATED_ISSUES}" ] && '
-		'printf \'%s\\n\' "${ORCHESTRATED_ISSUES}" | grep -qxF "${issue_number}"; then'
-	) in text, "Expected ORCHESTRATED_ISSUES gate inside the label/close loop"
+		'if [ -n "${TRACKING_ISSUES}" ] && '
+		'printf \'%s\\n\' "${TRACKING_ISSUES}" | grep -qxF "${issue_number}"; then'
+	) in text, "Expected TRACKING_ISSUES skip gate inside the label/close loop"
 
 	# Detection block must precede the label/close loop.
-	detect_pos = text.find("ORCH_ALIAS_FRAGMENT=\"\"")
-	gate_pos = text.find('Skipping orchestrator-managed issue #${issue_number}')
+	detect_pos = text.find("TRACKING_ISSUES=\"\"")
+	gate_pos = text.find('Skipping orchestrator-tracking issue #${issue_number}')
 	label_call_pos = text.find('set_issue_phase_label_resilient "${issue_number}" "${FINAL_LABEL}" "${REPOSITORY}"')
 	close_call_pos = text.find('gh_retry gh issue close "${issue_number}" -R "${REPOSITORY}"')
 	assert detect_pos != -1, "Detection block missing"
-	assert gate_pos != -1, "Skip-log marker missing inside label/close loop"
+	assert gate_pos != -1, "Tracking-skip log marker missing inside label/close loop"
 	assert label_call_pos != -1, "set_issue_phase_label_resilient call missing"
 	assert close_call_pos != -1, "gh issue close call missing"
 	assert detect_pos < gate_pos < label_call_pos, (
@@ -133,9 +134,87 @@ def test_orchestrator_tracking_issues_are_skipped_in_label_close_loop() -> None:
 		"Skip gate must precede the gh issue close call."
 	)
 
+	# Conservative fail-open contract: when the per-issue REST lookup also
+	# fails, classify as tracking (skip) rather than managed (close). This
+	# keeps the #1469 regression closed even when GitHub is degraded.
+	assert "conservatively treating as tracking (skip)" in text, (
+		"REST fallback must default to tracking-skip on metadata fetch failure"
+	)
+
+
+def test_orchestrator_managed_children_are_relabeled_and_closed_on_pr_merge() -> None:
+	"""Regression guard for the orchestrator-child stranding recurrence.
+
+	Orchestrator-managed child issues carry the `ai:orchestrator-managed`
+	label and the "Managed by: AI Orchestrator" body marker. Their PRs
+	always target an integration branch (`orchestrator/project-N`),
+	never `main`, so the previous skip-everything-orchestrator rule
+	combined with the `PR_BASE_REF == main` close gate left them stuck
+	open on `ai:ready-to-merge` until the orchestrator poller eventually
+	caught them via close_merged_issues_sweep.
+
+	Policy:
+	  - Detect children by `ai:orchestrator-managed` label OR the body
+	    marker, but NOT if they also carry `ai:orchestrator-tracking`
+	    (tracking takes precedence, skip wins).
+	  - On PR close, set FINAL_LABEL on the child and close the issue
+	    regardless of base ref.
+	  - Non-orchestrator standalone issues continue to use the original
+	    `PR_BASE_REF == main` close gate.
+	"""
+	text = _workflow_text()
+
+	# Two distinct buckets must exist.
+	assert "TRACKING_ISSUES=\"\"" in text, "Tracking bucket must be initialized"
+	assert "MANAGED_ISSUES=\"\"" in text, "Managed-children bucket must be initialized"
+
+	# Managed-child detection must include the label AND body marker as
+	# either signal, but must EXCLUDE issues with the tracking label (so
+	# tracking always wins).
+	assert 'index("ai:orchestrator-managed")' in text, (
+		"Managed-children classifier must check ai:orchestrator-managed label"
+	)
+	assert 'contains("Managed by: AI Orchestrator")' in text, (
+		"Managed-children classifier must check the body marker"
+	)
+	assert 'index("ai:orchestrator-tracking")) == null' in text, (
+		"Managed-children classifier must exclude issues that also carry "
+		"ai:orchestrator-tracking (tracking takes precedence)"
+	)
+
+	# Loop must compute is_managed_child for the active issue.
+	assert "is_managed_child=false" in text, "Default is_managed_child must be false"
+	assert (
+		'if [ -n "${MANAGED_ISSUES}" ] && '
+		'printf \'%s\\n\' "${MANAGED_ISSUES}" | grep -qxF "${issue_number}"; then'
+	) in text, "Loop must consult MANAGED_ISSUES for the current issue"
+	assert "is_managed_child=true" in text, "Loop must flip is_managed_child when matched"
+
+	# Close gate must include the managed-child branch — closing the
+	# issue when its PR merges into orchestrator/project-N (base != main).
+	assert (
+		'if [ "${PR_MERGED}" != "true" ] || [ "${PR_BASE_REF}" = "main" ] || [ "${is_managed_child}" = "true" ]; then'
+	) in text, (
+		"Close gate must close on PR_MERGED!=true, PR_BASE_REF==main, "
+		"OR is_managed_child==true"
+	)
+	assert "Closing orchestrator-managed child issue #${issue_number}" in text, (
+		"Managed-child close path must emit a distinguishing log line"
+	)
+
+	# Managed-child detection must run before the loop touches the label.
+	managed_classify_pos = text.find('index("ai:orchestrator-managed")')
+	loop_check_pos = text.find('is_managed_child=true')
+	label_call_pos = text.find('set_issue_phase_label_resilient "${issue_number}" "${FINAL_LABEL}" "${REPOSITORY}"')
+	assert managed_classify_pos != -1
+	assert loop_check_pos != -1
+	assert label_call_pos != -1
+	assert managed_classify_pos < loop_check_pos < label_call_pos
+
 
 if __name__ == "__main__":
 	test_payload_first_fallback_and_shared_helper_usage()
 	test_fallback_regex_drops_bare_mentions_keeps_closing_keywords_and_urls()
 	test_orchestrator_tracking_issues_are_skipped_in_label_close_loop()
+	test_orchestrator_managed_children_are_relabeled_and_closed_on_pr_merge()
 	print("PASS")


### PR DESCRIPTION
## Summary

The previous orchestrator skip rule in `issue_pr_status.yml` treated `ai:orchestrator-tracking` (parents) and `Managed by: AI Orchestrator` body marker (children) as one "skip everything" bucket. The body marker only appears on **child** issues (`orchestrate_poll_process.sh:8406`) — parent tracking bodies use different text (`orchestrate_lib.py:760`) — so the rule was silently skipping children that the workflow should have been finalizing. Combined with the `PR_BASE_REF == main` close gate (child PRs target `orchestrator/project-N`), this stranded children at `ai:ready-to-merge` until `close_merged_issues_sweep` eventually caught them.

### Changes

- **Split detection** into two buckets:
  - `TRACKING_ISSUES` (label `ai:orchestrator-tracking` only) — SKIP entirely; preserves #1469 regression guard.
  - `MANAGED_ISSUES` (label `ai:orchestrator-managed` OR body marker, AND no tracking label) — apply `FINAL_LABEL` and close on PR merge regardless of base ref.
- **Relax close gate** for managed children only: close on PR merge regardless of base ref. Standalone non-orchestrator issues keep the original `PR_BASE_REF == main` gate.
- **REST fallback** fails open conservatively to `TRACKING_ISSUES` so a transient GraphQL+REST outage cannot re-introduce #1469.

### Validity assessment of the four originally-proposed items

| # | Item | Status |
|---|---|---|
| 1 | Split orchestrator skip rule (only skip tracking parents) | **Applied** |
| 2 | Drop `PR_BASE_REF == main` gate for managed children | **Applied** |
| 3 | Defensive backstop in `close_merged_issues_sweep` for `ai:ready-to-merge` + verified merged PR | Already in place (commit `5cefb71`, sweep ready_label branch added 2026-04-27) |
| 4 | Regression test for child-flow | **Applied** (existing tracking test updated, new managed-child test added) |

The orchestrator poller's `reconcile_managed_issue_labels` and `close_merged_issues_sweep` paths remain authoritative backstops; this workflow's path is idempotent with them.

## Test plan

- [x] `python3 tests/test_issue_pr_status_payload_fallback_contract.py` (4 tests pass)
- [x] YAML syntax check: `python3 -c "import yaml; yaml.safe_load(...)"`
- [x] Bash syntax check on all extracted `run:` blocks
- [ ] CI: confirm full workflow-contract test suite passes
- [ ] Verify in production: orchestrator-managed child PR merging into `orchestrator/project-N` triggers `ai:merged` label + close on the child issue
- [ ] Verify in production: tracking-issue mention in a child PR body still does NOT auto-close the parent (#1469 regression)

https://claude.ai/code/session_019iDw5iNw2Lu2AVBbkfsg76

---
_Generated by [Claude Code](https://claude.ai/code/session_019iDw5iNw2Lu2AVBbkfsg76)_