### PR TITLE
review_autofix: stage integration-sync prompts + harden render_prompt placeholder check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,7 @@ jobs:
             prompts/mode-clarify-respond.txt
             prompts/mode-validate-generate.txt
             prompts/mode-validate-diagnose.txt
+            prompts/mode-validate-self-heal.txt
           )
 
           for pf in "${target_prompts[@]}"; do
@@ -261,7 +262,7 @@ jobs:
             fi
             rendered_file="$(mktemp)"
             bash scripts/render_prompt.sh "${pf}" > "${rendered_file}"
-            if grep -q '{{SERENA_EFFICIENCY_BLOCK_[A-Z_][A-Z_]*}}' "${rendered_file}"; then
+            if grep -qE '^\{\{SERENA_EFFICIENCY_BLOCK_[A-Z_]+\}\}$' "${rendered_file}"; then
               echo "FAIL: unresolved Serena placeholders remain after rendering ${pf}"
               rm -f "${rendered_file}"
               exit 1

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1018,6 +1018,30 @@ jobs:
               rm -f "${SUPPORT_PROMPTS_DIR}/conflict-resolver.txt"
             fi
           fi
+          if [ ! -f "${SUPPORT_PROMPTS_DIR}/integration-sync-conflict-resolver.txt" ]; then
+            src=".codex-workflow-src/prompts/integration-sync-conflict-resolver.txt"
+            if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/prompts/integration-sync-conflict-resolver.txt" ]; then
+              src=".codex-workflow-src-main/prompts/integration-sync-conflict-resolver.txt"
+            fi
+            if [ -f "${src}" ]; then
+              install -m 0644 "${src}" "${SUPPORT_PROMPTS_DIR}/integration-sync-conflict-resolver.txt"
+            else
+              echo "::warning::integration-sync-conflict-resolver.txt not found in checked-out support sources for ${SCRIPT_REF}; orchestrator/project-* runs will fall back to the generic conflict-resolver template (intent-injection disabled)."
+              rm -f "${SUPPORT_PROMPTS_DIR}/integration-sync-conflict-resolver.txt"
+            fi
+          fi
+          if [ ! -f "${SUPPORT_PROMPTS_DIR}/integration-sync-conflict-resolver-retry-prelude.txt" ]; then
+            src=".codex-workflow-src/prompts/integration-sync-conflict-resolver-retry-prelude.txt"
+            if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/prompts/integration-sync-conflict-resolver-retry-prelude.txt" ]; then
+              src=".codex-workflow-src-main/prompts/integration-sync-conflict-resolver-retry-prelude.txt"
+            fi
+            if [ -f "${src}" ]; then
+              install -m 0644 "${src}" "${SUPPORT_PROMPTS_DIR}/integration-sync-conflict-resolver-retry-prelude.txt"
+            else
+              echo "::warning::integration-sync-conflict-resolver-retry-prelude.txt not found in checked-out support sources for ${SCRIPT_REF}; resolver retries on integration-sync runs will use the original prompt verbatim (no reflexion guidance)."
+              rm -f "${SUPPORT_PROMPTS_DIR}/integration-sync-conflict-resolver-retry-prelude.txt"
+            fi
+          fi
 
       - name: Show disk usage (post support-source staging)
         run: df -h /

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -2161,6 +2161,7 @@ jobs:
             prompts/mode-clarify-respond.txt
             prompts/mode-validate-generate.txt
             prompts/mode-validate-diagnose.txt
+            prompts/mode-validate-self-heal.txt
           )
 
           for pf in "${target_prompts[@]}"; do
@@ -2170,7 +2171,7 @@ jobs:
             fi
             rendered_file="$(mktemp)"
             bash scripts/render_prompt.sh "${pf}" > "${rendered_file}"
-            if grep -q '{{SERENA_EFFICIENCY_BLOCK_[A-Z_][A-Z_]*}}' "${rendered_file}"; then
+            if grep -qE '^\{\{SERENA_EFFICIENCY_BLOCK_[A-Z_]+\}\}$' "${rendered_file}"; then
               echo "FAIL: unresolved Serena placeholders remain after rendering ${pf}"
               rm -f "${rendered_file}"
               exit 1

--- a/scripts/render_prompt.sh
+++ b/scripts/render_prompt.sh
@@ -65,7 +65,7 @@ while IFS= read -r line || [ -n "${line}" ]; do
 	esac
 done < "${PROMPT_FILE}" > "${RENDERED_FILE}"
 
-if grep -q '{{SERENA_EFFICIENCY_BLOCK_[A-Z_][A-Z_]*}}' "${RENDERED_FILE}"; then
+if grep -qE '^\{\{SERENA_EFFICIENCY_BLOCK_[A-Z_]+\}\}$' "${RENDERED_FILE}"; then
 	echo "Unresolved Serena placeholder token(s) in rendered output for ${PROMPT_FILE}" >&2
 	exit 1
 fi

--- a/scripts/review_conflict_resolve.sh
+++ b/scripts/review_conflict_resolve.sh
@@ -387,7 +387,7 @@ while [ "${attempt}" -le "${INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS}" ]; do
       "${RESOLVER_MARKER_VIOLATIONS_FILE}" \
       "${RESOLVER_FP_VIOLATIONS_FILE}"
     _effective_prompt_file="${RESOLVER_RETRY_PROMPT_FILE}"
-    echo "Conflict resolver retry ${attempt}/${INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS}: rebuilt reflexion prompt (prev markers=$(wc -l < "${RESOLVER_MARKER_VIOLATIONS_FILE}" 2>/dev/null | tr -d '[:space:]'), prev fingerprint_violations=$(wc -l < "${RESOLVER_FP_VIOLATIONS_FILE}" 2>/dev/null | tr -d '[:space:]'))."
+    echo "Conflict resolver retry ${attempt}/${INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS}: rebuilt reflexion prompt (prev markers=$(wc -l 2>/dev/null < "${RESOLVER_MARKER_VIOLATIONS_FILE}" | tr -d '[:space:]'), prev fingerprint_violations=$(wc -l 2>/dev/null < "${RESOLVER_FP_VIOLATIONS_FILE}" | tr -d '[:space:]'))."
   else
     _effective_prompt_file="${CONFLICT_RESOLVER_PROMPT_FILE}"
   fi

--- a/scripts/review_conflict_resolve.sh
+++ b/scripts/review_conflict_resolve.sh
@@ -387,10 +387,18 @@ while [ "${attempt}" -le "${INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS}" ]; do
       "${RESOLVER_MARKER_VIOLATIONS_FILE}" \
       "${RESOLVER_FP_VIOLATIONS_FILE}"
     _effective_prompt_file="${RESOLVER_RETRY_PROMPT_FILE}"
-    _prev_marker_count="$(wc -l 2>/dev/null < "${RESOLVER_MARKER_VIOLATIONS_FILE}" | tr -d '[:space:]')"
-    _prev_marker_count="${_prev_marker_count:-0}"
-    _prev_fp_violation_count="$(wc -l 2>/dev/null < "${RESOLVER_FP_VIOLATIONS_FILE}" | tr -d '[:space:]')"
-    _prev_fp_violation_count="${_prev_fp_violation_count:-0}"
+    if [ -f "${RESOLVER_MARKER_VIOLATIONS_FILE}" ]; then
+      _prev_marker_count="$(wc -l < "${RESOLVER_MARKER_VIOLATIONS_FILE}" | tr -d '[:space:]')"
+      _prev_marker_count="${_prev_marker_count:-0}"
+    else
+      _prev_marker_count=0
+    fi
+    if [ -f "${RESOLVER_FP_VIOLATIONS_FILE}" ]; then
+      _prev_fp_violation_count="$(wc -l < "${RESOLVER_FP_VIOLATIONS_FILE}" | tr -d '[:space:]')"
+      _prev_fp_violation_count="${_prev_fp_violation_count:-0}"
+    else
+      _prev_fp_violation_count=0
+    fi
     echo "Conflict resolver retry ${attempt}/${INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS}: rebuilt reflexion prompt (prev markers=${_prev_marker_count}, prev fingerprint_violations=${_prev_fp_violation_count})."
   else
     _effective_prompt_file="${CONFLICT_RESOLVER_PROMPT_FILE}"

--- a/scripts/review_conflict_resolve.sh
+++ b/scripts/review_conflict_resolve.sh
@@ -387,7 +387,11 @@ while [ "${attempt}" -le "${INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS}" ]; do
       "${RESOLVER_MARKER_VIOLATIONS_FILE}" \
       "${RESOLVER_FP_VIOLATIONS_FILE}"
     _effective_prompt_file="${RESOLVER_RETRY_PROMPT_FILE}"
-    echo "Conflict resolver retry ${attempt}/${INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS}: rebuilt reflexion prompt (prev markers=$(wc -l 2>/dev/null < "${RESOLVER_MARKER_VIOLATIONS_FILE}" | tr -d '[:space:]'), prev fingerprint_violations=$(wc -l 2>/dev/null < "${RESOLVER_FP_VIOLATIONS_FILE}" | tr -d '[:space:]'))."
+    _prev_marker_count="$(wc -l 2>/dev/null < "${RESOLVER_MARKER_VIOLATIONS_FILE}" | tr -d '[:space:]')"
+    _prev_marker_count="${_prev_marker_count:-0}"
+    _prev_fp_violation_count="$(wc -l 2>/dev/null < "${RESOLVER_FP_VIOLATIONS_FILE}" | tr -d '[:space:]')"
+    _prev_fp_violation_count="${_prev_fp_violation_count:-0}"
+    echo "Conflict resolver retry ${attempt}/${INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS}: rebuilt reflexion prompt (prev markers=${_prev_marker_count}, prev fingerprint_violations=${_prev_fp_violation_count})."
   else
     _effective_prompt_file="${CONFLICT_RESOLVER_PROMPT_FILE}"
   fi


### PR DESCRIPTION
## Summary

Three fixes prompted by analysis of two recent failed `review / codex-agent` runs:
1. PR #2731 (`tele-funtoken-msg-scoring`, run `25041430110`) — exited 1 with `Conflict resolver failed after retries.` on `orchestrator/project-2714`
2. PR #1717 (this repo, run `25045997555`) — exited 1 with `Unresolved Serena placeholder token(s) in rendered output for reviewer_prompt_body.txt`

### Fix A — `.github/workflows/review_autofix.yml`: stage integration-sync templates

The "Stage workflow support files" step only installs `conflict-resolver.txt` into `${SUPPORT_PROMPTS_DIR}`. On consumer-repo runs (`IS_WORKFLOW_SOURCE_REPO=false`) the integration-sync templates were never staged, so on a head ref matching `orchestrator/project-*`:

- `scripts/review_conflict_prepare.sh` warned `integration-sync-conflict-resolver template missing … falling back to generic conflict-resolver template (intent-injection disabled for this run).`
- `scripts/review_conflict_resolve.sh:_build_retry_prompt` couldn't find `integration-sync-conflict-resolver-retry-prelude.txt`, so retries 2/3 reused the original prompt verbatim with no reflexion guidance about the prior attempt's failures.

Add the same warn-on-missing install pattern used for `conflict-resolver.txt` for both integration-sync templates. Both already have file-existence guards in the consuming scripts, so a still-missing template degrades to the same fallback as today (no behavior change for repos that don't have these files yet).

### Fix B — `scripts/review_conflict_resolve.sh:390`: redirection ordering

The retry-status echo had `wc -l < "${FILE}" 2>/dev/null`. Bash processes redirections left-to-right, so on a missing file the `<` failure error is printed to the original stderr before `2>/dev/null` is set up. The log showed:

```
scripts/review_conflict_resolve.sh: line 390: …/resolver_marker_violations.txt: No such file or directory
```

on every retry where the prior `codex exec` failed (and the validation step that writes those files was skipped). Swapping the order to `wc -l 2>/dev/null < "${FILE}"` redirects fd 2 to /dev/null first, then the `<` failure is silently absorbed.

Per Copilot's review on this PR, also pre-compute the counts into shell vars and apply `${var:-0}` so the retry log line stays informative when the prior violation files don't exist (`prev markers=0, prev fingerprint_violations=0` instead of empty values).

### Fix C — `scripts/render_prompt.sh:68`: anchor unresolved-placeholder check to standalone lines

Discovered while analysing PR #1717's failed run. `render_prompt.sh`'s substitution only matches lines that EXACTLY equal a `{{SERENA_EFFICIENCY_BLOCK_*}}` placeholder. The matching unresolved-placeholder guard at line 68 used a loose regex (`{{...}}` anywhere in the rendered output), causing a false positive whenever user-supplied content interpolated into a heredoc body happens to mention the placeholder string inline. PR #1717's body literally contains `` `{{SERENA_EFFICIENCY_BLOCK_READ_ONLY}}` `` in a sentence; `review_run_reviewers.sh:241` interpolated `PR_INTENT_BLOCK` into the heredoc, the substitution case correctly skipped the inline mention, then the loose grep matched it as text and aborted.

Same latent bug existed in `.github/workflows/ci.yml:264` and `.github/workflows/test-and-mark-stable.yml:2173` (the static-prompt CI guards) — and `prompts/mode-validate-self-heal.txt:80` intentionally documents the placeholder names in a backtick-quoted bullet, so any validate-self-heal flow rendering that file would have failed identically. CI never noticed because `mode-validate-self-heal.txt` was not in either workflow's `target_prompts` list.

Anchor the regex to standalone lines (`^…$`) in all three guards so the check matches the substitution semantics. Also add `prompts/mode-validate-self-heal.txt` to the `target_prompts` list in `ci.yml` and `test-and-mark-stable.yml` so future authoring regressions in that file get caught at CI time.

Verified locally:
- Rendering `mode-validate-self-heal.txt` now exits 0 with the inline mentions preserved
- Rendering a body with a PR-body-style inline mention exits 0
- Rendering a typo'd standalone placeholder still exits 1 (regression coverage)

## Scope notes

- No behavior change for the workflow-source repo path (`IS_WORKFLOW_SOURCE_REPO=true`) of Fix A — `SUPPORT_PROMPTS_DIR` already points at the source `prompts/` directory, so the new install blocks no-op.
- Fix C does not address the underlying MCP namespace 422 issue PR #1717 is targeting; it just unblocks PR #1717's CI from this independent false-positive. The integration-sync resolver work (Fix A) and the `render_prompt.sh` work (Fix C) are unrelated but both surfaced from log analysis of consecutive failed runs and shipped together for batching.

## Test plan

- [ ] CI passes on this branch
- [ ] On the next consumer-repo `orchestrator/project-*` run, confirm the warning `integration-sync-conflict-resolver template missing` no longer fires and that retries (if any) build the reflexion prelude (Fix A)
- [ ] On any retry where the prior attempt failed, confirm no `line 390: … No such file or directory` lines appear in the log and the retry-status line shows numeric counts (Fix B)
- [ ] On any review_autofix run whose PR body or comments mention `{{SERENA_EFFICIENCY_BLOCK_…}}` as text, confirm rendering succeeds (Fix C)
