### PR TITLE
fix(e2e): pin wait-review to bait SHA so doc-only smoke can't latch onto a stale-success

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -890,6 +890,17 @@ jobs:
           fi
 
           echo "✓ Bait commit ${BAIT_SHA:0:7} pushed to ${BRANCH}"
+          # Diagnostic dump of the Contents-API response. Run-25147636528
+          # surfaced a failure mode where the bait push succeeded
+          # (commit + PR head pointer updated) but no pull_request
+          # synchronize event fanned out, so no review_autofix run was
+          # ever created — masquerading as a bait-removal failure
+          # downstream. Logging the API author/committer/url makes it
+          # cheap to verify the push wasn't silently demoted (e.g. to
+          # a token whose identity can't trigger workflows) without an
+          # out-of-band gh api call.
+          jq '{commit_sha: .commit.sha, commit_url: .commit.html_url, author: .commit.author.name, committer: .commit.committer.name, verification: .commit.verification.verified, content_url: .content.html_url}' /tmp/bait_resp.json 2>/dev/null \
+            || echo "  (could not parse bait_resp.json)"
           echo "status=injected" >> "$GITHUB_OUTPUT"
           echo "marker=${BAIT_MARKER}" >> "$GITHUB_OUTPUT"
           echo "bait_sha=${BAIT_SHA}" >> "$GITHUB_OUTPUT"
@@ -899,9 +910,31 @@ jobs:
         id: wait-review
         env:
           PR_NUMBER: ${{ steps.wait-implement.outputs.pr_number }}
+          # When inject-bait pushed a bait commit, pin the wait loop to
+          # review runs whose head_sha matches the bait commit. Without
+          # this filter, the loop sorts review runs by created_at and
+          # picks the latest, which during the deterministic-skip
+          # window (review_autofix.yml:339-433 + auto-merge tail at
+          # :543-656) is the implement-phase review run on the prior
+          # head SHA — already completed/success — causing wait-review
+          # to exit before any bait-triggered review run appears. This
+          # is the failure mode observed on run 25147636528 (the
+          # canary's implementation is doc-only, so the implement-phase
+          # review is always deterministically skipped and finishes
+          # fast enough to win the latest-by-created_at race). Empty
+          # when the bait injection was skipped (status != injected);
+          # the loop then falls back to the legacy latest-by-created_at
+          # filter so non-bait runs (no bait was injected this run) are
+          # unaffected.
+          BAIT_SHA: ${{ steps.inject-bait.outputs.bait_sha }}
         run: |
           set -euo pipefail
           echo "Waiting for review workflow on PR #${PR_NUMBER}..."
+          if [ -n "${BAIT_SHA:-}" ]; then
+            echo "Pinning to review runs with head_sha=${BAIT_SHA:0:7} (bait commit)"
+          else
+            echo "No bait SHA — using legacy latest-by-created_at filter"
+          fi
           echo "Inactivity timeout: ${REVIEW_TIMEOUT} minutes"
           INACTIVITY_LIMIT=$((REVIEW_TIMEOUT * 60))
           LAST_ACTIVITY=$(date +%s)
@@ -943,9 +976,24 @@ jobs:
             # Find the review workflow run for this PR's head branch
             PR_BRANCH="ai/issue-${{ steps.create-issue.outputs.issue_number }}"
 
-            # Look for workflow runs on this branch
-            REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&event=pull_request&per_page=5" \
-              --jq '[.workflow_runs[] | select(.name | test("Review|review|autofix"; "i"))] | sort_by(.created_at) | last' || echo "")
+            # Look for workflow runs on this branch.
+            # When BAIT_SHA is set the filter pins to head_sha == BAIT_SHA
+            # so the wait loop cannot mistake a stale implement-phase
+            # review run (head_sha = the implement commit, not the bait
+            # commit) for a bait-triggered run. per_page is widened to
+            # 100 because a doc-only PR's head can carry several extra
+            # workflow runs (CI, Internal: AI Review & Autofix, …) and
+            # the bait-triggered run could get crowded out of a small
+            # page. Falls back to the legacy latest-by-created_at filter
+            # only when the bait-injection step did not produce a SHA
+            # (status=skipped path).
+            if [ -n "${BAIT_SHA:-}" ]; then
+              REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&event=pull_request&per_page=100" \
+                --jq "[.workflow_runs[] | select(.name | test(\"Review|review|autofix\"; \"i\")) | select(.head_sha == \"${BAIT_SHA}\")] | sort_by(.created_at) | last" || echo "")
+            else
+              REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&event=pull_request&per_page=5" \
+                --jq '[.workflow_runs[] | select(.name | test("Review|review|autofix"; "i"))] | sort_by(.created_at) | last' || echo "")
+            fi
 
             # If rate-limited, skip this cycle entirely (don't corrupt state)
             if [ "$RATE_LIMIT_BACKOFF" -gt 0 ] && [ -z "$REVIEW_RUN" ]; then
@@ -1171,8 +1219,25 @@ jobs:
               PREV_STATE="$CUR_STATE"
             fi
 
-            # Inactivity timeout
+            # Inactivity timeout. When BAIT_SHA is set and the loop
+            # never matched a review run for that SHA, surface a
+            # distinct status so verify-bait-removed's failure isn't
+            # the first place the operator hears that the bait push
+            # never spawned a downstream review_autofix run. Dump the
+            # review-run inventory for the branch so the diagnosis
+            # doesn't require an out-of-band gh api call.
             if [ $IDLE -ge $INACTIVITY_LIMIT ]; then
+              # jq's `last` on an empty array yields the literal string
+              # "null" rather than empty, so both branches are needed.
+              if [ -n "${BAIT_SHA:-}" ] && { [ -z "${REVIEW_RUN:-}" ] || [ "${REVIEW_RUN}" = "null" ]; }; then
+                echo "::error::No review_autofix run with head_sha=${BAIT_SHA} ever appeared within ${REVIEW_TIMEOUT}m — bait push did not trigger downstream workflows"
+                echo "status=no_review_triggered" >> "$GITHUB_OUTPUT"
+                echo "Diagnostic: workflow runs visible on branch ${PR_BRANCH}:" >&2
+                gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&per_page=20" \
+                  --jq '.workflow_runs[] | "  \(.id) \(.name) event=\(.event) status=\(.status) conclusion=\(.conclusion // "null") head_sha=\(.head_sha[0:7])"' >&2 \
+                  || echo "  (inventory fetch failed)" >&2
+                exit 1
+              fi
               echo "::error::Review phase stalled — no activity for ${REVIEW_TIMEOUT} minutes"
               echo "status=timeout" >> "$GITHUB_OUTPUT"
               exit 1

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -899,7 +899,7 @@ jobs:
           # cheap to verify the push wasn't silently demoted (e.g. to
           # a token whose identity can't trigger workflows) without an
           # out-of-band gh api call.
-          jq '{commit_sha: .commit.sha, commit_url: .commit.html_url, author: .commit.author.name, committer: .commit.committer.name, verification: .commit.verification.verified, content_url: .content.html_url}' /tmp/bait_resp.json 2>/dev/null \
+          jq '{commit_sha: .commit.sha, commit_url: .commit.html_url, author: .commit.author.name, committer: .commit.committer.name, verification: .commit.verification.verified, content_url: .content.html_url} | with_entries(select(.value != null))' /tmp/bait_resp.json 2>/dev/null \
             || echo "  (could not parse bait_resp.json)"
           echo "status=injected" >> "$GITHUB_OUTPUT"
           echo "marker=${BAIT_MARKER}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

E2E smoke run [25147636528](https://github.com/shubhodeep1/coding-workflows/actions/runs/25147636528) failed at `verify-bait-removed` even though the editor never got a chance to act on the bait.

The implement phase produced a doc-only PR (only modifies `tests/e2e_smoke_canary.txt`), so the deterministic-skip gate at `review_autofix.yml:339-433` fired, the review run completed successfully in ~67s, applied `ai:review-skipped` + `ai:ready-to-merge`, and enabled auto-merge. ~26s later the e2e job pushed the bait commit. `wait-review` filtered review runs only by branch + event and picked the latest by `created_at`, so it matched the implement-phase run (head_sha `a4abe9b…`, already completed/success) and exited within 5s — before any bait-triggered run could be registered. `verify-bait-removed` then ran with the bait still on the canary and failed.

Verified via the GitHub API:
- Run #25147811755 head_sha = `a4abe9b…` (implement commit), conclusion = success at 04:44:08Z.
- Bait commit SHA = `91d6077a…`, pushed at 04:44:38Z.
- `?head_sha=91d6077a…` returns **0 workflow runs** — the bait push also did not fan out a `pull_request:synchronize` event at all (Bug B, separate failure mode being investigated).

## Changes

- `wait-review` now pins to `head_sha == BAIT_SHA` when `inject-bait` actually pushed a commit. Falls back to the legacy latest-by-created_at filter when bait injection was skipped (no bait → legacy behaviour is correct).
- `per_page` widened to 100 in the pinned path so the bait-triggered run isn't crowded out by other branch runs (CI, Internal: AI Review & Autofix, …).
- New `status=no_review_triggered`: when `BAIT_SHA` is set and the loop times out without matching a run for that SHA, log the branch's full review-run inventory and exit 1. This surfaces Bug B distinctly instead of having it masquerade as a `bait_remained` failure downstream.
- Diagnostic dump of the Contents-API response after a successful bait push (commit SHA, URLs, author/committer, verification) so the next investigation has identity attribution captured in-line.

## Test plan

- [ ] Trigger `test-and-mark-stable.yml` (release-gate) and confirm the new `Pinning to review runs with head_sha=…` log line appears in `Phase 4: Wait for review & autofix to complete`.
- [ ] If the smoke passes, confirm the wait-review picked up the bait-triggered review run (its `RUN_ID` should differ from the implement-phase review run id and `JOBS_JSON`'s SHA should equal `BAIT_SHA`).
- [ ] If the smoke fails with `status=no_review_triggered`, capture the inventory log — that confirms Bug B (bait push not fanning out a sync event) and unblocks the auto-merge / token-identity investigation.

https://claude.ai/code/session_011ynhoYTot5rSroewJAytB4

---
_Generated by [Claude Code](https://claude.ai/code/session_011ynhoYTot5rSroewJAytB4)_