### PR TITLE
fix(e2e): close auto-merge race that closes canary PR before bait push

### DIFF
--- a/.github/ai/label_contract.v1.json
+++ b/.github/ai/label_contract.v1.json
@@ -140,6 +140,10 @@
     "force-review": {
       "color": "fbca04",
       "description": "Force a full review_autofix cycle, bypassing the deterministic pre-review skip"
+    },
+    "e2e-smoke-test": {
+      "color": "5319e7",
+      "description": "E2E smoke test PR — review_autofix skips auto-merge"
     }
   },
   "phase_groups": [

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -2501,41 +2501,64 @@ jobs:
           # `force-review` so this workflow cannot drift from
           # .github/ai/label_contract.v1.json (`force-review` is
           # color `fbca04`, not `d93f0b`). `e2e-smoke-test` is NOT in
-          # the catalog (smoke-test infra label) so we POST it inline.
-          # Both ensures are idempotent — POST .../labels returns 422
-          # when the label already exists, which we treat as success.
+          # the catalog (smoke-test infra label) so we ensure it
+          # inline.
           if [ -f scripts/label_helpers.sh ]; then
             # shellcheck disable=SC1091
             source scripts/label_helpers.sh
           fi
+
+          # Inline POST-only ensure that treats GitHub's HTTP 422
+          # `already_exists` response as success. The earlier
+          # GET-then-POST pattern had a race: a transient blip on the
+          # GET could fail through to the POST, which would return
+          # 422 because the label DID exist, and the surrounding
+          # `||` chain treated that as failure — blocking smoke-test
+          # PR creation despite the desired state already being met
+          # (consensus finding from the multi-reviewer
+          # claude-branch-review). Mirrors the `already[_- ]exists`
+          # detection in `ensure_label_exists` from
+          # scripts/label_helpers.sh.
+          ensure_label_inline() {
+            local name="$1" color="$2" desc="$3"
+            local err_file
+            err_file="$(mktemp 2>/dev/null || echo /dev/null)"
+            if gh_retry gh api "repos/${REPOSITORY}/labels" \
+                 -f name="${name}" -f color="${color}" -f description="${desc}" \
+                 >/dev/null 2>"${err_file}"; then
+              [ "${err_file}" = /dev/null ] || rm -f "${err_file}"
+              return 0
+            fi
+            local err
+            err="$(cat "${err_file}" 2>/dev/null || true)"
+            [ "${err_file}" = /dev/null ] || rm -f "${err_file}"
+            if printf '%s' "${err}" | grep -Eqi 'already[ _-]*exists|already_exists'; then
+              return 0
+            fi
+            printf '%s\n' "${err}" >&2
+            return 1
+          }
+
           if type ensure_label_exists >/dev/null 2>&1; then
             ensure_label_exists "force-review" "${REPOSITORY}" || {
               echo "::error::Could not ensure 'force-review' label exists; aborting smoke-test PR creation (gh pr create --label would fail)"
               exit 1
             }
           else
-            # Fallback when label_helpers.sh isn't available (catalog
-            # values mirrored from .github/ai/label_contract.v1.json
-            # so the fallback path doesn't drift either).
-            gh_retry gh api "repos/${REPOSITORY}/labels/force-review" >/dev/null 2>&1 || \
-              gh_retry gh api "repos/${REPOSITORY}/labels" \
-                -f name="force-review" \
-                -f color="fbca04" \
-                -f description="Force a full review_autofix cycle, bypassing the deterministic pre-review skip" \
-                >/dev/null 2>&1 || {
-                  echo "::error::Could not ensure 'force-review' label exists; aborting smoke-test PR creation (gh pr create --label would fail)"
-                  exit 1
-                }
-          fi
-          gh_retry gh api "repos/${REPOSITORY}/labels/e2e-smoke-test" >/dev/null 2>&1 || \
-            gh_retry gh api "repos/${REPOSITORY}/labels" \
-              -f name="e2e-smoke-test" \
-              -f color="5319e7" \
-              -f description="E2E smoke test PR — review_autofix skips auto-merge" \
-              >/dev/null 2>&1 || {
-                echo "::error::Could not ensure 'e2e-smoke-test' label exists; aborting smoke-test PR creation (gh pr create --label would fail)"
+            # Catalog values mirrored from
+            # .github/ai/label_contract.v1.json so the fallback path
+            # doesn't drift either.
+            ensure_label_inline "force-review" "fbca04" \
+              "Force a full review_autofix cycle, bypassing the deterministic pre-review skip" || {
+                echo "::error::Could not ensure 'force-review' label exists; aborting smoke-test PR creation (gh pr create --label would fail)"
                 exit 1
               }
+          fi
+          ensure_label_inline "e2e-smoke-test" "5319e7" \
+            "E2E smoke test PR — review_autofix skips auto-merge" || {
+              echo "::error::Could not ensure 'e2e-smoke-test' label exists; aborting smoke-test PR creation (gh pr create --label would fail)"
+              exit 1
+            }
 
       - name: Create Pull Request
         if: env.SKIP_IMPLEMENT != 'true' && steps.commit_changes.outputs.did_commit == 'true'
@@ -2637,22 +2660,39 @@ jobs:
             # shellcheck disable=SC1091
             source scripts/label_helpers.sh
           fi
+
+          # Same POST-with-422-as-success ensure helper used by the
+          # earlier ensure step. Idempotent. Failures here are
+          # non-fatal because this is the backstop — the atomic
+          # `--label` path on `Create Pull Request` is the source of
+          # truth on the happy path.
+          ensure_label_inline() {
+            local name="$1" color="$2" desc="$3"
+            local err_file
+            err_file="$(mktemp 2>/dev/null || echo /dev/null)"
+            if gh_retry gh api "repos/${REPOSITORY}/labels" \
+                 -f name="${name}" -f color="${color}" -f description="${desc}" \
+                 >/dev/null 2>"${err_file}"; then
+              [ "${err_file}" = /dev/null ] || rm -f "${err_file}"
+              return 0
+            fi
+            local err
+            err="$(cat "${err_file}" 2>/dev/null || true)"
+            [ "${err_file}" = /dev/null ] || rm -f "${err_file}"
+            if printf '%s' "${err}" | grep -Eqi 'already[ _-]*exists|already_exists'; then
+              return 0
+            fi
+            return 1
+          }
+
           if type ensure_label_exists >/dev/null 2>&1; then
             ensure_label_exists "force-review" "${REPOSITORY}" >/dev/null 2>&1 || true
           else
-            gh_retry gh api "repos/${REPOSITORY}/labels/force-review" >/dev/null 2>&1 || \
-              gh_retry gh api "repos/${REPOSITORY}/labels" \
-                -f name="force-review" \
-                -f color="fbca04" \
-                -f description="Force a full review_autofix cycle, bypassing the deterministic pre-review skip" \
-                >/dev/null 2>&1 || true
+            ensure_label_inline "force-review" "fbca04" \
+              "Force a full review_autofix cycle, bypassing the deterministic pre-review skip" || true
           fi
-          gh_retry gh api "repos/${REPOSITORY}/labels/e2e-smoke-test" >/dev/null 2>&1 || \
-            gh_retry gh api "repos/${REPOSITORY}/labels" \
-              -f name="e2e-smoke-test" \
-              -f color="5319e7" \
-              -f description="E2E smoke test PR — review_autofix skips auto-merge" \
-              >/dev/null 2>&1 || true
+          ensure_label_inline "e2e-smoke-test" "5319e7" \
+            "E2E smoke test PR — review_autofix skips auto-merge" || true
 
           if ! gh_retry gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/labels" \
               -f "labels[]=force-review" \

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -2483,35 +2483,59 @@ jobs:
         # requires the label to already exist on the repo or the whole
         # PR creation fails — so this idempotent ensure step runs FIRST
         # and only when IS_SMOKE_TEST=true (no work for non-smoke runs).
+        # Failures here are FATAL: the next step's `gh pr create
+        # --label force-review --label e2e-smoke-test` will fail
+        # anyway, so we surface the cause loudly with a clear error
+        # message rather than letting it manifest downstream as an
+        # opaque PR-creation failure. (Copilot review on PR #1823.)
         if: env.SKIP_IMPLEMENT != 'true' && env.IS_SMOKE_TEST == 'true' && steps.commit_changes.outputs.did_commit == 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           source scripts/gh_helpers.sh 2>/dev/null || true
           type gh_retry &>/dev/null || gh_retry() { "$@"; }
 
-          # Color/description for `force-review` mirror the inline
-          # creation in test-and-mark-stable.yml; for `e2e-smoke-test`
-          # they're new (purple = test-infra convention). Both are
-          # idempotent — `gh api .../labels/<name>` returns 200 when
-          # present, otherwise we POST to create. Failures are non-fatal
-          # because the PR still gets created; the gate just won't see
-          # the labels and will run the production path.
-          gh_retry gh api "repos/${{ github.repository }}/labels/force-review" >/dev/null 2>&1 || \
-            gh_retry gh api "repos/${{ github.repository }}/labels" \
-              -f name="force-review" \
-              -f color="d93f0b" \
-              -f description="Bypass review_autofix deterministic skip" \
-              >/dev/null 2>&1 || \
-            echo "::warning::Could not ensure 'force-review' label exists; smoke-test PR may auto-merge"
-          gh_retry gh api "repos/${{ github.repository }}/labels/e2e-smoke-test" >/dev/null 2>&1 || \
-            gh_retry gh api "repos/${{ github.repository }}/labels" \
+          # Source the central label catalog (label_helpers.sh) for
+          # `force-review` so this workflow cannot drift from
+          # .github/ai/label_contract.v1.json (`force-review` is
+          # color `fbca04`, not `d93f0b`). `e2e-smoke-test` is NOT in
+          # the catalog (smoke-test infra label) so we POST it inline.
+          # Both ensures are idempotent — POST .../labels returns 422
+          # when the label already exists, which we treat as success.
+          if [ -f scripts/label_helpers.sh ]; then
+            # shellcheck disable=SC1091
+            source scripts/label_helpers.sh
+          fi
+          if type ensure_label_exists >/dev/null 2>&1; then
+            ensure_label_exists "force-review" "${REPOSITORY}" || {
+              echo "::error::Could not ensure 'force-review' label exists; aborting smoke-test PR creation (gh pr create --label would fail)"
+              exit 1
+            }
+          else
+            # Fallback when label_helpers.sh isn't available (catalog
+            # values mirrored from .github/ai/label_contract.v1.json
+            # so the fallback path doesn't drift either).
+            gh_retry gh api "repos/${REPOSITORY}/labels/force-review" >/dev/null 2>&1 || \
+              gh_retry gh api "repos/${REPOSITORY}/labels" \
+                -f name="force-review" \
+                -f color="fbca04" \
+                -f description="Force a full review_autofix cycle, bypassing the deterministic pre-review skip" \
+                >/dev/null 2>&1 || {
+                  echo "::error::Could not ensure 'force-review' label exists; aborting smoke-test PR creation (gh pr create --label would fail)"
+                  exit 1
+                }
+          fi
+          gh_retry gh api "repos/${REPOSITORY}/labels/e2e-smoke-test" >/dev/null 2>&1 || \
+            gh_retry gh api "repos/${REPOSITORY}/labels" \
               -f name="e2e-smoke-test" \
               -f color="5319e7" \
               -f description="E2E smoke test PR — review_autofix skips auto-merge" \
-              >/dev/null 2>&1 || \
-            echo "::warning::Could not ensure 'e2e-smoke-test' label exists; smoke-test PR may auto-merge"
+              >/dev/null 2>&1 || {
+                echo "::error::Could not ensure 'e2e-smoke-test' label exists; aborting smoke-test PR creation (gh pr create --label would fail)"
+                exit 1
+              }
 
       - name: Create Pull Request
         if: env.SKIP_IMPLEMENT != 'true' && steps.commit_changes.outputs.did_commit == 'true'
@@ -2567,31 +2591,32 @@ jobs:
           fi
           echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
 
-      - name: Apply E2E smoke-test labels to PR
-        # Applied at PR creation (not later) because the
-        # `pull_request: opened` event fires `internal-review.yml`
-        # immediately, and the gate decision in `review_autofix.yml`
-        # uses whatever labels are present at that moment. The wrapper
-        # does NOT trigger on `labeled`, so a label added after `opened`
-        # cannot retrigger the gate — by the time the e2e workflow's
-        # Phase 3b1 force-review-label step runs, the deterministic-
-        # skip-merge job has already auto-merged a doc-only canary PR
-        # (race observed in run 25150961704: PR merged at +50s, e2e
-        # bait push at +113s, then 30 min wait-review timeout).
+      - name: Backstop E2E smoke-test labels on PR after creation
+        # Best-effort post-create backstop. The atomic `--label` path
+        # in `Create Pull Request` above is the source of truth on the
+        # happy path; this step exists to cover the existing-PR-reuse
+        # fallback inside that step (when `gh pr create` fails because
+        # a PR already exists for the issue, no `--label` flags are
+        # applied — gh pr list / view returns the existing PR by URL
+        # without modifying its labels). It also re-asserts both
+        # labels in case the atomic path was preempted by a transient
+        # GitHub API issue. Idempotent.
         #
-        # Two labels are applied:
-        #   * `force-review`     — bypasses gate's deterministic_skip
-        #     so the codex-agent path runs (reviewers + editor + commit
-        #     + push), giving the bait commit something to react to.
-        #   * `e2e-smoke-test`   — marker checked by review_autofix.yml's
-        #     `Enable auto-merge on PR` step to skip auto-merge for
-        #     this PR specifically (scoped opt-out, so the repo-wide
-        #     ENABLE_AUTO_MERGE var stays untouched and non-e2e PRs
-        #     keep auto-merging as before).
+        # Early label presence matters because `pull_request: opened`
+        # fires `internal-review.yml` immediately, and the gate
+        # decision in `review_autofix.yml` uses whatever labels are
+        # present at that moment. The wrapper does NOT trigger on
+        # `labeled`, so a label added after `opened` cannot retrigger
+        # the gate — by the time the e2e workflow's Phase 3b1
+        # force-review-label step runs, the deterministic-skip-merge
+        # job has already auto-merged a doc-only canary PR (race
+        # observed in run 25150961704: PR merged at +50s, e2e bait
+        # push at +113s, then 30 min wait-review timeout).
         if: env.SKIP_IMPLEMENT != 'true' && env.IS_SMOKE_TEST == 'true' && steps.commit_changes.outputs.did_commit == 'true' && steps.create_pr.outputs.pr_url != ''
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           PR_URL: ${{ steps.create_pr.outputs.pr_url }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           source scripts/gh_helpers.sh 2>/dev/null || true
@@ -2599,34 +2624,42 @@ jobs:
 
           PR_NUMBER="$(printf '%s\n' "${PR_URL}" | sed -E 's#.*/pull/([0-9]+).*#\1#')"
           if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
-            echo "::warning::Could not extract PR number from URL '${PR_URL}'; skipping E2E label application"
+            echo "::warning::Could not extract PR number from URL '${PR_URL}'; skipping E2E label backstop"
             exit 0
           fi
 
-          # Label colors/descriptions mirror those in
-          # test-and-mark-stable.yml (force-review) and the catalog
-          # convention used by review_autofix.yml's
-          # deterministic-skip-merge job. ensure_label_exists pattern
-          # inlined to avoid a heavyweight label_helpers.sh source.
-          gh_retry gh api "repos/${{ github.repository }}/labels/force-review" >/dev/null 2>&1 || \
-            gh_retry gh api "repos/${{ github.repository }}/labels" \
-              -f name="force-review" \
-              -f color="d93f0b" \
-              -f description="Bypass review_autofix deterministic skip" \
-              >/dev/null 2>&1 || true
-          gh_retry gh api "repos/${{ github.repository }}/labels/e2e-smoke-test" >/dev/null 2>&1 || \
-            gh_retry gh api "repos/${{ github.repository }}/labels" \
+          # Re-use the central catalog so the backstop never drifts
+          # from .github/ai/label_contract.v1.json. The earlier
+          # `Ensure E2E smoke-test labels exist on repo` step has
+          # already created/verified both labels for this run; the
+          # ensure call here is cheap belt-and-braces.
+          if [ -f scripts/label_helpers.sh ]; then
+            # shellcheck disable=SC1091
+            source scripts/label_helpers.sh
+          fi
+          if type ensure_label_exists >/dev/null 2>&1; then
+            ensure_label_exists "force-review" "${REPOSITORY}" >/dev/null 2>&1 || true
+          else
+            gh_retry gh api "repos/${REPOSITORY}/labels/force-review" >/dev/null 2>&1 || \
+              gh_retry gh api "repos/${REPOSITORY}/labels" \
+                -f name="force-review" \
+                -f color="fbca04" \
+                -f description="Force a full review_autofix cycle, bypassing the deterministic pre-review skip" \
+                >/dev/null 2>&1 || true
+          fi
+          gh_retry gh api "repos/${REPOSITORY}/labels/e2e-smoke-test" >/dev/null 2>&1 || \
+            gh_retry gh api "repos/${REPOSITORY}/labels" \
               -f name="e2e-smoke-test" \
               -f color="5319e7" \
               -f description="E2E smoke test PR — review_autofix skips auto-merge" \
               >/dev/null 2>&1 || true
 
-          if ! gh_retry gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels" \
+          if ! gh_retry gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/labels" \
               -f "labels[]=force-review" \
               -f "labels[]=e2e-smoke-test" >/dev/null 2>&1; then
-            echo "::warning::Could not apply E2E smoke-test labels to PR #${PR_NUMBER}; review_autofix may auto-merge before the e2e bait phase runs"
+            echo "::warning::Backstop label apply failed on PR #${PR_NUMBER}; relying on the atomic --label path. review_autofix may auto-merge before the e2e bait phase runs if both paths missed."
           else
-            echo "✓ Applied force-review + e2e-smoke-test labels to PR #${PR_NUMBER}"
+            echo "✓ Backstop applied force-review + e2e-smoke-test labels to PR #${PR_NUMBER}"
           fi
 
       - name: Refetch memory helpers after commit cleanup

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -2497,68 +2497,41 @@ jobs:
           source scripts/gh_helpers.sh 2>/dev/null || true
           type gh_retry &>/dev/null || gh_retry() { "$@"; }
 
-          # Source the central label catalog (label_helpers.sh) for
-          # `force-review` so this workflow cannot drift from
-          # .github/ai/label_contract.v1.json (`force-review` is
-          # color `fbca04`, not `d93f0b`). `e2e-smoke-test` is NOT in
-          # the catalog (smoke-test infra label) so we ensure it
-          # inline.
-          if [ -f scripts/label_helpers.sh ]; then
-            # shellcheck disable=SC1091
-            source scripts/label_helpers.sh
+          # Both `force-review` and `e2e-smoke-test` are now in the
+          # central catalog (scripts/label_helpers.sh +
+          # .github/ai/label_contract.v1.json), so a single
+          # `ensure_label_exists` call gives us the correct
+          # color/description for each. The helper internally
+          # treats GitHub's "already_exists" response as success,
+          # killing the GET/POST race the earlier inline ensure
+          # pattern was vulnerable to (consensus claude-branch-
+          # review finding on this PR). If the helper isn't
+          # available — e.g., the support-source checkout in this
+          # job didn't land scripts/label_helpers.sh — fail loud
+          # rather than reinventing the catalog inline; the next
+          # `gh pr create --label` would fail anyway and we'd
+          # rather surface "label_helpers missing" than have a
+          # parallel inline catalog drift over time (Copilot review
+          # comment #4 on this PR).
+          if [ ! -f scripts/label_helpers.sh ]; then
+            echo "::error::scripts/label_helpers.sh not present in checkout; cannot ensure smoke-test labels via the catalog. Aborting smoke-test PR creation."
+            exit 1
+          fi
+          # shellcheck disable=SC1091
+          source scripts/label_helpers.sh
+          if ! type ensure_label_exists >/dev/null 2>&1; then
+            echo "::error::scripts/label_helpers.sh did not export ensure_label_exists; aborting smoke-test PR creation (catalog drift risk)."
+            exit 1
           fi
 
-          # Inline POST-only ensure that treats GitHub's HTTP 422
-          # `already_exists` response as success. The earlier
-          # GET-then-POST pattern had a race: a transient blip on the
-          # GET could fail through to the POST, which would return
-          # 422 because the label DID exist, and the surrounding
-          # `||` chain treated that as failure — blocking smoke-test
-          # PR creation despite the desired state already being met
-          # (consensus finding from the multi-reviewer
-          # claude-branch-review). Mirrors the `already[_- ]exists`
-          # detection in `ensure_label_exists` from
-          # scripts/label_helpers.sh.
-          ensure_label_inline() {
-            local name="$1" color="$2" desc="$3"
-            local err_file
-            err_file="$(mktemp 2>/dev/null || echo /dev/null)"
-            if gh_retry gh api "repos/${REPOSITORY}/labels" \
-                 -f name="${name}" -f color="${color}" -f description="${desc}" \
-                 >/dev/null 2>"${err_file}"; then
-              [ "${err_file}" = /dev/null ] || rm -f "${err_file}"
-              return 0
-            fi
-            local err
-            err="$(cat "${err_file}" 2>/dev/null || true)"
-            [ "${err_file}" = /dev/null ] || rm -f "${err_file}"
-            if printf '%s' "${err}" | grep -Eqi 'already[ _-]*exists|already_exists'; then
-              return 0
-            fi
-            printf '%s\n' "${err}" >&2
-            return 1
+          ensure_label_exists "force-review" "${REPOSITORY}" || {
+            echo "::error::Could not ensure 'force-review' label exists; aborting smoke-test PR creation (gh pr create --label would fail)"
+            exit 1
           }
-
-          if type ensure_label_exists >/dev/null 2>&1; then
-            ensure_label_exists "force-review" "${REPOSITORY}" || {
-              echo "::error::Could not ensure 'force-review' label exists; aborting smoke-test PR creation (gh pr create --label would fail)"
-              exit 1
-            }
-          else
-            # Catalog values mirrored from
-            # .github/ai/label_contract.v1.json so the fallback path
-            # doesn't drift either.
-            ensure_label_inline "force-review" "fbca04" \
-              "Force a full review_autofix cycle, bypassing the deterministic pre-review skip" || {
-                echo "::error::Could not ensure 'force-review' label exists; aborting smoke-test PR creation (gh pr create --label would fail)"
-                exit 1
-              }
-          fi
-          ensure_label_inline "e2e-smoke-test" "5319e7" \
-            "E2E smoke test PR — review_autofix skips auto-merge" || {
-              echo "::error::Could not ensure 'e2e-smoke-test' label exists; aborting smoke-test PR creation (gh pr create --label would fail)"
-              exit 1
-            }
+          ensure_label_exists "e2e-smoke-test" "${REPOSITORY}" || {
+            echo "::error::Could not ensure 'e2e-smoke-test' label exists; aborting smoke-test PR creation (gh pr create --label would fail)"
+            exit 1
+          }
 
       - name: Create Pull Request
         if: env.SKIP_IMPLEMENT != 'true' && steps.commit_changes.outputs.did_commit == 'true'
@@ -2652,47 +2625,24 @@ jobs:
           fi
 
           # Re-use the central catalog so the backstop never drifts
-          # from .github/ai/label_contract.v1.json. The earlier
-          # `Ensure E2E smoke-test labels exist on repo` step has
-          # already created/verified both labels for this run; the
-          # ensure call here is cheap belt-and-braces.
+          # from .github/ai/label_contract.v1.json. Both labels are
+          # cataloged, so a single `ensure_label_exists` call per
+          # label is enough. Failures here are non-fatal because
+          # this is the backstop — the atomic `--label` path on
+          # `Create Pull Request` is the source of truth on the
+          # happy path; the `Ensure E2E smoke-test labels exist on
+          # repo` step has already aborted the run if the catalog
+          # source itself is missing.
           if [ -f scripts/label_helpers.sh ]; then
             # shellcheck disable=SC1091
             source scripts/label_helpers.sh
           fi
-
-          # Same POST-with-422-as-success ensure helper used by the
-          # earlier ensure step. Idempotent. Failures here are
-          # non-fatal because this is the backstop — the atomic
-          # `--label` path on `Create Pull Request` is the source of
-          # truth on the happy path.
-          ensure_label_inline() {
-            local name="$1" color="$2" desc="$3"
-            local err_file
-            err_file="$(mktemp 2>/dev/null || echo /dev/null)"
-            if gh_retry gh api "repos/${REPOSITORY}/labels" \
-                 -f name="${name}" -f color="${color}" -f description="${desc}" \
-                 >/dev/null 2>"${err_file}"; then
-              [ "${err_file}" = /dev/null ] || rm -f "${err_file}"
-              return 0
-            fi
-            local err
-            err="$(cat "${err_file}" 2>/dev/null || true)"
-            [ "${err_file}" = /dev/null ] || rm -f "${err_file}"
-            if printf '%s' "${err}" | grep -Eqi 'already[ _-]*exists|already_exists'; then
-              return 0
-            fi
-            return 1
-          }
-
           if type ensure_label_exists >/dev/null 2>&1; then
             ensure_label_exists "force-review" "${REPOSITORY}" >/dev/null 2>&1 || true
+            ensure_label_exists "e2e-smoke-test" "${REPOSITORY}" >/dev/null 2>&1 || true
           else
-            ensure_label_inline "force-review" "fbca04" \
-              "Force a full review_autofix cycle, bypassing the deterministic pre-review skip" || true
+            echo "::warning::scripts/label_helpers.sh did not export ensure_label_exists; skipping non-fatal label backstop ensure (atomic --label path remains the source of truth)"
           fi
-          ensure_label_inline "e2e-smoke-test" "5319e7" \
-            "E2E smoke test PR — review_autofix skips auto-merge" || true
 
           if ! gh_retry gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/labels" \
               -f "labels[]=force-review" \

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -552,9 +552,16 @@ jobs:
           # the smoke-test fixture so the gate isn't drowned in
           # start/progress/finish notifications. SILENT > CRITICAL so
           # all callers' levels filter to no-op.
+          # Also export IS_SMOKE_TEST so the post-PR-creation step can
+          # auto-apply force-review + e2e-smoke-test labels — required
+          # because the canary edit is doc-only and the deterministic-
+          # skip-merge job in review_autofix.yml will otherwise enable
+          # auto-merge before the e2e gate's bait-injection phase has
+          # a chance to push (race observed in run 25150961704).
           if echo "${ISSUE_TITLE}" | grep -qi '\[E2E Smoke Test\]'; then
             echo "🔬 Smoke test detected — suppressing per-phase Telegram alerts"
             echo "ALERT_MSG_LEVEL=SILENT" >> "$GITHUB_ENV"
+            echo "IS_SMOKE_TEST=true" >> "$GITHUB_ENV"
           fi
 
       - name: Fetch issue comments
@@ -2470,6 +2477,42 @@ jobs:
 
           exit 1
 
+      - name: Ensure E2E smoke-test labels exist on repo
+        # Pre-creates the labels referenced by `Create Pull Request`'s
+        # conditional `--label` flags below. `gh pr create --label`
+        # requires the label to already exist on the repo or the whole
+        # PR creation fails — so this idempotent ensure step runs FIRST
+        # and only when IS_SMOKE_TEST=true (no work for non-smoke runs).
+        if: env.SKIP_IMPLEMENT != 'true' && env.IS_SMOKE_TEST == 'true' && steps.commit_changes.outputs.did_commit == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          source scripts/gh_helpers.sh 2>/dev/null || true
+          type gh_retry &>/dev/null || gh_retry() { "$@"; }
+
+          # Color/description for `force-review` mirror the inline
+          # creation in test-and-mark-stable.yml; for `e2e-smoke-test`
+          # they're new (purple = test-infra convention). Both are
+          # idempotent — `gh api .../labels/<name>` returns 200 when
+          # present, otherwise we POST to create. Failures are non-fatal
+          # because the PR still gets created; the gate just won't see
+          # the labels and will run the production path.
+          gh_retry gh api "repos/${{ github.repository }}/labels/force-review" >/dev/null 2>&1 || \
+            gh_retry gh api "repos/${{ github.repository }}/labels" \
+              -f name="force-review" \
+              -f color="d93f0b" \
+              -f description="Bypass review_autofix deterministic skip" \
+              >/dev/null 2>&1 || \
+            echo "::warning::Could not ensure 'force-review' label exists; smoke-test PR may auto-merge"
+          gh_retry gh api "repos/${{ github.repository }}/labels/e2e-smoke-test" >/dev/null 2>&1 || \
+            gh_retry gh api "repos/${{ github.repository }}/labels" \
+              -f name="e2e-smoke-test" \
+              -f color="5319e7" \
+              -f description="E2E smoke test PR — review_autofix skips auto-merge" \
+              >/dev/null 2>&1 || \
+            echo "::warning::Could not ensure 'e2e-smoke-test' label exists; smoke-test PR may auto-merge"
+
       - name: Create Pull Request
         if: env.SKIP_IMPLEMENT != 'true' && steps.commit_changes.outputs.did_commit == 'true'
         id: create_pr
@@ -2478,12 +2521,29 @@ jobs:
         run: |
           set -euo pipefail
 
-          if ! gh pr create \
-            --repo "${{ github.repository }}" \
-            --base "${PR_BASE_BRANCH}" \
-            --head "${TARGET_BRANCH}" \
-            --title "AI implementation for issue #${ISSUE_NUMBER}" \
-            --body "Automated implementation. Closes ${ISSUE_URL}" > "${RUNTIME_DIR}/created_pr_url.txt" 2> "${RUNTIME_DIR}/created_pr_url.err"; then
+          # Atomically apply force-review + e2e-smoke-test labels at PR
+          # creation time when this is a smoke-test run. Applying them
+          # post-creation would race the `pull_request: opened` event
+          # that fires `internal-review.yml` → `review_autofix.yml` gate
+          # — the gate snapshots labels and the wrapper does NOT trigger
+          # on `labeled`, so a label added afterwards cannot rewind the
+          # gate decision. Race observed in run 25150961704: doc-only
+          # canary PR auto-merged 50s after creation, before the e2e
+          # gate's Phase 3b1 force-review-label step ran. See
+          # `Ensure E2E smoke-test labels exist on repo` step above —
+          # `--label` here requires those labels to exist.
+          PR_CREATE_ARGS=(
+            --repo "${{ github.repository }}"
+            --base "${PR_BASE_BRANCH}"
+            --head "${TARGET_BRANCH}"
+            --title "AI implementation for issue #${ISSUE_NUMBER}"
+            --body "Automated implementation. Closes ${ISSUE_URL}"
+          )
+          if [ "${IS_SMOKE_TEST:-false}" = "true" ]; then
+            PR_CREATE_ARGS+=(--label "force-review" --label "e2e-smoke-test")
+          fi
+
+          if ! gh pr create "${PR_CREATE_ARGS[@]}" > "${RUNTIME_DIR}/created_pr_url.txt" 2> "${RUNTIME_DIR}/created_pr_url.err"; then
             echo "PR creation failed. This may indicate a PR was created by another process during execution."
             if [ -s "${RUNTIME_DIR}/created_pr_url.err" ]; then
               cat "${RUNTIME_DIR}/created_pr_url.err"
@@ -2506,6 +2566,68 @@ jobs:
             exit 1
           fi
           echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Apply E2E smoke-test labels to PR
+        # Applied at PR creation (not later) because the
+        # `pull_request: opened` event fires `internal-review.yml`
+        # immediately, and the gate decision in `review_autofix.yml`
+        # uses whatever labels are present at that moment. The wrapper
+        # does NOT trigger on `labeled`, so a label added after `opened`
+        # cannot retrigger the gate — by the time the e2e workflow's
+        # Phase 3b1 force-review-label step runs, the deterministic-
+        # skip-merge job has already auto-merged a doc-only canary PR
+        # (race observed in run 25150961704: PR merged at +50s, e2e
+        # bait push at +113s, then 30 min wait-review timeout).
+        #
+        # Two labels are applied:
+        #   * `force-review`     — bypasses gate's deterministic_skip
+        #     so the codex-agent path runs (reviewers + editor + commit
+        #     + push), giving the bait commit something to react to.
+        #   * `e2e-smoke-test`   — marker checked by review_autofix.yml's
+        #     `Enable auto-merge on PR` step to skip auto-merge for
+        #     this PR specifically (scoped opt-out, so the repo-wide
+        #     ENABLE_AUTO_MERGE var stays untouched and non-e2e PRs
+        #     keep auto-merging as before).
+        if: env.SKIP_IMPLEMENT != 'true' && env.IS_SMOKE_TEST == 'true' && steps.commit_changes.outputs.did_commit == 'true' && steps.create_pr.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          PR_URL: ${{ steps.create_pr.outputs.pr_url }}
+        run: |
+          set -euo pipefail
+          source scripts/gh_helpers.sh 2>/dev/null || true
+          type gh_retry &>/dev/null || gh_retry() { "$@"; }
+
+          PR_NUMBER="$(printf '%s\n' "${PR_URL}" | sed -E 's#.*/pull/([0-9]+).*#\1#')"
+          if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+            echo "::warning::Could not extract PR number from URL '${PR_URL}'; skipping E2E label application"
+            exit 0
+          fi
+
+          # Label colors/descriptions mirror those in
+          # test-and-mark-stable.yml (force-review) and the catalog
+          # convention used by review_autofix.yml's
+          # deterministic-skip-merge job. ensure_label_exists pattern
+          # inlined to avoid a heavyweight label_helpers.sh source.
+          gh_retry gh api "repos/${{ github.repository }}/labels/force-review" >/dev/null 2>&1 || \
+            gh_retry gh api "repos/${{ github.repository }}/labels" \
+              -f name="force-review" \
+              -f color="d93f0b" \
+              -f description="Bypass review_autofix deterministic skip" \
+              >/dev/null 2>&1 || true
+          gh_retry gh api "repos/${{ github.repository }}/labels/e2e-smoke-test" >/dev/null 2>&1 || \
+            gh_retry gh api "repos/${{ github.repository }}/labels" \
+              -f name="e2e-smoke-test" \
+              -f color="5319e7" \
+              -f description="E2E smoke test PR — review_autofix skips auto-merge" \
+              >/dev/null 2>&1 || true
+
+          if ! gh_retry gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels" \
+              -f "labels[]=force-review" \
+              -f "labels[]=e2e-smoke-test" >/dev/null 2>&1; then
+            echo "::warning::Could not apply E2E smoke-test labels to PR #${PR_NUMBER}; review_autofix may auto-merge before the e2e bait phase runs"
+          else
+            echo "✓ Applied force-review + e2e-smoke-test labels to PR #${PR_NUMBER}"
+          fi
 
       - name: Refetch memory helpers after commit cleanup
         if: env.SKIP_IMPLEMENT != 'true' && steps.commit_changes.outputs.did_commit == 'true' && steps.create_pr.outputs.pr_url != ''

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3937,9 +3937,33 @@ jobs:
           # commit lands, closing the PR before the e2e gate has read
           # the post-edit canary blob. Repo-wide ENABLE_AUTO_MERGE stays
           # untouched so non-e2e PRs keep auto-merging as before.
-          PR_LABELS_RAW="$(gh_retry gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels" --jq '[.[].name] | join(",")' 2>/dev/null || echo "")"
-          if printf '%s' "${PR_LABELS_RAW}" | tr ',' '\n' | grep -qx 'e2e-smoke-test'; then
-            echo "PR #${PR_NUMBER} carries 'e2e-smoke-test' label — auto-merge suppressed for the e2e gate's lifecycle."
+          #
+          # Fail-closed on API failure: if gh_retry exhausts its
+          # retries, we cannot tell whether the PR carries
+          # `e2e-smoke-test`. Defaulting to "no label → auto-merge"
+          # would silently bypass this guard for an e2e PR (consensus
+          # finding from the multi-reviewer claude-branch-review on
+          # this PR — when a transient API blip persists past 5
+          # retries, auto-merge would race the e2e gate again, the
+          # exact regression this guard was added to prevent). Skip
+          # auto-merge with a clear ::warning:: instead — non-e2e PRs
+          # lose auto-merge for one review_autofix cycle on a
+          # persistent outage, but the next sync event (next push,
+          # next reviewer commit) re-runs review_autofix and picks it
+          # up. This trade is asymmetric in our favour: a missed
+          # auto-merge on a non-e2e PR is recoverable; an e2e PR that
+          # auto-merges mid-test is not.
+          _label_err_file="$(mktemp 2>/dev/null || echo /dev/null)"
+          if PR_LABELS_RAW="$(gh_retry gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels" --jq '[.[].name] | join(",")' 2>"${_label_err_file}")"; then
+            [ "${_label_err_file}" = /dev/null ] || rm -f "${_label_err_file}"
+            if printf '%s' "${PR_LABELS_RAW}" | tr ',' '\n' | grep -qx 'e2e-smoke-test'; then
+              echo "PR #${PR_NUMBER} carries 'e2e-smoke-test' label — auto-merge suppressed for the e2e gate's lifecycle."
+              exit 0
+            fi
+          else
+            _label_err="$(cat "${_label_err_file}" 2>/dev/null || true)"
+            [ "${_label_err_file}" = /dev/null ] || rm -f "${_label_err_file}"
+            echo "::warning::Could not fetch labels for PR #${PR_NUMBER} (gh_retry exhausted): ${_label_err}. Failing closed: skipping auto-merge enablement so an e2e-smoke-test PR cannot race the e2e gate. Next sync event will re-run review_autofix and retry the merge enablement."
             exit 0
           fi
 

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3953,10 +3953,20 @@ jobs:
           # up. This trade is asymmetric in our favour: a missed
           # auto-merge on a non-e2e PR is recoverable; an e2e PR that
           # auto-merges mid-test is not.
+          # `--paginate ?per_page=100` so a PR carrying many labels
+          # (e.g., orchestrator-managed PRs that accumulate phase
+          # labels + review-blocked + e2e-smoke-test, easily >30) can
+          # still surface `e2e-smoke-test` on page ≥2. Without the
+          # override this endpoint defaults to 30/page and a label on
+          # page 2 is silently dropped, allowing auto-merge — the
+          # exact race this guard prevents (Copilot review #3 on
+          # PR #1823). With `--paginate`, gh emits one JSON array per
+          # page; `--jq '.[].name'` flattens to one label per line so
+          # the downstream `grep -qx` works regardless of page count.
           _label_err_file="$(mktemp 2>/dev/null || echo /dev/null)"
-          if PR_LABELS_RAW="$(gh_retry gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels" --jq '[.[].name] | join(",")' 2>"${_label_err_file}")"; then
+          if PR_LABELS_RAW="$(gh_retry gh api --paginate "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels?per_page=100" --jq '.[].name' 2>"${_label_err_file}")"; then
             [ "${_label_err_file}" = /dev/null ] || rm -f "${_label_err_file}"
-            if printf '%s' "${PR_LABELS_RAW}" | tr ',' '\n' | grep -qx 'e2e-smoke-test'; then
+            if printf '%s\n' "${PR_LABELS_RAW}" | grep -qx 'e2e-smoke-test'; then
               echo "PR #${PR_NUMBER} carries 'e2e-smoke-test' label — auto-merge suppressed for the e2e gate's lifecycle."
               exit 0
             fi

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3929,6 +3929,20 @@ jobs:
             exit 0
           fi
 
+          # Scoped opt-out for the e2e smoke test. The implement workflow
+          # tags PRs born from `[E2E Smoke Test]` issues with the
+          # `e2e-smoke-test` label. Without this guard the editor's
+          # bait-removal commit would race the e2e gate's verify-bait-
+          # removed step: auto-merge could fire the moment the editor
+          # commit lands, closing the PR before the e2e gate has read
+          # the post-edit canary blob. Repo-wide ENABLE_AUTO_MERGE stays
+          # untouched so non-e2e PRs keep auto-merging as before.
+          PR_LABELS_RAW="$(gh_retry gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels" --jq '[.[].name] | join(",")' 2>/dev/null || echo "")"
+          if printf '%s' "${PR_LABELS_RAW}" | tr ',' '\n' | grep -qx 'e2e-smoke-test'; then
+            echo "PR #${PR_NUMBER} carries 'e2e-smoke-test' label — auto-merge suppressed for the e2e gate's lifecycle."
+            exit 0
+          fi
+
           echo "Enabling auto-merge (squash) on PR #${PR_NUMBER}..."
           if gh_retry gh pr merge "${PR_NUMBER}" --repo "${{ github.repository }}" --squash --auto; then
             echo "Auto-merge enabled. PR will merge once all required checks pass."

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -858,7 +858,15 @@ jobs:
             echo "::error::PR #${PR_NUMBER} is already ${PR_STATE} (merged=${PR_MERGED}, merged_at=${PR_MERGED_AT}, closed_at=${PR_CLOSED_AT}) before bait could be injected — pushes to the head branch will not fan out a pull_request synchronize event, so no review_autofix run will be triggered. Likely cause: review_autofix.yml's deterministic-skip-merge job auto-merged the PR before the e2e gate's force-review/e2e-smoke-test labels took effect (see implement.yml 'Apply E2E smoke-test labels to PR' step and review_autofix.yml 'Enable auto-merge on PR' step's e2e-smoke-test guard)."
             echo "status=pr_already_closed" >> "$GITHUB_OUTPUT"
             echo "marker=${BAIT_MARKER}" >> "$GITHUB_OUTPUT"
-            exit 1
+            # Exit 0 (not 1) so the implicit `if: success()` on the
+            # downstream Phase 4 (wait-review) and Phase 7 verify
+            # summary still let those steps run. The summary owns the
+            # final pass/fail decision and special-cases this status —
+            # otherwise PASSED=false would never be set and the job
+            # would conclude success despite the ::error:: annotation
+            # above. Mirrors the exit-0-with-status pattern used by
+            # the other non-fatal inject-bait branches (lines below).
+            exit 0
           fi
 
           echo "Fetching current canary blob on branch ${BRANCH}..."

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -858,15 +858,25 @@ jobs:
             echo "::error::PR #${PR_NUMBER} is already ${PR_STATE} (merged=${PR_MERGED}, merged_at=${PR_MERGED_AT}, closed_at=${PR_CLOSED_AT}) before bait could be injected — pushes to the head branch will not fan out a pull_request synchronize event, so no review_autofix run will be triggered. Likely cause: review_autofix.yml's deterministic-skip-merge job auto-merged the PR before the e2e gate's force-review/e2e-smoke-test labels took effect (see implement.yml steps 'Ensure E2E smoke-test labels exist on repo' / 'Backstop E2E smoke-test labels on PR after creation' and review_autofix.yml 'Enable auto-merge on PR' step's e2e-smoke-test guard)."
             echo "status=pr_already_closed" >> "$GITHUB_OUTPUT"
             echo "marker=${BAIT_MARKER}" >> "$GITHUB_OUTPUT"
-            # Exit 0 (not 1) so the implicit `if: success()` on the
-            # downstream Phase 4 (wait-review) and Phase 7 verify
-            # summary still let those steps run. The summary owns the
-            # final pass/fail decision and special-cases this status —
-            # otherwise PASSED=false would never be set and the job
-            # would conclude success despite the ::error:: annotation
-            # above. Mirrors the exit-0-with-status pattern used by
-            # the other non-fatal inject-bait branches (lines below).
-            exit 0
+            # Fail fast. Phase 4 (wait-review), Phase 4b (verify-bait-
+            # removed), Phase 5 (orchestrator-scripts), Phase 6
+            # (review-blocked sim) and Phase 7 (cancel_on_pr_close)
+            # all default to `if: success()` and will be skipped from
+            # this point — appropriate, since their preconditions
+            # (open PR / live bait commit / writeable head branch)
+            # no longer hold once the PR is closed/merged. Exit 0
+            # would let those phases run on a sabotaged main flow,
+            # and on a busy repo wait-review's legacy-fallback could
+            # latch onto an unrelated review_autofix run on the
+            # branch and falsely report success. The `Verify all
+            # phases passed` summary is now `if: always()`, so it
+            # still consumes this output, hits the `pr_already_closed`
+            # special-case, and reports the correct cause regardless
+            # of which exit code we use here. (Copilot review #1+#2
+            # on this PR: the original commit's exit 1 was right;
+            # the prior fixup's exit 0 only made sense before
+            # `if: always()` landed on verify.)
+            exit 1
           fi
 
           echo "Fetching current canary blob on branch ${BRANCH}..."

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -830,6 +830,37 @@ jobs:
             echo "  … PR head SHA still moving (${HEAD_A:0:7} -> ${HEAD_B:0:7}); attempt ${stability_attempt}/5"
           done
 
+          # Fail-fast guard: if the PR is already closed/merged, the
+          # bait push will land on the branch but `pull_request:
+          # synchronize` does NOT fire for closed PRs, so no
+          # review_autofix run will ever see the bait commit. Without
+          # this guard, wait-review (Phase 4) sits for the full
+          # REVIEW_TIMEOUT (30m) before exiting with the misleading
+          # `no_review_triggered` status — which sends investigators
+          # chasing a fan-out bug instead of the real cause.
+          #
+          # Run 25150961704 was the canonical failure: PR auto-merged
+          # at +50s by the deterministic-skip-merge job, bait pushed
+          # at +113s, then 30 minutes of polling for a workflow that
+          # could never come. The implement workflow now stamps E2E
+          # PRs with `force-review` + `e2e-smoke-test` at creation
+          # time to suppress that auto-merge — this guard exists as
+          # defense-in-depth in case (a) the labels fail to apply,
+          # (b) someone manually merges the PR mid-test, or (c) a
+          # future auto-merge path is added that doesn't honor the
+          # e2e-smoke-test label.
+          PR_META=$(gh api "repos/${TEST_REPO}/pulls/${PR_NUMBER}" 2>/dev/null || echo "")
+          PR_STATE=$(printf '%s' "${PR_META}" | jq -r '.state // ""' 2>/dev/null || echo "")
+          PR_MERGED=$(printf '%s' "${PR_META}" | jq -r '.merged // false' 2>/dev/null || echo "false")
+          if [ "${PR_STATE}" = "closed" ] || [ "${PR_MERGED}" = "true" ]; then
+            PR_MERGED_AT=$(printf '%s' "${PR_META}" | jq -r '.merged_at // ""' 2>/dev/null || echo "")
+            PR_CLOSED_AT=$(printf '%s' "${PR_META}" | jq -r '.closed_at // ""' 2>/dev/null || echo "")
+            echo "::error::PR #${PR_NUMBER} is already ${PR_STATE} (merged=${PR_MERGED}, merged_at=${PR_MERGED_AT}, closed_at=${PR_CLOSED_AT}) before bait could be injected — pushes to the head branch will not fan out a pull_request synchronize event, so no review_autofix run will be triggered. Likely cause: review_autofix.yml's deterministic-skip-merge job auto-merged the PR before the e2e gate's force-review/e2e-smoke-test labels took effect (see implement.yml 'Apply E2E smoke-test labels to PR' step and review_autofix.yml 'Enable auto-merge on PR' step's e2e-smoke-test guard)."
+            echo "status=pr_already_closed" >> "$GITHUB_OUTPUT"
+            echo "marker=${BAIT_MARKER}" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
           echo "Fetching current canary blob on branch ${BRANCH}..."
           # The implementer should have set the canary to exactly 3 lines.
           # We fetch its SHA + decoded content so we can PUT a 4-line
@@ -2250,6 +2281,14 @@ jobs:
           BAIT_VERIFIED="${{ steps.verify-bait-removed.outputs.status }}"
           if [ "$BAIT_INJECTED" = "skipped" ]; then
             echo "  - Editor Bait. SKIPPED (could not inject — non-blocking)"
+          elif [ "$BAIT_INJECTED" = "pr_already_closed" ]; then
+            # Phase 3c's fail-fast guard: PR was already closed/merged
+            # before the bait could be injected (almost certainly the
+            # deterministic-skip-merge auto-merge race). Distinct from
+            # a generic editor failure — the editor never had a chance
+            # to run because the test setup itself was sabotaged.
+            echo "  ✗ Editor Bait. FAILED (pr_already_closed) — PR was merged/closed before bait injection; editor never invoked. See Phase 3c log."
+            PASSED=false
           elif [ "$BAIT_VERIFIED" = "success" ]; then
             echo "  ✓ Editor Bait. PASSED (editor removed bait + pushed fix commit)"
           else

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -855,7 +855,7 @@ jobs:
           if [ "${PR_STATE}" = "closed" ] || [ "${PR_MERGED}" = "true" ]; then
             PR_MERGED_AT=$(printf '%s' "${PR_META}" | jq -r '.merged_at // ""' 2>/dev/null || echo "")
             PR_CLOSED_AT=$(printf '%s' "${PR_META}" | jq -r '.closed_at // ""' 2>/dev/null || echo "")
-            echo "::error::PR #${PR_NUMBER} is already ${PR_STATE} (merged=${PR_MERGED}, merged_at=${PR_MERGED_AT}, closed_at=${PR_CLOSED_AT}) before bait could be injected — pushes to the head branch will not fan out a pull_request synchronize event, so no review_autofix run will be triggered. Likely cause: review_autofix.yml's deterministic-skip-merge job auto-merged the PR before the e2e gate's force-review/e2e-smoke-test labels took effect (see implement.yml 'Apply E2E smoke-test labels to PR' step and review_autofix.yml 'Enable auto-merge on PR' step's e2e-smoke-test guard)."
+            echo "::error::PR #${PR_NUMBER} is already ${PR_STATE} (merged=${PR_MERGED}, merged_at=${PR_MERGED_AT}, closed_at=${PR_CLOSED_AT}) before bait could be injected — pushes to the head branch will not fan out a pull_request synchronize event, so no review_autofix run will be triggered. Likely cause: review_autofix.yml's deterministic-skip-merge job auto-merged the PR before the e2e gate's force-review/e2e-smoke-test labels took effect (see implement.yml steps 'Ensure E2E smoke-test labels exist on repo' / 'Backstop E2E smoke-test labels on PR after creation' and review_autofix.yml 'Enable auto-merge on PR' step's e2e-smoke-test guard)."
             echo "status=pr_already_closed" >> "$GITHUB_OUTPUT"
             echo "marker=${BAIT_MARKER}" >> "$GITHUB_OUTPUT"
             # Exit 0 (not 1) so the implicit `if: success()` on the
@@ -2234,8 +2234,22 @@ jobs:
           retention-days: 30
 
       # ── Verification summary ───────────────────────────────────
+      # if: always() so the consolidated pass/fail table runs even when
+      # an upstream phase exits non-zero. Without this, an intermediate
+      # phase failure (e.g., wait-review hitting its own timeout) would
+      # short-circuit the job at the implicit `if: success()` and skip
+      # this summary, hiding the per-phase outcomes — including the
+      # `pr_already_closed` special-case from inject-bait, which the
+      # multi-reviewer claude-branch-review flagged as fragile in the
+      # success-only chaining model. Each step output is read via
+      # `${{ steps.X.outputs.Y }}` which evaluates to empty string for
+      # skipped/unset steps; the comparison logic below treats anything
+      # other than the expected "success" / "completed_with_findings"
+      # values as a phase failure and sets PASSED=false, so missing
+      # outputs correctly fail the test.
       - name: Verify all phases passed
         id: verify
+        if: always()
         env:
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
           PR_NUMBER: ${{ steps.wait-implement.outputs.pr_number }}

--- a/scripts/label_helpers.sh
+++ b/scripts/label_helpers.sh
@@ -55,6 +55,7 @@ declare -A _AI_LABEL_COLORS=(
 	["ai:needs-prompt-review"]="fbca04"
 	["ai:review-skipped"]="c2e0c6"
 	["force-review"]="fbca04"
+	["e2e-smoke-test"]="5319e7"
 )
 
 declare -A _AI_LABEL_DESCS=(
@@ -93,6 +94,7 @@ declare -A _AI_LABEL_DESCS=(
 	["ai:needs-prompt-review"]="Validation prompt self-heal PR awaiting manual review"
 	["ai:review-skipped"]="Reviewer panel + editor cycle skipped by deterministic gate (doc-only or under size threshold)"
 	["force-review"]="Force a full review_autofix cycle, bypassing the deterministic pre-review skip"
+	["e2e-smoke-test"]="E2E smoke test PR — review_autofix skips auto-merge"
 )
 
 _AI_PHASE_LABELS='["ai:done","ai:implementing","ai:awaiting-approval","ai:planning","ai:clarification","ai:validating","ai:validated","ai:validation-failed","ai:validation-fixing","ai:validation-recovery","ai:ready-to-merge","ai:needs-human","ai:blocked","ai:review-blocked","ai:implementation-failed","ai:merged","ai:closed"]'


### PR DESCRIPTION
## Summary

Fixes the failure mode observed in [run 25150961704](https://github.com/shubhodeep1/coding-workflows/actions/runs/25150961704) where `e2e-smoke-test` timed out for 30 minutes waiting for a `review_autofix` run that could never come.

**Root cause:** the canary edit is doc-only, so `review_autofix.yml`'s `deterministic-skip-merge` job auto-merged PR #1818 at +50s — well before `test-and-mark-stable.yml`'s Phase 3b1 force-review-label / Phase 3c inject-bait steps ran. Pushes to a closed PR's head branch don't fan out a `pull_request synchronize` event, so no `review_autofix` run for the bait SHA was ever created.

`internal-review.yml` triggers on `[opened, synchronize, reopened, ready_for_review, closed]` only — `labeled` is **not** in the list, so a `force-review` label applied after `opened` cannot rewind the gate decision. The fix has to land at PR creation time.

## Changes

1. **`implement.yml`** — when the linked issue title starts with `[E2E Smoke Test]`, set `IS_SMOKE_TEST=true` and atomically apply `force-review` + `e2e-smoke-test` labels via `gh pr create --label`, so they're present at the very first `pull_request: opened` event. A pre-step ensures both labels exist (gh pr create --label fails the whole creation if a label is missing).

2. **`review_autofix.yml`** — `Enable auto-merge on PR` step (codex-agent job) reads PR labels and skips when `e2e-smoke-test` is present. Scoped opt-out: the repo-wide `ENABLE_AUTO_MERGE` var is **not** touched; non-e2e PRs keep auto-merging as before. The `deterministic-skip-merge` job is already disabled by `force-review` (gate.`deterministic_skip` flips to false), so the two labels together cover both auto-merge sites.

3. **`test-and-mark-stable.yml`** — Phase 3c `inject-bait` reads PR state right after the head-stability loop and exits 1 with `status=pr_already_closed` if the PR is closed/merged. Defense-in-depth: turns a 30-minute misleading `no_review_triggered` timeout into an immediate, actionable error. The Phase 7 summary special-cases `pr_already_closed` so operators see the real cause.

## Test plan

- [ ] On next `Test & Mark Stable Release` run, verify implement.yml applies both labels at PR creation (visible in the PR's label list immediately on open).
- [ ] Verify the gate in `review_autofix.yml` reads `force-review` and emits `deterministic_skip=false`, so the codex-agent path runs instead of deterministic-skip-merge.
- [ ] Verify the codex-agent's `Enable auto-merge on PR` step logs `PR #N carries 'e2e-smoke-test' label — auto-merge suppressed`.
- [ ] Verify Phase 3c bait push lands on an open PR and Phase 4 `wait-review` matches the bait-SHA review_autofix run.
- [ ] Synthetic regression check: temporarily drop one of the labels in implement.yml and confirm Phase 3c exits fast with `status=pr_already_closed` instead of waiting 30 minutes (then revert).

https://claude.ai/code/session_01SR35qZ5TXSMxqjxyT3wDYQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SR35qZ5TXSMxqjxyT3wDYQ)_