### PR TITLE
fix(test-and-mark-stable): consolidate soft-error reports across every smoke-test job via deterministic concat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,11 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_test_and_mark_stable_plan_polling_guard.py
 
+      - name: Soft-error report consolidator unit tests
+        run: |
+          set -euo pipefail
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_consolidate_soft_error_reports.py
+
       - name: Workflow log collector coverage gate
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,11 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_consolidate_soft_error_reports.py
 
+      - name: UTF-8-safe Telegram truncation unit tests
+        run: |
+          set -euo pipefail
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_truncate_to_utf8_byte_cap.py
+
       - name: Workflow log collector coverage gate
         run: |
           set -euo pipefail

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -193,7 +193,6 @@ jobs:
       cancel-in-progress: true
     outputs:
       test_passed: ${{ steps.verify.outputs.passed }}
-      soft_error_summary: ${{ steps.soft-error-analyser.outputs.soft_error_summary }}
     env:
       GH_TOKEN: ${{ secrets.GH_PAT }}
       TEST_REPO: ${{ inputs.test_repo || github.repository }}
@@ -202,16 +201,18 @@ jobs:
       POLL_INTERVAL: 10
 
     steps:
-      # Checkout repo at the start so `if: always()` steps (Phase 8 soft-error
-      # analyser, Cleanup test artifacts) can find scripts/ even when an
-      # earlier phase exits non-zero. The original "Checkout repository for
-      # integration tests" step (Phase 5, ~line 1100) is skipped on early
-      # failure, leaving downstream `if: always()` steps with no scripts/
-      # on disk — observed in run 25115169454 where Phase 4b's bait failure
-      # cascaded into `python3: can't open file '...scripts/analyze_soft_errors.py'`
-      # and `_safe_gh_jq: command not found` in cleanup. The Phase 5 checkout
-      # is left in place (idempotent re-checkout against `ref: main`).
-      - name: Checkout repository (early — needed by Phase 8 & Cleanup on early failure)
+      # Checkout repo at the start so `if: always()` steps (per-phase
+      # soft-error analyser invocations, Cleanup test artifacts) can find
+      # scripts/ even when an earlier phase exits non-zero. The original
+      # "Checkout repository for integration tests" step (Phase 5,
+      # ~line 1100) is skipped on early failure, leaving downstream
+      # `if: always()` steps with no scripts/ on disk — observed in
+      # run 25115169454 where Phase 4b's bait failure cascaded into
+      # `python3: can't open file '...scripts/analyze_soft_errors.py'`
+      # and `_safe_gh_jq: command not found` in cleanup. The Phase 5
+      # checkout is left in place (idempotent re-checkout against
+      # `ref: main`).
+      - name: Checkout repository (early — needed by analyser & cleanup on early failure)
         uses: actions/checkout@v5
         with:
           ref: main
@@ -1665,8 +1666,9 @@ jobs:
 
             CUR_STATE="labels=${LABELS};poller=${POLLER_STATUS};conclusion=${POLLER_CONCLUSION}"
 
-            # Capture the latest poller run id (used by Phase 8's soft-error
-            # analyser to ingest the poller's logs alongside other phases).
+            # Capture the latest poller run id (used by the per-phase
+            # soft-error analyser invocation below to ingest the poller's
+            # logs as the `orchestrate_poll` phase artifact).
             if [ -n "${POLLER_RUN}" ] && [ "${POLLER_RUN}" != "null" ]; then
               POLLER_LATEST_ID=$(echo "${POLLER_RUN}" | jq -r '.id // empty')
               if [ -n "${POLLER_LATEST_ID}" ]; then
@@ -2081,118 +2083,14 @@ jobs:
           model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
           reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
 
-      # ── Phase 8: Soft-error analyser (non-blocking) ─────────────
-      # Pulls logs from every triggered phase run, filters to high-signal
-      # lines, and asks gpt-5.4-mini @ medium reasoning to summarise soft
-      # failures (rate-limit recoveries, codex fallbacks, summariser hard
-      # fails, etc.). The report is exposed as a job output so the notify
-      # job can attach it to the Telegram release message. Hard exits are
-      # avoided — analyser problems must never block a release.
-      # Wait briefly for every captured phase run to reach
-      # status=completed. The previous Phase 8 fired the moment Phase 7
-      # finished; on run 25126757724 that raced review_autofix's tail
-      # cleanup steps, so `gh run view --log` returned HTTP 404 ("run is
-      # still in progress") and the resulting report had no review_autofix
-      # signal at all (the phase that actually contained the root cause).
-      # The wait below caps at 5 minutes — long enough for review_autofix's
-      # cleanup tail (~40s on the failing run) and any orchestrate-poll /
-      # cancel-on-pr-close trailers to settle, short enough that a
-      # genuinely hung run does not block the release-gate Telegram
-      # notification indefinitely.
-      - name: "Phase 8a: Wait for all phase runs to complete"
-        id: phase8_wait
-        if: always()
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-          CLARIFY_RUN_ID: ${{ steps.wait-clarify.outputs.run_id }}
-          PLAN_RUN_ID: ${{ steps.wait-plan.outputs.run_id }}
-          IMPL_RUN_ID: ${{ steps.wait-implement.outputs.run_id }}
-          REVIEW_RUN_ID: ${{ steps.wait-review.outputs.review_run_id }}
-          RBSIM_POLLER_RUN_ID: ${{ steps.review-blocked-sim.outputs.poller_run_id }}
-          CANCEL_RUN_ID: ${{ steps.verify-cancel-on-close.outputs.cancel_run_id }}
-        run: |
-          set -euo pipefail
-          DEADLINE=$(( $(date +%s) + 300 ))
-          for KV in \
-            "clarify:${CLARIFY_RUN_ID:-}" \
-            "plan:${PLAN_RUN_ID:-}" \
-            "implement:${IMPL_RUN_ID:-}" \
-            "review_autofix:${REVIEW_RUN_ID:-}" \
-            "orchestrate_poll:${RBSIM_POLLER_RUN_ID:-}" \
-            "cancel_on_pr_close:${CANCEL_RUN_ID:-}"; do
-            PHASE="${KV%%:*}"
-            RID="${KV#*:}"
-            [ -n "${RID}" ] && [[ "${RID}" =~ ^[0-9]+$ ]] || continue
-            while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
-              STATUS=$(gh api "repos/${TEST_REPO}/actions/runs/${RID}" --jq '.status // ""' 2>/dev/null || echo "")
-              if [ "${STATUS}" = "completed" ]; then
-                echo "  ✓ ${PHASE} (run #${RID}) completed"
-                break
-              fi
-              echo "  ⏳ ${PHASE} (run #${RID}) status=${STATUS:-unknown}; waiting ..."
-              sleep 5
-            done
-          done
-
-      - name: "Phase 8: Soft-error log analyser"
-        id: soft-error-analyser
-        if: always()
-        continue-on-error: true
-        env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          LOG_ANALYZER_MODEL: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
-          LOG_ANALYZER_REASONING: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
-          CLARIFY_RUN_ID: ${{ steps.wait-clarify.outputs.run_id }}
-          PLAN_RUN_ID: ${{ steps.wait-plan.outputs.run_id }}
-          IMPL_RUN_ID: ${{ steps.wait-implement.outputs.run_id }}
-          REVIEW_RUN_ID: ${{ steps.wait-review.outputs.review_run_id }}
-          RBSIM_POLLER_RUN_ID: ${{ steps.review-blocked-sim.outputs.poller_run_id }}
-          CANCEL_RUN_ID: ${{ steps.verify-cancel-on-close.outputs.cancel_run_id }}
-        run: |
-          set -euo pipefail
-          REPORT="/tmp/soft_error_report.md"
-          ARGS=(--repo "${TEST_REPO}" --output "${REPORT}")
-          [ -n "${CLARIFY_RUN_ID:-}" ] && ARGS+=(--run "clarify=${CLARIFY_RUN_ID}")
-          [ -n "${PLAN_RUN_ID:-}" ] && ARGS+=(--run "plan=${PLAN_RUN_ID}")
-          [ -n "${IMPL_RUN_ID:-}" ] && ARGS+=(--run "implement=${IMPL_RUN_ID}")
-          [ -n "${REVIEW_RUN_ID:-}" ] && ARGS+=(--run "review_autofix=${REVIEW_RUN_ID}")
-          [ -n "${RBSIM_POLLER_RUN_ID:-}" ] && ARGS+=(--run "orchestrate_poll=${RBSIM_POLLER_RUN_ID}")
-          [ -n "${CANCEL_RUN_ID:-}" ] && ARGS+=(--run "cancel_on_pr_close=${CANCEL_RUN_ID}")
-
-          if [ "${#ARGS[@]}" -le 4 ]; then
-            echo "No phase runs captured; skipping analyser." > "${REPORT}"
-            echo "report_path=${REPORT}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          python3 scripts/analyze_soft_errors.py "${ARGS[@]}" || {
-            echo "::warning::Soft-error analyser exited non-zero — keeping fallback report"
-          }
-          echo "report_path=${REPORT}" >> "$GITHUB_OUTPUT"
-
-          # Truncate the report for downstream consumers (Telegram caps
-          # message bodies at 4096 chars; we leave headroom for the rest of
-          # the release-status text). The full untruncated report is uploaded
-          # as an artifact below.
-          if [ -f "${REPORT}" ]; then
-            head -c 2800 "${REPORT}" > /tmp/soft_error_report_short.md
-            {
-              echo 'soft_error_summary<<SOFT_ERR_EOF'
-              cat /tmp/soft_error_report_short.md
-              echo
-              echo 'SOFT_ERR_EOF'
-            } >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Upload soft-error report artifact
-        if: always() && steps.soft-error-analyser.outputs.report_path != ''
-        uses: actions/upload-artifact@v6
-        with:
-          name: soft-error-report-${{ github.run_id }}
-          path: /tmp/soft_error_report.md
-          if-no-files-found: ignore
-          retention-days: 30
+      # The previous Phase 8 in this job re-ran the LLM analyser across
+      # the 6 captured phases to produce a single combined report and
+      # truncated it byte-wise for the Telegram summary. That step was
+      # removed in favour of a deterministic concat performed in the
+      # `notify` job (see `Consolidate per-phase soft-error reports`),
+      # which can see every smoke-test sibling job's per-phase
+      # artifacts — not just this job's six. The per-phase analyser
+      # invocations above remain the source of truth.
 
       # ── Verification summary ───────────────────────────────────
       - name: Verify all phases passed
@@ -3768,8 +3666,73 @@ jobs:
     needs: [resolve-version, e2e-smoke-test, validate-scripts, orphan-workflows-test, orchestrate-decompose-test, validate-standalone-test, clarify-rejects-unsolvable-test, e2e-alt-model-test, validate, release]
     if: always()
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
+      # ── Consolidated soft-error report ─────────────────────────
+      # Replaces the historical Phase 8 LLM re-summarisation that lived
+      # inside `e2e-smoke-test`. Two reasons for moving this here:
+      #   1. Coverage: `notify` `needs:` every smoke-test job, so it can
+      #      see the per-phase artifacts emitted by orphan-workflows-test
+      #      (workflow_log_analysis, validation_refresh, update_workflows,
+      #      memory_maintenance), orchestrate-decompose-test,
+      #      validate-standalone-test, clarify-rejects-unsolvable-test,
+      #      and e2e-alt-model-test (alt_*). Phase 8 only saw the 6 e2e
+      #      phases.
+      #   2. Fidelity: pure-concat instead of an LLM second-pass means
+      #      every per-phase finding is preserved verbatim. The previous
+      #      flow re-ran the analyser model with an "<800 words" prompt
+      #      cap, which silently dropped findings during consolidation.
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Download per-phase soft-error reports
+        id: download_soft_errors
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@v6
+        with:
+          # `actions/download-artifact@v6` accepts a glob in `pattern`
+          # and downloads matching artifacts from the *current* workflow
+          # run. Each artifact lands in its own subdirectory (default
+          # behaviour); the consolidation script tolerates both that
+          # layout and the flattened `merge-multiple` layout.
+          pattern: soft-error-report-${{ github.run_id }}-*
+          path: /tmp/soft-error-artifacts
+          merge-multiple: false
+
+      - name: Consolidate per-phase soft-error reports
+        id: consolidate_soft_errors
+        if: always()
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/soft-error-artifacts
+          python3 scripts/consolidate_soft_error_reports.py \
+            --input-dir /tmp/soft-error-artifacts \
+            --output-full /tmp/soft_error_report.md \
+            --output-summary /tmp/soft_error_summary.md \
+            --max-summary-bytes 2800
+          echo "report_path=/tmp/soft_error_report.md" >> "$GITHUB_OUTPUT"
+          echo "summary_path=/tmp/soft_error_summary.md" >> "$GITHUB_OUTPUT"
+
+      - name: Upload consolidated soft-error report
+        if: always() && steps.consolidate_soft_errors.outputs.report_path != ''
+        uses: actions/upload-artifact@v6
+        with:
+          # Artifact name preserved for backward compatibility with any
+          # operator tooling that fetches `soft-error-report-<run_id>`.
+          name: soft-error-report-${{ github.run_id }}
+          path: /tmp/soft_error_report.md
+          if-no-files-found: ignore
+          retention-days: 30
+
       - name: Send Telegram notification
         id: tg_send
         env:
@@ -3833,11 +3796,20 @@ jobs:
           fi
           MSG+=$'\n'"Run: ${RUN_URL}"
 
-          # Append the soft-error analyser report (truncated upstream to fit
-          # comfortably within Telegram's 4096-char body cap). Non-blocking
-          # by design: any soft-failure findings are surfaced here so the
-          # release engineer sees them inline with the release notification.
-          SOFT_ERR='${{ needs.e2e-smoke-test.outputs.soft_error_summary }}'
+          # Append the consolidated soft-error summary built by the
+          # `Consolidate per-phase soft-error reports` step above. The
+          # script does section-aware truncation (it drops whole findings
+          # blocks rather than slicing mid-finding) and emits a status
+          # pill listing every phase's analyser status code so the
+          # release engineer can spot analyser failures (call_failed /
+          # api_skipped) at a glance even when there are no findings.
+          # Non-blocking by design: a missing summary file means the
+          # consolidation step itself failed, in which case the
+          # release-status header is still delivered.
+          SOFT_ERR=""
+          if [ -f /tmp/soft_error_summary.md ]; then
+            SOFT_ERR=$(cat /tmp/soft_error_summary.md)
+          fi
           if [ -n "${SOFT_ERR}" ]; then
             MSG+=$'\n\n'"---"$'\n'"${SOFT_ERR}"
           fi

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3792,17 +3792,26 @@ jobs:
 
           # Sanitize SOFT_ERROR_TELEGRAM_BYTES in shell before passing
           # to Python. `set -euo pipefail` is in effect, so a non-integer
-          # repo-var value (empty string, whitespace, "abc", etc.) would
-          # otherwise make argparse exit non-zero and abort the step
-          # before it writes report_path/summary_path — undermining the
-          # documented fail-open intent. Coerce invalid input to the
-          # default (2800) and emit a workflow warning so misconfiguration
-          # is visible without breaking the release-status notification.
+          # repo-var value (whitespace, "abc", etc.) would otherwise make
+          # argparse exit non-zero and abort the step before it writes
+          # report_path/summary_path — undermining the documented
+          # fail-open intent.
+          #
+          # Trimming first means a repo-var saved as `" 3000 "` (with
+          # incidental whitespace) is treated equivalently to `"3000"`
+          # rather than silently falling back to the default. The
+          # subsequent regex accepts any non-negative integer including
+          # `0`, which the Python consolidator interprets as "disable
+          # truncation" via its `max_bytes <= 0` branch — operators
+          # who set `SOFT_ERROR_TELEGRAM_BYTES=0` to opt out of the
+          # cap have their intent honoured rather than overridden.
           SOFT_ERROR_BYTES_RAW="${SOFT_ERROR_TELEGRAM_BYTES:-2800}"
-          if [[ "${SOFT_ERROR_BYTES_RAW}" =~ ^[0-9]+$ ]] && [ "${SOFT_ERROR_BYTES_RAW}" -gt 0 ]; then
-            SOFT_ERROR_BYTES="${SOFT_ERROR_BYTES_RAW}"
+          SOFT_ERROR_BYTES_TRIMMED="${SOFT_ERROR_BYTES_RAW#"${SOFT_ERROR_BYTES_RAW%%[![:space:]]*}"}"
+          SOFT_ERROR_BYTES_TRIMMED="${SOFT_ERROR_BYTES_TRIMMED%"${SOFT_ERROR_BYTES_TRIMMED##*[![:space:]]}"}"
+          if [[ "${SOFT_ERROR_BYTES_TRIMMED}" =~ ^[0-9]+$ ]]; then
+            SOFT_ERROR_BYTES="${SOFT_ERROR_BYTES_TRIMMED}"
           else
-            echo "::warning::Invalid SOFT_ERROR_TELEGRAM_BYTES='${SOFT_ERROR_BYTES_RAW}'; falling back to 2800."
+            echo "::warning::Invalid SOFT_ERROR_TELEGRAM_BYTES='${SOFT_ERROR_BYTES_RAW}' (must be a non-negative integer); falling back to 2800."
             SOFT_ERROR_BYTES=2800
           fi
 

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3682,12 +3682,22 @@ jobs:
       #      every per-phase finding is preserved verbatim. The previous
       #      flow re-ran the analyser model with an "<800 words" prompt
       #      cap, which silently dropped findings during consolidation.
+      # The notify job runs `if: always()` to deliver a Telegram message
+      # even when earlier jobs fail. Each setup step below is marked
+      # fail-open so a transient checkout/setup-python/download outage
+      # cannot suppress the release-status notification — the
+      # consolidation step degrades gracefully (empty-input stub) and
+      # the Telegram send step itself is `if: always()`.
       - name: Checkout repository
+        if: always()
+        continue-on-error: true
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Setup Python
+        if: always()
+        continue-on-error: true
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -3735,6 +3745,13 @@ jobs:
 
       - name: Send Telegram notification
         id: tg_send
+        # Always send the release-status notification, even if any of the
+        # upstream consolidation steps (checkout / setup-python / download
+        # / consolidate) failed. Without `if: always()` a single failure
+        # in those steps would suppress the notification entirely; the
+        # Telegram body simply omits the soft-error summary when its
+        # source file is missing.
+        if: always()
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3721,6 +3721,14 @@ jobs:
         id: consolidate_soft_errors
         if: always()
         continue-on-error: true
+        env:
+          # Surface the download step's outcome so the consolidator can
+          # emit a clearly-marked "download failed" stub if the input
+          # directory is empty for that reason — without this, a
+          # transient download outage would silently produce a "no
+          # findings" stub identical to a clean run, masking real
+          # per-phase findings that exist upstream.
+          DOWNLOAD_OUTCOME: ${{ steps.download_soft_errors.outcome }}
         run: |
           set -euo pipefail
           mkdir -p /tmp/soft-error-artifacts
@@ -3728,7 +3736,8 @@ jobs:
             --input-dir /tmp/soft-error-artifacts \
             --output-full /tmp/soft_error_report.md \
             --output-summary /tmp/soft_error_summary.md \
-            --max-summary-bytes 2800
+            --max-summary-bytes 2800 \
+            --download-status "${DOWNLOAD_OUTCOME:-unknown}"
           echo "report_path=/tmp/soft_error_report.md" >> "$GITHUB_OUTPUT"
           echo "summary_path=/tmp/soft_error_summary.md" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3689,6 +3689,7 @@ jobs:
       # consolidation step degrades gracefully (empty-input stub) and
       # the Telegram send step itself is `if: always()`.
       - name: Checkout repository
+        id: checkout_repo
         if: always()
         continue-on-error: true
         uses: actions/checkout@v5
@@ -3696,6 +3697,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Python
+        id: setup_python
         if: always()
         continue-on-error: true
         uses: actions/setup-python@v6
@@ -3729,17 +3731,55 @@ jobs:
           # findings" stub identical to a clean run, masking real
           # per-phase findings that exist upstream.
           DOWNLOAD_OUTCOME: ${{ steps.download_soft_errors.outcome }}
+          CHECKOUT_OUTCOME: ${{ steps.checkout_repo.outcome || 'success' }}
+          SETUP_PYTHON_OUTCOME: ${{ steps.setup_python.outcome || 'success' }}
         run: |
           set -euo pipefail
+          REPORT="/tmp/soft_error_report.md"
+          SUMMARY="/tmp/soft_error_summary.md"
           mkdir -p /tmp/soft-error-artifacts
+
+          # Fail-open shell fallback: if the upstream Checkout or
+          # Setup-Python steps failed (both are `continue-on-error: true`),
+          # the consolidator script and/or python3 may not be on disk.
+          # Without this guard, the `python3 scripts/...` invocation below
+          # would `set -e` exit the step before writing stub files, and
+          # the Telegram step would have nothing to attach. Detect the
+          # missing prerequisites and emit the same stub shape the
+          # consolidator would have, so downstream behaviour matches the
+          # documented fail-open intent.
+          if ! command -v python3 >/dev/null 2>&1 \
+             || [ ! -f scripts/consolidate_soft_error_reports.py ]; then
+            REASON="checkout=${CHECKOUT_OUTCOME} setup_python=${SETUP_PYTHON_OUTCOME}"
+            echo "::warning::Consolidator unavailable (${REASON}); writing fallback stub."
+            {
+              echo "# Consolidated soft-error report"
+              echo
+              echo "**CONSOLIDATOR UNAVAILABLE.** The notify job's"
+              echo "Checkout / Setup-Python step failed (${REASON}), so the"
+              echo "consolidation script could not be executed. Per-phase"
+              echo "soft-error artifacts may still exist upstream — inspect"
+              echo "the run's artifact list for"
+              echo "\`soft-error-report-<run_id>-<phase>\` entries."
+            } > "${REPORT}"
+            {
+              echo "## Soft-error consolidation"
+              echo "_CONSOLIDATOR UNAVAILABLE (${REASON}); inspect per-phase"
+              echo "artifacts directly in the run summary._"
+            } > "${SUMMARY}"
+            echo "report_path=${REPORT}" >> "$GITHUB_OUTPUT"
+            echo "summary_path=${SUMMARY}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           python3 scripts/consolidate_soft_error_reports.py \
             --input-dir /tmp/soft-error-artifacts \
-            --output-full /tmp/soft_error_report.md \
-            --output-summary /tmp/soft_error_summary.md \
+            --output-full "${REPORT}" \
+            --output-summary "${SUMMARY}" \
             --max-summary-bytes 2800 \
             --download-status "${DOWNLOAD_OUTCOME:-unknown}"
-          echo "report_path=/tmp/soft_error_report.md" >> "$GITHUB_OUTPUT"
-          echo "summary_path=/tmp/soft_error_summary.md" >> "$GITHUB_OUTPUT"
+          echo "report_path=${REPORT}" >> "$GITHUB_OUTPUT"
+          echo "summary_path=${SUMMARY}" >> "$GITHUB_OUTPUT"
 
       - name: Upload consolidated soft-error report
         if: always() && steps.consolidate_soft_errors.outputs.report_path != ''

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3750,15 +3750,22 @@ jobs:
 
           # Fail-open shell fallback: if the upstream Checkout or
           # Setup-Python steps failed (both are `continue-on-error: true`),
-          # the consolidator script and/or python3 may not be on disk.
-          # Without this guard, the `python3 scripts/...` invocation below
-          # would `set -e` exit the step before writing stub files, and
-          # the Telegram step would have nothing to attach. Detect the
-          # missing prerequisites and emit the same stub shape the
-          # consolidator would have, so downstream behaviour matches the
-          # documented fail-open intent.
+          # python3 and/or one of the consolidation scripts may not be on
+          # disk. Without this guard, the `python3 scripts/...` invocation
+          # below would `set -e` exit the step before writing stub files,
+          # and the Telegram step would have nothing to attach.
+          #
+          # We check BOTH helper scripts because the consolidator imports
+          # `truncate_to_utf8_byte_cap` as a sibling module — if that
+          # helper is missing or renamed (e.g. partial checkout, future
+          # refactor), the python invocation would `ImportError` before
+          # writing stubs. Belt-and-braces: also wrap the python call in
+          # an `||` fallback so any *other* unanticipated failure (env
+          # var corruption, missing system dep, etc.) still yields stub
+          # outputs rather than aborting the step.
           if ! command -v python3 >/dev/null 2>&1 \
-             || [ ! -f scripts/consolidate_soft_error_reports.py ]; then
+             || [ ! -f scripts/consolidate_soft_error_reports.py ] \
+             || [ ! -f scripts/truncate_to_utf8_byte_cap.py ]; then
             REASON="checkout=${CHECKOUT_OUTCOME} setup_python=${SETUP_PYTHON_OUTCOME}"
             echo "::warning::Consolidator unavailable (${REASON}); writing fallback stub."
             # Lead with the actual diagnostic — the failed step is the
@@ -3815,12 +3822,35 @@ jobs:
             SOFT_ERROR_BYTES=2800
           fi
 
-          python3 scripts/consolidate_soft_error_reports.py \
-            --input-dir /tmp/soft-error-artifacts \
-            --output-full "${REPORT}" \
-            --output-summary "${SUMMARY}" \
-            --max-summary-bytes "${SOFT_ERROR_BYTES}" \
-            --download-status "${DOWNLOAD_OUTCOME:-unknown}"
+          # `||` fallback: any unanticipated failure (system Python
+          # missing a stdlib module, OS-level error before argparse
+          # runs, etc.) still yields stub outputs so the Telegram
+          # step has something to attach. The script itself is
+          # already non-blocking for the documented failure modes
+          # (missing inputs, decode errors, OpenRouter outages),
+          # so this branch only fires for genuinely unexpected
+          # crashes.
+          if ! python3 scripts/consolidate_soft_error_reports.py \
+              --input-dir /tmp/soft-error-artifacts \
+              --output-full "${REPORT}" \
+              --output-summary "${SUMMARY}" \
+              --max-summary-bytes "${SOFT_ERROR_BYTES}" \
+              --download-status "${DOWNLOAD_OUTCOME:-unknown}"; then
+            echo "::warning::Consolidator exited non-zero unexpectedly; writing fallback stub."
+            {
+              echo "# Consolidated soft-error report"
+              echo
+              echo "**CONSOLIDATOR CRASHED.** \`scripts/consolidate_soft_error_reports.py\`"
+              echo "exited non-zero. The script is documented as non-blocking,"
+              echo "so this is unexpected — inspect the notify-job logs for"
+              echo "the traceback. Per-phase artifacts may still be available"
+              echo "as separate \`soft-error-report-<run_id>-<phase>\` entries."
+            } > "${REPORT}"
+            {
+              echo "## Soft-error consolidation"
+              echo "_CONSOLIDATOR CRASHED unexpectedly; see notify-job logs_"
+            } > "${SUMMARY}"
+          fi
           echo "report_path=${REPORT}" >> "$GITHUB_OUTPUT"
           echo "summary_path=${SUMMARY}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3990,12 +3990,20 @@ jobs:
           # `wc -c` output may include leading whitespace on some
           # implementations (BSD-derived `wc` pads with spaces; GNU
           # `wc` on `ubuntu-latest` typically does not). Under
-          # `set -euo pipefail`, a non-integer `MSG_BYTES` like
-          # `"  4500"` would make `[ -gt 4000 ]` exit with a numeric-
-          # comparison error, aborting the Telegram step before the
-          # send. Strip whitespace defensively so the comparison is
-          # robust to any future runner image change.
+          # `set -euo pipefail`, a non-integer `MSG_BYTES` would make
+          # `[ -gt 4000 ]` exit with a numeric-comparison error,
+          # aborting the Telegram step before the send. Strip
+          # whitespace defensively, then validate the result is
+          # actually numeric — if any future `wc` impl emits
+          # genuinely non-numeric padding (unlikely but cheap to guard
+          # against), skip truncation and let the message go through.
+          # Erring on the side of "send the message" matches the
+          # documented fail-open intent of the notify job.
           MSG_BYTES=$(printf '%s' "${MSG}" | wc -c | tr -d '[:space:]')
+          if ! [[ "${MSG_BYTES}" =~ ^[0-9]+$ ]]; then
+            echo "::warning::wc -c produced non-integer output '${MSG_BYTES}'; skipping truncation."
+            MSG_BYTES=0
+          fi
           if [ "${MSG_BYTES}" -gt 4000 ]; then
             if command -v python3 >/dev/null 2>&1 \
                && [ -f scripts/truncate_to_utf8_byte_cap.py ]; then

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3924,8 +3924,35 @@ jobs:
           fi
 
           # Telegram caps message bodies at 4096 chars; trim if necessary.
-          if [ "${#MSG}" -gt 4000 ]; then
-            MSG="${MSG:0:3950}"$'\n'"…[truncated; see artifact 'soft-error-report-${{ github.run_id }}']"
+          # The consolidator already does section-aware truncation up to
+          # 2800 bytes, and the typical release-status header (job-status
+          # pills + run URL) is ~300–500 bytes — so the combined message
+          # is normally well under 4096. This block is the fallback for
+          # the rare overflow case (large header, multi-line failure
+          # status, or operator-raised SOFT_ERROR_TELEGRAM_BYTES).
+          #
+          # Using bash's `${MSG:0:3950}` here can mid-byte-split a
+          # multi-byte UTF-8 sequence — the consolidated summary
+          # routinely contains ✓/✗/⏳/em-dashes, and the consolidator's
+          # status pill uses backticks plus phase names. A mid-codepoint
+          # slice corrupts the rendered Telegram message and (worse)
+          # makes the byte-count diverge from the visible character
+          # count. Hand off to scripts/truncate_to_utf8_byte_cap.py
+          # for codepoint-boundary-aware truncation. python3 is always
+          # preinstalled at /usr/bin/python3 on `ubuntu-latest`, even
+          # when `actions/setup-python` fails. If the helper script is
+          # itself unavailable (checkout failed), fall back to the
+          # legacy byte-slice — best-effort defence-in-depth so the
+          # notification still goes out.
+          MSG_BYTES=$(printf '%s' "${MSG}" | wc -c)
+          if [ "${MSG_BYTES}" -gt 4000 ]; then
+            if command -v python3 >/dev/null 2>&1 \
+               && [ -f scripts/truncate_to_utf8_byte_cap.py ]; then
+              MSG=$(printf '%s' "${MSG}" | python3 scripts/truncate_to_utf8_byte_cap.py 3950)
+            else
+              MSG="${MSG:0:3950}"
+            fi
+            MSG+=$'\n'"…[truncated; see artifact 'soft-error-report-${{ github.run_id }}']"
           fi
 
           # Send notification (persists — not auto-deleted)

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3733,6 +3733,15 @@ jobs:
           DOWNLOAD_OUTCOME: ${{ steps.download_soft_errors.outcome }}
           CHECKOUT_OUTCOME: ${{ steps.checkout_repo.outcome || 'success' }}
           SETUP_PYTHON_OUTCOME: ${{ steps.setup_python.outcome || 'success' }}
+          # Tunable Telegram-summary byte cap. Default 2800 leaves
+          # headroom under Telegram's 4096-char body cap for the rest
+          # of the release-status text (job-status pill, run URL, etc.);
+          # operators can override via repo var `SOFT_ERROR_TELEGRAM_BYTES`
+          # if the rest of the message body changes shape (e.g. more
+          # smoke-test sibling jobs are added). Pattern matches the
+          # other tunables in this workflow (`vars.LOG_ANALYZER_MODEL`
+          # / `vars.LOG_ANALYZER_REASONING`).
+          SOFT_ERROR_TELEGRAM_BYTES: ${{ vars.SOFT_ERROR_TELEGRAM_BYTES || '2800' }}
         run: |
           set -euo pipefail
           REPORT="/tmp/soft_error_report.md"
@@ -3752,20 +3761,29 @@ jobs:
              || [ ! -f scripts/consolidate_soft_error_reports.py ]; then
             REASON="checkout=${CHECKOUT_OUTCOME} setup_python=${SETUP_PYTHON_OUTCOME}"
             echo "::warning::Consolidator unavailable (${REASON}); writing fallback stub."
+            # Lead with the actual diagnostic — the failed step is the
+            # primary failure here, NOT a missing soft-error artifact.
+            # An earlier draft suggested inspecting per-phase artifacts
+            # first, but reviewers flagged that as misleading because it
+            # can send operators chasing the wrong cause; the per-phase
+            # artifacts may exist (they are uploaded by their own
+            # parent jobs, independent of this notify-job checkout) but
+            # the fix lives in the notify-job logs, not the artifacts.
             {
               echo "# Consolidated soft-error report"
               echo
               echo "**CONSOLIDATOR UNAVAILABLE.** The notify job's"
-              echo "Checkout / Setup-Python step failed (${REASON}), so the"
-              echo "consolidation script could not be executed. Per-phase"
-              echo "soft-error artifacts may still exist upstream — inspect"
-              echo "the run's artifact list for"
-              echo "\`soft-error-report-<run_id>-<phase>\` entries."
+              echo "Checkout / Setup-Python step failed (${REASON}); the"
+              echo "consolidation script could not be executed. To"
+              echo "diagnose, open this workflow run and inspect the"
+              echo "failed step's logs in the notify job — the per-phase"
+              echo "soft-error artifacts (uploaded by their own parent"
+              echo "jobs) are unrelated to this failure path."
             } > "${REPORT}"
             {
               echo "## Soft-error consolidation"
-              echo "_CONSOLIDATOR UNAVAILABLE (${REASON}); inspect per-phase"
-              echo "artifacts directly in the run summary._"
+              echo "_CONSOLIDATOR UNAVAILABLE (${REASON}); see the notify"
+              echo "job's failed step logs for the root cause._"
             } > "${SUMMARY}"
             echo "report_path=${REPORT}" >> "$GITHUB_OUTPUT"
             echo "summary_path=${SUMMARY}" >> "$GITHUB_OUTPUT"
@@ -3776,7 +3794,7 @@ jobs:
             --input-dir /tmp/soft-error-artifacts \
             --output-full "${REPORT}" \
             --output-summary "${SUMMARY}" \
-            --max-summary-bytes 2800 \
+            --max-summary-bytes "${SOFT_ERROR_TELEGRAM_BYTES}" \
             --download-status "${DOWNLOAD_OUTCOME:-unknown}"
           echo "report_path=${REPORT}" >> "$GITHUB_OUTPUT"
           echo "summary_path=${SUMMARY}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3807,18 +3807,20 @@ jobs:
           # Trimming first means a repo-var saved as `" 3000 "` (with
           # incidental whitespace) is treated equivalently to `"3000"`
           # rather than silently falling back to the default. The
-          # subsequent regex accepts any non-negative integer including
-          # `0`, which the Python consolidator interprets as "disable
-          # truncation" via its `max_bytes <= 0` branch — operators
-          # who set `SOFT_ERROR_TELEGRAM_BYTES=0` to opt out of the
-          # cap have their intent honoured rather than overridden.
+          # subsequent regex accepts any integer (incl. negatives like
+          # `-1`); both `0` and any negative value flow through to the
+          # Python consolidator's `max_bytes <= 0` branch which disables
+          # truncation entirely. Operators who set
+          # `SOFT_ERROR_TELEGRAM_BYTES=0` (or `-1`, by historical
+          # convention from other helpers in this repo) to opt out of
+          # the cap have their intent honoured rather than overridden.
           SOFT_ERROR_BYTES_RAW="${SOFT_ERROR_TELEGRAM_BYTES:-2800}"
           SOFT_ERROR_BYTES_TRIMMED="${SOFT_ERROR_BYTES_RAW#"${SOFT_ERROR_BYTES_RAW%%[![:space:]]*}"}"
           SOFT_ERROR_BYTES_TRIMMED="${SOFT_ERROR_BYTES_TRIMMED%"${SOFT_ERROR_BYTES_TRIMMED##*[![:space:]]}"}"
-          if [[ "${SOFT_ERROR_BYTES_TRIMMED}" =~ ^[0-9]+$ ]]; then
+          if [[ "${SOFT_ERROR_BYTES_TRIMMED}" =~ ^-?[0-9]+$ ]]; then
             SOFT_ERROR_BYTES="${SOFT_ERROR_BYTES_TRIMMED}"
           else
-            echo "::warning::Invalid SOFT_ERROR_TELEGRAM_BYTES='${SOFT_ERROR_BYTES_RAW}' (must be a non-negative integer); falling back to 2800."
+            echo "::warning::Invalid SOFT_ERROR_TELEGRAM_BYTES='${SOFT_ERROR_BYTES_RAW}' (must be an integer); falling back to 2800."
             SOFT_ERROR_BYTES=2800
           fi
 
@@ -3836,19 +3838,30 @@ jobs:
               --output-summary "${SUMMARY}" \
               --max-summary-bytes "${SOFT_ERROR_BYTES}" \
               --download-status "${DOWNLOAD_OUTCOME:-unknown}"; then
+            # The script is documented as non-blocking for every known
+            # failure mode (missing inputs, decode errors, OpenRouter
+            # outages), so any non-zero exit reaching this branch is
+            # unexpected — could be a traceback, an argparse failure
+            # from a future arg-format change, an environment-level
+            # OS error, etc. We don't pretend to know which; the stub
+            # just says "exited non-zero" and points at the notify-job
+            # logs.
             echo "::warning::Consolidator exited non-zero unexpectedly; writing fallback stub."
             {
               echo "# Consolidated soft-error report"
               echo
-              echo "**CONSOLIDATOR CRASHED.** \`scripts/consolidate_soft_error_reports.py\`"
-              echo "exited non-zero. The script is documented as non-blocking,"
-              echo "so this is unexpected — inspect the notify-job logs for"
-              echo "the traceback. Per-phase artifacts may still be available"
-              echo "as separate \`soft-error-report-<run_id>-<phase>\` entries."
+              echo "**CONSOLIDATOR EXITED NON-ZERO.**"
+              echo "\`scripts/consolidate_soft_error_reports.py\` returned a"
+              echo "non-zero exit code. The script is documented as non-blocking,"
+              echo "so any non-zero exit is itself a bug worth surfacing —"
+              echo "inspect the notify-job logs for the actual error (traceback,"
+              echo "argparse error, OS-level failure, etc.). Per-phase"
+              echo "artifacts may still be available as separate"
+              echo "\`soft-error-report-<run_id>-<phase>\` entries."
             } > "${REPORT}"
             {
               echo "## Soft-error consolidation"
-              echo "_CONSOLIDATOR CRASHED unexpectedly; see notify-job logs_"
+              echo "_CONSOLIDATOR EXITED NON-ZERO; see notify-job logs for the actual error_"
             } > "${SUMMARY}"
           fi
           echo "report_path=${REPORT}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3987,7 +3987,15 @@ jobs:
           # itself unavailable (checkout failed), fall back to the
           # legacy byte-slice — best-effort defence-in-depth so the
           # notification still goes out.
-          MSG_BYTES=$(printf '%s' "${MSG}" | wc -c)
+          # `wc -c` output may include leading whitespace on some
+          # implementations (BSD-derived `wc` pads with spaces; GNU
+          # `wc` on `ubuntu-latest` typically does not). Under
+          # `set -euo pipefail`, a non-integer `MSG_BYTES` like
+          # `"  4500"` would make `[ -gt 4000 ]` exit with a numeric-
+          # comparison error, aborting the Telegram step before the
+          # send. Strip whitespace defensively so the comparison is
+          # robust to any future runner image change.
+          MSG_BYTES=$(printf '%s' "${MSG}" | wc -c | tr -d '[:space:]')
           if [ "${MSG_BYTES}" -gt 4000 ]; then
             if command -v python3 >/dev/null 2>&1 \
                && [ -f scripts/truncate_to_utf8_byte_cap.py ]; then

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3950,7 +3950,18 @@ jobs:
                && [ -f scripts/truncate_to_utf8_byte_cap.py ]; then
               MSG=$(printf '%s' "${MSG}" | python3 scripts/truncate_to_utf8_byte_cap.py 3950)
             else
-              MSG="${MSG:0:3950}"
+              # Fallback when checkout/setup-python failed and the helper
+              # script isn't on disk. `${MSG:0:3950}` is char-oriented under
+              # bash's UTF-8 locale (the default in `ubuntu-latest` runners),
+              # so it could char-slice and still leave the message > 3950
+              # BYTES — exactly the case that trips Telegram's body cap.
+              # `head -c` is byte-oriented (POSIX), so the resulting message
+              # is guaranteed to fit even though we may mid-byte-split a
+              # codepoint (Telegram renders that as a U+FFFD glyph at the
+              # tail; not great, but better than message rejection).
+              # The python3 path above is preferred; this is defence-in-
+              # depth for the rare case where it's unavailable.
+              MSG=$(printf '%s' "${MSG}" | head -c 3950)
             fi
             MSG+=$'\n'"…[truncated; see artifact 'soft-error-report-${{ github.run_id }}']"
           fi

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3790,11 +3790,27 @@ jobs:
             exit 0
           fi
 
+          # Sanitize SOFT_ERROR_TELEGRAM_BYTES in shell before passing
+          # to Python. `set -euo pipefail` is in effect, so a non-integer
+          # repo-var value (empty string, whitespace, "abc", etc.) would
+          # otherwise make argparse exit non-zero and abort the step
+          # before it writes report_path/summary_path — undermining the
+          # documented fail-open intent. Coerce invalid input to the
+          # default (2800) and emit a workflow warning so misconfiguration
+          # is visible without breaking the release-status notification.
+          SOFT_ERROR_BYTES_RAW="${SOFT_ERROR_TELEGRAM_BYTES:-2800}"
+          if [[ "${SOFT_ERROR_BYTES_RAW}" =~ ^[0-9]+$ ]] && [ "${SOFT_ERROR_BYTES_RAW}" -gt 0 ]; then
+            SOFT_ERROR_BYTES="${SOFT_ERROR_BYTES_RAW}"
+          else
+            echo "::warning::Invalid SOFT_ERROR_TELEGRAM_BYTES='${SOFT_ERROR_BYTES_RAW}'; falling back to 2800."
+            SOFT_ERROR_BYTES=2800
+          fi
+
           python3 scripts/consolidate_soft_error_reports.py \
             --input-dir /tmp/soft-error-artifacts \
             --output-full "${REPORT}" \
             --output-summary "${SUMMARY}" \
-            --max-summary-bytes "${SOFT_ERROR_TELEGRAM_BYTES}" \
+            --max-summary-bytes "${SOFT_ERROR_BYTES}" \
             --download-status "${DOWNLOAD_OUTCOME:-unknown}"
           echo "report_path=${REPORT}" >> "$GITHUB_OUTPUT"
           echo "summary_path=${SUMMARY}" >> "$GITHUB_OUTPUT"

--- a/scripts/consolidate_soft_error_reports.py
+++ b/scripts/consolidate_soft_error_reports.py
@@ -162,6 +162,27 @@ def parse_status(markdown: str) -> str:
 	return m.group("status") if m else "unknown"
 
 
+def _read_report_safe(path: Path) -> tuple[str | None, str | None]:
+	"""Read a per-phase report, returning (text, error). Fail-open by design.
+
+	A single malformed artifact must not crash the consolidator (the entry-
+	point docstring promises non-blocking behaviour). `OSError` covers
+	missing files / permission issues; reading with `errors="replace"`
+	covers non-UTF-8 byte sequences (e.g. binary garbage in a corrupted
+	artifact) by substituting U+FFFD rather than raising
+	`UnicodeDecodeError`.
+	"""
+	try:
+		# `errors="replace"` is intentional — see docstring above. Any
+		# replacement chars in the input would already be present in the
+		# original analyser report (which itself reads logs with
+		# `errors="replace"`), so this only kicks in for genuinely
+		# corrupted artifacts.
+		return path.read_text(encoding="utf-8", errors="replace"), None
+	except OSError as exc:
+		return None, f"{type(exc).__name__}: {exc}"
+
+
 def build_full_report(ordered: list[tuple[str, Path]]) -> str:
 	"""Concatenate per-phase reports verbatim with phase-banner separators."""
 	parts: list[str] = [
@@ -183,10 +204,9 @@ def build_full_report(ordered: list[tuple[str, Path]]) -> str:
 		"",
 	]
 	for phase, path in ordered:
-		try:
-			body = path.read_text(encoding="utf-8")
-		except OSError as exc:
-			body = f"_(could not read {path.name}: {exc})_"
+		body, err = _read_report_safe(path)
+		if body is None:
+			body = f"_(could not read {path.name}: {err})_"
 		parts.append(f"## Phase: `{phase}`")
 		parts.append("")
 		parts.append(body.rstrip())
@@ -215,9 +235,8 @@ def build_summary(
 	finding_blocks: list[str] = []
 
 	for phase, path in ordered:
-		try:
-			markdown = path.read_text(encoding="utf-8")
-		except OSError:
+		markdown, _err = _read_report_safe(path)
+		if markdown is None:
 			statuses.append((phase, "unreadable"))
 			continue
 		statuses.append((phase, parse_status(markdown)))
@@ -247,23 +266,36 @@ def build_summary(
 		head = "\n".join(lines[: 2 if pill else 1]) + "\n"
 		kept_blocks: list[str] = []
 		running = head
+		# Track the running byte length incrementally to avoid re-encoding
+		# the cumulative string on every iteration (O(n²) → O(n)).
+		running_bytes = len(running.encode("utf-8"))
 		truncation_marker = "\n\n…[truncated for Telegram cap; see consolidated artifact]\n"
 		marker_bytes = len(truncation_marker.encode("utf-8"))
 		for block in finding_blocks:
-			candidate = running + "\n" + block + "\n"
-			if len(candidate.encode("utf-8")) + marker_bytes > max_bytes:
+			# Block separator matches the original concat (`"\n" + block + "\n"`).
+			separator_and_block_bytes = len(("\n" + block + "\n").encode("utf-8"))
+			if running_bytes + separator_and_block_bytes + marker_bytes > max_bytes:
 				break
-			running = candidate
+			running += "\n" + block + "\n"
+			running_bytes += separator_and_block_bytes
 			kept_blocks.append(block)
 		if kept_blocks:
 			summary = running.rstrip() + truncation_marker
 		else:
-			# Even the first block doesn't fit. Truncate it inline.
+			# Even the first block doesn't fit. Truncate at a valid UTF-8
+			# character boundary so we never split a multi-byte codepoint
+			# (release-gate logs contain ✓/✗/⏳/—/etc.). Walking back over
+			# any continuation bytes (top two bits == 0b10) lands `i` on
+			# the start of the next codepoint.
 			budget = max_bytes - len(head.encode("utf-8")) - marker_bytes
 			if budget > 0 and finding_blocks:
-				inline = finding_blocks[0].encode("utf-8")[:budget].decode(
-					"utf-8", errors="ignore"
-				)
+				encoded_block = finding_blocks[0].encode("utf-8")
+				if len(encoded_block) > budget:
+					i = budget
+					while i > 0 and (encoded_block[i] & 0xC0) == 0x80:
+						i -= 1
+					encoded_block = encoded_block[:i]
+				inline = encoded_block.decode("utf-8", errors="ignore")
 				summary = head + "\n" + inline + truncation_marker
 			else:
 				summary = head + truncation_marker

--- a/scripts/consolidate_soft_error_reports.py
+++ b/scripts/consolidate_soft_error_reports.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Consolidate per-phase soft-error reports into one deterministic markdown file.
+
+The release-gate smoke test (`test-and-mark-stable.yml`) emits one soft-error
+report artifact per phase via `.github/actions/run-soft-error-analyzer`. The
+historical Phase 8 analyser then re-summarised the raw logs through OpenRouter
+to produce a single combined report; that step (a) only saw 6 of 17 phases
+because it lived inside `e2e-smoke-test`, and (b) re-ran the LLM with the
+"<800 words" output cap, which dropped per-phase findings during
+consolidation.
+
+This script replaces that step with a pure-concat merge: it reads every
+downloaded per-phase report, concatenates them in a deterministic order, and
+extracts each report's `## Soft errors (per phase)` section to assemble a
+section-aware Telegram summary that fits inside Telegram's 4096-char body cap
+without byte-truncating mid-finding.
+
+Inputs are filesystem-only; no network calls. Non-blocking: missing inputs or
+unparseable reports yield warnings, never hard failures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Canonical phase order. Phases produced by the release-gate smoke test
+# in pipeline order so the consolidated report reads top-to-bottom along
+# the same axis an operator would mentally trace through the workflow.
+# Anything not listed here is sorted alphabetically and appended.
+CANONICAL_PHASE_ORDER = [
+	"clarify",
+	"plan",
+	"implement",
+	"review_autofix",
+	"orchestrate_poll",
+	"cancel_on_pr_close",
+	"workflow_log_analysis",
+	"validation_refresh",
+	"update_workflows",
+	"memory_maintenance",
+	"orchestrate_decompose",
+	"validate_standalone",
+	"clarify_negative",
+	"alt_clarify",
+	"alt_plan",
+	"alt_implement",
+	"alt_review_autofix",
+]
+
+# Per-phase artifact names follow the pattern
+# `soft-error-report-<run_id>-<phase>`. After download via
+# `actions/download-artifact@v6` with `merge-multiple: false` (the default),
+# each artifact lands in its own subdirectory named after the artifact;
+# `merge-multiple: true` flattens them into the input dir. We support both.
+ARTIFACT_NAME_RE = re.compile(r"^soft-error-report-\d+-(?P<phase>.+?)(?:\.md)?$")
+REPORT_FILENAME_RE = re.compile(r"^soft-error-report-\d+-(?P<phase>.+?)\.md$")
+
+# `## Soft errors (per phase)` section header emitted by the per-phase
+# analyser prompt. We extract everything from this header up to (but not
+# including) the next `## ` heading or end-of-file.
+SECTION_HEADER_RE = re.compile(r"^##\s+Soft errors\s+\(per phase\)\s*$", re.MULTILINE)
+NEXT_HEADING_RE = re.compile(r"^##\s+\S", re.MULTILINE)
+
+# Header line emitted by analyze_soft_errors.py:
+# `## Soft-error analyzer (status: <code>, model: ..., reasoning: ...)`
+ANALYSER_HEADER_RE = re.compile(
+	r"^##\s+Soft-error analyzer\s+\(status:\s*`(?P<status>[^`]+)`",
+	re.MULTILINE,
+)
+
+
+def discover_reports(input_dir: Path) -> list[tuple[str, Path]]:
+	"""Return [(phase, markdown_path)] for every per-phase report found.
+
+	Tolerates both layouts produced by `actions/download-artifact@v6`:
+	  - merge-multiple=false (default): each artifact in its own subdir
+	    `<input_dir>/soft-error-report-<run>-<phase>/<artifact>.md`
+	  - merge-multiple=true: flattened into `<input_dir>/<artifact>.md`
+	The artifact contents are written by the composite action as
+	`/tmp/<artifact_name>.md`, so the inner filename matches the artifact
+	name with a `.md` suffix.
+	"""
+	found: list[tuple[str, Path]] = []
+	if not input_dir.is_dir():
+		return found
+
+	# Layout 1: subdir per artifact.
+	for child in sorted(input_dir.iterdir()):
+		if child.is_dir():
+			m = ARTIFACT_NAME_RE.match(child.name)
+			if not m:
+				continue
+			phase = m.group("phase")
+			# Pick the first .md inside the subdir. The composite action
+			# writes exactly one file per artifact, so this is unambiguous.
+			md_files = sorted(child.glob("*.md"))
+			if md_files:
+				found.append((phase, md_files[0]))
+
+	# Layout 2: flattened into input_dir.
+	for md in sorted(input_dir.glob("*.md")):
+		m = REPORT_FILENAME_RE.match(md.name)
+		if not m:
+			continue
+		phase = m.group("phase")
+		# Skip if we already picked this phase up via layout 1.
+		if any(p == phase for p, _ in found):
+			continue
+		found.append((phase, md))
+
+	return found
+
+
+def order_reports(reports: list[tuple[str, Path]]) -> list[tuple[str, Path]]:
+	"""Sort reports by canonical pipeline order, then alphabetically."""
+	canonical_index = {phase: i for i, phase in enumerate(CANONICAL_PHASE_ORDER)}
+	return sorted(
+		reports,
+		key=lambda pair: (canonical_index.get(pair[0], len(canonical_index)), pair[0]),
+	)
+
+
+def extract_findings_section(markdown: str) -> str:
+	"""Return the `## Soft errors (per phase)` section body, or empty string.
+
+	Returns "" when the section is absent or contains only whitespace /
+	"none" / "no findings" placeholders. The caller treats "" as
+	"this phase had no findings worth surfacing in the summary".
+	"""
+	header_match = SECTION_HEADER_RE.search(markdown)
+	if not header_match:
+		return ""
+	start = header_match.end()
+	tail = markdown[start:]
+	next_match = NEXT_HEADING_RE.search(tail)
+	body = tail[: next_match.start()] if next_match else tail
+	body = body.strip()
+	if not body:
+		return ""
+	# Drop placeholder bodies the model emits when it found nothing.
+	lower = body.lower()
+	placeholder_signatures = (
+		"no soft errors",
+		"no findings",
+		"none observed",
+		"no issues",
+		"(none)",
+	)
+	stripped_punct = re.sub(r"[\s\.\-_*`]+", " ", lower).strip()
+	if stripped_punct in {"none", "n a", "na"}:
+		return ""
+	if any(sig in lower and len(body) < 160 for sig in placeholder_signatures):
+		return ""
+	return body
+
+
+def parse_status(markdown: str) -> str:
+	m = ANALYSER_HEADER_RE.search(markdown)
+	return m.group("status") if m else "unknown"
+
+
+def build_full_report(ordered: list[tuple[str, Path]]) -> str:
+	"""Concatenate per-phase reports verbatim with phase-banner separators."""
+	parts: list[str] = [
+		"# Consolidated soft-error report",
+		"",
+		(
+			"Pure concatenation of every per-phase soft-error analyser report "
+			"emitted during this release-gate run. Each section below is the "
+			"verbatim output of `scripts/analyze_soft_errors.py` for one "
+			"phase; no further LLM summarisation is applied at the "
+			"consolidation step."
+		),
+		"",
+		f"Phases included ({len(ordered)}): "
+		+ ", ".join(phase for phase, _ in ordered)
+		+ ".",
+		"",
+		"---",
+		"",
+	]
+	for phase, path in ordered:
+		try:
+			body = path.read_text(encoding="utf-8")
+		except OSError as exc:
+			body = f"_(could not read {path.name}: {exc})_"
+		parts.append(f"## Phase: `{phase}`")
+		parts.append("")
+		parts.append(body.rstrip())
+		parts.append("")
+		parts.append("---")
+		parts.append("")
+	return "\n".join(parts).rstrip() + "\n"
+
+
+def build_summary(
+	ordered: list[tuple[str, Path]],
+	*,
+	max_bytes: int,
+) -> str:
+	"""Build a section-aware Telegram summary.
+
+	Iterates phases in canonical order, extracting each phase's
+	`## Soft errors (per phase)` section and emitting it under a phase
+	heading. If no phase has findings, returns the literal "no findings"
+	stub so the operator can distinguish "analyser ran clean" from
+	"analyser silently broke" (the latter still surfaces via the report
+	header `status` codes which are included up-front).
+	"""
+	lines: list[str] = ["## Soft-error consolidation"]
+	statuses: list[tuple[str, str]] = []
+	finding_blocks: list[str] = []
+
+	for phase, path in ordered:
+		try:
+			markdown = path.read_text(encoding="utf-8")
+		except OSError:
+			statuses.append((phase, "unreadable"))
+			continue
+		statuses.append((phase, parse_status(markdown)))
+		findings = extract_findings_section(markdown)
+		if findings:
+			finding_blocks.append(f"### {phase}\n{findings}")
+
+	# Status pill line — always emitted, lets operator spot analyser
+	# crashes (call_failed / api_skipped / unreadable) at a glance.
+	pill = " ".join(f"{phase}={status}" for phase, status in statuses)
+	if pill:
+		lines.append(f"_status:_ {pill}")
+		lines.append("")
+
+	if finding_blocks:
+		lines.append("\n\n".join(finding_blocks))
+	else:
+		lines.append("_No soft-error findings reported by any phase._")
+
+	summary = "\n".join(lines).rstrip() + "\n"
+
+	if max_bytes > 0 and len(summary.encode("utf-8")) > max_bytes:
+		# Section-aware truncation: drop whole finding blocks from the
+		# tail until we fit. This preserves the most likely-relevant
+		# (canonical-order earliest) phases over later supplemental
+		# phases. The status pill always survives.
+		head = "\n".join(lines[: 2 if pill else 1]) + "\n"
+		kept_blocks: list[str] = []
+		running = head
+		truncation_marker = "\n\n…[truncated for Telegram cap; see consolidated artifact]\n"
+		marker_bytes = len(truncation_marker.encode("utf-8"))
+		for block in finding_blocks:
+			candidate = running + "\n" + block + "\n"
+			if len(candidate.encode("utf-8")) + marker_bytes > max_bytes:
+				break
+			running = candidate
+			kept_blocks.append(block)
+		if kept_blocks:
+			summary = running.rstrip() + truncation_marker
+		else:
+			# Even the first block doesn't fit. Truncate it inline.
+			budget = max_bytes - len(head.encode("utf-8")) - marker_bytes
+			if budget > 0 and finding_blocks:
+				inline = finding_blocks[0].encode("utf-8")[:budget].decode(
+					"utf-8", errors="ignore"
+				)
+				summary = head + "\n" + inline + truncation_marker
+			else:
+				summary = head + truncation_marker
+	return summary
+
+
+def main() -> int:
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument(
+		"--input-dir",
+		required=True,
+		type=Path,
+		help="Directory containing downloaded per-phase artifacts.",
+	)
+	parser.add_argument(
+		"--output-full",
+		required=True,
+		type=Path,
+		help="Path to write the full concatenated markdown report.",
+	)
+	parser.add_argument(
+		"--output-summary",
+		required=True,
+		type=Path,
+		help="Path to write the section-aware Telegram summary.",
+	)
+	parser.add_argument(
+		"--max-summary-bytes",
+		type=int,
+		default=2800,
+		help=(
+			"Byte cap for the Telegram summary. Set to 0 to disable. "
+			"Default 2800 leaves headroom under Telegram's 4096-char "
+			"body cap for the rest of the release-status message."
+		),
+	)
+	args = parser.parse_args()
+
+	args.output_full.parent.mkdir(parents=True, exist_ok=True)
+	args.output_summary.parent.mkdir(parents=True, exist_ok=True)
+
+	reports = discover_reports(args.input_dir)
+	if not reports:
+		print(
+			f"::warning::consolidate_soft_error_reports: no per-phase reports "
+			f"found in {args.input_dir}; emitting empty consolidation.",
+			file=sys.stderr,
+		)
+		args.output_full.write_text(
+			"# Consolidated soft-error report\n\n"
+			"_No per-phase soft-error artifacts were downloaded._\n",
+			encoding="utf-8",
+		)
+		args.output_summary.write_text(
+			"## Soft-error consolidation\n"
+			"_No per-phase soft-error artifacts were downloaded._\n",
+			encoding="utf-8",
+		)
+		return 0
+
+	ordered = order_reports(reports)
+	args.output_full.write_text(build_full_report(ordered), encoding="utf-8")
+	args.output_summary.write_text(
+		build_summary(ordered, max_bytes=args.max_summary_bytes),
+		encoding="utf-8",
+	)
+
+	print(
+		f"consolidate_soft_error_reports: merged {len(ordered)} phase reports "
+		f"({', '.join(p for p, _ in ordered)}) -> {args.output_full}, "
+		f"summary -> {args.output_summary}",
+		file=sys.stderr,
+	)
+	return 0
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/scripts/consolidate_soft_error_reports.py
+++ b/scripts/consolidate_soft_error_reports.py
@@ -76,9 +76,9 @@ def discover_reports(input_dir: Path) -> list[tuple[str, Path]]:
 	"""Return [(phase, markdown_path)] for every per-phase report found.
 
 	Tolerates both layouts produced by `actions/download-artifact@v6`:
-	  - merge-multiple=false (default): each artifact in its own subdir
-	    `<input_dir>/soft-error-report-<run>-<phase>/<artifact>.md`
-	  - merge-multiple=true: flattened into `<input_dir>/<artifact>.md`
+	(a) merge-multiple=false (default): each artifact in its own
+	subdirectory `<input_dir>/soft-error-report-<run>-<phase>/<file>.md`.
+	(b) merge-multiple=true: flattened into `<input_dir>/<file>.md`.
 	The artifact contents are written by the composite action as
 	`/tmp/<artifact_name>.md`, so the inner filename matches the artifact
 	name with a `.md` suffix.

--- a/scripts/consolidate_soft_error_reports.py
+++ b/scripts/consolidate_soft_error_reports.py
@@ -71,7 +71,28 @@ REPORT_FILENAME_RE = re.compile(r"^soft-error-report-\d+-(?P<phase>.+?)\.md$")
 # analyser prompt. We extract everything from this header up to (but not
 # including) the next `## ` heading or end-of-file.
 SECTION_HEADER_RE = re.compile(r"^##\s+Soft errors\s+\(per phase\)\s*$", re.MULTILINE)
-NEXT_HEADING_RE = re.compile(r"^##\s+\S", re.MULTILINE)
+# Stop the findings extraction at the next KNOWN top-level heading
+# emitted by `analyze_soft_errors.py`'s prompt. Matching any `##` would
+# prematurely truncate findings whose body legitimately contains a
+# `##` line (e.g. an LLM that quoted a log heading or used `##` in
+# its commentary). Anchored to the literal section names so the
+# parser can't be confused by content.
+NEXT_HEADING_RE = re.compile(
+	r"^##\s+(?:Patterns to watch|Likely benign)\b",
+	re.MULTILINE,
+)
+
+# Whole-line placeholder regex. Matches a single line whose entire
+# content (modulo leading bullet/whitespace and trailing punctuation)
+# is one of the known "no findings" sigils the analyser emits. Used to
+# distinguish "the model found nothing" from "the model found
+# something whose text happens to contain the substring 'no findings'".
+PLACEHOLDER_LINE_RE = re.compile(
+	r"^\s*[-*•]?\s*"
+	r"(?:none(?:\s+observed)?|no\s+(?:soft\s+)?(?:errors|findings|issues)|n/?a|\(\s*none\s*\))"
+	r"\s*\.?\s*$",
+	re.IGNORECASE,
+)
 
 # Header line emitted by analyze_soft_errors.py:
 # `## Soft-error analyzer (status: <code>, model: ..., reasoning: ...)`
@@ -197,18 +218,22 @@ def extract_findings_section(markdown: str) -> str:
 	if not body:
 		return ""
 	# Drop placeholder bodies the model emits when it found nothing.
-	lower = body.lower()
-	placeholder_signatures = (
-		"no soft errors",
-		"no findings",
-		"none observed",
-		"no issues",
-		"(none)",
-	)
-	stripped_punct = re.sub(r"[\s\.\-_*`]+", " ", lower).strip()
-	if stripped_punct in {"none", "n a", "na"}:
-		return ""
-	if any(sig in lower and len(body) < 160 for sig in placeholder_signatures):
+	# A previous iteration of this check matched placeholder strings
+	# as substrings against bodies under 160 chars, which incorrectly
+	# filtered out legitimate short findings like "No soft errors were
+	# found in the rate limiting module" — multiple PR reviewers
+	# reproduced the false-positive.
+	#
+	# The current logic is whole-line: if EVERY non-blank line in the
+	# body matches `PLACEHOLDER_LINE_RE` (i.e. the body consists
+	# entirely of placeholder sigils, optionally bullet-prefixed), the
+	# section is empty. A real finding that mentions "no findings" in
+	# prose passes through because that prose line won't match the
+	# anchored regex.
+	non_blank_lines = [ln for ln in body.splitlines() if ln.strip()]
+	if non_blank_lines and all(
+		PLACEHOLDER_LINE_RE.match(ln) for ln in non_blank_lines
+	):
 		return ""
 	return body
 

--- a/scripts/consolidate_soft_error_reports.py
+++ b/scripts/consolidate_soft_error_reports.py
@@ -157,6 +157,26 @@ def extract_findings_section(markdown: str) -> str:
 	return body
 
 
+def _truncate_bytes_at_utf8_boundary(text: str, cap: int) -> str:
+	"""Truncate `text` so its UTF-8 byte length is `<= cap`, on a codepoint
+	boundary. Returns "" when `cap <= 0`. Used as a last-resort guard
+	when the assembled summary head alone would exceed `max_bytes`
+	(degenerate but possible if an operator passes a tiny cap or the
+	status pill explodes for an unusually large run).
+	"""
+	if cap <= 0:
+		return ""
+	encoded = text.encode("utf-8")
+	if len(encoded) <= cap:
+		return text
+	i = cap
+	# Walk back over UTF-8 continuation bytes (top two bits == 0b10) so
+	# the slice never lands inside a multi-byte codepoint.
+	while i > 0 and (encoded[i] & 0xC0) == 0x80:
+		i -= 1
+	return encoded[:i].decode("utf-8", errors="ignore")
+
+
 def parse_status(markdown: str) -> str:
 	m = ANALYSER_HEADER_RE.search(markdown)
 	return m.group("status") if m else "unknown"
@@ -298,16 +318,19 @@ def build_summary(
 				- marker_bytes
 			)
 			if budget > 0 and finding_blocks:
-				encoded_block = finding_blocks[0].encode("utf-8")
-				if len(encoded_block) > budget:
-					i = budget
-					while i > 0 and (encoded_block[i] & 0xC0) == 0x80:
-						i -= 1
-					encoded_block = encoded_block[:i]
-				inline = encoded_block.decode("utf-8", errors="ignore")
+				inline = _truncate_bytes_at_utf8_boundary(finding_blocks[0], budget)
 				summary = head + "\n" + inline + truncation_marker
 			else:
 				summary = head + truncation_marker
+
+	# Last-resort cap guard: if the assembled `head + marker` (or even
+	# `head` alone, on a tiny cap) still overflows `max_bytes`, truncate
+	# the whole summary on a UTF-8 boundary. This keeps the contract
+	# `len(summary.encode('utf-8')) <= max_bytes` an absolute invariant
+	# rather than a best-effort claim, so the Telegram send step can
+	# rely on it without re-checking.
+	if max_bytes > 0 and len(summary.encode("utf-8")) > max_bytes:
+		summary = _truncate_bytes_at_utf8_boundary(summary, max_bytes)
 	return summary
 
 

--- a/scripts/consolidate_soft_error_reports.py
+++ b/scripts/consolidate_soft_error_reports.py
@@ -26,6 +26,15 @@ import re
 import sys
 from pathlib import Path
 
+# Sibling-script import: both this file and `truncate_to_utf8_byte_cap.py`
+# live in scripts/, and the workflow runs us as `python3 scripts/...`,
+# so scripts/ is on sys.path. The pattern matches `ai_memory.py`'s
+# `from ai_memory_lib import ...`. Sharing the truncation algorithm
+# keeps boundary handling in lockstep across both code paths — the
+# tests that exercise the helper indirectly cover the consolidator
+# too.
+from truncate_to_utf8_byte_cap import truncate_bytes_to_utf8_cap
+
 # Canonical phase order. Phases produced by the release-gate smoke test
 # in pipeline order so the consolidated report reads top-to-bottom along
 # the same axis an operator would mentally trace through the workflow.
@@ -159,28 +168,20 @@ def extract_findings_section(markdown: str) -> str:
 
 def _truncate_bytes_at_utf8_boundary(text: str, cap: int) -> str:
 	"""Truncate `text` so its UTF-8 byte length is `<= cap`, on a codepoint
-	boundary. Returns "" when `cap <= 0`. Used as a last-resort guard
-	when the assembled summary head alone would exceed `max_bytes`
-	(degenerate but possible if an operator passes a tiny cap or the
-	status pill explodes for an unusually large run).
+	boundary. Returns "" when `cap <= 0` (per the consolidator's
+	`max_bytes <= 0` opt-out semantic). Wraps the canonical
+	`truncate_bytes_to_utf8_cap` helper so both scripts share boundary
+	handling — see that module's docstring for the algorithm.
 
-	Decodes with `errors="replace"` (mirroring `_read_report_safe`) so
-	any malformed UTF-8 bytes that survived an upstream `errors="replace"`
-	read are still surfaced as visible U+FFFD characters rather than
-	silently dropped — keeps diagnostic behaviour consistent across the
-	two read paths.
+	Decodes with `errors="replace"` so any malformed UTF-8 that survived
+	an upstream `errors="replace"` read surfaces as visible U+FFFD
+	characters rather than silently dropped — diagnostic behaviour stays
+	consistent with `_read_report_safe`.
 	"""
 	if cap <= 0:
 		return ""
-	encoded = text.encode("utf-8")
-	if len(encoded) <= cap:
-		return text
-	i = cap
-	# Walk back over UTF-8 continuation bytes (top two bits == 0b10) so
-	# the slice never lands inside a multi-byte codepoint.
-	while i > 0 and (encoded[i] & 0xC0) == 0x80:
-		i -= 1
-	return encoded[:i].decode("utf-8", errors="replace")
+	truncated = truncate_bytes_to_utf8_cap(text.encode("utf-8"), cap)
+	return truncated.decode("utf-8", errors="replace")
 
 
 def parse_status(markdown: str) -> str:

--- a/scripts/consolidate_soft_error_reports.py
+++ b/scripts/consolidate_soft_error_reports.py
@@ -346,13 +346,11 @@ def main() -> int:
 		default="success",
 		help=(
 			"Outcome of the upstream `actions/download-artifact` step "
-			"(e.g. `success`, `failure`, `cancelled`, `skipped`). When "
-			"the input directory is empty, this lets the stub artifact "
-			"distinguish 'no per-phase analyser ran' (download succeeded "
-			"but produced nothing) from 'download step itself failed' "
-			"(real findings exist upstream but were not retrievable). "
-			"Operators reading the consolidated artifact would otherwise "
-			"see the same empty stub in both cases."
+			"(`success`, `failure`, `cancelled`, or `skipped`). Only "
+			"`failure` and `cancelled` trigger the DOWNLOAD FAILED stub; "
+			"any other value (including `unknown` from broken env "
+			"plumbing) falls through to the neutral 'no artifacts' "
+			"stub so a miswired pipeline cannot fabricate a fake outage."
 		),
 	)
 	args = parser.parse_args()
@@ -362,7 +360,16 @@ def main() -> int:
 
 	reports = discover_reports(args.input_dir)
 	if not reports:
-		download_failed = args.download_status not in ("", "success")
+		# Only escalate to a "DOWNLOAD FAILED" stub for the genuinely
+		# negative GitHub Actions step outcomes — `failure` (the
+		# download step failed under `continue-on-error`) and
+		# `cancelled`. Anything else (`success`, `skipped`, `""`,
+		# `unknown`, or a typo from broken env plumbing) falls through
+		# to the neutral "no artifacts" stub. Default-deny on every
+		# non-success token would make a routine env-var miswire look
+		# identical to a real download outage in the consolidated
+		# artifact, drowning real outage signal in noise.
+		download_failed = args.download_status in ("failure", "cancelled")
 		if download_failed:
 			print(
 				f"::warning::consolidate_soft_error_reports: no per-phase "

--- a/scripts/consolidate_soft_error_reports.py
+++ b/scripts/consolidate_soft_error_reports.py
@@ -286,8 +286,17 @@ def build_summary(
 			# character boundary so we never split a multi-byte codepoint
 			# (release-gate logs contain ✓/✗/⏳/—/etc.). Walking back over
 			# any continuation bytes (top two bits == 0b10) lands `i` on
-			# the start of the next codepoint.
-			budget = max_bytes - len(head.encode("utf-8")) - marker_bytes
+			# the start of the next codepoint. The `+1` accounts for the
+			# `"\n"` separator we'll insert between `head` and `inline`
+			# when assembling the final string — without it we would
+			# overflow `max_bytes` by one byte.
+			separator_bytes = len("\n".encode("utf-8"))
+			budget = (
+				max_bytes
+				- len(head.encode("utf-8"))
+				- separator_bytes
+				- marker_bytes
+			)
 			if budget > 0 and finding_blocks:
 				encoded_block = finding_blocks[0].encode("utf-8")
 				if len(encoded_block) > budget:
@@ -332,6 +341,20 @@ def main() -> int:
 			"body cap for the rest of the release-status message."
 		),
 	)
+	parser.add_argument(
+		"--download-status",
+		default="success",
+		help=(
+			"Outcome of the upstream `actions/download-artifact` step "
+			"(e.g. `success`, `failure`, `cancelled`, `skipped`). When "
+			"the input directory is empty, this lets the stub artifact "
+			"distinguish 'no per-phase analyser ran' (download succeeded "
+			"but produced nothing) from 'download step itself failed' "
+			"(real findings exist upstream but were not retrievable). "
+			"Operators reading the consolidated artifact would otherwise "
+			"see the same empty stub in both cases."
+		),
+	)
 	args = parser.parse_args()
 
 	args.output_full.parent.mkdir(parents=True, exist_ok=True)
@@ -339,21 +362,48 @@ def main() -> int:
 
 	reports = discover_reports(args.input_dir)
 	if not reports:
-		print(
-			f"::warning::consolidate_soft_error_reports: no per-phase reports "
-			f"found in {args.input_dir}; emitting empty consolidation.",
-			file=sys.stderr,
-		)
-		args.output_full.write_text(
-			"# Consolidated soft-error report\n\n"
-			"_No per-phase soft-error artifacts were downloaded._\n",
-			encoding="utf-8",
-		)
-		args.output_summary.write_text(
-			"## Soft-error consolidation\n"
-			"_No per-phase soft-error artifacts were downloaded._\n",
-			encoding="utf-8",
-		)
+		download_failed = args.download_status not in ("", "success")
+		if download_failed:
+			print(
+				f"::warning::consolidate_soft_error_reports: no per-phase "
+				f"reports found in {args.input_dir} AND download step "
+				f"reported `{args.download_status}`; emitting "
+				f"download-failure stub. Real findings may exist upstream.",
+				file=sys.stderr,
+			)
+			full_body = (
+				"# Consolidated soft-error report\n\n"
+				f"**DOWNLOAD FAILED.** The upstream "
+				f"`actions/download-artifact` step reported "
+				f"`{args.download_status}`, so no per-phase soft-error "
+				"artifacts could be retrieved for consolidation. Real "
+				"findings may exist upstream — inspect the individual "
+				"`soft-error-report-<run_id>-<phase>` artifacts directly "
+				"in the run summary.\n"
+			)
+			summary_body = (
+				"## Soft-error consolidation\n"
+				f"_DOWNLOAD FAILED (`{args.download_status}`); per-phase "
+				"artifacts could not be retrieved. Inspect them "
+				"individually in the run's artifact list._\n"
+			)
+		else:
+			print(
+				f"::warning::consolidate_soft_error_reports: no per-phase "
+				f"reports found in {args.input_dir}; emitting empty "
+				f"consolidation.",
+				file=sys.stderr,
+			)
+			full_body = (
+				"# Consolidated soft-error report\n\n"
+				"_No per-phase soft-error artifacts were downloaded._\n"
+			)
+			summary_body = (
+				"## Soft-error consolidation\n"
+				"_No per-phase soft-error artifacts were downloaded._\n"
+			)
+		args.output_full.write_text(full_body, encoding="utf-8")
+		args.output_summary.write_text(summary_body, encoding="utf-8")
 		return 0
 
 	ordered = order_reports(reports)

--- a/scripts/consolidate_soft_error_reports.py
+++ b/scripts/consolidate_soft_error_reports.py
@@ -93,24 +93,71 @@ def discover_reports(input_dir: Path) -> list[tuple[str, Path]]:
 	name with a `.md` suffix.
 	"""
 	found: list[tuple[str, Path]] = []
-	if not input_dir.is_dir():
+	# `is_dir()` itself can raise OSError on transient FS / permission
+	# issues (NFS hiccup, permission-denied on the runner's tmpdir,
+	# stale handle from a half-written download artifact). Treat any
+	# such failure the same as "no reports found" — the script
+	# contract is non-blocking, so a directory we can't even stat
+	# should degrade to the empty stub rather than crash.
+	try:
+		if not input_dir.is_dir():
+			return found
+	except OSError as exc:
+		print(
+			f"::warning::discover_reports: cannot stat input dir "
+			f"{input_dir}: {exc}; treating as empty.",
+			file=sys.stderr,
+		)
 		return found
 
-	# Layout 1: subdir per artifact.
-	for child in sorted(input_dir.iterdir()):
-		if child.is_dir():
-			m = ARTIFACT_NAME_RE.match(child.name)
-			if not m:
+	# Layout 1: subdir per artifact. Wrap the directory walks in
+	# try/except OSError so a permission glitch or transient FS error
+	# on a single subdir doesn't crash the whole consolidator —
+	# matches the docstring's fail-open contract.
+	try:
+		children = sorted(input_dir.iterdir())
+	except OSError as exc:
+		print(
+			f"::warning::discover_reports: iterdir({input_dir}) failed: "
+			f"{exc}; falling through to layout 2.",
+			file=sys.stderr,
+		)
+		children = []
+	for child in children:
+		try:
+			if not child.is_dir():
 				continue
-			phase = m.group("phase")
-			# Pick the first .md inside the subdir. The composite action
-			# writes exactly one file per artifact, so this is unambiguous.
+		except OSError:
+			continue
+		m = ARTIFACT_NAME_RE.match(child.name)
+		if not m:
+			continue
+		phase = m.group("phase")
+		# Pick the first .md inside the subdir. The composite action
+		# writes exactly one file per artifact, so this is unambiguous.
+		try:
 			md_files = sorted(child.glob("*.md"))
-			if md_files:
-				found.append((phase, md_files[0]))
+		except OSError as exc:
+			print(
+				f"::warning::discover_reports: glob({child}/*.md) failed: "
+				f"{exc}; skipping subdir.",
+				file=sys.stderr,
+			)
+			continue
+		if md_files:
+			found.append((phase, md_files[0]))
 
 	# Layout 2: flattened into input_dir.
-	for md in sorted(input_dir.glob("*.md")):
+	try:
+		flat_md = sorted(input_dir.glob("*.md"))
+	except OSError as exc:
+		print(
+			f"::warning::discover_reports: glob({input_dir}/*.md) failed: "
+			f"{exc}; returning what layout 1 found.",
+			file=sys.stderr,
+		)
+		flat_md = []
+	for md in flat_md:
 		m = REPORT_FILENAME_RE.match(md.name)
 		if not m:
 			continue

--- a/scripts/consolidate_soft_error_reports.py
+++ b/scripts/consolidate_soft_error_reports.py
@@ -168,18 +168,22 @@ def extract_findings_section(markdown: str) -> str:
 
 def _truncate_bytes_at_utf8_boundary(text: str, cap: int) -> str:
 	"""Truncate `text` so its UTF-8 byte length is `<= cap`, on a codepoint
-	boundary. Returns "" when `cap <= 0` (per the consolidator's
-	`max_bytes <= 0` opt-out semantic). Wraps the canonical
-	`truncate_bytes_to_utf8_cap` helper so both scripts share boundary
-	handling — see that module's docstring for the algorithm.
+	boundary. Wraps the canonical `truncate_bytes_to_utf8_cap` helper so
+	both scripts share boundary handling — see that module's docstring
+	for the algorithm.
+
+	Callers in this module always invoke this wrapper under
+	`if max_bytes > 0` guards in `build_summary`, so `cap <= 0` is not
+	a reachable path here. The `max_bytes <= 0` operator opt-out
+	("no truncation, return everything") is implemented one level up
+	in `build_summary` itself by skipping the truncation block
+	entirely — this wrapper does not need to mirror that semantic.
 
 	Decodes with `errors="replace"` so any malformed UTF-8 that survived
 	an upstream `errors="replace"` read surfaces as visible U+FFFD
 	characters rather than silently dropped — diagnostic behaviour stays
 	consistent with `_read_report_safe`.
 	"""
-	if cap <= 0:
-		return ""
 	truncated = truncate_bytes_to_utf8_cap(text.encode("utf-8"), cap)
 	return truncated.decode("utf-8", errors="replace")
 

--- a/scripts/consolidate_soft_error_reports.py
+++ b/scripts/consolidate_soft_error_reports.py
@@ -163,6 +163,12 @@ def _truncate_bytes_at_utf8_boundary(text: str, cap: int) -> str:
 	when the assembled summary head alone would exceed `max_bytes`
 	(degenerate but possible if an operator passes a tiny cap or the
 	status pill explodes for an unusually large run).
+
+	Decodes with `errors="replace"` (mirroring `_read_report_safe`) so
+	any malformed UTF-8 bytes that survived an upstream `errors="replace"`
+	read are still surfaced as visible U+FFFD characters rather than
+	silently dropped — keeps diagnostic behaviour consistent across the
+	two read paths.
 	"""
 	if cap <= 0:
 		return ""
@@ -174,7 +180,7 @@ def _truncate_bytes_at_utf8_boundary(text: str, cap: int) -> str:
 	# the slice never lands inside a multi-byte codepoint.
 	while i > 0 and (encoded[i] & 0xC0) == 0x80:
 		i -= 1
-	return encoded[:i].decode("utf-8", errors="ignore")
+	return encoded[:i].decode("utf-8", errors="replace")
 
 
 def parse_status(markdown: str) -> str:

--- a/scripts/truncate_to_utf8_byte_cap.py
+++ b/scripts/truncate_to_utf8_byte_cap.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python3
 """Truncate stdin to a UTF-8 byte cap on a codepoint boundary.
 
-Reads bytes from stdin, writes <= cap bytes to stdout, never splitting
-a multi-byte UTF-8 sequence. Used by the release-gate notify step
-to enforce Telegram's 4096-char body limit without corrupting the
-multi-byte glyphs (✓/✗/⏳/em-dashes) the consolidated soft-error
-summary routinely contains.
+Reads bytes from stdin and writes a UTF-8-safe prefix to stdout that
+never splits a multi-byte UTF-8 sequence. Used by the release-gate
+notify step to enforce Telegram's 4096-char body limit without
+corrupting the multi-byte glyphs (✓/✗/⏳/em-dashes) the consolidated
+soft-error summary routinely contains.
 
 Usage: cat msg.txt | truncate_to_utf8_byte_cap.py <cap>
+
+Output size guarantee. When `cap > 0`, output is `<= cap` bytes and
+ends on a UTF-8 codepoint boundary. When `cap == 0` the script is a
+no-op (writes the input verbatim) — this matches the consolidator's
+`max_bytes <= 0` opt-out semantic for operators who want the full
+summary regardless of size, so the output may exceed `cap` in this
+documented opt-out case. Negative caps are rejected at the CLI layer
+with exit 2.
 
 The library function `truncate_bytes_to_utf8_cap` is the canonical
 truncation algorithm — `scripts/consolidate_soft_error_reports.py`
@@ -26,19 +34,25 @@ import sys
 
 
 def truncate_bytes_to_utf8_cap(data: bytes, cap: int) -> bytes:
-	"""Return a prefix of `data` whose byte length is `<= cap`, ending on
-	a UTF-8 codepoint boundary when the input is valid UTF-8.
+	"""Return a prefix of `data` ending on a UTF-8 codepoint boundary.
 
-	**Contract.** Callers MUST pass valid UTF-8 input. Under that
-	assumption, the returned prefix is the maximal valid-UTF-8 prefix
-	whose length is `<= cap`. For malformed input the function still
-	returns a byte-level prefix obtained by walking back over
-	continuation bytes, but the result is not guaranteed to decode
-	cleanly — that case is out of scope for the release-gate use sites
-	(both the Telegram MSG and the consolidator's per-phase reports
-	originate from `errors="replace"` reads, which always re-encode to
-	valid UTF-8). Adding strict-decode validation here would cost a
-	full decode on every call without benefiting any real call site.
+	**Output size contract.** When `cap > 0`, the returned prefix is
+	`<= cap` bytes long. When `cap <= 0`, truncation is disabled and
+	the input is returned unchanged — the result CAN exceed `cap`
+	(see the "edge cases" paragraph below). Library callers that need
+	a hard `<= cap` upper bound MUST pass `cap > 0`.
+
+	**UTF-8 validity contract.** Callers MUST pass valid UTF-8 input.
+	Under that assumption, the returned prefix is the MAXIMAL
+	valid-UTF-8 prefix whose length is `<= cap`. For malformed input
+	the function still returns a byte-level prefix obtained by walking
+	back over continuation bytes, but the result is not guaranteed to
+	decode cleanly — that case is out of scope for the release-gate
+	use sites (both the Telegram MSG and the consolidator's per-phase
+	reports originate from `errors="replace"` reads, which always
+	re-encode to valid UTF-8). Adding strict-decode validation here
+	would cost a full decode on every call without benefiting any
+	real call site.
 
 	If `data[cap]` (the first byte beyond the cap) is a continuation
 	byte (top two bits == 0b10), the cap fell inside a multi-byte
@@ -46,14 +60,15 @@ def truncate_bytes_to_utf8_cap(data: bytes, cap: int) -> bytes:
 	slice `data[:i]` then ends on a clean codepoint boundary because
 	the codepoint containing `data[cap]` is fully excluded.
 
-	Edge cases. (a) `cap <= 0` returns the input unchanged; this
-	matches operator opt-out semantics at the consolidator level
-	(`max_bytes <= 0` → no truncation), so a CLI invocation
-	`truncate_to_utf8_byte_cap.py 0` is the same as a no-op.
-	A negative `cap` is also treated as a no-op rather than letting
-	Python's negative-index slicing (`data[:-1]`) silently strip a
-	tail byte — the helper is a library function, and library
-	functions should not surprise their callers.
+	Edge cases. (a) `cap <= 0` is the documented opt-out path:
+	returns the input unchanged. This matches operator opt-out
+	semantics at the consolidator level (`max_bytes <= 0` → no
+	truncation), so a CLI invocation `truncate_to_utf8_byte_cap.py 0`
+	is the same as a no-op. A negative `cap` is also treated as a
+	no-op rather than letting Python's negative-index slicing
+	(`data[:-1]`) silently strip a tail byte — the helper is a
+	library function, and library functions should not surprise their
+	callers. NOTE the output may exceed `cap` in this branch.
 	(b) `cap >= len(data)` returns data unchanged — the input already
 	fits, no truncation needed. (c) Malformed UTF-8 input causes the
 	walk-back to step over continuation bytes until it finds a non-

--- a/scripts/truncate_to_utf8_byte_cap.py
+++ b/scripts/truncate_to_utf8_byte_cap.py
@@ -9,6 +9,12 @@ summary routinely contains.
 
 Usage: cat msg.txt | truncate_to_utf8_byte_cap.py <cap>
 
+The library function `truncate_bytes_to_utf8_cap` is the canonical
+truncation algorithm — `scripts/consolidate_soft_error_reports.py`
+imports it so both code paths share boundary handling. Tests for the
+maximality and validity of the algorithm live in
+`tests/test_truncate_to_utf8_byte_cap.py`.
+
 Exit codes are reserved for argument errors only — payload size never
 causes failure (the whole point is to make the truncation a fail-open
 defensive backstop for the Telegram step).
@@ -17,6 +23,39 @@ defensive backstop for the Telegram step).
 from __future__ import annotations
 
 import sys
+
+
+def truncate_bytes_to_utf8_cap(data: bytes, cap: int) -> bytes:
+	"""Return the maximal valid-UTF-8 prefix of `data` whose length is `<= cap`.
+
+	If `data[cap]` (the first byte beyond the cap) is a continuation
+	byte (top two bits == 0b10), the cap fell inside a multi-byte
+	codepoint; walk back to the leader's position and stop there. The
+	slice `data[:i]` then ends on a clean codepoint boundary because
+	the codepoint containing `data[cap]` is fully excluded.
+
+	Edge cases. (a) `cap == 0` returns data unchanged, mirroring the
+	consolidator's `max_bytes <= 0` operator opt-out semantic.
+	(b) `cap >= len(data)` returns data unchanged — the input already
+	fits, no truncation needed. (c) Malformed UTF-8 input causes the
+	walk-back to step over continuation bytes until it finds a non-
+	continuation or hits i=0, returning at most an empty bytes object
+	rather than corrupted output.
+
+	An earlier version of this helper examined `data[i-1]` and
+	unconditionally dropped any leader byte at the boundary. That
+	pattern silently lost a complete codepoint when the cap landed
+	exactly on a codepoint boundary (e.g. cap=4 against `b"αα"`
+	returned `b"α"` instead of `b"αα"`); multiple PR reviewers
+	reproduced the data-loss. The current implementation examines
+	`data[cap]` instead, so an exact-boundary cap is preserved.
+	"""
+	if cap == 0 or len(data) <= cap:
+		return data
+	i = cap
+	while i > 0 and (data[i] & 0xC0) == 0x80:
+		i -= 1
+	return data[:i]
 
 
 def main() -> int:
@@ -33,25 +72,10 @@ def main() -> int:
 		return 2
 
 	data = sys.stdin.buffer.read()
-	if cap == 0 or len(data) <= cap:
-		sys.stdout.buffer.write(data)
-		return 0
-
-	i = cap
-	# Walk back over UTF-8 continuation bytes (top two bits == 0b10) so
-	# the slice never lands inside a multi-byte codepoint.
-	while i > 0 and (data[i - 1] & 0xC0) == 0x80:
-		i -= 1
-	# If the byte just before the boundary is itself a multi-byte leader
-	# (0xC0+) without enough trailing bytes, drop it too — otherwise the
-	# downstream `decode("utf-8")` would surface a U+FFFD for the orphaned
-	# leader and Telegram's renderer would show a literal replacement
-	# glyph in the message body.
-	if i > 0 and data[i - 1] >= 0xC0:
-		i -= 1
-	sys.stdout.buffer.write(data[:i])
+	sys.stdout.buffer.write(truncate_bytes_to_utf8_cap(data, cap))
 	return 0
 
 
 if __name__ == "__main__":
 	sys.exit(main())
+

--- a/scripts/truncate_to_utf8_byte_cap.py
+++ b/scripts/truncate_to_utf8_byte_cap.py
@@ -46,10 +46,14 @@ def truncate_bytes_to_utf8_cap(data: bytes, cap: int) -> bytes:
 	slice `data[:i]` then ends on a clean codepoint boundary because
 	the codepoint containing `data[cap]` is fully excluded.
 
-	Edge cases. (a) `cap == 0` returns the input unchanged; this
+	Edge cases. (a) `cap <= 0` returns the input unchanged; this
 	matches operator opt-out semantics at the consolidator level
 	(`max_bytes <= 0` → no truncation), so a CLI invocation
 	`truncate_to_utf8_byte_cap.py 0` is the same as a no-op.
+	A negative `cap` is also treated as a no-op rather than letting
+	Python's negative-index slicing (`data[:-1]`) silently strip a
+	tail byte — the helper is a library function, and library
+	functions should not surprise their callers.
 	(b) `cap >= len(data)` returns data unchanged — the input already
 	fits, no truncation needed. (c) Malformed UTF-8 input causes the
 	walk-back to step over continuation bytes until it finds a non-
@@ -64,7 +68,7 @@ def truncate_bytes_to_utf8_cap(data: bytes, cap: int) -> bytes:
 	reproduced the data-loss. The current implementation examines
 	`data[cap]` instead, so an exact-boundary cap is preserved.
 	"""
-	if cap == 0 or len(data) <= cap:
+	if cap <= 0 or len(data) <= cap:
 		return data
 	i = cap
 	while i > 0 and (data[i] & 0xC0) == 0x80:

--- a/scripts/truncate_to_utf8_byte_cap.py
+++ b/scripts/truncate_to_utf8_byte_cap.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Truncate stdin to a UTF-8 byte cap on a codepoint boundary.
+
+Reads bytes from stdin, writes <= cap bytes to stdout, never splitting
+a multi-byte UTF-8 sequence. Used by the release-gate notify step
+to enforce Telegram's 4096-char body limit without corrupting the
+multi-byte glyphs (✓/✗/⏳/em-dashes) the consolidated soft-error
+summary routinely contains.
+
+Usage: cat msg.txt | truncate_to_utf8_byte_cap.py <cap>
+
+Exit codes are reserved for argument errors only — payload size never
+causes failure (the whole point is to make the truncation a fail-open
+defensive backstop for the Telegram step).
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> int:
+	if len(sys.argv) != 2:
+		print("usage: truncate_to_utf8_byte_cap.py <cap>", file=sys.stderr)
+		return 2
+	try:
+		cap = int(sys.argv[1])
+	except ValueError:
+		print(f"cap must be an integer, got {sys.argv[1]!r}", file=sys.stderr)
+		return 2
+	if cap < 0:
+		print(f"cap must be non-negative, got {cap}", file=sys.stderr)
+		return 2
+
+	data = sys.stdin.buffer.read()
+	if cap == 0 or len(data) <= cap:
+		sys.stdout.buffer.write(data)
+		return 0
+
+	i = cap
+	# Walk back over UTF-8 continuation bytes (top two bits == 0b10) so
+	# the slice never lands inside a multi-byte codepoint.
+	while i > 0 and (data[i - 1] & 0xC0) == 0x80:
+		i -= 1
+	# If the byte just before the boundary is itself a multi-byte leader
+	# (0xC0+) without enough trailing bytes, drop it too — otherwise the
+	# downstream `decode("utf-8")` would surface a U+FFFD for the orphaned
+	# leader and Telegram's renderer would show a literal replacement
+	# glyph in the message body.
+	if i > 0 and data[i - 1] >= 0xC0:
+		i -= 1
+	sys.stdout.buffer.write(data[:i])
+	return 0
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/scripts/truncate_to_utf8_byte_cap.py
+++ b/scripts/truncate_to_utf8_byte_cap.py
@@ -26,7 +26,19 @@ import sys
 
 
 def truncate_bytes_to_utf8_cap(data: bytes, cap: int) -> bytes:
-	"""Return the maximal valid-UTF-8 prefix of `data` whose length is `<= cap`.
+	"""Return a prefix of `data` whose byte length is `<= cap`, ending on
+	a UTF-8 codepoint boundary when the input is valid UTF-8.
+
+	**Contract.** Callers MUST pass valid UTF-8 input. Under that
+	assumption, the returned prefix is the maximal valid-UTF-8 prefix
+	whose length is `<= cap`. For malformed input the function still
+	returns a byte-level prefix obtained by walking back over
+	continuation bytes, but the result is not guaranteed to decode
+	cleanly — that case is out of scope for the release-gate use sites
+	(both the Telegram MSG and the consolidator's per-phase reports
+	originate from `errors="replace"` reads, which always re-encode to
+	valid UTF-8). Adding strict-decode validation here would cost a
+	full decode on every call without benefiting any real call site.
 
 	If `data[cap]` (the first byte beyond the cap) is a continuation
 	byte (top two bits == 0b10), the cap fell inside a multi-byte
@@ -34,13 +46,15 @@ def truncate_bytes_to_utf8_cap(data: bytes, cap: int) -> bytes:
 	slice `data[:i]` then ends on a clean codepoint boundary because
 	the codepoint containing `data[cap]` is fully excluded.
 
-	Edge cases. (a) `cap == 0` returns data unchanged, mirroring the
-	consolidator's `max_bytes <= 0` operator opt-out semantic.
+	Edge cases. (a) `cap == 0` returns the input unchanged; this
+	matches operator opt-out semantics at the consolidator level
+	(`max_bytes <= 0` → no truncation), so a CLI invocation
+	`truncate_to_utf8_byte_cap.py 0` is the same as a no-op.
 	(b) `cap >= len(data)` returns data unchanged — the input already
 	fits, no truncation needed. (c) Malformed UTF-8 input causes the
 	walk-back to step over continuation bytes until it finds a non-
 	continuation or hits i=0, returning at most an empty bytes object
-	rather than corrupted output.
+	rather than crashing.
 
 	An earlier version of this helper examined `data[i-1]` and
 	unconditionally dropped any leader byte at the boundary. That

--- a/tests/test_consolidate_soft_error_reports.py
+++ b/tests/test_consolidate_soft_error_reports.py
@@ -109,17 +109,25 @@ def test_discover_missing_dir_returns_empty():
 	assert csr.discover_reports(Path("/tmp/this-path-does-not-exist-xyz")) == []
 
 
-def test_discover_oserror_on_iterdir_falls_through_to_layout2():
-	"""Permission-denied / transient FS errors during layout-1 walk
-	must not crash the consolidator. Layout-2 (flat) results should
-	still be returned. Matches the docstring's fail-open contract.
+def test_discover_oserror_on_top_level_iterdir_returns_empty():
+	"""If the top-level `iterdir()` raises OSError, layout-1 discovery
+	is skipped. Layout-2 then runs `glob("*.md")` independently — its
+	own try/except handles glob failures. Combined with no flat-layout
+	files, this returns [].
+
+	Regression: an earlier version of this test used a `Path.iterdir`
+	monkeypatch and asserted that layout-2 still recovered a flat file.
+	That assertion happened to pass because CPython's `Path.glob` does
+	NOT call `Path.iterdir()` internally — the patch only broke
+	layout-1. To avoid testing CPython internals, this test now
+	exercises the simpler invariant: when iterdir fails AND no
+	flat-layout files exist, discovery returns empty (not crash).
+	The per-child OSError path is covered by
+	`test_discover_oserror_on_child_glob_skips_subdir` below.
 	"""
 	import unittest.mock as mock
 	with tempfile.TemporaryDirectory() as tmp:
 		root = Path(tmp)
-		# Drop a flat-layout report so layout-2 has something to find.
-		_write_per_phase_report(root, run_id="9", phase="clarify", findings="x", flatten=True)
-		# Patch iterdir to raise OSError, simulating a transient FS issue.
 		original_iterdir = Path.iterdir
 
 		def _broken_iterdir(self):
@@ -129,8 +137,38 @@ def test_discover_oserror_on_iterdir_falls_through_to_layout2():
 
 		with mock.patch.object(Path, "iterdir", _broken_iterdir):
 			found = csr.discover_reports(root)
-		# Layout-1 walk failed cleanly; layout-2 still picked up clarify.
-		assert [p for p, _ in found] == ["clarify"]
+		assert found == []
+
+
+def test_discover_oserror_on_child_glob_skips_subdir():
+	"""Per-child OSError on layout-1's `child.glob("*.md")` must skip
+	that subdir without aborting the whole walk — sibling subdirs and
+	the layout-2 path keep working.
+	"""
+	import unittest.mock as mock
+	with tempfile.TemporaryDirectory() as tmp:
+		root = Path(tmp)
+		# Two layout-1 subdirs: one will simulate a glob OSError,
+		# the other should be discovered cleanly.
+		_write_per_phase_report(root, run_id="9", phase="clarify", findings="x", flatten=False)
+		_write_per_phase_report(root, run_id="9", phase="plan", findings="y", flatten=False)
+		clarify_dir = root / "soft-error-report-9-clarify"
+
+		original_glob = Path.glob
+
+		def _broken_glob(self, *args, **kwargs):
+			if self == clarify_dir:
+				raise OSError("simulated permission denied on subdir glob")
+			return original_glob(self, *args, **kwargs)
+
+		with mock.patch.object(Path, "glob", _broken_glob):
+			found = csr.discover_reports(root)
+		# The clarify subdir was skipped; plan was still discovered.
+		phases = sorted(p for p, _ in found)
+		assert phases == ["plan"], (
+			f"expected ['plan'], got {phases!r} (clarify should have been "
+			"skipped due to glob OSError)"
+		)
 
 
 def test_discover_oserror_on_is_dir_returns_empty():
@@ -143,6 +181,35 @@ def test_discover_oserror_on_is_dir_returns_empty():
 		with mock.patch.object(Path, "is_dir", side_effect=OSError("stale handle")):
 			found = csr.discover_reports(root)
 		assert found == []
+
+
+def test_discover_oserror_on_per_child_is_dir_skips_child():
+	"""Per-child `is_dir()` OSError must skip that child without
+	crashing — covers the inner `try/except` distinct from the outer
+	one tested in `test_discover_oserror_on_is_dir_returns_empty`.
+	"""
+	import unittest.mock as mock
+	with tempfile.TemporaryDirectory() as tmp:
+		root = Path(tmp)
+		_write_per_phase_report(root, run_id="9", phase="clarify", findings="x", flatten=False)
+		_write_per_phase_report(root, run_id="9", phase="plan", findings="y", flatten=False)
+		clarify_dir = root / "soft-error-report-9-clarify"
+
+		original_is_dir = Path.is_dir
+
+		def _selective_is_dir_raise(self):
+			if self == clarify_dir:
+				raise OSError("simulated stat failure on child")
+			return original_is_dir(self)
+
+		with mock.patch.object(Path, "is_dir", _selective_is_dir_raise):
+			found = csr.discover_reports(root)
+		# clarify skipped due to per-child is_dir failure; plan recovered.
+		phases = sorted(p for p, _ in found)
+		assert phases == ["plan"], (
+			f"expected ['plan'], got {phases!r} (clarify should have been "
+			"skipped due to per-child is_dir OSError)"
+		)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_consolidate_soft_error_reports.py
+++ b/tests/test_consolidate_soft_error_reports.py
@@ -267,6 +267,50 @@ def test_summary_byte_cap_is_absolute_even_when_head_overflows():
 			summary.encode("utf-8").decode("utf-8")
 
 
+def test_zero_cap_disables_truncation():
+	"""max_bytes=0 means the operator opted out of the cap entirely.
+
+	The Python consolidator's `max_bytes <= 0` branch skips the
+	truncation path and returns the full assembled summary. Verifies
+	the contract Python documents (and the new shell sanitization
+	relies on for `SOFT_ERROR_TELEGRAM_BYTES=0`).
+	"""
+	with tempfile.TemporaryDirectory() as tmp:
+		root = Path(tmp)
+		# Make the summary > 2800 bytes so it would normally be truncated.
+		_write_per_phase_report(
+			root, run_id="9", phase="clarify",
+			findings="### clarify\n" + ("X" * 4000),
+		)
+		_, summary = _run_consolidator(root, max_bytes=0)
+		assert len(summary.encode("utf-8")) > 2800, "fixture must exceed default cap"
+		assert "[truncated for Telegram cap" not in summary
+		assert ("X" * 100) in summary
+
+
+def test_truncate_helper_preserves_multibyte_content():
+	"""Truncating after a multi-byte codepoint keeps it intact.
+
+	Walking back over UTF-8 continuation bytes (top two bits == 0b10)
+	must land on a codepoint boundary, so the resulting string round-
+	trips cleanly through `encode("utf-8").decode("utf-8")` even when
+	the requested cap straddles the middle of a 2- or 3-byte sequence.
+	The `errors="replace"` decode setting is defence-in-depth: with
+	the boundary walk in place no malformed sequences should reach
+	the decode call, but if any do they surface as U+FFFD rather
+	than silently disappearing (matching `_read_report_safe`'s
+	`errors="replace"` policy).
+	"""
+	# 'αβγδε' is 5 codepoints × 2 bytes each = 10 bytes total.
+	# Caps of 1..10 should all yield prefixes that decode cleanly.
+	greek = "αβγδε"
+	for cap in range(1, 12):
+		out = csr._truncate_bytes_at_utf8_boundary(greek, cap)
+		# Output must be valid UTF-8 (round-trip with strict decode).
+		out.encode("utf-8").decode("utf-8")
+		assert len(out.encode("utf-8")) <= cap
+
+
 def test_summary_drops_whole_blocks_before_inline_truncation():
 	"""When multiple findings exist, drop later blocks (canonical-order tail) first."""
 	with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_consolidate_soft_error_reports.py
+++ b/tests/test_consolidate_soft_error_reports.py
@@ -109,6 +109,42 @@ def test_discover_missing_dir_returns_empty():
 	assert csr.discover_reports(Path("/tmp/this-path-does-not-exist-xyz")) == []
 
 
+def test_discover_oserror_on_iterdir_falls_through_to_layout2():
+	"""Permission-denied / transient FS errors during layout-1 walk
+	must not crash the consolidator. Layout-2 (flat) results should
+	still be returned. Matches the docstring's fail-open contract.
+	"""
+	import unittest.mock as mock
+	with tempfile.TemporaryDirectory() as tmp:
+		root = Path(tmp)
+		# Drop a flat-layout report so layout-2 has something to find.
+		_write_per_phase_report(root, run_id="9", phase="clarify", findings="x", flatten=True)
+		# Patch iterdir to raise OSError, simulating a transient FS issue.
+		original_iterdir = Path.iterdir
+
+		def _broken_iterdir(self):
+			if self == root:
+				raise OSError("simulated transient FS error")
+			return original_iterdir(self)
+
+		with mock.patch.object(Path, "iterdir", _broken_iterdir):
+			found = csr.discover_reports(root)
+		# Layout-1 walk failed cleanly; layout-2 still picked up clarify.
+		assert [p for p, _ in found] == ["clarify"]
+
+
+def test_discover_oserror_on_is_dir_returns_empty():
+	"""OSError from `input_dir.is_dir()` itself (e.g. stale NFS handle)
+	must degrade to the empty stub rather than crash.
+	"""
+	import unittest.mock as mock
+	with tempfile.TemporaryDirectory() as tmp:
+		root = Path(tmp)
+		with mock.patch.object(Path, "is_dir", side_effect=OSError("stale handle")):
+			found = csr.discover_reports(root)
+		assert found == []
+
+
 # ---------------------------------------------------------------------------
 # Ordering
 # ---------------------------------------------------------------------------

--- a/tests/test_consolidate_soft_error_reports.py
+++ b/tests/test_consolidate_soft_error_reports.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Tests for scripts/consolidate_soft_error_reports.py.
+
+Covers the four behaviours operators rely on for the release-gate
+notification path:
+
+1. Discovery across both `actions/download-artifact@v6` layouts
+   (subdir-per-artifact and flattened/merge-multiple).
+2. Canonical pipeline ordering with alphabetical fallback for
+   unknown phases.
+3. Placeholder filtering (`None observed`, `no findings`, etc.)
+   excluding empty findings sections from the Telegram summary.
+4. Section-aware truncation that respects `max_bytes` exactly and
+   never splits a multi-byte UTF-8 codepoint.
+
+Plus the download-status-driven stub variants (`success` →
+neutral stub, `failure`/`cancelled` → DOWNLOAD FAILED stub,
+everything else → neutral so a miswired pipeline can't fabricate
+fake outage signal).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import consolidate_soft_error_reports as csr
+
+
+def _write_per_phase_report(
+	root: Path,
+	*,
+	run_id: str,
+	phase: str,
+	findings: str | None,
+	status: str = "ok",
+	flatten: bool = False,
+) -> Path:
+	"""Materialise a per-phase soft-error report under `root` in the
+	chosen `actions/download-artifact@v6` layout. Returns the directory
+	the consolidator should be pointed at.
+	"""
+	artifact_name = f"soft-error-report-{run_id}-{phase}"
+	if flatten:
+		md_path = root / f"{artifact_name}.md"
+	else:
+		subdir = root / artifact_name
+		subdir.mkdir(parents=True, exist_ok=True)
+		md_path = subdir / f"{artifact_name}.md"
+	body = (
+		f"## Soft-error analyzer (status: `{status}`, model: `m`, "
+		"reasoning: `r`)\n\n"
+	)
+	if findings is not None:
+		body += "## Soft errors (per phase)\n" + findings + "\n"
+	md_path.write_text(body, encoding="utf-8")
+	return md_path
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+def test_discover_subdir_layout():
+	with tempfile.TemporaryDirectory() as tmp:
+		root = Path(tmp)
+		_write_per_phase_report(root, run_id="9", phase="clarify", findings="x", flatten=False)
+		_write_per_phase_report(root, run_id="9", phase="implement", findings="y", flatten=False)
+		found = csr.discover_reports(root)
+		phases = sorted(p for p, _ in found)
+		assert phases == ["clarify", "implement"], phases
+
+
+def test_discover_flat_layout():
+	with tempfile.TemporaryDirectory() as tmp:
+		root = Path(tmp)
+		_write_per_phase_report(root, run_id="9", phase="clarify", findings="x", flatten=True)
+		_write_per_phase_report(root, run_id="9", phase="plan", findings="y", flatten=True)
+		found = csr.discover_reports(root)
+		phases = sorted(p for p, _ in found)
+		assert phases == ["clarify", "plan"], phases
+
+
+def test_discover_mixed_layout_no_duplicates():
+	"""When the same phase appears in both layouts, dedup by phase name."""
+	with tempfile.TemporaryDirectory() as tmp:
+		root = Path(tmp)
+		_write_per_phase_report(root, run_id="9", phase="clarify", findings="x", flatten=False)
+		_write_per_phase_report(root, run_id="9", phase="clarify", findings="y", flatten=True)
+		_write_per_phase_report(root, run_id="9", phase="plan", findings="z", flatten=True)
+		found = csr.discover_reports(root)
+		phases = sorted(p for p, _ in found)
+		assert phases == ["clarify", "plan"], phases
+
+
+def test_discover_empty_dir_returns_empty():
+	with tempfile.TemporaryDirectory() as tmp:
+		assert csr.discover_reports(Path(tmp)) == []
+
+
+def test_discover_missing_dir_returns_empty():
+	assert csr.discover_reports(Path("/tmp/this-path-does-not-exist-xyz")) == []
+
+
+# ---------------------------------------------------------------------------
+# Ordering
+# ---------------------------------------------------------------------------
+
+def test_canonical_pipeline_order():
+	"""Canonical phases come back in pipeline order regardless of input order."""
+	pairs = [
+		("review_autofix", Path("/r")),
+		("clarify", Path("/c")),
+		("implement", Path("/i")),
+		("plan", Path("/p")),
+	]
+	ordered = csr.order_reports(pairs)
+	assert [p for p, _ in ordered] == ["clarify", "plan", "implement", "review_autofix"]
+
+
+def test_unknown_phases_alphabetical_fallback():
+	"""Phases not in CANONICAL_PHASE_ORDER sort alphabetically AFTER known ones."""
+	pairs = [
+		("zeta_phase", Path("/z")),
+		("plan", Path("/p")),
+		("alpha_phase", Path("/a")),
+	]
+	ordered = csr.order_reports(pairs)
+	assert [p for p, _ in ordered] == ["plan", "alpha_phase", "zeta_phase"]
+
+
+# ---------------------------------------------------------------------------
+# Placeholder filtering
+# ---------------------------------------------------------------------------
+
+def test_findings_section_extracted():
+	md = (
+		"## Soft-error analyzer (status: `ok`, model: `m`, reasoning: `r`)\n\n"
+		"## Soft errors (per phase)\n"
+		"- Rate-limit retry on attempt 2.\n"
+		"\n## Patterns to watch\n- Repeated 429s.\n"
+	)
+	body = csr.extract_findings_section(md)
+	assert "Rate-limit retry" in body
+	assert "Patterns to watch" not in body
+
+
+def test_placeholder_none_observed_filtered():
+	md = (
+		"## Soft-error analyzer (status: `ok`, model: `m`, reasoning: `r`)\n\n"
+		"## Soft errors (per phase)\nNone observed.\n"
+	)
+	assert csr.extract_findings_section(md) == ""
+
+
+def test_placeholder_no_findings_filtered():
+	md = (
+		"## Soft-error analyzer (status: `ok`, model: `m`, reasoning: `r`)\n\n"
+		"## Soft errors (per phase)\nNo findings.\n"
+	)
+	assert csr.extract_findings_section(md) == ""
+
+
+def test_placeholder_no_issues_filtered():
+	md = (
+		"## Soft-error analyzer (status: `ok`, model: `m`, reasoning: `r`)\n\n"
+		"## Soft errors (per phase)\nNo issues.\n"
+	)
+	assert csr.extract_findings_section(md) == ""
+
+
+def test_missing_findings_section_returns_empty():
+	md = "## Soft-error analyzer (status: `ok`, model: `m`, reasoning: `r`)\n\nbody.\n"
+	assert csr.extract_findings_section(md) == ""
+
+
+# ---------------------------------------------------------------------------
+# Status header parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_status_ok():
+	md = "## Soft-error analyzer (status: `ok`, model: `m`, reasoning: `r`)\n"
+	assert csr.parse_status(md) == "ok"
+
+
+def test_parse_status_call_failed():
+	md = "## Soft-error analyzer (status: `call_failed`, model: `m`, reasoning: `r`)\n"
+	assert csr.parse_status(md) == "call_failed"
+
+
+def test_parse_status_unknown_when_header_absent():
+	assert csr.parse_status("garbage") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Section-aware truncation
+# ---------------------------------------------------------------------------
+
+def _run_consolidator(input_dir: Path, *, max_bytes: int, download_status: str = "success") -> tuple[str, str]:
+	"""Invoke the consolidator end-to-end and return (full_text, summary_text)."""
+	with tempfile.TemporaryDirectory() as outdir:
+		full = Path(outdir) / "full.md"
+		summary = Path(outdir) / "summary.md"
+		subprocess.run(
+			[
+				sys.executable,
+				str(REPO_ROOT / "scripts" / "consolidate_soft_error_reports.py"),
+				"--input-dir", str(input_dir),
+				"--output-full", str(full),
+				"--output-summary", str(summary),
+				"--max-summary-bytes", str(max_bytes),
+				"--download-status", download_status,
+			],
+			check=True,
+			capture_output=True,
+		)
+		return full.read_text(encoding="utf-8"), summary.read_text(encoding="utf-8")
+
+
+def test_summary_respects_byte_cap_with_unicode():
+	"""Multi-byte unicode payload truncated within an exact byte cap, decoding cleanly."""
+	with tempfile.TemporaryDirectory() as tmp:
+		root = Path(tmp)
+		# Greek letters are 2-byte UTF-8 each; ensure the budget straddles
+		# a codepoint boundary so the boundary-walk logic is exercised.
+		findings = "### clarify\n" + ("αβγδε" * 80)
+		_write_per_phase_report(root, run_id="9", phase="clarify", findings=findings)
+		for cap in (200, 300, 500):
+			_, summary = _run_consolidator(root, max_bytes=cap)
+			assert len(summary.encode("utf-8")) <= cap, (
+				f"cap={cap} but summary is {len(summary.encode('utf-8'))} bytes"
+			)
+			# Round-trip decode must succeed (no replacement chars introduced).
+			summary.encode("utf-8").decode("utf-8")
+
+
+def test_summary_drops_whole_blocks_before_inline_truncation():
+	"""When multiple findings exist, drop later blocks (canonical-order tail) first."""
+	with tempfile.TemporaryDirectory() as tmp:
+		root = Path(tmp)
+		# Two phases with sizable findings; canonical order puts clarify
+		# before plan, so plan should be dropped first when budget tight.
+		_write_per_phase_report(root, run_id="9", phase="clarify", findings="### clarify\n" + ("X" * 200))
+		_write_per_phase_report(root, run_id="9", phase="plan", findings="### plan\n" + ("Y" * 200))
+		_, summary = _run_consolidator(root, max_bytes=400)
+		# Tight cap: clarify's content should appear, plan's should be dropped
+		# before we resort to inline-slicing clarify.
+		assert "X" * 50 in summary
+		assert summary.count("Y") < 50, "plan block should have been dropped"
+
+
+def test_summary_emits_no_findings_stub_when_all_placeholders():
+	with tempfile.TemporaryDirectory() as tmp:
+		root = Path(tmp)
+		_write_per_phase_report(root, run_id="9", phase="clarify", findings="None observed.")
+		_write_per_phase_report(root, run_id="9", phase="plan", findings="No issues.")
+		_, summary = _run_consolidator(root, max_bytes=2800)
+		assert "No soft-error findings reported by any phase." in summary
+		# Status pill must still surface every phase.
+		assert "clarify=ok" in summary
+		assert "plan=ok" in summary
+
+
+# ---------------------------------------------------------------------------
+# Download-status-driven stubs
+# ---------------------------------------------------------------------------
+
+def test_download_status_success_with_empty_dir_emits_neutral_stub():
+	with tempfile.TemporaryDirectory() as tmp:
+		full, summary = _run_consolidator(Path(tmp), max_bytes=2800, download_status="success")
+		assert "DOWNLOAD FAILED" not in summary
+		assert "DOWNLOAD FAILED" not in full
+		assert "No per-phase soft-error artifacts were downloaded." in summary
+
+
+def test_download_status_failure_emits_alarm_stub():
+	with tempfile.TemporaryDirectory() as tmp:
+		full, summary = _run_consolidator(Path(tmp), max_bytes=2800, download_status="failure")
+		assert "DOWNLOAD FAILED" in summary
+		assert "DOWNLOAD FAILED" in full
+
+
+def test_download_status_cancelled_emits_alarm_stub():
+	with tempfile.TemporaryDirectory() as tmp:
+		_, summary = _run_consolidator(Path(tmp), max_bytes=2800, download_status="cancelled")
+		assert "DOWNLOAD FAILED" in summary
+
+
+def test_download_status_unknown_falls_through_to_neutral():
+	"""A miswired env var must NOT fabricate fake outage signal."""
+	with tempfile.TemporaryDirectory() as tmp:
+		_, summary = _run_consolidator(Path(tmp), max_bytes=2800, download_status="unknown")
+		assert "DOWNLOAD FAILED" not in summary
+
+
+def test_download_status_skipped_falls_through_to_neutral():
+	with tempfile.TemporaryDirectory() as tmp:
+		_, summary = _run_consolidator(Path(tmp), max_bytes=2800, download_status="skipped")
+		assert "DOWNLOAD FAILED" not in summary
+
+
+# ---------------------------------------------------------------------------
+# UTF-8 robustness
+# ---------------------------------------------------------------------------
+
+def test_corrupted_artifact_does_not_crash_consolidator():
+	"""A non-UTF-8 byte sequence in one artifact must not abort consolidation."""
+	with tempfile.TemporaryDirectory() as tmp:
+		root = Path(tmp)
+		_write_per_phase_report(root, run_id="9", phase="clarify", findings="### clarify\nfine.")
+		# Corrupted artifact for plan: write raw non-UTF8 bytes alongside a
+		# valid findings section so we can check the fallback.
+		subdir = root / "soft-error-report-9-plan"
+		subdir.mkdir(parents=True, exist_ok=True)
+		(subdir / "soft-error-report-9-plan.md").write_bytes(
+			b"## Soft-error analyzer (status: `ok`, model: `m`, reasoning: `r`)\n"
+			b"\n\xff\xfe\xfd corrupted bytes\n"
+			b"## Soft errors (per phase)\nfinding here\n"
+		)
+		full, summary = _run_consolidator(root, max_bytes=2800)
+		# Both phases must have status entries; neither should crash.
+		assert "clarify=" in summary
+		assert "plan=" in summary
+		# The full report contains the corrupted phase verbatim
+		# (with U+FFFD replacements where invalid bytes lived).
+		assert "Phase: `clarify`" in full
+		assert "Phase: `plan`" in full
+
+
+# ---------------------------------------------------------------------------
+# Test runner
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+	passed = 0
+	failed = 0
+	for func in test_funcs:
+		name = func.__name__
+		try:
+			func()
+			print(f"  PASS  {name}")
+			passed += 1
+		except Exception as exc:
+			print(f"  FAIL  {name}: {exc}")
+			failed += 1
+
+	print(f"\n{passed} passed, {failed} failed, {passed + failed} total")
+	return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_consolidate_soft_error_reports.py
+++ b/tests/test_consolidate_soft_error_reports.py
@@ -43,8 +43,9 @@ def _write_per_phase_report(
 	flatten: bool = False,
 ) -> Path:
 	"""Materialise a per-phase soft-error report under `root` in the
-	chosen `actions/download-artifact@v6` layout. Returns the directory
-	the consolidator should be pointed at.
+	chosen `actions/download-artifact@v6` layout. Returns the markdown
+	file path that was written (callers point the consolidator at
+	`root` itself, not at the returned path).
 	"""
 	artifact_name = f"soft-error-report-{run_id}-{phase}"
 	if flatten:
@@ -237,6 +238,32 @@ def test_summary_respects_byte_cap_with_unicode():
 				f"cap={cap} but summary is {len(summary.encode('utf-8'))} bytes"
 			)
 			# Round-trip decode must succeed (no replacement chars introduced).
+			summary.encode("utf-8").decode("utf-8")
+
+
+def test_summary_byte_cap_is_absolute_even_when_head_overflows():
+	"""Degenerate: cap so small the status pill alone exceeds it.
+
+	The contract `len(summary.encode('utf-8')) <= max_bytes` must hold
+	absolutely — Telegram will reject the message otherwise. Earlier
+	iterations of the truncation logic returned `head + marker` even
+	when that combination already exceeded `max_bytes`.
+	"""
+	with tempfile.TemporaryDirectory() as tmp:
+		root = Path(tmp)
+		# Spread findings across many canonical phases so the status
+		# pill itself becomes long.
+		long_phase_set = ("clarify", "plan", "implement", "review_autofix", "orchestrate_poll", "cancel_on_pr_close")
+		for phase in long_phase_set:
+			_write_per_phase_report(root, run_id="9", phase=phase, findings=f"### {phase}\nminor.")
+		# Cap below the pill+marker combined size to exercise the
+		# last-resort truncation guard.
+		for cap in (50, 80, 120):
+			_, summary = _run_consolidator(root, max_bytes=cap)
+			assert len(summary.encode("utf-8")) <= cap, (
+				f"cap={cap} but summary is {len(summary.encode('utf-8'))} bytes"
+			)
+			# Round-trip must still be valid UTF-8.
 			summary.encode("utf-8").decode("utf-8")
 
 

--- a/tests/test_consolidate_soft_error_reports.py
+++ b/tests/test_consolidate_soft_error_reports.py
@@ -279,6 +279,65 @@ def test_placeholder_no_issues_filtered():
 	assert csr.extract_findings_section(md) == ""
 
 
+def test_findings_with_double_hash_in_body_not_truncated():
+	"""Regression: a finding whose body legitimately contains a `##`
+	line must not be truncated by `NEXT_HEADING_RE`. Multi-model PR
+	review (minimax, grok-4) reproduced premature truncation when an
+	LLM quoted a log heading inside a finding body. The fix anchors
+	the next-heading regex to the two known stop sections from the
+	analyser prompt (`## Patterns to watch`, `## Likely benign`).
+	"""
+	md = (
+		"## Soft-error analyzer (status: `ok`, model: `m`, reasoning: `r`)\n\n"
+		"## Soft errors (per phase)\n"
+		"### clarify\n"
+		"- LLM quoted a log heading verbatim:\n"
+		"  ## Rate Limit Issue (this is INSIDE the finding body)\n"
+		"- second finding line that previously got truncated\n"
+		"\n## Patterns to watch\n"
+		"- this content must NOT appear in the extracted findings\n"
+	)
+	body = csr.extract_findings_section(md)
+	assert "## Rate Limit Issue" in body, (
+		"finding body containing a `##` line must not be truncated"
+	)
+	assert "second finding line" in body, (
+		"content after the inner `##` must survive extraction"
+	)
+	assert "Patterns to watch" not in body
+	assert "this content must NOT appear" not in body
+
+
+def test_real_finding_mentioning_placeholder_phrase_preserved():
+	"""Regression: a legitimate short finding that *mentions* a
+	placeholder phrase in prose ("no soft errors", "no findings",
+	etc.) must NOT be filtered out. Five PR reviewers (deepseek,
+	minimax, kimi-k2, grok-4, glm-5) reproduced the false-positive
+	where the substring-based check dropped real findings under 160
+	chars that happened to contain placeholder substrings.
+	"""
+	md = (
+		"## Soft-error analyzer (status: `ok`, model: `m`, reasoning: `r`)\n\n"
+		"## Soft errors (per phase)\n"
+		"No soft errors were found in the rate limiting module, "
+		"but the editor reviewer logged a noop-suspicious flip.\n"
+	)
+	body = csr.extract_findings_section(md)
+	assert body != "", "real finding must not be filtered out"
+	assert "rate limiting module" in body
+	assert "noop-suspicious" in body
+
+
+def test_pure_placeholder_body_still_filtered_with_bullet():
+	"""Whole-line placeholder with a leading bullet still filtered."""
+	md = (
+		"## Soft-error analyzer (status: `ok`, model: `m`, reasoning: `r`)\n\n"
+		"## Soft errors (per phase)\n"
+		"- None observed.\n"
+	)
+	assert csr.extract_findings_section(md) == ""
+
+
 def test_missing_findings_section_returns_empty():
 	md = "## Soft-error analyzer (status: `ok`, model: `m`, reasoning: `r`)\n\nbody.\n"
 	assert csr.extract_findings_section(md) == ""

--- a/tests/test_truncate_to_utf8_byte_cap.py
+++ b/tests/test_truncate_to_utf8_byte_cap.py
@@ -173,6 +173,25 @@ def test_helper_rejects_negative_cap():
 	assert proc.returncode == 2
 
 
+def test_library_function_treats_negative_cap_as_noop():
+	"""Direct library calls with negative cap return the input unchanged.
+
+	Without this guard, `data[:cap]` would invoke Python's negative-
+	index slicing and silently strip a tail byte (a real PR-review
+	finding from kimi-k2). The CLI wrapper rejects negative caps with
+	exit 2, but library callers go through `truncate_bytes_to_utf8_cap`
+	directly and would otherwise hit the footgun.
+	"""
+	import importlib.util
+	spec = importlib.util.spec_from_file_location("_t", SCRIPT)
+	mod = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(mod)
+	assert mod.truncate_bytes_to_utf8_cap(b"hello", -1) == b"hello"
+	assert mod.truncate_bytes_to_utf8_cap(b"hello", -100) == b"hello"
+	# cap=0 also a no-op (operator opt-out at consolidator level).
+	assert mod.truncate_bytes_to_utf8_cap(b"hello", 0) == b"hello"
+
+
 def test_helper_rejects_non_integer_cap():
 	proc = subprocess.run(
 		[sys.executable, str(SCRIPT), "abc"],

--- a/tests/test_truncate_to_utf8_byte_cap.py
+++ b/tests/test_truncate_to_utf8_byte_cap.py
@@ -28,6 +28,31 @@ def _truncate(payload: bytes, cap: int) -> bytes:
 	return proc.stdout
 
 
+def _assert_maximal_valid_prefix(out: bytes, payload: bytes, cap: int) -> None:
+	"""Stronger assertion than `len(out) <= cap` + decode-validity: the
+	output must be the LONGEST valid-UTF-8 prefix of `payload` that fits
+	in `cap` bytes. Catches the data-loss bug where the truncator
+	silently shortens the output even when a longer valid prefix exists
+	(e.g. when the cap lands exactly on a codepoint boundary).
+	"""
+	assert len(out) <= cap, f"cap={cap} but got {len(out)} bytes"
+	out.decode("utf-8")  # must be valid UTF-8 (strict).
+	assert payload.startswith(out), "output must be a prefix of the input"
+
+	# Maximality: any longer prefix of payload (still within cap) must
+	# fail strict UTF-8 decode. Otherwise we discarded bytes that fit.
+	for j in range(len(out) + 1, min(cap, len(payload)) + 1):
+		try:
+			payload[:j].decode("utf-8")
+		except UnicodeDecodeError:
+			continue
+		raise AssertionError(
+			f"truncation undershot: out={len(out)} bytes, but prefix of "
+			f"length {j} also decodes as valid UTF-8 (cap={cap}, "
+			f"input_len={len(payload)})"
+		)
+
+
 def test_short_input_passes_through_unchanged():
 	out = _truncate(b"hello world", 100)
 	assert out == b"hello world"
@@ -48,20 +73,64 @@ def test_truncation_lands_on_codepoint_boundary_with_unicode():
 	"""Multi-byte UTF-8 (Greek, 2 bytes each) must not be split mid-codepoint."""
 	payload = ("αβγδε" * 1000).encode("utf-8")  # 10 000 bytes
 	for cap in (100, 200, 500, 999, 1234, 3950):
-		out = _truncate(payload, cap)
-		assert len(out) <= cap, f"cap={cap} but got {len(out)} bytes"
-		# Strict UTF-8 decode must succeed — no partial codepoints.
-		out.decode("utf-8")
+		_assert_maximal_valid_prefix(_truncate(payload, cap), payload, cap)
 
 
 def test_truncation_with_emoji_no_mid_byte_split():
-	"""4-byte UTF-8 emoji must not be split mid-codepoint."""
+	"""3- and 4-byte UTF-8 codepoints must not be split mid-codepoint."""
 	# ⏳ is 3 bytes in UTF-8; 🚀 is 4 bytes.
 	payload = ("⏳🚀" * 500).encode("utf-8")
 	for cap in (50, 200, 1000):
+		_assert_maximal_valid_prefix(_truncate(payload, cap), payload, cap)
+
+
+def test_exact_codepoint_boundary_preserves_full_codepoint():
+	"""Regression: cap landing exactly on a codepoint boundary must NOT
+	drop a complete glyph that already fits.
+
+	An earlier walk-back implementation examined `data[i-1]` and
+	unconditionally dropped the leader at the boundary, which silently
+	shortened the output by one whole codepoint at every exact-boundary
+	cap. Multi-model PR review (6 of 7 reviewers, conf 5/5) reproduced
+	the bug; this test pins the corrected algorithm.
+	"""
+	# `αα` is exactly 4 UTF-8 bytes; cap=4 must return all 4.
+	payload = "αα".encode("utf-8")
+	out = _truncate(payload, 4)
+	assert out == payload, f"expected {payload!r}, got {out!r}"
+
+	# `α` is exactly 2 bytes; cap=2 must return all 2.
+	payload = "α".encode("utf-8")
+	out = _truncate(payload, 2)
+	assert out == payload, f"expected {payload!r}, got {out!r}"
+
+	# More general: every cap in [n*2 for n in 1..5] against ααααα
+	# (10 bytes, 5 codepoints) must return exactly that many codepoints
+	# — never one fewer than fits.
+	payload = ("α" * 5).encode("utf-8")
+	for codepoints_to_keep in range(1, 6):
+		cap = codepoints_to_keep * 2  # 2 bytes per α
 		out = _truncate(payload, cap)
-		assert len(out) <= cap
-		out.decode("utf-8")  # strict decode
+		assert out == payload[:cap], (
+			f"cap={cap} expected {codepoints_to_keep} α's "
+			f"({payload[:cap]!r}) but got {out!r}"
+		)
+
+
+def test_exact_boundary_with_three_byte_codepoint():
+	"""Same exact-boundary regression for 3-byte codepoints."""
+	# ⏳ is 3 bytes (0xE2 0x8F 0xB3); cap=3 must return the full glyph.
+	payload = "⏳".encode("utf-8")
+	out = _truncate(payload, 3)
+	assert out == payload, f"expected {payload!r}, got {out!r}"
+
+	payload = ("⏳" * 3).encode("utf-8")  # 9 bytes total
+	for codepoints_to_keep in range(1, 4):
+		cap = codepoints_to_keep * 3
+		out = _truncate(payload, cap)
+		assert out == payload[:cap], (
+			f"cap={cap} expected {codepoints_to_keep} ⏳'s, got {out!r}"
+		)
 
 
 def test_zero_cap_passes_through_input_unchanged():
@@ -71,18 +140,28 @@ def test_zero_cap_passes_through_input_unchanged():
 	assert out == payload
 
 
-def test_orphan_leader_dropped_at_boundary():
-	"""A boundary that lands right on a multi-byte leader drops the leader.
+def test_cap_inside_multibyte_codepoint_drops_partial():
+	"""A cap that lands INSIDE a multi-byte codepoint must drop the
+	whole partial codepoint — including its leader.
 
 	Without that, downstream `decode("utf-8")` would emit U+FFFD for the
 	orphaned 0xC0+ byte and Telegram's renderer would show a literal
 	replacement glyph.
 	"""
-	# `α` = 0xCE 0xB1 (2 bytes). cap=1 lands on the leader 0xCE; the
-	# helper must walk back to drop it, leaving an empty output.
+	# `α` = 0xCE 0xB1 (2 bytes). cap=1 lands on the leader 0xCE — the
+	# next byte (0xB1) would extend the codepoint but is excluded.
+	# data[1] = 0xB1 is a continuation byte, so walk-back from i=1
+	# reaches i=0; output is empty.
 	payload = "α".encode("utf-8")
-	out = _truncate(payload, 1)
-	assert out == b""
+	assert _truncate(payload, 1) == b""
+
+	# `ααα` = 6 bytes; cap=5 lands inside the 3rd α (mid-codepoint).
+	# Walk back to drop the partial codepoint → 4 bytes = "αα".
+	payload = "ααα".encode("utf-8")
+	out = _truncate(payload, 5)
+	assert out == "αα".encode("utf-8"), (
+		f"cap=5 inside ααα expected b'αα' (4 bytes), got {out!r}"
+	)
 
 
 def test_helper_rejects_negative_cap():

--- a/tests/test_truncate_to_utf8_byte_cap.py
+++ b/tests/test_truncate_to_utf8_byte_cap.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Tests for scripts/truncate_to_utf8_byte_cap.py.
+
+Verifies the release-gate notify step's UTF-8-safe truncation helper
+honours its byte-cap contract under multi-byte payloads (✓/✗/⏳/
+em-dashes the consolidated soft-error summary routinely contains)
+without splitting a codepoint and without corrupting the rendered
+Telegram message.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "truncate_to_utf8_byte_cap.py"
+
+
+def _truncate(payload: bytes, cap: int) -> bytes:
+	proc = subprocess.run(
+		[sys.executable, str(SCRIPT), str(cap)],
+		input=payload,
+		capture_output=True,
+		check=True,
+	)
+	return proc.stdout
+
+
+def test_short_input_passes_through_unchanged():
+	out = _truncate(b"hello world", 100)
+	assert out == b"hello world"
+
+
+def test_short_unicode_passes_through_unchanged():
+	out = _truncate("✓ release SUCCEEDED — all gates passed".encode("utf-8"), 100)
+	assert out.decode("utf-8") == "✓ release SUCCEEDED — all gates passed"
+
+
+def test_truncation_respects_byte_cap_with_ascii():
+	out = _truncate(b"a" * 5000, 100)
+	assert len(out) <= 100
+	assert out == b"a" * 100
+
+
+def test_truncation_lands_on_codepoint_boundary_with_unicode():
+	"""Multi-byte UTF-8 (Greek, 2 bytes each) must not be split mid-codepoint."""
+	payload = ("αβγδε" * 1000).encode("utf-8")  # 10 000 bytes
+	for cap in (100, 200, 500, 999, 1234, 3950):
+		out = _truncate(payload, cap)
+		assert len(out) <= cap, f"cap={cap} but got {len(out)} bytes"
+		# Strict UTF-8 decode must succeed — no partial codepoints.
+		out.decode("utf-8")
+
+
+def test_truncation_with_emoji_no_mid_byte_split():
+	"""4-byte UTF-8 emoji must not be split mid-codepoint."""
+	# ⏳ is 3 bytes in UTF-8; 🚀 is 4 bytes.
+	payload = ("⏳🚀" * 500).encode("utf-8")
+	for cap in (50, 200, 1000):
+		out = _truncate(payload, cap)
+		assert len(out) <= cap
+		out.decode("utf-8")  # strict decode
+
+
+def test_zero_cap_passes_through_input_unchanged():
+	"""cap=0 mirrors the consolidator's "disable truncation" semantic."""
+	payload = b"abc" * 1000
+	out = _truncate(payload, 0)
+	assert out == payload
+
+
+def test_orphan_leader_dropped_at_boundary():
+	"""A boundary that lands right on a multi-byte leader drops the leader.
+
+	Without that, downstream `decode("utf-8")` would emit U+FFFD for the
+	orphaned 0xC0+ byte and Telegram's renderer would show a literal
+	replacement glyph.
+	"""
+	# `α` = 0xCE 0xB1 (2 bytes). cap=1 lands on the leader 0xCE; the
+	# helper must walk back to drop it, leaving an empty output.
+	payload = "α".encode("utf-8")
+	out = _truncate(payload, 1)
+	assert out == b""
+
+
+def test_helper_rejects_negative_cap():
+	proc = subprocess.run(
+		[sys.executable, str(SCRIPT), "-5"],
+		input=b"hello",
+		capture_output=True,
+	)
+	assert proc.returncode == 2
+
+
+def test_helper_rejects_non_integer_cap():
+	proc = subprocess.run(
+		[sys.executable, str(SCRIPT), "abc"],
+		input=b"hello",
+		capture_output=True,
+	)
+	assert proc.returncode == 2
+
+
+def main() -> int:
+	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+	passed = 0
+	failed = 0
+	for func in test_funcs:
+		name = func.__name__
+		try:
+			func()
+			print(f"  PASS  {name}")
+			passed += 1
+		except Exception as exc:
+			print(f"  FAIL  {name}: {exc}")
+			failed += 1
+
+	print(f"\n{passed} passed, {failed} failed, {passed + failed} total")
+	return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())


### PR DESCRIPTION
## Summary

The release-gate's final soft-error summary could read "no issues" even when individual per-phase analyser runs flagged real soft failures. Two root causes:

1. **Coverage gap.** The Phase 8 consolidation lived inside `e2e-smoke-test` and only saw its own 6 phase run IDs. The 11 additional per-phase artifacts produced by sibling smoke-test jobs (`workflow_log_analysis`, `validation_refresh`, `update_workflows`, `memory_maintenance`, `orchestrate_decompose`, `validate_standalone`, `clarify_negative`, `alt_clarify`, `alt_plan`, `alt_implement`, `alt_review_autofix`) never reached the consolidated report or the Telegram notification.
2. **Fidelity loss.** Phase 8 re-ran the OpenRouter analyser across the 6 logs at once with an `<800 words` prompt cap; the model consolidated per-phase findings into "patterns to watch" or dropped them. The Telegram summary was then byte-truncated at 2800 chars, which could chop off real findings depending on section ordering.

This PR replaces the LLM second-pass with a deterministic concat performed in the `notify` job — which already `needs:` every smoke-test sibling and therefore can see every per-phase artifact.

## What changed

- New `scripts/consolidate_soft_error_reports.py`: pure-concat merger. Walks the downloaded artifact directory, sorts phases by canonical pipeline order, concatenates the per-phase markdown verbatim, and assembles a section-aware Telegram summary that drops whole finding blocks (rather than slicing mid-finding) plus a status pill exposing each phase's analyser status code (`ok` / `call_failed` / `api_skipped` / `unreadable`) so analyser failures are visible at a glance.
- `notify` job now downloads `soft-error-report-${{ github.run_id }}-*` (every per-phase artifact in this run), runs the consolidator, uploads the consolidated report under the existing `soft-error-report-<run_id>` artifact name, and reads the section-aware summary file for the Telegram body.
- Removed the redundant Phase 8 LLM re-summarisation, its 5-min wait step, its per-phase env wiring, the byte-truncated `soft_error_summary` job output, and the now-redundant artifact upload from `e2e-smoke-test`. The per-phase analyser invocations remain the source of truth.

## Backward compatibility

The `soft-error-report-${{ github.run_id }}` artifact name is preserved (now contains the consolidated concat instead of the LLM re-summarisation). The Telegram trailer's "see artifact 'soft-error-report-…'" reference still resolves correctly. No external workflows / scripts referenced the removed `soft_error_summary` job output.

## Test plan

- [x] YAML parses cleanly (`yaml.safe_load`); all 11 jobs intact; 6 expected steps in the new `notify` job in the right order.
- [x] Local smoke test of `consolidate_soft_error_reports.py` against three scenarios:
  - Mixed reports (findings + `None observed` + `call_failed`) — only the real finding survives in the summary; placeholder is filtered; status pill shows `call_failed` for the broken phase.
  - All `api_skipped` reports — emits `_No soft-error findings reported by any phase._` with status pill so the operator can tell "analyser ran but found nothing" from "analyser was unreachable".
  - Empty input directory — emits the empty-consolidation stub without crashing.
- [ ] End-to-end: dispatch `Test & Mark Stable Release` on a non-release branch with `dry_run=true` (or wait for next release-gate run) to confirm the new artifact is produced and the Telegram body shows the section-aware summary.

https://claude.ai/code/session_01K1HhjbriX5LjoQoCMzsVWX

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1HhjbriX5LjoQoCMzsVWX)_