### PR TITLE
soft-error analyser: per-phase coverage, source-echo filter, no token caps

### DIFF
--- a/.github/actions/run-soft-error-analyzer/action.yml
+++ b/.github/actions/run-soft-error-analyzer/action.yml
@@ -71,11 +71,14 @@ runs:
         WAIT_SECS: ${{ inputs.wait_for_completion_secs }}
       run: |
         set -euo pipefail
-        # Poll each phase run until status=completed or the cap elapses.
+        # Poll each phase run until status=completed or its per-run
+        # deadline elapses. The deadline is set INSIDE the outer loop
+        # so each phase gets its own ${WAIT_SECS}-second budget — a
+        # global deadline across all phases would short-change the
+        # last phase if earlier phases burned most of the budget.
         # Fail-open: if a run never completes we still invoke the
         # analyser; the script's existing fallback returns a stub for
         # unreadable runs rather than crashing the workflow.
-        DEADLINE=$(( $(date +%s) + WAIT_SECS ))
         while IFS= read -r LINE; do
           [ -n "${LINE}" ] || continue
           PHASE="${LINE%%=*}"
@@ -84,6 +87,7 @@ runs:
           RID="${RID// }"
           [ -n "${PHASE}" ] && [ -n "${RID}" ] || continue
           [[ "${RID}" =~ ^[0-9]+$ ]] || continue
+          DEADLINE=$(( $(date +%s) + WAIT_SECS ))
           while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
             STATUS=$(gh api "repos/${REPO}/actions/runs/${RID}" --jq '.status // ""' 2>/dev/null || echo "")
             if [ "${STATUS}" = "completed" ]; then
@@ -93,15 +97,16 @@ runs:
             echo "  ⏳ ${PHASE} (run #${RID}) status=${STATUS:-unknown}; waiting ..."
             sleep 5
           done
-          # If the deadline lapsed before this run completed, log a
-          # warning and continue. The analyser will get a stub for
-          # this phase but won't crash.
+          # If the per-run deadline lapsed before this run completed,
+          # log a warning and continue with the NEXT phase run. The
+          # analyser will get a stub for this phase but won't crash,
+          # and subsequent phases still get their full status check.
           if [ "$(date +%s)" -ge "${DEADLINE}" ]; then
             FINAL_STATUS=$(gh api "repos/${REPO}/actions/runs/${RID}" --jq '.status // "unknown"' 2>/dev/null || echo "unknown")
             if [ "${FINAL_STATUS}" != "completed" ]; then
               echo "::warning::Soft-error analyser wait deadline elapsed for ${PHASE} (run #${RID}, status=${FINAL_STATUS}); analyser will see partial logs."
             fi
-            break
+            continue
           fi
         done <<< "${PHASE_RUNS}"
 

--- a/.github/actions/run-soft-error-analyzer/action.yml
+++ b/.github/actions/run-soft-error-analyzer/action.yml
@@ -1,0 +1,161 @@
+name: Run soft-error analyser
+description: >-
+  Wait for one or more sub-workflow runs to finish, then invoke
+  scripts/analyze_soft_errors.py against them and upload the resulting
+  markdown report as an artifact. Designed to be called from any release-
+  gate smoke-test job (e2e-smoke-test, orchestrate-decompose-test,
+  validate-standalone-test, orphan-workflows-test, clarify-rejects-
+  unsolvable-test, e2e-alt-model-test) immediately after each phase's
+  run id becomes available, so each phase gets its own per-run report
+  instead of the single end-of-job sweep that races completion.
+
+inputs:
+  phase_runs:
+    description: >-
+      Multi-line list of `phase=run_id` pairs (one per line).
+      Empty / blank lines are ignored. At least one valid pair is
+      required; if none parse, the analyser is skipped fail-open.
+    required: true
+  repo:
+    description: owner/repo of the runs being analysed.
+    required: true
+  artifact_name:
+    description: >-
+      Name of the uploaded artifact. The full markdown report is
+      written to /tmp/${artifact_name}.md inside the runner.
+    required: true
+  wait_for_completion_secs:
+    description: >-
+      Maximum seconds to wait for each phase run to reach
+      `status=completed` before invoking the analyser. The previous
+      single end-of-job analyser raced review_autofix's tail and
+      hit HTTP 404 fetching its still-in-progress logs; per-phase
+      callers typically only need a few seconds because the wait-*
+      step has already polled to completion, but cumulative callers
+      (Phase 8) want a longer cap to cover the slowest phase.
+    required: false
+    default: "120"
+  model:
+    description: OpenRouter model id (LOG_ANALYZER_MODEL).
+    required: false
+    default: openai/gpt-5.4-mini
+  reasoning:
+    description: OpenRouter reasoning effort (LOG_ANALYZER_REASONING).
+    required: false
+    default: medium
+  openrouter_api_key:
+    description: OpenRouter API key. If empty, analyser writes a `api_skipped` stub.
+    required: false
+    default: ""
+  gh_token:
+    description: GitHub token used for `gh run view --log` and run-status polling.
+    required: true
+
+outputs:
+  report_path:
+    description: Absolute path to the generated markdown report on the runner.
+    value: ${{ steps.run-analyser.outputs.report_path }}
+  status_code:
+    description: Parsed status code from the report header (`ok` / `call_failed` / etc).
+    value: ${{ steps.run-analyser.outputs.status_code }}
+
+runs:
+  using: composite
+  steps:
+    - name: Wait for phase runs to reach completed state
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh_token }}
+        REPO: ${{ inputs.repo }}
+        PHASE_RUNS: ${{ inputs.phase_runs }}
+        WAIT_SECS: ${{ inputs.wait_for_completion_secs }}
+      run: |
+        set -euo pipefail
+        # Poll each phase run until status=completed or the cap elapses.
+        # Fail-open: if a run never completes we still invoke the
+        # analyser; the script's existing fallback returns a stub for
+        # unreadable runs rather than crashing the workflow.
+        DEADLINE=$(( $(date +%s) + WAIT_SECS ))
+        while IFS= read -r LINE; do
+          [ -n "${LINE}" ] || continue
+          PHASE="${LINE%%=*}"
+          RID="${LINE#*=}"
+          PHASE="${PHASE// }"
+          RID="${RID// }"
+          [ -n "${PHASE}" ] && [ -n "${RID}" ] || continue
+          [[ "${RID}" =~ ^[0-9]+$ ]] || continue
+          while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
+            STATUS=$(gh api "repos/${REPO}/actions/runs/${RID}" --jq '.status // ""' 2>/dev/null || echo "")
+            if [ "${STATUS}" = "completed" ]; then
+              echo "  ✓ ${PHASE} (run #${RID}) completed"
+              break
+            fi
+            echo "  ⏳ ${PHASE} (run #${RID}) status=${STATUS:-unknown}; waiting ..."
+            sleep 5
+          done
+          # If the deadline lapsed before this run completed, log a
+          # warning and continue. The analyser will get a stub for
+          # this phase but won't crash.
+          if [ "$(date +%s)" -ge "${DEADLINE}" ]; then
+            FINAL_STATUS=$(gh api "repos/${REPO}/actions/runs/${RID}" --jq '.status // "unknown"' 2>/dev/null || echo "unknown")
+            if [ "${FINAL_STATUS}" != "completed" ]; then
+              echo "::warning::Soft-error analyser wait deadline elapsed for ${PHASE} (run #${RID}, status=${FINAL_STATUS}); analyser will see partial logs."
+            fi
+            break
+          fi
+        done <<< "${PHASE_RUNS}"
+
+    - name: Invoke analyser
+      id: run-analyser
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh_token }}
+        OPENROUTER_API_KEY: ${{ inputs.openrouter_api_key }}
+        REPO: ${{ inputs.repo }}
+        PHASE_RUNS: ${{ inputs.phase_runs }}
+        ARTIFACT_NAME: ${{ inputs.artifact_name }}
+        LOG_ANALYZER_MODEL: ${{ inputs.model }}
+        LOG_ANALYZER_REASONING: ${{ inputs.reasoning }}
+      run: |
+        set -euo pipefail
+        REPORT="/tmp/${ARTIFACT_NAME}.md"
+        ARGS=(--repo "${REPO}" --output "${REPORT}" --model "${LOG_ANALYZER_MODEL}" --reasoning "${LOG_ANALYZER_REASONING}")
+        ADDED=0
+        while IFS= read -r LINE; do
+          [ -n "${LINE}" ] || continue
+          PHASE="${LINE%%=*}"
+          RID="${LINE#*=}"
+          PHASE="${PHASE// }"
+          RID="${RID// }"
+          [ -n "${PHASE}" ] && [ -n "${RID}" ] || continue
+          [[ "${RID}" =~ ^[0-9]+$ ]] || continue
+          ARGS+=(--run "${PHASE}=${RID}")
+          ADDED=$((ADDED + 1))
+        done <<< "${PHASE_RUNS}"
+        if [ "${ADDED}" -eq 0 ]; then
+          echo "No valid phase=run_id pairs supplied; skipping analyser."
+          {
+            echo "## Soft-error analyzer (status: \`no_runs\`, model: \`${LOG_ANALYZER_MODEL}\`, reasoning: \`${LOG_ANALYZER_REASONING}\`)"
+            echo
+            echo "Composite action received no parseable phase_runs entries."
+          } > "${REPORT}"
+          echo "report_path=${REPORT}" >> "$GITHUB_OUTPUT"
+          echo "status_code=no_runs" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        python3 scripts/analyze_soft_errors.py "${ARGS[@]}" || {
+          echo "::warning::Soft-error analyser exited non-zero — keeping fallback report"
+        }
+        echo "report_path=${REPORT}" >> "$GITHUB_OUTPUT"
+        STATUS_LINE=$(head -n1 "${REPORT}" 2>/dev/null || echo "")
+        STATUS_CODE=$(printf '%s' "${STATUS_LINE}" | sed -nE 's/.*status:\s*`([^`]+)`.*/\1/p')
+        echo "status_code=${STATUS_CODE:-unknown}" >> "$GITHUB_OUTPUT"
+
+    - name: Upload soft-error report artifact
+      if: always() && steps.run-analyser.outputs.report_path != ''
+      uses: actions/upload-artifact@v6
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ steps.run-analyser.outputs.report_path }}
+        if-no-files-found: ignore
+        retention-days: 30

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3317,7 +3317,7 @@ jobs:
           # clarify/plan run on `main` so the post-creation id ordering
           # is the only available filter.
           BRANCH="ai/issue-${ISSUE_NUMBER}"
-          for spec in "clarify:${PRE_CLARIFY:-0}::main" "plan:${PRE_PLAN:-0}::main" "implement:${PRE_IMPLEMENT:-0}:${BRANCH}" "review_autofix:${PRE_REVIEW:-0}:${BRANCH}"; do
+          for spec in "clarify:${PRE_CLARIFY:-0}:main" "plan:${PRE_PLAN:-0}:main" "implement:${PRE_IMPLEMENT:-0}:${BRANCH}" "review_autofix:${PRE_REVIEW:-0}:${BRANCH}"; do
             WF="${spec%%:*}"
             REST="${spec#*:}"
             PRE="${REST%%:*}"

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -388,6 +388,20 @@ jobs:
             sleep "$POLL_INTERVAL"
           done
 
+      # Per-phase soft-error analysis: clarify
+      - name: "Phase 1b: Soft-error analyser (clarify)"
+        if: always() && steps.wait-clarify.outputs.run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            clarify=${{ steps.wait-clarify.outputs.run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-clarify
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
+
       # ── Phase 2: Wait for Plan to complete ──────────────────────
       - name: "Phase 2: Wait for plan to complete"
         id: wait-plan
@@ -544,6 +558,20 @@ jobs:
             echo "  ... idle ${IDLE}s (timeout in ~${REMAINING}m) — plan_run: ${PLAN_RUN_STATUS}, labels: ${LABELS:-none}"
             sleep "$POLL_INTERVAL"
           done
+
+      # Per-phase soft-error analysis: plan
+      - name: "Phase 2b: Soft-error analyser (plan)"
+        if: always() && steps.wait-plan.outputs.run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            plan=${{ steps.wait-plan.outputs.run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-plan
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
 
       # ── Phase 3: Approve and wait for implementation ────────────
       - name: "Phase 3a: Approve the plan"
@@ -736,6 +764,21 @@ jobs:
       # the PR so the gate's override path kicks in and the full reviewer
       # → editor pipeline runs. Without this label, the gate would skip
       # review and the bait would never be removed.
+
+      # Per-phase soft-error analysis: implement
+      - name: "Phase 3b2: Soft-error analyser (implement)"
+        if: always() && steps.wait-implement.outputs.run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            implement=${{ steps.wait-implement.outputs.run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-implement
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
+
       - name: "Phase 3b1: Apply force-review label to smoke PR"
         id: force-review-label
         if: steps.wait-implement.outputs.pr_number != ''
@@ -1046,6 +1089,26 @@ jobs:
             sleep "$POLL_INTERVAL"
             ELAPSED=$((ELAPSED + POLL_INTERVAL))
           done
+
+      # Per-phase soft-error analysis: review_autofix.
+      # Wait cap is bumped to 300s here because the previous single
+      # end-of-job analyser raced review_autofix's tail (it exited
+      # right when wait-review's FAILED_STEPS shortcut tripped and
+      # the review run still had ~40s of cleanup steps to run),
+      # producing the HTTP 404 report we observed on run 25126757724.
+      - name: "Phase 4c: Soft-error analyser (review_autofix)"
+        if: always() && steps.wait-review.outputs.review_run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            review_autofix=${{ steps.wait-review.outputs.review_run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-review_autofix
+          wait_for_completion_secs: "300"
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
 
       # ── Phase 4b: Verify the editor removed the bait commit ───
       # Closes the loop on Phase 3c: confirms the reviewer→editor→commit
@@ -1747,6 +1810,20 @@ jobs:
           fi
           echo "═══════════════════════════════════════════"
 
+      # Per-phase soft-error analysis: orchestrate-poll (RBSIM)
+      - name: "Phase 6b: Soft-error analyser (orchestrate-poll)"
+        if: always() && steps.review-blocked-sim.outputs.poller_run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            orchestrate_poll=${{ steps.review-blocked-sim.outputs.poller_run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-orchestrate_poll
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
+
       # ── Phase 7: Verify cancel_on_pr_close fires on PR close ───
       # Closes the smoke-test PR and watches internal-cancel-on-pr-close.yml
       # complete successfully. This is the only path through the
@@ -1831,6 +1908,20 @@ jobs:
           echo "status=success" >> "$GITHUB_OUTPUT"
           echo "cancel_run_id=${NEW_RUN_ID}" >> "$GITHUB_OUTPUT"
 
+      # Per-phase soft-error analysis: cancel-on-pr-close
+      - name: "Phase 7b: Soft-error analyser (cancel-on-pr-close)"
+        if: always() && steps.verify-cancel-on-close.outputs.cancel_run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            cancel_on_pr_close=${{ steps.verify-cancel-on-close.outputs.cancel_run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-cancel_on_pr_close
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
+
       # ── Phase 8: Soft-error analyser (non-blocking) ─────────────
       # Pulls logs from every triggered phase run, filters to high-signal
       # lines, and asks gpt-5.4-mini @ medium reasoning to summarise soft
@@ -1838,6 +1929,53 @@ jobs:
       # fails, etc.). The report is exposed as a job output so the notify
       # job can attach it to the Telegram release message. Hard exits are
       # avoided — analyser problems must never block a release.
+      # Wait briefly for every captured phase run to reach
+      # status=completed. The previous Phase 8 fired the moment Phase 7
+      # finished; on run 25126757724 that raced review_autofix's tail
+      # cleanup steps, so `gh run view --log` returned HTTP 404 ("run is
+      # still in progress") and the resulting report had no review_autofix
+      # signal at all (the phase that actually contained the root cause).
+      # The wait below caps at 5 minutes — long enough for review_autofix's
+      # cleanup tail (~40s on the failing run) and any orchestrate-poll /
+      # cancel-on-pr-close trailers to settle, short enough that a
+      # genuinely hung run does not block the release-gate Telegram
+      # notification indefinitely.
+      - name: "Phase 8a: Wait for all phase runs to complete"
+        id: phase8_wait
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          CLARIFY_RUN_ID: ${{ steps.wait-clarify.outputs.run_id }}
+          PLAN_RUN_ID: ${{ steps.wait-plan.outputs.run_id }}
+          IMPL_RUN_ID: ${{ steps.wait-implement.outputs.run_id }}
+          REVIEW_RUN_ID: ${{ steps.wait-review.outputs.review_run_id }}
+          RBSIM_POLLER_RUN_ID: ${{ steps.review-blocked-sim.outputs.poller_run_id }}
+          CANCEL_RUN_ID: ${{ steps.verify-cancel-on-close.outputs.cancel_run_id }}
+        run: |
+          set -euo pipefail
+          DEADLINE=$(( $(date +%s) + 300 ))
+          for KV in \
+            "clarify:${CLARIFY_RUN_ID:-}" \
+            "plan:${PLAN_RUN_ID:-}" \
+            "implement:${IMPL_RUN_ID:-}" \
+            "review_autofix:${REVIEW_RUN_ID:-}" \
+            "orchestrate_poll:${RBSIM_POLLER_RUN_ID:-}" \
+            "cancel_on_pr_close:${CANCEL_RUN_ID:-}"; do
+            PHASE="${KV%%:*}"
+            RID="${KV#*:}"
+            [ -n "${RID}" ] && [[ "${RID}" =~ ^[0-9]+$ ]] || continue
+            while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
+              STATUS=$(gh api "repos/${TEST_REPO}/actions/runs/${RID}" --jq '.status // ""' 2>/dev/null || echo "")
+              if [ "${STATUS}" = "completed" ]; then
+                echo "  ✓ ${PHASE} (run #${RID}) completed"
+                break
+              fi
+              echo "  ⏳ ${PHASE} (run #${RID}) status=${STATUS:-unknown}; waiting ..."
+              sleep 5
+            done
+          done
+
       - name: "Phase 8: Soft-error log analyser"
         id: soft-error-analyser
         if: always()
@@ -2252,6 +2390,13 @@ jobs:
             exit 1
           fi
 
+      # Required for the run-soft-error-analyzer composite action below.
+      - name: Checkout repository (for soft-error analyser)
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 1
+
       # Generic helper: dispatch a workflow_dispatch workflow by file name
       # and capture the resulting run id, then wait for completion. Each
       # invocation runs in its own step so failures attribute to the
@@ -2336,6 +2481,19 @@ jobs:
           echo "::error::workflow-log-analysis run #${NEW_ID} timed out"
           exit 1
 
+      - name: "Soft-error analyser (workflow-log-analysis)"
+        if: always() && steps.dispatch_log_analysis.outputs.run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            workflow_log_analysis=${{ steps.dispatch_log_analysis.outputs.run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-workflow_log_analysis
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
+
       - name: Dispatch & watch — validation-refresh
         id: dispatch_validation_refresh
         timeout-minutes: 42
@@ -2380,6 +2538,19 @@ jobs:
           done
           echo "::error::validation-refresh run #${NEW_ID} timed out"
           exit 1
+
+      - name: "Soft-error analyser (validation-refresh)"
+        if: always() && steps.dispatch_validation_refresh.outputs.run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            validation_refresh=${{ steps.dispatch_validation_refresh.outputs.run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-validation_refresh
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
 
       - name: Dispatch & watch — update_workflows (allow_workflow_edits=false)
         id: dispatch_update_workflows
@@ -2433,6 +2604,19 @@ jobs:
           echo "::error::update_workflows run #${NEW_ID} timed out"
           exit 1
 
+      - name: "Soft-error analyser (update_workflows)"
+        if: always() && steps.dispatch_update_workflows.outputs.run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            update_workflows=${{ steps.dispatch_update_workflows.outputs.run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-update_workflows
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
+
       - name: Dispatch & watch — internal-memory-maintenance
         id: dispatch_memory_maintenance
         timeout-minutes: 25
@@ -2479,6 +2663,19 @@ jobs:
           echo "::error::internal-memory-maintenance run #${NEW_ID} timed out"
           exit 1
 
+      - name: "Soft-error analyser (memory_maintenance)"
+        if: always() && steps.dispatch_memory_maintenance.outputs.run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            memory_maintenance=${{ steps.dispatch_memory_maintenance.outputs.run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-memory_maintenance
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
+
   # ──────────────────────────────────────────────────────────────────
   # Job 1d: Orchestrate decompose end-to-end test
   # Exercises the orchestrate root: project-description → tracking issue
@@ -2500,6 +2697,15 @@ jobs:
         run: |
           set -euo pipefail
           [ -n "${GH_TOKEN}" ] || { echo "::error::GH_PAT required"; exit 1; }
+
+      # Required for the run-soft-error-analyzer composite action below;
+      # the action invokes scripts/analyze_soft_errors.py from the repo
+      # checkout root.
+      - name: Checkout repository (for soft-error analyser)
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 1
 
       - name: Dispatch internal-orchestrate.yml with multi-issue project
         id: dispatch
@@ -2607,6 +2813,19 @@ jobs:
           fi
           echo "✓ Decomposition produced ${CHILD_COUNT} child issues: ${CHILDREN}"
 
+      - name: "Soft-error analyser (orchestrate-decompose)"
+        if: always() && steps.dispatch.outputs.run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            orchestrate=${{ steps.dispatch.outputs.run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-orchestrate_decompose
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
+
       - name: Cleanup orchestrate test issues
         if: always()
         env:
@@ -2684,6 +2903,13 @@ jobs:
           set -euo pipefail
           [ -n "${GH_TOKEN}" ] || { echo "::error::GH_PAT required"; exit 1; }
 
+      # Required for the run-soft-error-analyzer composite action below.
+      - name: Checkout repository (for soft-error analyser)
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 1
+
       - name: Dispatch internal-validate.yml standalone
         id: dispatch
         run: |
@@ -2733,6 +2959,19 @@ jobs:
           echo "::error::validate run #${NEW_ID} timed out"
           exit 1
 
+      - name: "Soft-error analyser (validate-standalone)"
+        if: always() && steps.dispatch.outputs.run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            validate=${{ steps.dispatch.outputs.run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-validate_standalone
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
+
   # ──────────────────────────────────────────────────────────────────
   # Job 1f: Clarify-rejects-unsolvable negative test
   # Files an issue that is intentionally under-specified and asserts
@@ -2748,16 +2987,54 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_PAT }}
       TEST_REPO: ${{ inputs.test_repo || github.repository }}
     steps:
+      # Required for the run-soft-error-analyzer composite action below.
+      - name: Checkout repository (for soft-error analyser)
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 1
+
       - name: Create unsolvable issue
         id: create
         run: |
           set -euo pipefail
+          # Capture the latest clarify.yml run id BEFORE creating the
+          # issue so the post-create capture step can find the new
+          # run via `id > PRE_CLARIFY_RUN_ID`.
+          PRE_CLARIFY_RUN_ID=$(gh api "repos/${TEST_REPO}/actions/workflows/clarify.yml/runs?per_page=1" --jq '.workflow_runs[0].id // 0' 2>/dev/null || echo "0")
+          echo "pre_clarify_run_id=${PRE_CLARIFY_RUN_ID}" >> "$GITHUB_OUTPUT"
           TITLE="[E2E Clarify Negative Test] under-specified task (run ${GITHUB_RUN_ID})"
           BODY="Make it better."
           NUMBER=$(gh api "repos/${TEST_REPO}/issues" \
             -f title="${TITLE}" -f body="${BODY}" --jq '.number')
           echo "issue_number=${NUMBER}" >> "$GITHUB_OUTPUT"
           echo "Created issue #${NUMBER}"
+
+      - name: Capture clarify run id (negative test)
+        id: capture_clarify_run
+        if: steps.create.outputs.issue_number != ''
+        env:
+          PRE: ${{ steps.create.outputs.pre_clarify_run_id }}
+        run: |
+          set -euo pipefail
+          # Poll up to 90s for clarify.yml to register a new run id
+          # past the pre-create snapshot. Fail-open: emits empty
+          # output when no new run is observed; the analyser step
+          # below skips (its `if:` gates on non-empty output).
+          DEADLINE=$(( $(date +%s) + 90 ))
+          NEW_ID=""
+          while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
+            NEW_ID=$(gh api "repos/${TEST_REPO}/actions/workflows/clarify.yml/runs?per_page=10" \
+              --jq "[.workflow_runs[] | select(.id > ${PRE:-0})] | sort_by(.created_at) | last | .id // empty" 2>/dev/null || echo "")
+            [ -n "${NEW_ID}" ] && break
+            sleep 5
+          done
+          if [ -n "${NEW_ID}" ]; then
+            echo "run_id=${NEW_ID}" >> "$GITHUB_OUTPUT"
+            echo "✓ Captured negative-test clarify run #${NEW_ID}"
+          else
+            echo "::warning::Could not capture clarify run id for negative-test issue (analyser will be skipped)"
+          fi
 
       - name: Wait for clarify to flag for clarification
         id: wait
@@ -2862,6 +3139,19 @@ jobs:
           echo "::error::Clarify did not act on the under-specified issue within timeout"
           exit 1
 
+      - name: "Soft-error analyser (clarify negative test)"
+        if: always() && steps.capture_clarify_run.outputs.run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            clarify_negative=${{ steps.capture_clarify_run.outputs.run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-clarify_negative
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
+
       - name: Cleanup negative-test issue
         if: always() && steps.create.outputs.issue_number != ''
         env:
@@ -2913,6 +3203,13 @@ jobs:
       # internal-implement.yml via the WORKFLOW_EDITOR_MODEL repo var.
       ALT_EDITOR_MODEL: ${{ vars.ALT_EDITOR_MODEL || 'anthropic/claude-sonnet-4-6' }}
     steps:
+      # Required for the run-soft-error-analyzer composite action below.
+      - name: Checkout repository (for soft-error analyser)
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 1
+
       - name: Validate prerequisites
         run: |
           set -euo pipefail
@@ -2944,6 +3241,13 @@ jobs:
         id: create
         run: |
           set -euo pipefail
+          # Capture the latest run id of each phase workflow BEFORE creating
+          # the issue. The post-wait capture step uses these as anchors to
+          # find the new alt-model phase runs (id > pre_<phase>_run_id).
+          for WF in clarify plan implement review_autofix; do
+            LATEST=$(gh api "repos/${TEST_REPO}/actions/workflows/${WF}.yml/runs?per_page=1" --jq '.workflow_runs[0].id // 0' 2>/dev/null || echo "0")
+            echo "pre_${WF}_run_id=${LATEST}" >> "$GITHUB_OUTPUT"
+          done
           TITLE="[E2E Smoke Test alt-model] update canary (run ${GITHUB_RUN_ID})"
           # Same canary task as the main e2e job so we exercise the full
           # implement→review path; only the editor model varies. Body is
@@ -2993,6 +3297,98 @@ jobs:
           done
           echo "::error::Alt-model run timed out before reaching review stage"
           exit 1
+
+      - name: Capture alt-model phase run ids
+        id: capture_alt_runs
+        if: always() && steps.create.outputs.issue_number != ''
+        env:
+          ISSUE_NUMBER: ${{ steps.create.outputs.issue_number }}
+          PRE_CLARIFY: ${{ steps.create.outputs.pre_clarify_run_id }}
+          PRE_PLAN: ${{ steps.create.outputs.pre_plan_run_id }}
+          PRE_IMPLEMENT: ${{ steps.create.outputs.pre_implement_run_id }}
+          PRE_REVIEW: ${{ steps.create.outputs.pre_review_autofix_run_id }}
+        run: |
+          set -euo pipefail
+          # For each phase, find the most recent workflow run with an id
+          # greater than the snapshot taken before the issue was created.
+          # We additionally filter by `head_branch == ai/issue-${ISSUE_NUMBER}`
+          # for implement/review (those run on the PR branch, so the
+          # branch name disambiguates collisions with concurrent runs);
+          # clarify/plan run on `main` so the post-creation id ordering
+          # is the only available filter.
+          BRANCH="ai/issue-${ISSUE_NUMBER}"
+          for spec in "clarify:${PRE_CLARIFY:-0}::main" "plan:${PRE_PLAN:-0}::main" "implement:${PRE_IMPLEMENT:-0}:${BRANCH}" "review_autofix:${PRE_REVIEW:-0}:${BRANCH}"; do
+            WF="${spec%%:*}"
+            REST="${spec#*:}"
+            PRE="${REST%%:*}"
+            REST="${REST#*:}"
+            BRANCH_FILTER="${REST}"
+            if [ -n "${BRANCH_FILTER}" ]; then
+              QUERY="repos/${TEST_REPO}/actions/workflows/${WF}.yml/runs?per_page=20&branch=${BRANCH_FILTER}"
+            else
+              QUERY="repos/${TEST_REPO}/actions/workflows/${WF}.yml/runs?per_page=20"
+            fi
+            NEW_ID=$(gh api "${QUERY}" --jq "[.workflow_runs[] | select(.id > ${PRE})] | sort_by(.created_at) | last | .id // empty" 2>/dev/null || echo "")
+            if [ -n "${NEW_ID}" ]; then
+              echo "${WF}_run_id=${NEW_ID}" >> "$GITHUB_OUTPUT"
+              echo "  ✓ alt-model ${WF} run #${NEW_ID}"
+            else
+              echo "  ⚠ alt-model ${WF} run not found (analyser will skip this phase)"
+            fi
+          done
+
+      - name: "Soft-error analyser (alt-model clarify)"
+        if: always() && steps.capture_alt_runs.outputs.clarify_run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            clarify=${{ steps.capture_alt_runs.outputs.clarify_run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-alt_clarify
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
+
+      - name: "Soft-error analyser (alt-model plan)"
+        if: always() && steps.capture_alt_runs.outputs.plan_run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            plan=${{ steps.capture_alt_runs.outputs.plan_run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-alt_plan
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
+
+      - name: "Soft-error analyser (alt-model implement)"
+        if: always() && steps.capture_alt_runs.outputs.implement_run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            implement=${{ steps.capture_alt_runs.outputs.implement_run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-alt_implement
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
+
+      - name: "Soft-error analyser (alt-model review_autofix)"
+        if: always() && steps.capture_alt_runs.outputs.review_autofix_run_id != ''
+        uses: ./.github/actions/run-soft-error-analyzer
+        with:
+          phase_runs: |
+            review_autofix=${{ steps.capture_alt_runs.outputs.review_autofix_run_id }}
+          repo: ${{ env.TEST_REPO }}
+          artifact_name: soft-error-report-${{ github.run_id }}-alt_review_autofix
+          wait_for_completion_secs: "300"
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          gh_token: ${{ secrets.GH_PAT }}
+          model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
+          reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
 
       - name: Cleanup alt-model artifacts
         if: always() && steps.create.outputs.issue_number != ''

--- a/scripts/analyze_soft_errors.py
+++ b/scripts/analyze_soft_errors.py
@@ -114,7 +114,7 @@ SOFT_ERROR_EXCLUDE_RE = re.compile("|".join(SOFT_ERROR_EXCLUDE_PATTERNS), re.IGN
 #      `\033[36;1m` (handles malformed/nested groups).
 GROUP_RUN_START_RE = re.compile(r"##\[group\]Run\b")
 GROUP_END_RE = re.compile(r"##\[endgroup\]")
-ANSI_CYAN_BOLD_RE = re.compile(r"\x1b?\[36;1m")
+ANSI_CYAN_BOLD_RE = re.compile(r"\x1b\[36;1m")
 
 
 def strip_source_echo(text: str) -> str:

--- a/scripts/analyze_soft_errors.py
+++ b/scripts/analyze_soft_errors.py
@@ -25,16 +25,17 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-# Per-run cap on the *filtered* log payload sent to the analyser. With ~6
-# phase runs (clarify, plan, implement, review_autofix, orchestrate_poll,
-# cancel_on_pr_close) this caps the user-message body at ≤240K chars
-# (≈80K tokens at 3 chars/token), leaving the system prompt, per-run
-# framing, and model-specific tokenization slack a large headroom inside
-# gpt-5.4-mini's 200K-token window. Lowered from the initial 60000 after
-# review feedback to keep total prompt size firmly under the model's
-# context limit even when reviewer/codex log lines balloon under
-# rate-limit retries.
-PER_RUN_CHAR_BUDGET = 40000
+# Per-run cap on the *filtered* log payload sent to the analyser.
+#
+# Set to `None` to disable input-side truncation entirely — the
+# release-gate operator chose this so per-phase analyser invocations
+# get the complete soft-error signal even when reviewer/codex log
+# volume is high. The downstream OpenRouter call still has its own
+# context-window limit (gpt-5.4-mini = 200K tokens); on overflow the
+# existing `call_failed` fallback path in `main()` writes a stub
+# report rather than crashing the workflow, so the operator can
+# safely opt for "no truncation" without breaking the release gate.
+PER_RUN_CHAR_BUDGET: int | None = None
 
 # Patterns that mark soft-error candidates worth surfacing. Matched
 # case-insensitively. Everything else gets dropped from the per-run payload to
@@ -91,6 +92,56 @@ SOFT_ERROR_EXCLUDE_PATTERNS = [
 	r"\bSTATUS=completed\b.*\bCONCLUSION=success\b",
 ]
 SOFT_ERROR_EXCLUDE_RE = re.compile("|".join(SOFT_ERROR_EXCLUDE_PATTERNS), re.IGNORECASE)
+
+
+# GitHub Actions step source preamble.
+#
+# When a `run:` step starts, the runner emits a `##[group]Run …` header,
+# echoes every line of the shell script source bracketed by ANSI cyan-bold
+# (`\033[36;1m...\033[0m`) plus the `shell:` and `env:` blocks, then closes
+# with `##[endgroup]` *before* the actual step output begins. None of those
+# preamble lines are real workflow events — they are verbatim copies of the
+# step source. Without filtering them out the SOFT_ERROR_RE matcher trips
+# on every literal `echo "::warning::Codex returned empty output on attempt
+# ${attempt}"` etc. inside the script source, producing false-positive
+# findings for retries that never fired (the unexpanded `${attempt}` /
+# `$rc` shell variable references in the matched lines are the giveaway).
+#
+# `strip_source_echo` runs over `gh run view --log` output (which
+# preserves the `\033[36;1m` color sequences) and removes:
+#   1. Everything between `##[group]Run …` and the matching `##[endgroup]`.
+#   2. As a defensive second pass, any line whose body still contains
+#      `\033[36;1m` (handles malformed/nested groups).
+GROUP_RUN_START_RE = re.compile(r"##\[group\]Run\b")
+GROUP_END_RE = re.compile(r"##\[endgroup\]")
+ANSI_CYAN_BOLD_RE = re.compile(r"\x1b?\[36;1m")
+
+
+def strip_source_echo(text: str) -> str:
+	"""Drop GH Actions step source preamble lines from log text.
+
+	Removes the `##[group]Run … ##[endgroup]` block (script source +
+	`shell:` + `env:` echo) so SOFT_ERROR_RE does not match against
+	echoed `echo "...failed..."` strings inside step source code.
+	"""
+	if not text:
+		return text
+	out: list[str] = []
+	in_group_run = False
+	for line in text.splitlines():
+		if in_group_run:
+			if GROUP_END_RE.search(line):
+				in_group_run = False
+			continue
+		if GROUP_RUN_START_RE.search(line):
+			in_group_run = True
+			continue
+		if ANSI_CYAN_BOLD_RE.search(line):
+			# Defensive: catches stray cyan-bold echoes outside a
+			# detected ##[group]Run … ##[endgroup] envelope.
+			continue
+		out.append(line)
+	return "\n".join(out)
 
 
 def _gh_api(path: str, *, accept: str = "application/vnd.github+json") -> bytes:
@@ -153,10 +204,23 @@ def fetch_run_logs(repo: str, run_id: str) -> str:
 		return f"[soft-error-analyzer] could not fetch logs for run {run_id}: {exc}"
 
 
-def filter_soft_error_lines(text: str, char_budget: int) -> str:
-	"""Keep only lines that look like soft-error signal, plus 1 line of context."""
+def filter_soft_error_lines(text: str, char_budget: int | None) -> str:
+	"""Keep only lines that look like soft-error signal, plus 1 line of context.
+
+	`char_budget=None` disables truncation entirely (operator opt-in for
+	complete signal at the cost of larger OpenRouter payloads). The
+	caller-supplied integer cap, when set, truncates from the middle so
+	both the head (early-pipeline failures) and tail (post-mortem
+	fallbacks) survive.
+	"""
 	if not text:
 		return ""
+	# Drop GH Actions step source preamble first so SOFT_ERROR_RE does
+	# not match against echoed `echo "...failed..."` strings inside the
+	# step source. The unexpanded `${attempt}` / `$rc` variables in
+	# such echoes were producing false-positive "retry fired" findings
+	# even when no retry actually happened.
+	text = strip_source_echo(text)
 	lines = text.splitlines()
 	keep = [False] * len(lines)
 	for i, line in enumerate(lines):
@@ -186,12 +250,9 @@ def filter_soft_error_lines(text: str, char_budget: int) -> str:
 		last_emitted = i
 
 	joined = "\n".join(out)
-	if len(joined) <= char_budget:
+	if char_budget is None or len(joined) <= char_budget:
 		return joined
 
-	# Truncate from the middle so the head (early-pipeline failures) and tail
-	# (post-mortem fallbacks) both survive — those are the highest-signal
-	# regions for soft-error triage.
 	half = char_budget // 2
 	head = joined[: half - 50]
 	tail = joined[-(half - 50):]
@@ -242,11 +303,15 @@ def call_openrouter(
 	api_key: str,
 ) -> str:
 	url = "https://openrouter.ai/api/v1/chat/completions"
+	# `max_tokens` deliberately omitted — release-gate operator opted out
+	# of an output cap. OpenRouter / the underlying model uses its
+	# default response limit, which is sufficient for the bounded
+	# markdown report this prompt requests (system prompt enforces
+	# "<800 words" and three-section structure).
 	body = {
 		"model": model,
 		"messages": messages,
 		"reasoning": {"effort": reasoning},
-		"max_tokens": 1500,
 	}
 	data = json.dumps(body).encode("utf-8")
 	req = urllib.request.Request(


### PR DESCRIPTION
## Summary

Three connected fixes to the release-gate soft-error analyser, driven by run 25126757724 (analysed in PR #1789). The end-of-job Phase 8 analyser raced `review_autofix`'s tail cleanup, fetched its logs while still in progress, returned HTTP 404 for the only phase that contained the actual root cause (editor produced no edit, fallback summary, deferred autofix never pushed), and produced an "all clear except logs unavailable" report. The clarify/plan findings in that same report were also false positives — the matcher was triggering on GitHub Actions' verbatim step-source echo (lines like ``Codex returned empty output on attempt ${attempt}.`` with unexpanded `${attempt}` — a giveaway that the line came from script source, not an actual event).

Per-phase analyser coverage now extends across **every** smoke-test job in `test-and-mark-stable.yml`, not just the 6 sub-workflow runs that `e2e-smoke-test` triggers.

## What changed

**`scripts/analyze_soft_errors.py`**
- New `strip_source_echo` drops `##[group]Run … ##[endgroup]` envelopes and any line carrying the cyan-bold ANSI prefix (`\x1b[36;1m`), so SOFT_ERROR_RE no longer matches against echoed step source.
- `PER_RUN_CHAR_BUDGET = None` — input-side truncation disabled.
- `max_tokens=1500` removed from the OpenRouter call body — output cap removed.

**`.github/actions/run-soft-error-analyzer/` (new composite action)**
Wraps wait-for-completion polling, analyser invocation, and artifact upload. Inputs accept multi-line `phase=run_id` pairs and pass through model/reasoning/secrets so each smoke-test job can call the analyser per phase without duplicating ~25 lines of shell.

**`.github/workflows/test-and-mark-stable.yml`** — per-phase analyser invocations with `if: always()`:

| Job | Phase invocations |
|---|---|
| `e2e-smoke-test` | clarify, plan, implement, review_autofix (300s wait cap), orchestrate_poll, cancel_on_pr_close |
| `orchestrate-decompose-test` | internal-orchestrate dispatch |
| `validate-standalone-test` | internal-validate dispatch |
| `orphan-workflows-test` | workflow-log-analysis, validation-refresh, update_workflows, internal-memory-maintenance |
| `clarify-rejects-unsolvable-test` | clarify negative-test (new pre-create snapshot + post-create capture) |
| `e2e-alt-model-test` | clarify, plan, implement, review_autofix (new pre-create snapshots + branch-filter capture) |

Each invocation uploads a separate artifact `soft-error-report-${run_id}-<phase>.md`. Phase 8 keeps its existing cumulative artifact for downstream Telegram notification, but is now preceded by **Phase 8a** which polls every captured run to `status=completed` (cap 300s) before the analyser fires — closing the race that produced the unusable report on run 25126757724.

Five jobs gain `actions/checkout@v5` because the composite action runs `python3 scripts/analyze_soft_errors.py` from the repo root: `orchestrate-decompose-test`, `validate-standalone-test`, `orphan-workflows-test`, `clarify-rejects-unsolvable-test`, `e2e-alt-model-test`.

## Test plan

- [ ] Trigger `test-and-mark-stable.yml` (workflow_dispatch with `dry_run=false`) and confirm:
  - Each job uploads its per-phase `soft-error-report-${run_id}-<phase>` artifact
  - Phase 8 artifact contains a non-stub review_autofix section (the "still in progress" HTTP 404 should be eliminated by the 8a wait guard)
  - Phase 8a logs show "✓ <phase> (run #N) completed" lines for every captured run
- [ ] Verify the source-echo filter by inspecting any per-phase report and confirming none of the findings reference unexpanded `${attempt}` / `$rc` shell variables.
- [ ] Confirm the analyser does not exceed gpt-5.4-mini's 200K-token context window with `PER_RUN_CHAR_BUDGET=None` on a typical run; if it does, the existing `call_failed` fallback path writes a stub report rather than crashing the gate.

## Notes

- The `[force-review]` PR-title marker / `force-review` label can override the docs-only deterministic skip on this PR, but the changes here are workflow + script (not docs-only), so the gate should run normally.
- `review_autofix.yml`'s deterministic skip is ineligible because the diff includes `.yml` and `.py`, not just `.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GbS2HPbsuvpqKRzz8njUHA)_