### PR TITLE
review_autofix: skip MCP for reviewer slugs that 422 on responses-API namespace envelope

### DIFF
--- a/scripts/render_prompt.sh
+++ b/scripts/render_prompt.sh
@@ -65,7 +65,7 @@ while IFS= read -r line || [ -n "${line}" ]; do
 	esac
 done < "${PROMPT_FILE}" > "${RENDERED_FILE}"
 
-if grep -q '{{SERENA_EFFICIENCY_BLOCK_[A-Z_][A-Z_]*}}' "${RENDERED_FILE}"; then
+if grep -qE '^\{\{SERENA_EFFICIENCY_BLOCK_[A-Z_][A-Z_]*\}\}$' "${RENDERED_FILE}"; then
 	echo "Unresolved Serena placeholder token(s) in rendered output for ${PROMPT_FILE}" >&2
 	exit 1
 fi

--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -717,37 +717,6 @@ reviewer_prompt_rendered="$(mktemp)"
   cd "${SUPPORT_ROOT_DIR}"
   bash "${SUPPORT_SCRIPTS_DIR}/render_prompt.sh" "${REVIEWER_PROMPT_BODY_FILE}"
 ) > "${reviewer_prompt_rendered}"
-
-# No-MCP variant of the rendered body. Built by substituting the Serena
-# efficiency placeholder with a fallback note BEFORE rendering, so the
-# rendered output has no Serena guidance. Used by reviewer slugs whose
-# upstream OpenRouter providers reject the v0.125 namespace tool envelope
-# (see MCP_INCOMPATIBLE_REVIEWER_MODELS above). When the deny-list is empty
-# this file is built but never consumed.
-REVIEWER_PROMPT_BODY_FILE_NO_MCP="${RUNTIME_DIR}/reviewer_prompt_body_no_mcp.txt"
-no_mcp_note_file="$(mktemp)"
-cat > "${no_mcp_note_file}" <<'NO_MCP_NOTE'
-SERENA MCP UNAVAILABLE FOR THIS REVIEWER
-- Serena MCP is not registered for this codex-cli invocation due to an upstream provider compatibility gap on /v1/responses.
-- Use shell tools instead: rg/grep for pattern search; cat/sed/awk for targeted file reads.
-- For impact analysis (where is this called?), grep the symbol name across the repository.
-- All other review guidance still applies — read efficiently, avoid full-file scans when targeted reads suffice.
-NO_MCP_NOTE
-no_mcp_pre_render="$(mktemp)"
-awk -v note_file="${no_mcp_note_file}" '
-  /^\{\{SERENA_EFFICIENCY_BLOCK_READ_ONLY\}\}$/ {
-    while ((getline line < note_file) > 0) print line
-    close(note_file)
-    next
-  }
-  { print }
-' "${REVIEWER_PROMPT_BODY_FILE}" > "${no_mcp_pre_render}"
-(
-  cd "${SUPPORT_ROOT_DIR}"
-  bash "${SUPPORT_SCRIPTS_DIR}/render_prompt.sh" "${no_mcp_pre_render}"
-) > "${REVIEWER_PROMPT_BODY_FILE_NO_MCP}"
-rm -f "${no_mcp_pre_render}" "${no_mcp_note_file}"
-
 mv "${reviewer_prompt_rendered}" "${REVIEWER_PROMPT_BODY_FILE}"
 
 # Assemble the base reviewer prompt (used by both passes in two-pass mode,
@@ -785,9 +754,6 @@ assemble_reviewer_prompt() {
 
 # Assemble the default (pass 1 / single-pass) prompt.
 assemble_reviewer_prompt "${REVIEWER_PROMPT_FILE}" "${REVIEWER_PROMPT_BODY_FILE}"
-# Sibling no-MCP prompt for reviewer slugs in MCP_INCOMPATIBLE_REVIEWER_MODELS.
-REVIEWER_PROMPT_FILE_NO_MCP="${RUNTIME_DIR}/reviewer_prompt_no_mcp.txt"
-assemble_reviewer_prompt "${REVIEWER_PROMPT_FILE_NO_MCP}" "${REVIEWER_PROMPT_BODY_FILE_NO_MCP}"
 
 run_reviewer() {
   local model="$1"
@@ -795,13 +761,9 @@ run_reviewer() {
   local output_prefix="${3:-review}"
   local prompt_file="${4:-${REVIEWER_PROMPT_FILE}}"
   local reasoning_level="${5:-}"
-  local prompt_file_no_mcp="${6:-}"
   local strip_mcp=0
   if is_mcp_incompatible_model "${model}"; then
     strip_mcp=1
-    if [ -n "${prompt_file_no_mcp}" ] && [ -s "${prompt_file_no_mcp}" ]; then
-      prompt_file="${prompt_file_no_mcp}"
-    fi
   fi
   local output_file="${PREVIOUS_REVIEWS_DIR}/${output_prefix}_${safe_name}.txt"
   local status_file="${PREVIOUS_REVIEWS_DIR}/status_${output_prefix}_${safe_name}.txt"
@@ -869,8 +831,9 @@ run_reviewer() {
 
   # Strip MCP server tables from this reviewer's isolated codex-home for slugs
   # whose upstream provider rejects the v0.125 namespace tool envelope on
-  # /v1/responses. The accompanying no-MCP prompt body (chosen above) tells
-  # the model Serena is unavailable and to use shell tools instead.
+  # /v1/responses. The Serena prompt block already says "If Serena tools are
+  # unavailable or error, fall back to normal file operations" so the model
+  # naturally falls back to shell tools (rg/grep/cat) when MCP is absent.
   if [ "${strip_mcp}" = "1" ]; then
     for cfg_path in "${reviewer_codex_home}/config.toml" "${reviewer_codex_home}/.codex/config.toml"; do
       if [ -f "${cfg_path}" ]; then
@@ -1112,8 +1075,6 @@ run_reviewer_pass() {
   local pass_prefix="$1"
   local pass_prompt="$2"
   local pass_reasoning="${3:-}"
-  local pass_prompt_no_mcp="${4:-}"
-
   local -a pass_pids=()
   local -a pass_models=()
   local -a pass_status_files=()
@@ -1126,7 +1087,7 @@ run_reviewer_pass() {
     pass_models+=("${model}")
     pass_status_files+=("${PREVIOUS_REVIEWS_DIR}/status_${pass_prefix}_${safe_name}.txt")
     pass_log_files+=("${PREVIOUS_REVIEWS_DIR}/${pass_prefix}_${safe_name}.log")
-    run_reviewer "${model}" "${safe_name}" "${pass_prefix}" "${pass_prompt}" "${pass_reasoning}" "${pass_prompt_no_mcp}" >&2 &
+    run_reviewer "${model}" "${safe_name}" "${pass_prefix}" "${pass_prompt}" "${pass_reasoning}" >&2 &
     pass_pids+=("$!")
   done <<< "${REVIEWER_MODELS}"
 
@@ -1205,11 +1166,9 @@ if [ "${TWO_PASS_ENABLED}" = "true" ]; then
   # ── PASS 1: broad sweep at medium thinking ──
   echo "=== PASS 1: Broad sweep (medium reasoning) ==="
   PASS1_PROMPT_FILE="${RUNTIME_DIR}/reviewer_prompt_pass1.txt"
-  PASS1_PROMPT_FILE_NO_MCP="${RUNTIME_DIR}/reviewer_prompt_pass1_no_mcp.txt"
   assemble_reviewer_prompt "${PASS1_PROMPT_FILE}" "${REVIEWER_PROMPT_BODY_FILE}"
-  assemble_reviewer_prompt "${PASS1_PROMPT_FILE_NO_MCP}" "${REVIEWER_PROMPT_BODY_FILE_NO_MCP}"
 
-  pass1_successful="$(run_reviewer_pass "pass1" "${PASS1_PROMPT_FILE}" "medium" "${PASS1_PROMPT_FILE_NO_MCP}")"
+  pass1_successful="$(run_reviewer_pass "pass1" "${PASS1_PROMPT_FILE}" "medium")"
   echo "Pass 1 complete: ${pass1_successful} reviewers successful."
 
   # Check for PR closure after pass 1
@@ -1234,11 +1193,9 @@ if [ "${TWO_PASS_ENABLED}" = "true" ]; then
   # ── PASS 2: deep review at full thinking, with cross-pollination ──
   echo "=== PASS 2: Deep review (${REVIEWER_REASONING_EFFORT:-xhigh} reasoning) ==="
   PASS2_PROMPT_FILE="${RUNTIME_DIR}/reviewer_prompt_pass2.txt"
-  PASS2_PROMPT_FILE_NO_MCP="${RUNTIME_DIR}/reviewer_prompt_pass2_no_mcp.txt"
   assemble_reviewer_prompt "${PASS2_PROMPT_FILE}" "${REVIEWER_PROMPT_BODY_FILE}" "${CROSS_POLLINATION_FILE}"
-  assemble_reviewer_prompt "${PASS2_PROMPT_FILE_NO_MCP}" "${REVIEWER_PROMPT_BODY_FILE_NO_MCP}" "${CROSS_POLLINATION_FILE}"
 
-  pass2_successful="$(run_reviewer_pass "review" "${PASS2_PROMPT_FILE}" "" "${PASS2_PROMPT_FILE_NO_MCP}")"
+  pass2_successful="$(run_reviewer_pass "review" "${PASS2_PROMPT_FILE}" "")"
   echo "Pass 2 complete: ${pass2_successful} reviewers successful."
   reviewers_successful="${pass2_successful}"
 
@@ -1250,7 +1207,7 @@ if [ "${TWO_PASS_ENABLED}" = "true" ]; then
   fi
 else
   echo "Single-pass review mode."
-  reviewers_successful="$(run_reviewer_pass "review" "${REVIEWER_PROMPT_FILE}" "" "${REVIEWER_PROMPT_FILE_NO_MCP}")"
+  reviewers_successful="$(run_reviewer_pass "review" "${REVIEWER_PROMPT_FILE}" "")"
   echo "Review complete: ${reviewers_successful} reviewers successful."
 
   # Produce REVIEWER_CONSENSUS_FILE so the editor + memory-record step get the

--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -166,9 +166,10 @@ x-ai/grok-4.1-fast}"
 is_mcp_incompatible_model() {
   local model="$1"
   local incompat
-  while IFS= read -r incompat; do
-    incompat="${incompat## }"
-    incompat="${incompat%% }"
+  # Use default IFS so `read` strips leading/trailing whitespace (spaces, tabs)
+  # — robust to operator-supplied values that may carry indentation or tabs
+  # from multi-line GitHub Actions env definitions.
+  while read -r incompat; do
     [ -z "${incompat}" ] && continue
     [ "${model}" = "${incompat}" ] && return 0
   done <<< "${MCP_INCOMPATIBLE_REVIEWER_MODELS}"

--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -150,6 +150,45 @@ EOF
   rm -rf "${probe_home}" 2>/dev/null || true
 }
 
+# Reviewer slugs whose upstream OpenRouter providers reject codex-cli v0.125's
+# `type: "namespace"` MCP tool envelope on /v1/responses with HTTP 422 "Provider
+# returned error". For these, strip MCP from the per-reviewer codex-home so no
+# namespace tool is sent. Empirically determined from review run #25041117408:
+# minimax/minimax-m2.5, moonshotai/kimi-k2.5, z-ai/glm-5 accept the envelope;
+# deepseek/deepseek-v4-pro, qwen/qwen3.6-plus, x-ai/grok-4.1-fast reject it.
+# Re-evaluate when bumping codex-cli or rotating reviewer slugs. Newline-
+# separated like REVIEWER_MODELS; override via env to add/remove without an
+# edit. Empty value disables the no-MCP fallback path entirely.
+MCP_INCOMPATIBLE_REVIEWER_MODELS="${MCP_INCOMPATIBLE_REVIEWER_MODELS-deepseek/deepseek-v4-pro
+qwen/qwen3.6-plus
+x-ai/grok-4.1-fast}"
+
+is_mcp_incompatible_model() {
+  local model="$1"
+  local incompat
+  while IFS= read -r incompat; do
+    incompat="${incompat## }"
+    incompat="${incompat%% }"
+    [ -z "${incompat}" ] && continue
+    [ "${model}" = "${incompat}" ] && return 0
+  done <<< "${MCP_INCOMPATIBLE_REVIEWER_MODELS}"
+  return 1
+}
+
+# Strip every [mcp_servers.*] table (and sub-tables like [mcp_servers.git.env])
+# from the given codex config.toml. Mirrors the awk pattern in setup_serena.sh's
+# remove_mcp_server_blocks but matches all server names. Used to neuter MCP for
+# reviewer slugs that 422 on namespace-wrapped tool envelopes.
+strip_all_mcp_server_blocks() {
+  local codex_cfg="$1"
+  [ -f "${codex_cfg}" ] || return 0
+  awk '
+    /^[[:space:]]*\[mcp_servers\./ { skip=1; next }
+    /^[[:space:]]*\[/ { skip=0 }
+    !skip { print }
+  ' "${codex_cfg}" > "${codex_cfg}.tmp" && mv "${codex_cfg}.tmp" "${codex_cfg}" || { rm -f "${codex_cfg}.tmp"; return 1; }
+}
+
 mkdir -p "${PREVIOUS_REVIEWS_DIR}"
 
 run_cache_probe || true
@@ -677,6 +716,37 @@ reviewer_prompt_rendered="$(mktemp)"
   cd "${SUPPORT_ROOT_DIR}"
   bash "${SUPPORT_SCRIPTS_DIR}/render_prompt.sh" "${REVIEWER_PROMPT_BODY_FILE}"
 ) > "${reviewer_prompt_rendered}"
+
+# No-MCP variant of the rendered body. Built by substituting the Serena
+# efficiency placeholder with a fallback note BEFORE rendering, so the
+# rendered output has no Serena guidance. Used by reviewer slugs whose
+# upstream OpenRouter providers reject the v0.125 namespace tool envelope
+# (see MCP_INCOMPATIBLE_REVIEWER_MODELS above). When the deny-list is empty
+# this file is built but never consumed.
+REVIEWER_PROMPT_BODY_FILE_NO_MCP="${RUNTIME_DIR}/reviewer_prompt_body_no_mcp.txt"
+no_mcp_note_file="$(mktemp)"
+cat > "${no_mcp_note_file}" <<'NO_MCP_NOTE'
+SERENA MCP UNAVAILABLE FOR THIS REVIEWER
+- Serena MCP is not registered for this codex-cli invocation due to an upstream provider compatibility gap on /v1/responses.
+- Use shell tools instead: rg/grep for pattern search; cat/sed/awk for targeted file reads.
+- For impact analysis (where is this called?), grep the symbol name across the repository.
+- All other review guidance still applies — read efficiently, avoid full-file scans when targeted reads suffice.
+NO_MCP_NOTE
+no_mcp_pre_render="$(mktemp)"
+awk -v note_file="${no_mcp_note_file}" '
+  /^\{\{SERENA_EFFICIENCY_BLOCK_READ_ONLY\}\}$/ {
+    while ((getline line < note_file) > 0) print line
+    close(note_file)
+    next
+  }
+  { print }
+' "${REVIEWER_PROMPT_BODY_FILE}" > "${no_mcp_pre_render}"
+(
+  cd "${SUPPORT_ROOT_DIR}"
+  bash "${SUPPORT_SCRIPTS_DIR}/render_prompt.sh" "${no_mcp_pre_render}"
+) > "${REVIEWER_PROMPT_BODY_FILE_NO_MCP}"
+rm -f "${no_mcp_pre_render}" "${no_mcp_note_file}"
+
 mv "${reviewer_prompt_rendered}" "${REVIEWER_PROMPT_BODY_FILE}"
 
 # Assemble the base reviewer prompt (used by both passes in two-pass mode,
@@ -714,6 +784,9 @@ assemble_reviewer_prompt() {
 
 # Assemble the default (pass 1 / single-pass) prompt.
 assemble_reviewer_prompt "${REVIEWER_PROMPT_FILE}" "${REVIEWER_PROMPT_BODY_FILE}"
+# Sibling no-MCP prompt for reviewer slugs in MCP_INCOMPATIBLE_REVIEWER_MODELS.
+REVIEWER_PROMPT_FILE_NO_MCP="${RUNTIME_DIR}/reviewer_prompt_no_mcp.txt"
+assemble_reviewer_prompt "${REVIEWER_PROMPT_FILE_NO_MCP}" "${REVIEWER_PROMPT_BODY_FILE_NO_MCP}"
 
 run_reviewer() {
   local model="$1"
@@ -721,6 +794,14 @@ run_reviewer() {
   local output_prefix="${3:-review}"
   local prompt_file="${4:-${REVIEWER_PROMPT_FILE}}"
   local reasoning_level="${5:-}"
+  local prompt_file_no_mcp="${6:-}"
+  local strip_mcp=0
+  if is_mcp_incompatible_model "${model}"; then
+    strip_mcp=1
+    if [ -n "${prompt_file_no_mcp}" ] && [ -s "${prompt_file_no_mcp}" ]; then
+      prompt_file="${prompt_file_no_mcp}"
+    fi
+  fi
   local output_file="${PREVIOUS_REVIEWS_DIR}/${output_prefix}_${safe_name}.txt"
   local status_file="${PREVIOUS_REVIEWS_DIR}/status_${output_prefix}_${safe_name}.txt"
 	local log_file="${PREVIOUS_REVIEWS_DIR}/${output_prefix}_${safe_name}.log"
@@ -784,6 +865,19 @@ run_reviewer() {
   fi
   mkdir -p "${reviewer_codex_home}/bin"
   export CODEX_HOME="${reviewer_codex_home}"
+
+  # Strip MCP server tables from this reviewer's isolated codex-home for slugs
+  # whose upstream provider rejects the v0.125 namespace tool envelope on
+  # /v1/responses. The accompanying no-MCP prompt body (chosen above) tells
+  # the model Serena is unavailable and to use shell tools instead.
+  if [ "${strip_mcp}" = "1" ]; then
+    for cfg_path in "${reviewer_codex_home}/config.toml" "${reviewer_codex_home}/.codex/config.toml"; do
+      if [ -f "${cfg_path}" ]; then
+        strip_all_mcp_server_blocks "${cfg_path}" || \
+          echo "::warning::Failed to strip MCP blocks from ${cfg_path} for reviewer ${model}; namespace tool envelope may still trigger 422." >&2
+      fi
+    done
+  fi
 
   while [ "${attempt}" -le 3 ]; do
     # Early exit if PR was closed/merged (detected by watchdog or another reviewer)
@@ -1017,6 +1111,7 @@ run_reviewer_pass() {
   local pass_prefix="$1"
   local pass_prompt="$2"
   local pass_reasoning="${3:-}"
+  local pass_prompt_no_mcp="${4:-}"
 
   local -a pass_pids=()
   local -a pass_models=()
@@ -1030,7 +1125,7 @@ run_reviewer_pass() {
     pass_models+=("${model}")
     pass_status_files+=("${PREVIOUS_REVIEWS_DIR}/status_${pass_prefix}_${safe_name}.txt")
     pass_log_files+=("${PREVIOUS_REVIEWS_DIR}/${pass_prefix}_${safe_name}.log")
-    run_reviewer "${model}" "${safe_name}" "${pass_prefix}" "${pass_prompt}" "${pass_reasoning}" >&2 &
+    run_reviewer "${model}" "${safe_name}" "${pass_prefix}" "${pass_prompt}" "${pass_reasoning}" "${pass_prompt_no_mcp}" >&2 &
     pass_pids+=("$!")
   done <<< "${REVIEWER_MODELS}"
 
@@ -1109,9 +1204,11 @@ if [ "${TWO_PASS_ENABLED}" = "true" ]; then
   # ── PASS 1: broad sweep at medium thinking ──
   echo "=== PASS 1: Broad sweep (medium reasoning) ==="
   PASS1_PROMPT_FILE="${RUNTIME_DIR}/reviewer_prompt_pass1.txt"
+  PASS1_PROMPT_FILE_NO_MCP="${RUNTIME_DIR}/reviewer_prompt_pass1_no_mcp.txt"
   assemble_reviewer_prompt "${PASS1_PROMPT_FILE}" "${REVIEWER_PROMPT_BODY_FILE}"
+  assemble_reviewer_prompt "${PASS1_PROMPT_FILE_NO_MCP}" "${REVIEWER_PROMPT_BODY_FILE_NO_MCP}"
 
-  pass1_successful="$(run_reviewer_pass "pass1" "${PASS1_PROMPT_FILE}" "medium")"
+  pass1_successful="$(run_reviewer_pass "pass1" "${PASS1_PROMPT_FILE}" "medium" "${PASS1_PROMPT_FILE_NO_MCP}")"
   echo "Pass 1 complete: ${pass1_successful} reviewers successful."
 
   # Check for PR closure after pass 1
@@ -1136,9 +1233,11 @@ if [ "${TWO_PASS_ENABLED}" = "true" ]; then
   # ── PASS 2: deep review at full thinking, with cross-pollination ──
   echo "=== PASS 2: Deep review (${REVIEWER_REASONING_EFFORT:-xhigh} reasoning) ==="
   PASS2_PROMPT_FILE="${RUNTIME_DIR}/reviewer_prompt_pass2.txt"
+  PASS2_PROMPT_FILE_NO_MCP="${RUNTIME_DIR}/reviewer_prompt_pass2_no_mcp.txt"
   assemble_reviewer_prompt "${PASS2_PROMPT_FILE}" "${REVIEWER_PROMPT_BODY_FILE}" "${CROSS_POLLINATION_FILE}"
+  assemble_reviewer_prompt "${PASS2_PROMPT_FILE_NO_MCP}" "${REVIEWER_PROMPT_BODY_FILE_NO_MCP}" "${CROSS_POLLINATION_FILE}"
 
-  pass2_successful="$(run_reviewer_pass "review" "${PASS2_PROMPT_FILE}" "")"
+  pass2_successful="$(run_reviewer_pass "review" "${PASS2_PROMPT_FILE}" "" "${PASS2_PROMPT_FILE_NO_MCP}")"
   echo "Pass 2 complete: ${pass2_successful} reviewers successful."
   reviewers_successful="${pass2_successful}"
 
@@ -1150,7 +1249,7 @@ if [ "${TWO_PASS_ENABLED}" = "true" ]; then
   fi
 else
   echo "Single-pass review mode."
-  reviewers_successful="$(run_reviewer_pass "review" "${REVIEWER_PROMPT_FILE}" "")"
+  reviewers_successful="$(run_reviewer_pass "review" "${REVIEWER_PROMPT_FILE}" "" "${REVIEWER_PROMPT_FILE_NO_MCP}")"
   echo "Review complete: ${reviewers_successful} reviewers successful."
 
   # Produce REVIEWER_CONSENSUS_FILE so the editor + memory-record step get the


### PR DESCRIPTION
## Summary

3 of 6 reviewers (`deepseek/deepseek-v4-pro`, `qwen/qwen3.6-plus`, `x-ai/grok-4.1-fast`) hard-failed every attempt with `HTTP 422 Unprocessable Entity: Provider returned error` on `https://openrouter.ai/api/v1/responses` ([review run 25041117408 log line 18779](https://github.com/shubhodeep1/coding-workflows/actions/runs/25041117408)). Result: `REVIEWERS_SUCCESSFUL=3`, ~6 doomed codex calls wasted per iteration, vendor diversity halved in consensus.

## Root cause

Diffed `openai/codex` `rust-v0.114.0..rust-v0.125.0`. v0.114 emitted MCP tools flat:

```
{ "type": "function", "name": "mcp__serena__find_symbol", "parameters": {…} }
```

v0.125 wraps them in a `namespace` envelope (`codex-rs/tools/src/tool_registry_plan.rs:505-560`):

```
{ "type": "namespace", "name": "serena", "tools": [ { "type": "function", "name": "mcp__serena__find_symbol", … }, … ] }
```

`ToolSpec` enum confirms — v0.114 had `function | local_shell | image_generation | web_search | custom`; v0.125 added `namespace` and `tool_search`. v0.125 even logs-and-skips MCP tools that aren't namespaced (no flat fallback). OpenRouter's `/v1/responses` shim forwards the envelope to the upstream; MiniMax/Moonshot/Z-AI accept it, DeepSeek/Qwen/xAI strict-validate and 422 on unknown tool `type`. The model catalog has nothing to do with it — `apply_patch_tool_type`, `truncation_policy`, `input_modalities`, etc. are consumed locally; none affect the wire shape.

## Fix

For slugs in `MCP_INCOMPATIBLE_REVIEWER_MODELS` (default: the 3 broken ones; env-overridable), strip every `[mcp_servers.*]` table from the per-reviewer isolated `config.toml` before invoking codex-cli. With no MCP servers registered, codex-cli emits no `namespace` envelope, the upstream provider stops 422-ing, and the canonical Serena prompt block's existing fallback line (`prompts/serena-efficiency-block.txt:11`: *"If Serena tools are unavailable or error, fall back to normal file operations"*) tells the model to use shell commands instead.

Compatible reviewers (minimax/kimi/glm) keep full Serena via canonical CODEX_HOME — `is_mcp_incompatible_model` returns false for them, `strip_mcp=0`, no behavioral change. Editor unchanged (uses `openai/gpt-5.3-codex` which is OpenAI-native on `/v1/responses` and accepts the namespace envelope).

When OpenRouter / upstream eventually fixes the responses-API gap for those vendors, remove the slug from the deny-list (or set `MCP_INCOMPATIBLE_REVIEWER_MODELS=` in env).

## Files changed

- `scripts/review_run_reviewers.sh` (+50 / -0)
  - `MCP_INCOMPATIBLE_REVIEWER_MODELS` constant + `is_mcp_incompatible_model` + `strip_all_mcp_server_blocks` helpers (the awk pattern mirrors `setup_serena.sh:95-110` but matches every server name).
  - In `run_reviewer`: detect deny-listed slug → `strip_mcp=1` → after copying CODEX_HOME, strip `[mcp_servers.*]` tables from the reviewer's `config.toml`. Same prompt for all reviewers.
- `scripts/render_prompt.sh` (+1 / -1) — anchor the unresolved-placeholder guard to standalone lines (`^…$`), matching the substitution semantics. Pre-existing latent bug (independently identified in PR #1716) that this PR's body otherwise triggers because it mentions the placeholder string as inline backtick-quoted prose, which `review_run_reviewers.sh:241` interpolates into the prompt heredoc. Without the anchor fix the unanchored grep guard false-positives on the inline mention and aborts the script under `set -e`.

## Test plan

- [x] `bash -n scripts/review_run_reviewers.sh scripts/render_prompt.sh` — syntax clean
- [x] `shellcheck --severity=error` — error-clean on both files
- [x] Hand-tested awk strip pattern against a representative `config.toml` containing `[mcp_servers.serena]`, `[mcp_servers.serena.env]`, `[mcp_servers.context7]`, `[mcp_servers.git]`, `[mcp_servers.git.env]` — every block stripped, `[model_providers.openrouter]` / `[sandbox_workspace_write]` preserved
- [x] Hand-tested `render_prompt.sh` anchor fix: inline mention of placeholder in body → passes (was failing); typo'd standalone placeholder still fails (regression coverage)
- [x] Hand-tested `is_mcp_incompatible_model` matching with leading tabs / multi-space prefixes / trailing tabs — all three deny-listed slugs match correctly, minimax (compatible) correctly outside the set
- [ ] **Live release-gate run** — recommend a single `review_autofix` run on a feature PR to confirm `REVIEWERS_SUCCESSFUL=6` and that the deny-listed reviewers produce non-empty output

🤖 Generated with [Claude Code](https://claude.com/claude-code)