### PR TITLE
implement: drop smoke-test low-reasoning override

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -542,16 +542,6 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_ENV"
 
-      - name: Detect smoke test and tune LLM settings
-        if: env.SKIP_IMPLEMENT != 'true'
-        run: |
-          set -euo pipefail
-          ISSUE_TITLE="$(jq -r '.title // ""' "${ISSUE_META_FILE}")"
-          if echo "${ISSUE_TITLE}" | grep -qi '\[E2E Smoke Test\]'; then
-            echo "🔬 Smoke test detected — switching to low reasoning effort"
-            echo "MODEL_REASONING_EFFORT=low" >> "$GITHUB_ENV"
-          fi
-
       - name: Fetch issue comments
         if: env.SKIP_IMPLEMENT != 'true'
         env:


### PR DESCRIPTION
## Summary

- Remove the "Detect smoke test and tune LLM settings" step in `.github/workflows/implement.yml` that forced `MODEL_REASONING_EFFORT=low` for `[E2E Smoke Test]` issues.
- Smoke runs now use the workflow-level default (`xhigh`), matching the regular path.

## Why

Job log analysis (issue #1719, run a0afe288) showed the implement step failing after 5 retries with the editor producing zero file changes. Every attempt logged the same Codex CLI router error pattern:

```
ERROR codex_core::tools::router: error=unsupported call: activate_project
ERROR codex_core::tools::router: error=unsupported call: git_status
ERROR codex_core::tools::router: error=unsupported call: search_for_pattern
ERROR codex_core::session: failed to record rollout items: thread <uuid> not found
```

At `low` reasoning, `openai/gpt-5.3-codex` (via OpenRouter) emits Serena MCP tool calls without their `mcp__serena__` prefix; the Codex tool router rejects each as `unsupported call`, the session eventually corrupts, and Codex flushes 0 bytes. The retry loop in `implement.yml:932-1139` then exhausts all 5 attempts and exits 1.

Restoring `xhigh` reasoning for smoke runs eliminates the failure mode.

## Scope

Per CLAUDE.md §5 (minimal change set), only `implement.yml` is touched here — that is the workflow whose failure was observed. The same override pattern exists in `clarify.yml`, `plan.yml`, and `review_autofix.yml` and can be addressed in a follow-up if it surfaces in their logs.

## Test plan

- [ ] Re-trigger an `[E2E Smoke Test]` issue end-to-end (clarify → plan → implement) and confirm the implement step succeeds with file changes on attempt 1.
- [ ] Confirm `MODEL_REASONING_EFFORT` stays at the workflow-level default (`xhigh`) inside the "Run Codex implementation" step env.
- [ ] Confirm no `error=unsupported call: activate_project` lines appear in the new run log.

https://claude.ai/code/session_01WE5SUgV6kyktLo7yH8Fedc

---
_Generated by [Claude Code](https://claude.ai/code/session_01WE5SUgV6kyktLo7yH8Fedc)_