### PR TITLE
fix(mcp): default CONTEXT7_DISABLED and GIT_MCP_DISABLED to true

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -503,8 +503,8 @@ jobs:
           SERENA_VERSION: ${{ vars.SERENA_VERSION || 'main' }}
           SERENA_LANGUAGES: ${{ vars.SERENA_LANGUAGES || '' }}
           SERENA_DISABLED: ${{ vars.SERENA_DISABLED || 'false' }}
-          CONTEXT7_DISABLED: ${{ vars.CONTEXT7_DISABLED || 'false' }}
-          GIT_MCP_DISABLED: ${{ vars.GIT_MCP_DISABLED || 'false' }}
+          CONTEXT7_DISABLED: ${{ vars.CONTEXT7_DISABLED || 'true' }}
+          GIT_MCP_DISABLED: ${{ vars.GIT_MCP_DISABLED || 'true' }}
           SERENA_IGNORED_DIRS: ${{ vars.SERENA_IGNORED_DIRS || '' }}
           PYTHONDONTWRITEBYTECODE: "1"
         run: |

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -796,8 +796,8 @@ jobs:
           SERENA_VERSION: ${{ vars.SERENA_VERSION || 'main' }}
           SERENA_LANGUAGES: ${{ vars.SERENA_LANGUAGES || '' }}
           SERENA_DISABLED: ${{ vars.SERENA_DISABLED || 'false' }}
-          CONTEXT7_DISABLED: ${{ vars.CONTEXT7_DISABLED || 'false' }}
-          GIT_MCP_DISABLED: ${{ vars.GIT_MCP_DISABLED || 'false' }}
+          CONTEXT7_DISABLED: ${{ vars.CONTEXT7_DISABLED || 'true' }}
+          GIT_MCP_DISABLED: ${{ vars.GIT_MCP_DISABLED || 'true' }}
           SERENA_IGNORED_DIRS: ${{ vars.SERENA_IGNORED_DIRS || '' }}
           PYTHONDONTWRITEBYTECODE: "1"
         run: |

--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -439,8 +439,8 @@ jobs:
           SERENA_VERSION: ${{ vars.SERENA_VERSION || 'main' }}
           SERENA_LANGUAGES: ${{ vars.SERENA_LANGUAGES || '' }}
           SERENA_DISABLED: ${{ vars.SERENA_DISABLED || 'false' }}
-          CONTEXT7_DISABLED: ${{ vars.CONTEXT7_DISABLED || 'false' }}
-          GIT_MCP_DISABLED: ${{ vars.GIT_MCP_DISABLED || 'false' }}
+          CONTEXT7_DISABLED: ${{ vars.CONTEXT7_DISABLED || 'true' }}
+          GIT_MCP_DISABLED: ${{ vars.GIT_MCP_DISABLED || 'true' }}
           SERENA_IGNORED_DIRS: ${{ vars.SERENA_IGNORED_DIRS || '' }}
           PYTHONDONTWRITEBYTECODE: "1"
         run: |

--- a/.github/workflows/orchestrate_clarify_respond.yml
+++ b/.github/workflows/orchestrate_clarify_respond.yml
@@ -550,8 +550,8 @@ jobs:
           SERENA_VERSION: ${{ vars.SERENA_VERSION || 'main' }}
           SERENA_LANGUAGES: ${{ vars.SERENA_LANGUAGES || '' }}
           SERENA_DISABLED: ${{ vars.SERENA_DISABLED || 'false' }}
-          CONTEXT7_DISABLED: ${{ vars.CONTEXT7_DISABLED || 'false' }}
-          GIT_MCP_DISABLED: ${{ vars.GIT_MCP_DISABLED || 'false' }}
+          CONTEXT7_DISABLED: ${{ vars.CONTEXT7_DISABLED || 'true' }}
+          GIT_MCP_DISABLED: ${{ vars.GIT_MCP_DISABLED || 'true' }}
           SERENA_IGNORED_DIRS: ${{ vars.SERENA_IGNORED_DIRS || '' }}
           PYTHONDONTWRITEBYTECODE: "1"
         run: |

--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -396,8 +396,8 @@ jobs:
           SERENA_VERSION: ${{ vars.SERENA_VERSION || 'main' }}
           SERENA_LANGUAGES: ${{ vars.SERENA_LANGUAGES || '' }}
           SERENA_DISABLED: ${{ vars.SERENA_DISABLED || 'false' }}
-          CONTEXT7_DISABLED: ${{ vars.CONTEXT7_DISABLED || 'false' }}
-          GIT_MCP_DISABLED: ${{ vars.GIT_MCP_DISABLED || 'false' }}
+          CONTEXT7_DISABLED: ${{ vars.CONTEXT7_DISABLED || 'true' }}
+          GIT_MCP_DISABLED: ${{ vars.GIT_MCP_DISABLED || 'true' }}
           SERENA_IGNORED_DIRS: ${{ vars.SERENA_IGNORED_DIRS || '' }}
           ENABLE_VALIDATION: ${{ vars.ENABLE_VALIDATION || 'true' }}
           MAX_VALIDATE_CYCLES: ${{ vars.MAX_VALIDATE_CYCLES || '3' }}

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -732,8 +732,8 @@ jobs:
           SERENA_VERSION: ${{ vars.SERENA_VERSION || 'main' }}
           SERENA_LANGUAGES: ${{ vars.SERENA_LANGUAGES || '' }}
           SERENA_DISABLED: ${{ vars.SERENA_DISABLED || 'false' }}
-          CONTEXT7_DISABLED: ${{ vars.CONTEXT7_DISABLED || 'false' }}
-          GIT_MCP_DISABLED: ${{ vars.GIT_MCP_DISABLED || 'false' }}
+          CONTEXT7_DISABLED: ${{ vars.CONTEXT7_DISABLED || 'true' }}
+          GIT_MCP_DISABLED: ${{ vars.GIT_MCP_DISABLED || 'true' }}
           SERENA_IGNORED_DIRS: ${{ vars.SERENA_IGNORED_DIRS || '' }}
           PYTHONDONTWRITEBYTECODE: "1"
         run: |

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1195,8 +1195,8 @@ jobs:
           SERENA_VERSION: ${{ vars.SERENA_VERSION || 'main' }}
           SERENA_LANGUAGES: ${{ vars.SERENA_LANGUAGES || '' }}
           SERENA_DISABLED: ${{ vars.SERENA_DISABLED || 'false' }}
-          CONTEXT7_DISABLED: ${{ vars.CONTEXT7_DISABLED || 'false' }}
-          GIT_MCP_DISABLED: ${{ vars.GIT_MCP_DISABLED || 'false' }}
+          CONTEXT7_DISABLED: ${{ vars.CONTEXT7_DISABLED || 'true' }}
+          GIT_MCP_DISABLED: ${{ vars.GIT_MCP_DISABLED || 'true' }}
           SERENA_IGNORED_DIRS: ${{ vars.SERENA_IGNORED_DIRS || '' }}
           PYTHONDONTWRITEBYTECODE: "1"
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -562,8 +562,8 @@ jobs:
           SERENA_VERSION: ${{ vars.SERENA_VERSION || 'main' }}
           SERENA_LANGUAGES: ${{ vars.SERENA_LANGUAGES || '' }}
           SERENA_DISABLED: ${{ vars.SERENA_DISABLED || 'false' }}
-          CONTEXT7_DISABLED: ${{ vars.CONTEXT7_DISABLED || 'false' }}
-          GIT_MCP_DISABLED: ${{ vars.GIT_MCP_DISABLED || 'false' }}
+          CONTEXT7_DISABLED: ${{ vars.CONTEXT7_DISABLED || 'true' }}
+          GIT_MCP_DISABLED: ${{ vars.GIT_MCP_DISABLED || 'true' }}
           SERENA_IGNORED_DIRS: ${{ vars.SERENA_IGNORED_DIRS || '' }}
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `SERENA_VERSION` | No | `main` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, validate | Version/branch of the Serena MCP server |
 | `SERENA_LANGUAGES` | No | `""` (empty) | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, validate | Languages for Serena symbol analysis |
 | `SERENA_DISABLED` | No | `false` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, validate | Disable the Serena MCP server |
-| `CONTEXT7_DISABLED` | No | `false` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, orchestrate_clarify_respond, validate | Disable the optional Context7 MCP server |
-| `GIT_MCP_DISABLED` | No | `false` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, orchestrate_clarify_respond, validate | Disable the optional Git MCP server setup (preloaded diff artifacts remain the fallback). |
+| `CONTEXT7_DISABLED` | No | `true` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, orchestrate_clarify_respond, validate | Disable the optional Context7 MCP server. Default flipped to `true` because failed Context7 handshakes leave Codex emitting an invalid `tools[N]` entry that OpenRouter→Azure rejects with HTTP 400 (#1754). |
+| `GIT_MCP_DISABLED` | No | `true` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, orchestrate_clarify_respond, validate | Disable the optional Git MCP server setup (preloaded diff artifacts remain the fallback). Default flipped to `true` for the same MCP-handshake reason as `CONTEXT7_DISABLED` (#1754). |
 | `OPENROUTER_PROMPT_CACHE_DISABLED` | No | `false` | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, orchestrate_clarify_respond, validate | Kill switch for OpenRouter prompt-cache instrumentation. `false` enables cache-friendly prompt ordering and cache telemetry logging; `true` disables explicit cache breakpoints and related instrumentation. (No longer consumed by `workflow-log-analysis`, which is Codex-only.) |
 | `WORKFLOW_ORCHESTRATE_MODEL` | No | (falls back to `WORKFLOW_EDITOR_MODEL`) | orchestrate, orchestrate_poll | Model override for orchestrator decomposer and judge |
 | `ORCHESTRATE_POLL_INTERVAL` | No | `30` | orchestrate | Reserved poll interval setting (current poll cadence is controlled by the poller wrapper cron schedule) |
@@ -999,8 +999,8 @@ The analyzer is now a context-prep stage only — it loads the collector report,
 | `FINGERPRINT_PER_FILE_CAP` | `12` | Cap on `must_contain`/`must_not_contain` patterns captured per file per merged sub-issue |
 | `FINGERPRINT_MIN_PATTERN_CHARS` | `12` | Minimum trimmed-line length for a captured fingerprint pattern |
 | `ACTIONS_RUNS_CACHE_TTL_SECONDS` | `60` | Cross-tick cache TTL (seconds) for `GET /actions/runs` snapshots persisted on the `ai-memory` branch and reused by orchestrator poll run-state readers |
-| `CONTEXT7_DISABLED` | `false` | Disable the optional Context7 MCP server setup in workflows |
-| `GIT_MCP_DISABLED` | `false` | Disable the optional Git MCP server setup in workflows (preloaded diff artifacts remain fallback) |
+| `CONTEXT7_DISABLED` | `true` | Disable the optional Context7 MCP server setup in workflows (default flipped per #1754) |
+| `GIT_MCP_DISABLED` | `true` | Disable the optional Git MCP server setup in workflows (preloaded diff artifacts remain fallback; default flipped per #1754) |
 | `AI_MEMORY_BRANCH` | `ai-memory` | Branch used for persistent AI memory |
 | `AI_MEMORY_ROOT` | `ai-memory` | Memory root path used by workflows |
 | `AI_MEMORY_RETRIEVAL_PROFILES` | `ai-memory/config/retrieval_profiles.v1.json` | Retrieval role config |

--- a/scripts/setup_serena.sh
+++ b/scripts/setup_serena.sh
@@ -12,8 +12,8 @@
 #   SERENA_VERSION         Git ref to install (default: "main")
 #   SERENA_LANGUAGES       Space-separated list of languages to force (e.g. "typescript python")
 #   SERENA_DISABLED        Set to "true" to skip Serena setup entirely
-#   CONTEXT7_DISABLED      Set to "true" to skip Context7 MCP setup (default: "false")
-#   GIT_MCP_DISABLED       Set to "true" to skip Git MCP setup (default: "false")
+#   CONTEXT7_DISABLED      Set to "true" to skip Context7 MCP setup (default: "true")
+#   GIT_MCP_DISABLED       Set to "true" to skip Git MCP setup (default: "true")
 #
 # This script:
 #   1. Installs uv if not present
@@ -565,7 +565,7 @@ echo "Serena MCP server appended to ${CODEX_CONFIG}"
 CONTEXT7_CONFIG_TOUCHED="true"
 remove_mcp_server_blocks "context7" "${CODEX_CONFIG}" || echo "::warning::Failed to clean existing Context7 MCP config; continuing without updating Context7 MCP config." >&2
 
-if [ "${CONTEXT7_DISABLED:-false}" != "true" ]; then
+if [ "${CONTEXT7_DISABLED:-true}" != "true" ]; then
 	if cat >> "${CODEX_CONFIG}" <<CONTEXT7_MCP_EOF
 
 [mcp_servers.context7]
@@ -590,7 +590,7 @@ else
 	echo "::warning::Failed to clean existing Git MCP config; continuing without updating Git MCP config." >&2
 fi
 
-if [ "${GIT_MCP_DISABLED:-false}" != "true" ]; then
+if [ "${GIT_MCP_DISABLED:-true}" != "true" ]; then
 	if [ "${GIT_CONFIG_CLEANED}" = "true" ]; then
 		GIT_MCP_BIN="$(uvx --from "mcp-server-git" which mcp-server-git 2>/dev/null || true)"
 		if [ -z "${GIT_MCP_BIN}" ] || [ ! -x "${GIT_MCP_BIN}" ]; then


### PR DESCRIPTION
## Summary

Flip the workflow-level fallback defaults for `CONTEXT7_DISABLED` and `GIT_MCP_DISABLED` from `'false'` to `'true'`, and mirror the change in `scripts/setup_serena.sh` and the README docs.

## Motivation

Per #1754: when an optional MCP server (Context7, Git MCP) fails its initialize handshake, Codex still emits a tool stub for it whose `function` field is `undefined`. OpenRouter's Azure back-end rejects that payload with HTTP 400. Codex 0.114 catches the error and exits 0 with no final summary, which lands in the workflow's `cmd_rc==0` + empty-output retry branch. All 5 implement attempts then return zero-byte output and the job fails after exhausting retries.

Concrete recent example: implement run `25091341828` for issue #1754 — 5/5 attempts produced empty `CODEX_OUTPUT_FILE`, no Serena tool usage stats, job exited 1.

Both MCPs are explicitly optional in the codebase (`required = false` in the config blocks). Disabling them by default removes the handshake-failure vector entirely; operators who want them can opt in via repo variables (`CONTEXT7_DISABLED=false`, `GIT_MCP_DISABLED=false`).

## Files changed

- `.github/workflows/{clarify,plan,implement,review_autofix,orchestrate,orchestrate_poll,orchestrate_clarify_respond,validate}.yml` — `vars.* || 'false'` → `vars.* || 'true'`
- `scripts/setup_serena.sh` — bash defaults `${VAR:-false}` → `${VAR:-true}` and updated header comments
- `README.md` — updated default columns in both env-var tables to `true` with a brief note linking #1754

## Test plan

- [ ] Trigger an `implement.yml` run that previously hit the Azure 400 path; confirm Codex completes without empty-output retries
- [ ] Confirm `setup_serena.sh` standalone still runs cleanly when env vars are unset (only Serena MCP block written, Context7/Git skipped with the existing skip messages)
- [ ] Spot-check a `validate.yml` and a `review_autofix.yml` run to confirm the same default applies and there are no regressions in the existing Serena-only path

https://claude.ai/code/session_018kiKZagtZagYaERRZScSeL

---
_Generated by [Claude Code](https://claude.ai/code/session_018kiKZagtZagYaERRZScSeL)_