### PR TITLE
fix(release-gate): repair v1.0.113 failures + silence per-phase alerts

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -350,6 +350,10 @@ jobs:
           if echo "${ISSUE_TITLE}" | grep -qi '\[E2E Smoke Test\]'; then
             echo "🔬 Smoke test detected — switching to low reasoning effort"
             echo "MODEL_REASONING_EFFORT=low" >> "$GITHUB_ENV"
+            # Suppress per-phase Telegram alerts from this clarify run; the
+            # test-and-mark-stable gate emits a single combined pass/fail
+            # notification at the end. SILENT > CRITICAL so all levels filter.
+            echo "ALERT_MSG_LEVEL=SILENT" >> "$GITHUB_ENV"
           fi
 
       - name: Fetch issue comments

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -542,6 +542,21 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_ENV"
 
+      - name: Detect smoke test and silence Telegram alerts
+        if: env.SKIP_IMPLEMENT != 'true'
+        run: |
+          set -euo pipefail
+          # The test-and-mark-stable gate emits ONE combined pass/fail
+          # Telegram message at the end via raw curl. Suppress every
+          # per-phase alert from this implement run when the issue is
+          # the smoke-test fixture so the gate isn't drowned in
+          # start/progress/finish notifications. SILENT > CRITICAL so
+          # all callers' levels filter to no-op.
+          if echo "${ISSUE_TITLE}" | grep -qi '\[E2E Smoke Test\]'; then
+            echo "🔬 Smoke test detected — suppressing per-phase Telegram alerts"
+            echo "ALERT_MSG_LEVEL=SILENT" >> "$GITHUB_ENV"
+          fi
+
       - name: Fetch issue comments
         if: env.SKIP_IMPLEMENT != 'true'
         env:

--- a/.github/workflows/internal-memory-maintenance.yml
+++ b/.github/workflows/internal-memory-maintenance.yml
@@ -15,7 +15,9 @@ permissions:
   contents: write
 
 env:
-  ALERT_MSG_LEVEL: ${{ inputs.alert_msg_level != '' && inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
+  # `inputs` is null on schedule-triggered runs; use `github.event.inputs`
+  # (which is null-safe via `||`) to avoid a parse-time/runtime miss.
+  ALERT_MSG_LEVEL: ${{ (github.event.inputs.alert_msg_level || '') != '' && github.event.inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
 
 jobs:
   maintenance:

--- a/.github/workflows/internal-memory-maintenance.yml
+++ b/.github/workflows/internal-memory-maintenance.yml
@@ -3,21 +3,10 @@ name: "Internal: Memory Maintenance"
 on:
   schedule:
     - cron: "0 3 1 * *"  # 1st of each month at 03:00 UTC
-  workflow_dispatch:
-    inputs:
-      alert_msg_level:
-        description: Override the Telegram alert threshold for this run. Set to SILENT when dispatched from the test-and-mark-stable smoke gate to avoid drowning the gate's combined notification in per-job alerts.
-        required: false
-        default: ""
-        type: string
+  workflow_dispatch: {}
 
 permissions:
   contents: write
-
-env:
-  # `inputs` is null on schedule-triggered runs; use `github.event.inputs`
-  # (which is null-safe via `||`) to avoid a parse-time/runtime miss.
-  ALERT_MSG_LEVEL: ${{ (github.event.inputs.alert_msg_level || '') != '' && github.event.inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
 
 jobs:
   maintenance:

--- a/.github/workflows/internal-memory-maintenance.yml
+++ b/.github/workflows/internal-memory-maintenance.yml
@@ -3,10 +3,19 @@ name: "Internal: Memory Maintenance"
 on:
   schedule:
     - cron: "0 3 1 * *"  # 1st of each month at 03:00 UTC
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      alert_msg_level:
+        description: Override the Telegram alert threshold for this run. Set to SILENT when dispatched from the test-and-mark-stable smoke gate to avoid drowning the gate's combined notification in per-job alerts.
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: write
+
+env:
+  ALERT_MSG_LEVEL: ${{ inputs.alert_msg_level != '' && inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
 
 jobs:
   maintenance:

--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -36,11 +36,22 @@ jobs:
 
     steps:
       - name: Log trigger context
+        env:
+          PROJECT_DESCRIPTION: ${{ inputs.project_description }}
         run: |
           echo "Orchestrate workflow triggered"
           echo "Run ID: ${{ github.run_id }}"
           echo "Model: ${MODEL_EDITOR}"
           echo "Reasoning: ${MODEL_REASONING_EFFORT}"
+          # The test-and-mark-stable gate's orchestrate-decompose-test step
+          # dispatches this workflow with a project_description prefixed
+          # `[E2E Orchestrate Smoke <run_id>]`; suppress per-phase Telegram
+          # alerts so the gate's combined pass/fail message is the only
+          # notification. SILENT > CRITICAL so all callers' levels filter.
+          if printf '%s' "${PROJECT_DESCRIPTION}" | grep -qiE '\[E2E (Orchestrate )?Smoke'; then
+            echo "🔬 Smoke orchestrate detected — suppressing per-phase Telegram alerts"
+            echo "ALERT_MSG_LEVEL=SILENT" >> "$GITHUB_ENV"
+          fi
 
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/orchestrate_clarify_respond.yml
+++ b/.github/workflows/orchestrate_clarify_respond.yml
@@ -58,12 +58,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           set -euo pipefail
-          ISSUE_BODY="$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}" --jq '.body // ""')"
+          ISSUE_PAYLOAD="$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}")"
+          ISSUE_BODY="$(printf '%s' "${ISSUE_PAYLOAD}" | jq -r '.body // ""')"
+          ISSUE_TITLE="$(printf '%s' "${ISSUE_PAYLOAD}" | jq -r '.title // ""')"
           if printf '%s' "${ISSUE_BODY}" | grep -qF 'Managed by: AI Orchestrator'; then
             echo "is_orchestrator=true" >> "$GITHUB_OUTPUT"
           else
             echo "Issue #${ISSUE_NUMBER} is not orchestrator-managed. Skipping."
             echo "is_orchestrator=false" >> "$GITHUB_OUTPUT"
+          fi
+          # Suppress per-phase Telegram alerts when the orchestrator
+          # tracking parent of this child is the test-and-mark-stable
+          # smoke fixture (title `[Orchestrator] E2E …`). The gate emits
+          # a single combined pass/fail notification at the end.
+          TRACKING_NUM="$(printf '%s' "${ISSUE_BODY}" | sed -n 's/.*Tracking issue: #\([0-9][0-9]*\).*/\1/p' | head -n1)"
+          if [ -n "${TRACKING_NUM}" ]; then
+            TRACKING_TITLE="$(gh api "repos/${{ github.repository }}/issues/${TRACKING_NUM}" --jq '.title // ""' 2>/dev/null || echo "")"
+            if printf '%s' "${TRACKING_TITLE}" | grep -qiE '^\[Orchestrator\] E2E '; then
+              echo "🔬 Smoke orchestrator parent (#${TRACKING_NUM}) — suppressing per-phase Telegram alerts"
+              echo "ALERT_MSG_LEVEL=SILENT" >> "$GITHUB_ENV"
+            fi
           fi
 
       - name: Resolve integration ref

--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -119,6 +119,19 @@ jobs:
           echo "has_tracking=true" >> "$GITHUB_OUTPUT"
           echo "has_work=true" >> "$GITHUB_OUTPUT"
 
+          # If every active tracking issue is the test-and-mark-stable
+          # smoke fixture, suppress per-phase Telegram alerts; the gate
+          # emits a single combined pass/fail notification at the end.
+          # SILENT > CRITICAL so all callers' levels filter to no-op.
+          # We only set SILENT when EVERY tracking issue is a smoke
+          # fixture so production projects sharing a poll cycle keep
+          # their alerts.
+          NON_SMOKE="$(echo "${TRACKING_ISSUES}" | jq '[.[] | select(.title | test("^\\[Orchestrator\\] E2E "; "i") | not)] | length')"
+          if [ "${NON_SMOKE}" = "0" ]; then
+            echo "🔬 All tracking issues are smoke fixtures — suppressing per-phase Telegram alerts"
+            echo "ALERT_MSG_LEVEL=SILENT" >> "$GITHUB_ENV"
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -350,6 +350,10 @@ jobs:
           if echo "${ISSUE_TITLE}" | grep -qi '\[E2E Smoke Test\]'; then
             echo "🔬 Smoke test detected — switching to low reasoning effort"
             echo "MODEL_REASONING_EFFORT=low" >> "$GITHUB_ENV"
+            # Suppress per-phase Telegram alerts from this plan run; the
+            # test-and-mark-stable gate emits a single combined pass/fail
+            # notification at the end. SILENT > CRITICAL so all levels filter.
+            echo "ALERT_MSG_LEVEL=SILENT" >> "$GITHUB_ENV"
           fi
 
       - name: Fetch issue comments

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2461,6 +2461,20 @@ jobs:
         run: |
           set -euo pipefail
           bash "${SUPPORT_SCRIPTS_DIR}/review_run_reviewers.sh"
+
+      - name: Upload per-reviewer logs (always)
+        if: always() && env.PREVIOUS_REVIEWS_DIR != ''
+        uses: actions/upload-artifact@v6
+        with:
+          name: reviewer-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ env.PREVIOUS_REVIEWS_DIR }}/*.log
+            ${{ env.PREVIOUS_REVIEWS_DIR }}/status_*.txt
+            ${{ env.PREVIOUS_REVIEWS_DIR }}/review_*.txt
+            ${{ env.PREVIOUS_REVIEWS_DIR }}/pass1_*.txt
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Record reviewer consensus candidate in memory (fail-open)
         if: steps.retrigger_guard.outputs.max_iterations_reached != 'true' && env.PR_CLOSED != 'true'
         run: |

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1840,20 +1840,24 @@ jobs:
           fi
 
           if [ "$IS_SMOKE" = "true" ]; then
-            echo "🔬 Smoke test PR detected — switching to low reasoning effort (full reviewer set retained)"
-            echo "REVIEWER_REASONING_EFFORT=low" >> "$GITHUB_ENV"
-            echo "EDITOR_REASONING_EFFORT=low" >> "$GITHUB_ENV"
-            # Keep the full production REVIEWER_MODELS list so the smoke gate
-            # exercises every reviewer the consumer pipeline will use; only the
-            # reasoning effort is dialled down. A previous variant pruned the
-            # set to 2 fast models, which hid regressions in models that only
-            # appeared in the production list. Per CLAUDE.md §1 (correctness >
-            # speed) and the release-gate contract: comprehensive coverage
-            # over runtime savings.
-            # Patch the already-written codex config to use low reasoning (if present)
-            if [ -f "${HOME}/.codex/config.toml" ]; then
-              sed -i 's/^[[:space:]]*model_reasoning_effort = ".*"/model_reasoning_effort = "low"/' "${HOME}/.codex/config.toml"
-            fi
+            echo "🔬 Smoke test PR detected — keeping workflow-level default reasoning"
+            # PR #1723 removed the low-reasoning override in implement.yml after
+            # log analysis (issue #1719) showed openai/gpt-5.3-codex emits
+            # Serena MCP calls without the mcp__serena__ prefix at low
+            # reasoning, the Codex tool router rejects them as `unsupported
+            # call: activate_project / git_status / search_for_pattern`, the
+            # session corrupts, and the editor produces 0 file changes. The
+            # release v1.0.113 run hit the identical failure here: PR #1735's
+            # editor (review_autofix's codex-agent) ran 3 attempts × 1700+
+            # Serena calls, produced no commit, and Phase 4b reported
+            # "Editor failed to remove bait line E2E_EDITOR_BAIT_<run>".
+            # Mirror PR #1723: keep the full reviewer set + the workflow-level
+            # default reasoning (xhigh) for smoke runs too. Per CLAUDE.md §1
+            # correctness > speed.
+            # Suppress per-phase Telegram alerts; the test-and-mark-stable
+            # gate emits a single combined pass/fail notification at the
+            # end via raw curl. SILENT > CRITICAL so all levels filter.
+            echo "ALERT_MSG_LEVEL=SILENT" >> "$GITHUB_ENV"
           else
             echo "Standard PR — using default LLM settings"
           fi

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -2418,8 +2418,13 @@ jobs:
           sleep 4
           WF_FILE="internal-memory-maintenance.yml"
           PRE=$(gh api "repos/${TEST_REPO}/actions/workflows/${WF_FILE}/runs?per_page=1" --jq '.workflow_runs[0].id // 0' 2>/dev/null || echo 0)
-          gh workflow run "${WF_FILE}" --repo "${TEST_REPO}" \
-            --field alert_msg_level=SILENT
+          # internal-memory-maintenance is a thin wrapper around the
+          # reusable memory_maintenance.yml; neither the wrapper nor the
+          # called workflow nor `ai_memory.py compact` emit Telegram
+          # alerts (per Copilot review on PR #1742), so there is no
+          # `alert_msg_level` input to pass — the smoke gate dispatch
+          # already produces no per-phase pings here.
+          gh workflow run "${WF_FILE}" --repo "${TEST_REPO}"
           DEADLINE=$(( $(date +%s) + 900 ))
           NEW_ID=""
           while [ "$(date +%s)" -lt "${DEADLINE}" ]; do

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -2220,10 +2220,10 @@ jobs:
     # ceiling ~115m), and the orchestrate-decompose-test PR run #204
     # cancelled at 30m on `deep-audit` while the smoke watcher's 1500s
     # DEADLINE was already exhausted. Sum of in-step DEADLINEs below
-    # (workflow-log-analysis 5400 + validation-refresh 2400 +
-    # update_workflows 600 + memory-maintenance 900 = 9300s ≈ 155m)
-    # plus a 25m headroom for runner queueing and step setup.
-    timeout-minutes: 180
+    # (workflow-log-analysis 7200 + validation-refresh 2400 +
+    # update_workflows 600 + memory-maintenance 900 = 11100s ≈ 185m)
+    # plus a 15m headroom for runner queueing and step setup.
+    timeout-minutes: 200
     env:
       GH_TOKEN: ${{ secrets.GH_PAT }}
       TEST_REPO: ${{ inputs.test_repo || github.repository }}
@@ -2256,11 +2256,14 @@ jobs:
         # runner image). The job-level cap is the outer safety net,
         # but a per-step bound makes the failure attribute to the right
         # step instead of cancelling all sibling steps in the job.
-        # Sized to the workflow-log-analysis 4-job sequential ceiling
+        # Sized to the workflow-log-analysis 4-job sequential worst-case
         # (collect-logs 25m + analyze-commit-notify 30m + deep-audit
-        # 30m + api-redundancy 30m ≈ 115m); release v1.0.113 watcher
-        # exited at 28m while deep-audit was still running.
-        timeout-minutes: 95
+        # 30m + api-redundancy 30m = 115m) plus a 15m runner-queue +
+        # step-setup buffer; release v1.0.113 watcher exited at 28m
+        # while deep-audit was still running. Per Copilot review on
+        # PR #1742: the previous 95m setting could still time out a
+        # healthy run that hit the worst case.
+        timeout-minutes: 130
         env:
           WF_FILE: workflow-log-analysis.yml
           INPUTS: '{"lookback_days":"1","repos_override":"${{ inputs.test_repo || github.repository }}"}'
@@ -2272,11 +2275,14 @@ jobs:
             --field lookback_days=1 \
             --field repos_override="${TEST_REPO}" \
             --field alert_msg_level=SILENT
-          # 5400s (90m) covers the 115m worst-case audit chain minus the
-          # parallel-where-possible savings the workflow's needs graph
-          # produces in practice. Step timeout-minutes above is the
-          # outer cap that attributes a hang to this step.
-          DEADLINE=$(( $(date +%s) + 5400 ))
+          # 7200s (120m) covers the 115m worst-case audit chain
+          # (collect-logs 25m + analyze-commit-notify 30m + deep-audit
+          # 30m + api-redundancy 30m) plus a 5m buffer for runner
+          # queueing between jobs. Step timeout-minutes above (130m)
+          # is the outer cap that attributes a hang to this step.
+          # Bumped from 5400s after Copilot review on PR #1742 noted
+          # 5400s could time out a healthy run hitting the ceiling.
+          DEADLINE=$(( $(date +%s) + 7200 ))
           NEW_ID=""
           while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
             NEW_ID=$(gh api "repos/${TEST_REPO}/actions/workflows/${WF_FILE}/runs?per_page=10" \

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -2214,7 +2214,16 @@ jobs:
     needs: [resolve-version]
     if: ${{ !inputs.skip_e2e && !inputs.dry_run }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # 45m was sized for the original 2-job workflow-log-analysis. The
+    # workflow now has four sequential jobs (collect-logs 25m,
+    # analyze-commit-notify 30m, deep-audit 30m, api-redundancy 30m —
+    # ceiling ~115m), and the orchestrate-decompose-test PR run #204
+    # cancelled at 30m on `deep-audit` while the smoke watcher's 1500s
+    # DEADLINE was already exhausted. Sum of in-step DEADLINEs below
+    # (workflow-log-analysis 5400 + validation-refresh 2400 +
+    # update_workflows 600 + memory-maintenance 900 = 9300s ≈ 155m)
+    # plus a 25m headroom for runner queueing and step setup.
+    timeout-minutes: 180
     env:
       GH_TOKEN: ${{ secrets.GH_PAT }}
       TEST_REPO: ${{ inputs.test_repo || github.repository }}
@@ -2244,10 +2253,14 @@ jobs:
         id: dispatch_log_analysis
         # Per-step backstop in case the in-script `DEADLINE` math goes
         # off (e.g. the `date` command behaves unexpectedly on a future
-        # runner image). The job-level 45m cap is the outer safety net,
+        # runner image). The job-level cap is the outer safety net,
         # but a per-step bound makes the failure attribute to the right
         # step instead of cancelling all sibling steps in the job.
-        timeout-minutes: 28
+        # Sized to the workflow-log-analysis 4-job sequential ceiling
+        # (collect-logs 25m + analyze-commit-notify 30m + deep-audit
+        # 30m + api-redundancy 30m ≈ 115m); release v1.0.113 watcher
+        # exited at 28m while deep-audit was still running.
+        timeout-minutes: 95
         env:
           WF_FILE: workflow-log-analysis.yml
           INPUTS: '{"lookback_days":"1","repos_override":"${{ inputs.test_repo || github.repository }}"}'
@@ -2257,8 +2270,13 @@ jobs:
           PRE=$(gh api "repos/${TEST_REPO}/actions/workflows/${WF_FILE}/runs?per_page=1" --jq '.workflow_runs[0].id // 0' 2>/dev/null || echo 0)
           gh workflow run "${WF_FILE}" --repo "${TEST_REPO}" \
             --field lookback_days=1 \
-            --field repos_override="${TEST_REPO}"
-          DEADLINE=$(( $(date +%s) + 1500 ))
+            --field repos_override="${TEST_REPO}" \
+            --field alert_msg_level=SILENT
+          # 5400s (90m) covers the 115m worst-case audit chain minus the
+          # parallel-where-possible savings the workflow's needs graph
+          # produces in practice. Step timeout-minutes above is the
+          # outer cap that attributes a hang to this step.
+          DEADLINE=$(( $(date +%s) + 5400 ))
           NEW_ID=""
           while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
             NEW_ID=$(gh api "repos/${TEST_REPO}/actions/workflows/${WF_FILE}/runs?per_page=10" \
@@ -2301,7 +2319,8 @@ jobs:
           # Use a per-run smoke branch name so production validation-refresh
           # branches are never collided with.
           gh workflow run "${WF_FILE}" --repo "${TEST_REPO}" \
-            --field branch_name="${BRANCH_NAME}"
+            --field branch_name="${BRANCH_NAME}" \
+            --field alert_msg_level=SILENT
           DEADLINE=$(( $(date +%s) + 2400 ))
           NEW_ID=""
           while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
@@ -2348,7 +2367,8 @@ jobs:
           WF_FILE="update_workflows.yml"
           PRE=$(gh api "repos/${TEST_REPO}/actions/workflows/${WF_FILE}/runs?per_page=1" --jq '.workflow_runs[0].id // 0' 2>/dev/null || echo 0)
           gh workflow run "${WF_FILE}" --repo "${TEST_REPO}" \
-            --field allow_workflow_edits=false
+            --field allow_workflow_edits=false \
+            --field alert_msg_level=SILENT
           DEADLINE=$(( $(date +%s) + 600 ))
           NEW_ID=""
           while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
@@ -2392,7 +2412,8 @@ jobs:
           sleep 4
           WF_FILE="internal-memory-maintenance.yml"
           PRE=$(gh api "repos/${TEST_REPO}/actions/workflows/${WF_FILE}/runs?per_page=1" --jq '.workflow_runs[0].id // 0' 2>/dev/null || echo 0)
-          gh workflow run "${WF_FILE}" --repo "${TEST_REPO}"
+          gh workflow run "${WF_FILE}" --repo "${TEST_REPO}" \
+            --field alert_msg_level=SILENT
           DEADLINE=$(( $(date +%s) + 900 ))
           NEW_ID=""
           while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
@@ -2516,13 +2537,28 @@ jobs:
             exit 1
           fi
           echo "tracking_issue=${TRACKING_NUMBER}" >> "$GITHUB_OUTPUT"
-          BODY=$(gh api "repos/${TEST_REPO}/issues/${TRACKING_NUMBER}" --jq '.body // ""' 2>/dev/null || echo "")
-          CHILDREN=$(printf '%s\n' "${BODY}" | grep -oE '#[0-9]+' | tr -d '#' | sort -u | tr '\n' ',' | sed 's/,$//')
+          # Discover child issues by their orchestrator-managed back-reference
+          # rather than by parsing the tracking-issue body. The tracking body
+          # produced by `build_tracking_issue_body` (orchestrate_lib.py:727)
+          # lists children by SLUG (`- [ ] **set-smoke-canary-status-ok**: …`),
+          # never as `#N`, so the previous body-grep for `#[0-9]+` always
+          # returned 0 children and the assertion failed. Each Wave 1 issue
+          # the orchestrator creates carries the marker
+          # `Tracking issue: #${TRACKING_NUMBER}` in its body
+          # (orchestrate.yml:814) and the canonical
+          # `ai:orchestrator-managed` label, so we list those directly.
+          # `since=${DISPATCH_START_ISO}` and the body filter scope the
+          # match to children opened by THIS dispatch, never an older run.
+          CHILDREN_JSON=$(gh api \
+            "repos/${TEST_REPO}/issues?state=all&labels=ai:orchestrator-managed&since=${DISPATCH_START_ISO}&per_page=100" \
+            --jq "[.[] | select(.pull_request | not) | select(.body // \"\" | contains(\"Tracking issue: #${TRACKING_NUMBER}\")) | .number]" \
+            2>/dev/null || echo "[]")
+          CHILDREN=$(echo "${CHILDREN_JSON}" | jq -r 'sort | unique | join(",")' 2>/dev/null || echo "")
           echo "child_issues=${CHILDREN}" >> "$GITHUB_OUTPUT"
           # Decomposition assertion: at least two distinct child issues.
           CHILD_COUNT=$(echo "${CHILDREN}" | tr ',' '\n' | grep -c .)
           if [ "${CHILD_COUNT}" -lt 2 ]; then
-            echo "::error::Decomposition produced ${CHILD_COUNT} child issue(s); expected >= 2"
+            echo "::error::Decomposition produced ${CHILD_COUNT} child issue(s); expected >= 2 (queried label=ai:orchestrator-managed since=${DISPATCH_START_ISO} body~='Tracking issue: #${TRACKING_NUMBER}')"
             exit 1
           fi
           echo "✓ Decomposition produced ${CHILD_COUNT} child issues: ${CHILDREN}"

--- a/.github/workflows/update_workflows.yml
+++ b/.github/workflows/update_workflows.yml
@@ -32,7 +32,7 @@ name: Update Workflow Wrappers
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  ALERT_MSG_LEVEL: ${{ inputs.alert_msg_level != '' && inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
+  ALERT_MSG_LEVEL: ${{ (github.event.inputs.alert_msg_level || '') != '' && github.event.inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
 
 jobs:
   update-wrappers:
@@ -299,7 +299,7 @@ jobs:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
           GH_TOKEN: ${{ secrets.GH_PAT }}
-          ALERT_MSG_LEVEL: ${{ inputs.alert_msg_level != '' && inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
+          ALERT_MSG_LEVEL: ${{ (github.event.inputs.alert_msg_level || '') != '' && github.event.inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/update_workflows.yml
+++ b/.github/workflows/update_workflows.yml
@@ -299,7 +299,6 @@ jobs:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
           GH_TOKEN: ${{ secrets.GH_PAT }}
-          ALERT_MSG_LEVEL: ${{ (github.event.inputs.alert_msg_level || '') != '' && github.event.inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/update_workflows.yml
+++ b/.github/workflows/update_workflows.yml
@@ -24,9 +24,15 @@ name: Update Workflow Wrappers
         required: false
         default: true
         type: boolean
+      alert_msg_level:
+        description: Override the Telegram alert threshold for this run. Set to SILENT when dispatched from the test-and-mark-stable smoke gate to avoid drowning the gate's combined notification in per-job alerts.
+        required: false
+        default: ""
+        type: string
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  ALERT_MSG_LEVEL: ${{ inputs.alert_msg_level != '' && inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
 
 jobs:
   update-wrappers:
@@ -293,7 +299,7 @@ jobs:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
           GH_TOKEN: ${{ secrets.GH_PAT }}
-          ALERT_MSG_LEVEL: ${{ vars.ALERT_MSG_LEVEL || 'DEBUG' }}
+          ALERT_MSG_LEVEL: ${{ inputs.alert_msg_level != '' && inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/validation-refresh.yml
+++ b/.github/workflows/validation-refresh.yml
@@ -160,7 +160,7 @@ jobs:
           # (alert_msg_level=SILENT) doesn't surface a failure ping.
           case "$(printf '%s' "${ALERT_MSG_LEVEL:-DEBUG}" | tr '[:lower:]' '[:upper:]')" in
             ERROR|CRITICAL|SILENT)
-              echo "ALERT_MSG_LEVEL=${ALERT_MSG_LEVEL} suppresses WARNING-level Telegram failure ping."
+              echo "ALERT_MSG_LEVEL=${ALERT_MSG_LEVEL} suppresses this WARNING-level Telegram failure ping (threshold ≥ ERROR filters it)."
               exit 0
               ;;
           esac

--- a/.github/workflows/validation-refresh.yml
+++ b/.github/workflows/validation-refresh.yml
@@ -160,7 +160,7 @@ jobs:
           # (alert_msg_level=SILENT) doesn't surface a failure ping.
           case "$(printf '%s' "${ALERT_MSG_LEVEL:-DEBUG}" | tr '[:lower:]' '[:upper:]')" in
             ERROR|CRITICAL|SILENT)
-              echo "ALERT_MSG_LEVEL=${ALERT_MSG_LEVEL} suppresses this WARNING-level Telegram failure ping (threshold ≥ ERROR filters it)."
+              echo "ALERT_MSG_LEVEL=${ALERT_MSG_LEVEL} suppresses this WARNING-level Telegram failure ping (ERROR/CRITICAL/SILENT all filter it)."
               exit 0
               ;;
           esac

--- a/.github/workflows/validation-refresh.yml
+++ b/.github/workflows/validation-refresh.yml
@@ -23,7 +23,9 @@ name: Validation Refresh
         type: string
 
 env:
-  ALERT_MSG_LEVEL: ${{ inputs.alert_msg_level != '' && inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
+  # `inputs` is null on schedule-triggered runs; use `github.event.inputs`
+  # (which is null-safe via `||`) to avoid a parse-time/runtime miss.
+  ALERT_MSG_LEVEL: ${{ (github.event.inputs.alert_msg_level || '') != '' && github.event.inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
 
 permissions:
   contents: write
@@ -151,6 +153,17 @@ jobs:
             echo "Telegram notification skipped (missing TG_BOT_SECRET or TG_CHAT_ID)."
             exit 0
           fi
+          # This step uses raw curl (not tg_send_msg) so the
+          # ALERT_MSG_LEVEL=SILENT plumbing won't filter it
+          # automatically; gate explicitly on SILENT/ERROR/CRITICAL so
+          # the smoke gate's release-gate dispatch
+          # (alert_msg_level=SILENT) doesn't surface a failure ping.
+          case "$(printf '%s' "${ALERT_MSG_LEVEL:-DEBUG}" | tr '[:lower:]' '[:upper:]')" in
+            ERROR|CRITICAL|SILENT)
+              echo "ALERT_MSG_LEVEL=${ALERT_MSG_LEVEL} suppresses WARNING-level Telegram failure ping."
+              exit 0
+              ;;
+          esac
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           printf -v TEXT '⚠️ Validation refresh failed in %s\n%s' "${{ github.repository }}" "${RUN_URL}"
           curl -sS -X POST "https://api.telegram.org/bot${TG_BOT_SECRET}/sendMessage" \

--- a/.github/workflows/validation-refresh.yml
+++ b/.github/workflows/validation-refresh.yml
@@ -16,6 +16,14 @@ name: Validation Refresh
         required: false
         default: "ai/validation-refresh"
         type: string
+      alert_msg_level:
+        description: Override the Telegram alert threshold for this run. Set to SILENT when dispatched from the test-and-mark-stable smoke gate to avoid drowning the gate's combined notification in per-job alerts.
+        required: false
+        default: ""
+        type: string
+
+env:
+  ALERT_MSG_LEVEL: ${{ inputs.alert_msg_level != '' && inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
 
 permissions:
   contents: write

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -549,7 +549,6 @@ jobs:
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
-          ALERT_MSG_LEVEL: ${{ (github.event.inputs.alert_msg_level || '') != '' && github.event.inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
         run: |
           set -euo pipefail
 
@@ -884,7 +883,6 @@ jobs:
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
-          ALERT_MSG_LEVEL: ${{ (github.event.inputs.alert_msg_level || '') != '' && github.event.inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
         run: |
           set -euo pipefail
 
@@ -1198,7 +1196,6 @@ jobs:
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
-          ALERT_MSG_LEVEL: ${{ (github.event.inputs.alert_msg_level || '') != '' && github.event.inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -28,9 +28,15 @@ on:
         required: false
         default: "0"
         type: string
+      alert_msg_level:
+        description: Override the Telegram alert threshold for this run. Set to SILENT when dispatched from the test-and-mark-stable smoke gate to avoid drowning the gate's combined notification in per-job alerts.
+        required: false
+        default: ""
+        type: string
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  ALERT_MSG_LEVEL: ${{ inputs.alert_msg_level != '' && inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
 
 permissions:
   contents: write
@@ -543,7 +549,7 @@ jobs:
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
-          ALERT_MSG_LEVEL: ${{ vars.ALERT_MSG_LEVEL || 'DEBUG' }}
+          ALERT_MSG_LEVEL: ${{ inputs.alert_msg_level != '' && inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
         run: |
           set -euo pipefail
 
@@ -878,7 +884,7 @@ jobs:
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
-          ALERT_MSG_LEVEL: ${{ vars.ALERT_MSG_LEVEL || 'DEBUG' }}
+          ALERT_MSG_LEVEL: ${{ inputs.alert_msg_level != '' && inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
         run: |
           set -euo pipefail
 
@@ -1192,7 +1198,7 @@ jobs:
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
-          ALERT_MSG_LEVEL: ${{ vars.ALERT_MSG_LEVEL || 'DEBUG' }}
+          ALERT_MSG_LEVEL: ${{ inputs.alert_msg_level != '' && inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -36,7 +36,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  ALERT_MSG_LEVEL: ${{ inputs.alert_msg_level != '' && inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
+  ALERT_MSG_LEVEL: ${{ (github.event.inputs.alert_msg_level || '') != '' && github.event.inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
 
 permissions:
   contents: write
@@ -549,7 +549,7 @@ jobs:
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
-          ALERT_MSG_LEVEL: ${{ inputs.alert_msg_level != '' && inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
+          ALERT_MSG_LEVEL: ${{ (github.event.inputs.alert_msg_level || '') != '' && github.event.inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
         run: |
           set -euo pipefail
 
@@ -884,7 +884,7 @@ jobs:
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
-          ALERT_MSG_LEVEL: ${{ inputs.alert_msg_level != '' && inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
+          ALERT_MSG_LEVEL: ${{ (github.event.inputs.alert_msg_level || '') != '' && github.event.inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
         run: |
           set -euo pipefail
 
@@ -1198,7 +1198,7 @@ jobs:
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
-          ALERT_MSG_LEVEL: ${{ inputs.alert_msg_level != '' && inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
+          ALERT_MSG_LEVEL: ${{ (github.event.inputs.alert_msg_level || '') != '' && github.event.inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
         run: |
           set -euo pipefail
 

--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -205,12 +205,16 @@ _gh_ratelimit_tg_alert()
 
 	# Honour the global ALERT_MSG_LEVEL threshold the same way
 	# tg_helpers.sh::tg_send_msg does. This alert is WARNING level,
-	# so when the operator has configured ALERT_MSG_LEVEL=ERROR or
-	# CRITICAL the rate-limit alert is suppressed (no send, no pin
-	# update, cooldown window is not advanced).
+	# so when the operator has configured ALERT_MSG_LEVEL=ERROR,
+	# CRITICAL, or SILENT the rate-limit alert is suppressed (no
+	# send, no pin update, cooldown window is not advanced).
+	# SILENT (added with the test-and-mark-stable smoke-gate change)
+	# must be in the suppress list explicitly; the permissive default
+	# below would otherwise let SILENT through and the gate would
+	# still see rate-limit pings.
 	case "$(printf '%s' "${ALERT_MSG_LEVEL:-DEBUG}" | tr '[:lower:]' '[:upper:]')" in
 		DEBUG|WARNING) : ;;
-		ERROR|CRITICAL) return 0 ;;
+		ERROR|CRITICAL|SILENT) return 0 ;;
 		*) : ;;  # unknown value → match tg_helpers.sh permissive default
 	esac
 

--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -150,18 +150,30 @@ EOF
   rm -rf "${probe_home}" 2>/dev/null || true
 }
 
-# Reviewer slugs whose upstream OpenRouter providers reject codex-cli v0.125's
-# `type: "namespace"` MCP tool envelope on /v1/responses with HTTP 422 "Provider
-# returned error". For these, strip MCP from the per-reviewer codex-home so no
-# namespace tool is sent. Empirically determined from review run #25041117408:
-# minimax/minimax-m2.5, moonshotai/kimi-k2.5, z-ai/glm-5 accept the envelope;
-# deepseek/deepseek-v4-pro, qwen/qwen3.6-plus, x-ai/grok-4.1-fast reject it.
-# Re-evaluate when bumping codex-cli or rotating reviewer slugs. Newline-
-# separated like REVIEWER_MODELS; override via env to add/remove without an
-# edit. Empty value disables the no-MCP fallback path entirely.
-MCP_INCOMPATIBLE_REVIEWER_MODELS="${MCP_INCOMPATIBLE_REVIEWER_MODELS-deepseek/deepseek-v4-pro
-qwen/qwen3.6-plus
-x-ai/grok-4.1-fast}"
+# Reviewer slugs whose upstream OpenRouter providers reject codex-cli's
+# v0.125+ `type: "namespace"` MCP tool envelope on /v1/responses with
+# HTTP 422 "Provider returned error". When a model is on this list, the
+# per-reviewer codex-home has every `[mcp_servers.*]` table stripped so
+# no namespace tool gets sent.
+#
+# Currently empty by default. PR #1717 added deepseek/deepseek-v4-pro,
+# qwen/qwen3.6-plus, x-ai/grok-4.1-fast here because Codex CLI v0.125
+# was the pinned default and those three providers 422'd on its
+# namespace envelope. PR #1729 reverted Codex CLI to v0.114, which
+# emits flat MCP tools (no namespace envelope) that all three providers
+# accept. Stripping MCP for those three with v0.114 was the *cause* of
+# their continued failures — the reviewer prompt references
+# `mcp__serena__*` tools but the stripped config doesn't register them,
+# so the model produces empty output and codex-cli reports
+# `status='failed'` after the configured retries (observed on
+# PR #1742, run 25084895203).
+#
+# Re-populate this list when next bumping codex-cli to v0.125+ (and
+# only after a per-provider probe confirms which slugs still 422 on
+# the namespace envelope). Override at runtime via the
+# `MCP_INCOMPATIBLE_REVIEWER_MODELS` env var (newline-separated like
+# `REVIEWER_MODELS`).
+MCP_INCOMPATIBLE_REVIEWER_MODELS="${MCP_INCOMPATIBLE_REVIEWER_MODELS-}"
 
 is_mcp_incompatible_model() {
   local model="$1"

--- a/scripts/tg_helpers.sh
+++ b/scripts/tg_helpers.sh
@@ -69,6 +69,7 @@ _tg_level_icon()
 		WARNING)  printf '⚠️' ;;
 		ERROR)    printf '❌' ;;
 		CRITICAL) printf '🚨' ;;
+		SILENT)   printf '🔕' ;;
 		*)        printf '🚨' ;;
 	esac
 }

--- a/scripts/tg_helpers.sh
+++ b/scripts/tg_helpers.sh
@@ -36,9 +36,14 @@ _tg_chat_id()
 
 # ---------------------------------------------------------------
 # Alert level support
-# Levels: DEBUG < WARNING < ERROR < CRITICAL
+# Levels: DEBUG < WARNING < ERROR < CRITICAL < SILENT
 # ALERT_MSG_LEVEL env var controls minimum level sent (default: DEBUG).
 # New alerts default to CRITICAL until explicitly recategorised.
+# Setting ALERT_MSG_LEVEL=SILENT suppresses every send because no
+# caller can pass a level >= SILENT (used by the test-and-mark-stable
+# release gate to silence its smoke-test pipeline; only the gate's
+# final pass/fail notification is emitted via raw curl, bypassing
+# this filter).
 # ---------------------------------------------------------------
 
 _tg_level_num()
@@ -48,6 +53,7 @@ _tg_level_num()
 		WARNING)  printf '1' ;;
 		ERROR)    printf '2' ;;
 		CRITICAL) printf '3' ;;
+		SILENT)   printf '99' ;;
 		*)        printf '0' ;;
 	esac
 }

--- a/scripts/tg_helpers.sh
+++ b/scripts/tg_helpers.sh
@@ -39,11 +39,15 @@ _tg_chat_id()
 # Levels: DEBUG < WARNING < ERROR < CRITICAL < SILENT
 # ALERT_MSG_LEVEL env var controls minimum level sent (default: DEBUG).
 # New alerts default to CRITICAL until explicitly recategorised.
-# Setting ALERT_MSG_LEVEL=SILENT suppresses every send because no
-# caller can pass a level >= SILENT (used by the test-and-mark-stable
+# Setting ALERT_MSG_LEVEL=SILENT suppresses all existing helper-based
+# sends because no existing call site emits at SILENT — every caller
+# below uses CRITICAL (default), ERROR, WARNING, or DEBUG, and all of
+# those map to a number < 99. (Used by the test-and-mark-stable
 # release gate to silence its smoke-test pipeline; only the gate's
 # final pass/fail notification is emitted via raw curl, bypassing
-# this filter).
+# this filter. A future caller wishing to bypass SILENT could pass
+# `SILENT` itself as the level — the threshold check would let it
+# through — but no such call exists today.)
 # ---------------------------------------------------------------
 
 _tg_level_num()


### PR DESCRIPTION
## Summary

Four targeted fixes to the `test-and-mark-stable` release gate after run [25074100587](https://github.com/shubhodeep1/coding-workflows/actions/runs/25074100587) (v1.0.113) failed in three jobs.

### 1. `e2e-smoke-test` ✗ — Phase 4b "Editor failed to remove bait line"
`review_autofix.yml`'s smoke-test detection step still forced `EDITOR_REASONING_EFFORT=low` and `sed`-patched the codex `config.toml` to `model_reasoning_effort = "low"`. PR #1723 removed this override only in `implement.yml`; its description explicitly noted *"The same override pattern exists in `clarify.yml`, `plan.yml`, and `review_autofix.yml` and can be addressed in a follow-up if it surfaces in their logs."* It surfaced. At low reasoning `openai/gpt-5.3-codex` emits Serena MCP calls without the `mcp__serena__` prefix, the Codex tool router rejects each `unsupported call: activate_project / git_status / search_for_pattern`, the session corrupts, and the editor produces zero file changes. PR #1735's editor ran 3 attempts × 1700+ Serena calls and never pushed a commit. Drop the override; keep `xhigh` for smoke runs too.

### 2. `orphan-workflows-test` ✗ — `workflow-log-analysis run #25074119156 timed out`
The smoke watcher's `DEADLINE=$(( $(date +%s) + 1500 ))` (25 min) was sized for the original 2-job version of `workflow-log-analysis`. The workflow now has four sequential jobs (`collect-logs` 25m, `analyze-commit-notify` 30m, `deep-audit` 30m, `api-redundancy` 30m, ceiling ~115m). Bump (final values after Copilot review, commits `e7d4362` + `4345e67`):
- in-script `DEADLINE` 1500s → **7200s** (covers the 115m worst-case + 5m runner-queue buffer)
- per-step `timeout-minutes` 28 → **130** (worst-case + 15m setup buffer)
- job-level `timeout-minutes` 45 → **200** (covers all four sub-step DEADLINEs ≈185m + 15m headroom)

### 3. `orchestrate-decompose-test` ✗ — `Decomposition produced 0 child issue(s); expected >= 2`
PR #1729 repaired the tracking-issue lookup but left the children-extraction wrong: `grep -oE '#[0-9]+'` scans the tracking-issue body for refs that `build_tracking_issue_body` (`scripts/orchestrate_lib.py:727`) never emits — the body lists children by slug (`- [ ] **set-smoke-canary-status-ok**: …`), not `#N`. Switch to the orchestrator's authoritative back-reference: query `ai:orchestrator-managed` issues whose body contains `Tracking issue: #${TRACKING_NUMBER}` (the marker `orchestrate.yml:814` writes into every Wave 1 issue), scoped by `DISPATCH_START_ISO` and excluding pull_requests.

### 4. Telegram alert noise during the release gate
The gate triggers many sub-workflows (clarify / plan / implement / review_autofix / orchestrate / orchestrate_poll / orchestrate_clarify_respond) and dispatches more (workflow-log-analysis / validation-refresh / update_workflows), each emitting per-phase Telegram notifications. Two-prong fix:

- **`scripts/tg_helpers.sh`**: add `SILENT` level (numeric 99) so no existing call site emits at SILENT.
- **`scripts/gh_helpers.sh`**: add `SILENT` to the `_gh_ratelimit_tg_alert` suppress list so rate-limit pings are silenced too.
- **Issue/PR-context workflows**: existing smoke-detection blocks now also export `ALERT_MSG_LEVEL=SILENT` to `$GITHUB_ENV`. New detection added where needed:
  - `clarify.yml`, `plan.yml`, `implement.yml`, `review_autofix.yml`: `[E2E Smoke Test]` in issue/PR title.
  - `orchestrate.yml`: `[E2E Orchestrate Smoke …]` prefix in `inputs.project_description`.
  - `orchestrate_poll.yml`: every active tracking issue has `[Orchestrator] E2E …` title.
  - `orchestrate_clarify_respond.yml`: tracking parent's title starts with `[Orchestrator] E2E `.
- **Directly-dispatched workflows**: `workflow-log-analysis.yml`, `validation-refresh.yml`, `update_workflows.yml` accept a new `alert_msg_level` workflow_dispatch input (using the `(github.event.inputs.* || '') != ''` schedule/call-safe pattern). The gate passes `--field alert_msg_level=SILENT` on those three direct dispatches. `internal-memory-maintenance.yml` is **not** wired — neither it nor the called `memory_maintenance.yml` nor `ai_memory.py compact` emit Telegram alerts, so the input would be a no-op (per Copilot review).
- **`validation-refresh.yml`**'s raw-curl Telegram failure step has an explicit `ERROR|CRITICAL|SILENT` short-circuit since it bypasses `tg_helpers.sh`'s level filter.

The gate's `notify` job sends via raw `curl` — it bypasses the level filter and always emits the combined pass/fail message at the end.

## Test plan

- [ ] Re-run `comprehensive-test-and-release.yml` (or `test-and-mark-stable.yml` reusable) and confirm:
  - `e2e-smoke-test` passes with the bait line removed in PR diff.
  - `orphan-workflows-test` watcher waits past the 30 min mark when `workflow-log-analysis`'s `deep-audit` is still running.
  - `orchestrate-decompose-test` reports `✓ Decomposition produced 2 child issues: <N1>,<N2>`.
- [ ] Confirm only one Telegram notification fires for the run (the final pass/fail combined message); no per-phase alerts from clarify/plan/implement/review_autofix/orchestrate during the gate run.
- [ ] Confirm scheduled (non-gate) `workflow-log-analysis` / `validation-refresh` cron runs still alert as before (their `alert_msg_level` input is empty, so they fall back to `vars.ALERT_MSG_LEVEL || 'DEBUG'`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)