### PR TITLE
fix(release-gate): make orchestrate-decompose smoke decomposition deterministic

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -2487,14 +2487,17 @@ jobs:
           set -euo pipefail
           WF_FILE="internal-orchestrate.yml"
           # Two-issue project description with an explicit dependency so the
-          # orchestrator must produce >=2 issues across >=2 waves. Stays
-          # inside the smoke canary file family to minimise blast radius and
-          # lets cleanup target the new issues by title prefix.
-          PROJECT_DESC="[E2E Orchestrate Smoke ${GITHUB_RUN_ID}] Update tests/e2e_smoke_canary.txt with two changes that MUST be decomposed into TWO separate child issues wired by an explicit dependency_edges entry. "
-          PROJECT_DESC+="DO NOT collapse these into a single child issue. Both changes touch the same file (tests/e2e_smoke_canary.txt), so per the decomposer's same-file-siblings rule in prompts/mode-orchestrate.txt they MUST serialize into different waves via an explicit dependency_edges entry — leaving both edits in one issue is the prohibited 'unresolved conflict at planning time' failure mode. "
-          PROJECT_DESC+="Issue 1 (no dependencies, files_touched=[tests/e2e_smoke_canary.txt]): set the file's first line to exactly 'status: ok'. "
-          PROJECT_DESC+="Issue 2 (depends on Issue 1, files_touched=[tests/e2e_smoke_canary.txt]): append exactly the line 'decompose-run: ${GITHUB_RUN_ID}'. Represent this dependency in the orchestrate_decomposition.v1 schema as a dependency_edges entry {from: <Issue 1 id>, to: <Issue 2 id>}. Issue 2 must execute AFTER Issue 1 has merged because its acceptance criterion is that the file's first line already reads 'status: ok' AND the appended line is present; combining them into one PR removes the dependency-aware wave ordering this smoke test exists to exercise. "
-          PROJECT_DESC+="Constraints: both issues target the same file; declare the dependency edge Issue 1 -> Issue 2 in the orchestrator DAG; this is fully specified — no clarification is needed."
+          # orchestrator must produce >=2 issues across >=2 waves. The two
+          # sub-issues target DIFFERENT files (canary.txt vs canary_b.txt) so
+          # the decomposer's "one concern per issue" rule does not pressure it
+          # to collapse them. Issue 2's content is derived from Issue 1's
+          # output, so the dependency edge is structurally inevitable rather
+          # than judgment-dependent. Cleanup still targets new issues via
+          # tracking-issue back-reference + title-prefix marker.
+          PROJECT_DESC="[E2E Orchestrate Smoke ${GITHUB_RUN_ID}] This is an author-decomposed project that requires TWO sequential child issues touching DIFFERENT files. Per the orchestrator's author-decomposition rule (see prompts/mode-orchestrate.txt), honor the enumeration below verbatim — emit exactly two issues with the stated dependency edge. "
+          PROJECT_DESC+="Issue 1 (no dependencies, files_touched=[tests/e2e_smoke_canary.txt]): set the first line of tests/e2e_smoke_canary.txt to exactly 'status: ok'. "
+          PROJECT_DESC+="Issue 2 (depends on Issue 1, files_touched=[tests/e2e_smoke_canary_b.txt]): edit tests/e2e_smoke_canary_b.txt — change its first line to mirror the first line of tests/e2e_smoke_canary.txt (which Issue 1 establishes as 'status: ok') AND append the line 'decompose-run: ${GITHUB_RUN_ID}'. Issue 2's acceptance criterion explicitly requires reading Issue 1's output at implementation time, so Issue 2 MUST execute AFTER Issue 1 has merged. "
+          PROJECT_DESC+="Represent this dependency in the orchestrate_decomposition.v1 schema as a dependency_edges entry {from: <Issue 1 id>, to: <Issue 2 id>}. The two issues' files_touched lists MUST NOT overlap. This is fully specified — no clarification is needed."
           PRE=$(gh api "repos/${TEST_REPO}/actions/workflows/${WF_FILE}/runs?per_page=1" --jq '.workflow_runs[0].id // 0' 2>/dev/null || echo 0)
           # Capture the dispatch start time before dispatching so the
           # post-run lookup can use it as a lower-bound created_at filter

--- a/prompts/mode-orchestrate.txt
+++ b/prompts/mode-orchestrate.txt
@@ -21,6 +21,20 @@ Rules:
   knowledge of sibling issues.
 - Keep issues focused. One concern per issue. A single issue should be
   implementable within a single PR touching at most ~10 files.
+- Author-supplied decomposition (OVERRIDES the "one concern per issue" rule
+  above): if the project description **explicitly enumerates** sub-issues
+  with structural markers — `Issue 1: …, Issue 2: …`, a numbered list of
+  distinct sub-tasks, or named child IDs that the description references in
+  dependency declarations — honor that enumeration verbatim. Emit exactly the
+  enumerated issues, in the stated order, with the stated `dependency_edges`.
+  The author has already done the decomposition work; do NOT collapse
+  explicitly-enumerated issues into a single issue even if they appear to
+  share a single concern, and do NOT insert additional issues beyond the
+  enumeration unless one of the stated issues is internally too large per the
+  per-issue implementation-time budget rule below (only then split that
+  single oversized issue into sequential sub-issues, preserving the rest of
+  the author's enumeration). This rule lets users (and smoke tests) drive a
+  deterministic multi-issue decomposition when they need one.
 - If a feature naturally spans many files or modules, split it into sequential
   issues (foundation first, then layers that depend on it).
 - Per-issue implementation-time budget: each issue MUST be scoped so the

--- a/tests/e2e_smoke_canary_b.txt
+++ b/tests/e2e_smoke_canary_b.txt
@@ -1,0 +1,6 @@
+# Orchestrate-decompose smoke canary B.
+# Owned by .github/workflows/test-and-mark-stable.yml :: orchestrate-decompose-test.
+# Issue 2 of the smoke project_description targets this file so that the two
+# decomposed sub-issues touch DIFFERENT files (no files_touched overlap),
+# making the two-issue + dependency_edges shape structurally inevitable.
+status: pending


### PR DESCRIPTION
## Summary

Run #25091768619 of `orchestrate-decompose-test` failed on the
`CHILD_COUNT >= 2` assertion again — the decomposer collapsed the two
canary edits into a single child issue. PR #1752's prompt-engineering nudge
("DO NOT collapse … MUST be TWO") was LLM-judgment-dependent and didn't hold.

Root cause is **structural, not flake**: two trivial line-edits to one
canary file are reasonably *one concern* under the orchestrate prompt's
own rule `prompts/mode-orchestrate.txt:22` ("Keep issues focused. One
concern per issue."). The same-file-siblings rule (lines 103–107) and
`auto_serialize_file_overlaps` (`scripts/orchestrate_lib.py:464`) only
serialize **already-emitted** siblings — they can't create siblings out
of nothing. So as long as the smoke asks the LLM to over-split a one-
concern task against its own prompt rules, it will keep flapping.

Two complementary fixes:

1. **Restructure the smoke so the two sub-issues touch different files.**
   Issue 1 edits `tests/e2e_smoke_canary.txt`; Issue 2 edits a new
   dedicated seed `tests/e2e_smoke_canary_b.txt`. Issue 2's body says its
   first line must mirror Issue 1's output (the first line of `canary.txt`)
   — so the dependency edge is **structural** (Issue 2's content is
   computed *from* Issue 1's output) rather than just restated. Different
   files → no temptation to collapse under "one concern"; semantic cross-
   file content dependency → real `dependency_edges` entry.

2. **Add an "author-supplied decomposition" rule to
   `prompts/mode-orchestrate.txt`** that explicitly **overrides** "one
   concern per issue" when the project description enumerates sub-issues
   with structural markers (`Issue 1:`, `Issue 2:`, numbered lists, named
   child IDs in dependency declarations). The decomposer is now told to
   honor that enumeration verbatim. This gives users (and the smoke test)
   a deterministic multi-issue forcing function for any pre-decomposed
   project description.

No changes to `scripts/orchestrate_lib.py` or the orchestrate workflow
itself — this is a smoke-test design fix plus a decomposer prompt rule
addition.

## Test plan

- [ ] CI lint passes (`yamllint`, `actionlint`, prompt validation)
- [ ] `orchestrate-decompose-test` job in `test-and-mark-stable` produces
      ≥ 2 child issues on the next release-gate run, without depending on
      LLM judgment to override "one concern per issue"
- [ ] Cleanup phase still closes both children + tracking issue
      (back-reference and title-marker paths unchanged)
- [ ] Verify the new prompt rule doesn't unintentionally trigger on real
      user descriptions — the rule fires only on explicit enumeration
      markers (`Issue N:`, numbered sub-task lists, named child IDs)

https://claude.ai/code/session_01FeFAMGi1v9quDbW1aeEGJw

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeFAMGi1v9quDbW1aeEGJw)_