### PR TITLE
fix(implement): make CI-workflow restriction conditional on ALLOW_WORKFLOW_EDITS

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -900,7 +900,7 @@ jobs:
           Restrictions:
 
           - Do not ask clarification questions.
-          - Do not change CI workflows.
+          {{WORKFLOW_EDIT_RESTRICTION}}
           - Do not modify ai_pipeline.md or codex_system_instructions.md.
 
           Your output should be repository changes only.

--- a/prompts/mode-implement.txt
+++ b/prompts/mode-implement.txt
@@ -20,7 +20,7 @@ Your task:
 
 Restrictions:
 - Do not ask clarification questions.
-- Do not change CI workflows.
+{{WORKFLOW_EDIT_RESTRICTION}}
 - Do not modify ai_pipeline.md or codex_system_instructions.md.
 
 Sibling-conflict discipline (prevents merge conflicts with parallel sibling

--- a/scripts/render_prompt.sh
+++ b/scripts/render_prompt.sh
@@ -50,14 +50,37 @@ extract_section() {
 extract_section "READ_ONLY" "${READ_ONLY_FILE}"
 extract_section "READ_WRITE" "${READ_WRITE_FILE}"
 
+# {{WORKFLOW_EDIT_RESTRICTION}} resolves to one of two lines based on
+# ${ALLOW_WORKFLOW_EDITS}. The implement-mode prompt previously hard-coded
+# "Do not change CI workflows." which contradicted plans whose `files_touched`
+# set legitimately includes `.github/workflows/**` when the workflow runs with
+# ALLOW_WORKFLOW_EDITS=true (downstream commit/validate gates already honour
+# the same env var). Default is "false" so the prohibitive line stays the
+# safe fallback for any caller that forgets to export the env var.
+if [ "${ALLOW_WORKFLOW_EDITS:-false}" = "true" ]; then
+	WORKFLOW_EDIT_RESTRICTION_LINE="- CI workflow edits under .github/workflows/ are permitted when required by the approved plan; keep changes inside the plan's stated file scope."
+else
+	WORKFLOW_EDIT_RESTRICTION_LINE="- Do not change CI workflows."
+fi
+
 line=""
 while IFS= read -r line || [ -n "${line}" ]; do
-	case "${line}" in
+	# Strip leading whitespace before matching so placeholders embedded in
+	# indented heredocs (e.g. the inline template in .github/workflows/
+	# implement.yml) substitute the same way as left-justified placeholders
+	# in prompts/*.txt. The substitution body is emitted unindented; the
+	# prompt is plain text consumed by the model so indentation drift on
+	# substituted lines is immaterial.
+	trimmed_line="${line#"${line%%[![:space:]]*}"}"
+	case "${trimmed_line}" in
 		"{{SERENA_EFFICIENCY_BLOCK_READ_ONLY}}")
 			cat "${READ_ONLY_FILE}"
 			;;
 		"{{SERENA_EFFICIENCY_BLOCK_READ_WRITE}}")
 			cat "${READ_WRITE_FILE}"
+			;;
+		"{{WORKFLOW_EDIT_RESTRICTION}}")
+			printf '%s\n' "${WORKFLOW_EDIT_RESTRICTION_LINE}"
 			;;
 		*)
 			printf '%s\n' "${line}"
@@ -65,8 +88,13 @@ while IFS= read -r line || [ -n "${line}" ]; do
 	esac
 done < "${PROMPT_FILE}" > "${RENDERED_FILE}"
 
-if grep -qE '^\{\{SERENA_EFFICIENCY_BLOCK_[A-Z_][A-Z_]*\}\}$' "${RENDERED_FILE}"; then
+if grep -qE '^[[:space:]]*\{\{SERENA_EFFICIENCY_BLOCK_[A-Z_][A-Z_]*\}\}[[:space:]]*$' "${RENDERED_FILE}"; then
 	echo "Unresolved Serena placeholder token(s) in rendered output for ${PROMPT_FILE}" >&2
+	exit 1
+fi
+
+if grep -qE '^[[:space:]]*\{\{WORKFLOW_EDIT_RESTRICTION\}\}[[:space:]]*$' "${RENDERED_FILE}"; then
+	echo "Unresolved WORKFLOW_EDIT_RESTRICTION placeholder in rendered output for ${PROMPT_FILE}" >&2
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary

- The implement-mode prompt previously hard-coded `- Do not change CI workflows.` regardless of `ALLOW_WORKFLOW_EDITS`. Downstream commit/validate gates already honour the env var; the prompt was the only layer that didn't.
- Replace the static line with a `{{WORKFLOW_EDIT_RESTRICTION}}` placeholder, resolved by `scripts/render_prompt.sh` against `ALLOW_WORKFLOW_EDITS` (default: prohibitive line, so callers that forget to export the env var keep the safe fallback).
- Also fix a latent issue in `render_prompt.sh`: indented placeholders inside the inline heredoc in `.github/workflows/implement.yml` were silently passed through verbatim instead of being substituted (existing `{{SERENA_EFFICIENCY_BLOCK_READ_WRITE}}` usage was already affected). The matcher now strips leading whitespace, and the unresolved-placeholder check matches indented forms too so typos fail fast.

## Why

Run [25143269520](https://github.com/shubhodeep1/coding-workflows/actions/runs/25143269520) for issue #1792 failed with `Codex bailed: 2 consecutive empty-output attempts`. The orchestrator-managed plan asked the editor model to edit `.github/workflows/review_autofix.yml`, but the same prompt also said `- Do not change CI workflows.`, `- Do not ask clarification questions.`, and `Your output should be repository changes only.` — a contradiction the model (gpt-5.3-codex @ xhigh) couldn't resolve, so it spent 60k + 86k tokens on internal reasoning across the two attempts and emitted nothing. The empty-streak bail (added in #1771) then exited the loop.

## Test plan

- [x] `bash scripts/render_prompt.sh prompts/mode-implement.txt` resolves cleanly with `ALLOW_WORKFLOW_EDITS=true`, `=false`, and unset (defaults to prohibitive line)
- [x] Indented heredoc placeholder (10-space lead) substitutes the same as left-justified
- [x] CI prompt-lint contract on all `prompts/mode-implement*.txt` + `mode-clarify-respond.txt` still passes
- [ ] Re-run issue #1792 (or any orchestrator-driven plan touching `.github/workflows/`) end-to-end and confirm Codex emits patches instead of empty output

https://claude.ai/code/session_01Qw4DLEe444sCoWtizJwm6g

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qw4DLEe444sCoWtizJwm6g)_