### PR TITLE
refactor(validation-refresh): drop consumer-repo PR/push, render-only drift monitor

### DIFF
--- a/.github/workflows/validation-refresh.yml
+++ b/.github/workflows/validation-refresh.yml
@@ -28,8 +28,10 @@ env:
   ALERT_MSG_LEVEL: ${{ (github.event.inputs.alert_msg_level || '') != '' && github.event.inputs.alert_msg_level || vars.ALERT_MSG_LEVEL || 'DEBUG' }}
 
 permissions:
-  contents: write
-  pull-requests: write
+  # Read-only: this workflow renders + self-tests validation assets in a temp
+  # clone of each consumer repo for drift monitoring only. It does not commit,
+  # push, or open pull requests in this repo or any consumer repo.
+  contents: read
 
 concurrency:
   group: validation-refresh-${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -1700,13 +1700,13 @@ self-heal patches cannot be merged without explicit human action.
   - Manual dispatch (`workflow_dispatch`) with optional `repos_file` and `branch_name` inputs
 - Runtime:
   - Reads target repositories from `.github/ai/consumer_repos.json`
-  - For each target repo, clones the repo, checks out/creates `ai/validation-refresh` (or configured branch), and ensures validation onboarding assets exist. If `.ai/validate.yml` is missing, refresh bootstraps it from `examples/validation-fixtures/python-repo-checks.yml` and ensures executable `scripts/run_validation_repo_checks.sh` exists (diagnostics include `manifest_bootstrapped_from`, `repo_check_entry_seeded`, and `repo_check_entry_preserved_existing`). It then renders validation assets from `.ai/validate.yml` using `scripts/render_validation_templates.py`, runs deterministic lint (`scripts/validation_lint.py`) and deterministic self-test (`scripts/validate_driver.sh`), and pushes refresh commits when files changed.
-- PR behavior:
-  - Green path (render/lint/self-test pass): opens/updates a non-draft PR and enables existing repo auto-merge via `gh pr merge --squash --auto`. If auto-merge enablement fails on an existing PR, the workflow preserves the PR's prior draft state instead of forcing it back to draft.
-  - Red path (any refresh stage failure with file changes): opens/updates a draft PR including diagnostics in the body.
+  - For each target repo, clones the repo into a temporary workspace and checks out the `ai/validation-refresh` branch locally (the local branch is never pushed back to the remote). If `.ai/validate.yml` is missing, refresh bootstraps it from `examples/validation-fixtures/python-repo-checks.yml` and ensures executable `scripts/run_validation_repo_checks.sh` exists (diagnostics include `manifest_bootstrapped_from`, `repo_check_entry_seeded`, and `repo_check_entry_preserved_existing`). It then renders validation assets from `.ai/validate.yml` using `scripts/render_validation_templates.py`, runs deterministic lint (`scripts/validation_lint.py`) and deterministic self-test (`scripts/validate_driver.sh`).
+- Drift reporting only — no PRs:
+  - This workflow does NOT commit, push, or open pull requests in consumer repos. Consumers are expected to render validation assets on demand inside their own validation flow, so there is no need to ship a `chore(validation): refresh validation assets` PR ahead of time.
+  - When the rendered output differs from what is checked into the consumer repo, the result includes a `validation_assets_drifted_no_push` diagnostic. The outcome is `green` when render/lint/self-test all pass and `red` when any stage fails.
 - Failure/no-op behavior:
-  - Manifest-less repos are bootstrapped (not skipped), but the seeded `.ai/validate.yml` and `scripts/run_validation_repo_checks.sh` are onboarding stubs. Repo owners still need to replace placeholder checks/values with real repository-specific validation logic.
-  - Pipeline failure with no file diff: records error and does not create a no-op PR.
+  - Manifest-less repos are bootstrapped in the temp clone (not skipped), but the seeded `.ai/validate.yml` and `scripts/run_validation_repo_checks.sh` are onboarding stubs. Repo owners still need to replace placeholder checks/values with real repository-specific validation logic and commit them in their own repo.
+  - Pipeline failure with no file diff: records error (`pipeline_failed_without_changes`).
   - Workflow writes machine-readable summary JSON, appends a human summary to `$GITHUB_STEP_SUMMARY`, and sends Telegram failure notification (`TG_BOT_SECRET` + `TG_ADMIN_CHAT_ID`) on workflow failure.
 
 ### Nightly Validation Self-Test Status

--- a/scripts/validation_refresh_runner.py
+++ b/scripts/validation_refresh_runner.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
-"""Refresh validation assets across consumer repositories and open/update PRs."""
+"""Render and self-test validation assets against consumer repositories.
+
+Runs the validation template render + lint + self-test pipeline against each
+configured consumer repo in a temporary clone for monitoring purposes only.
+This runner deliberately does NOT commit, push, or open pull requests in the
+consumer repositories — consumers are expected to render the validation assets
+on demand inside their own validation flow. The summary reports drift so the
+operator can see when consumer repos are out of sync.
+"""
 
 from __future__ import annotations
 
@@ -26,7 +34,6 @@ except ModuleNotFoundError:
 
 
 REPO_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
-PR_NUMBER_RE = re.compile(r"/pull/(?P<number>\d+)(?:/|$|#|\?)")
 
 
 @dataclass(frozen=True)
@@ -113,19 +120,22 @@ class RefreshResult:
 
 
 class ValidationRefreshRunner:
-	"""Runs refresh flow for a set of repositories."""
+	"""Renders validation assets in a temp clone and reports drift; never pushes."""
 
 	def __init__(
 		self,
 		*,
 		source_root: Path,
 		branch_name: str,
-		commit_message: str,
-		pr_title: str,
+		commit_message: str = "",
+		pr_title: str = "",
 		executor: CommandExecutor | None = None,
 	) -> None:
 		self.source_root = source_root
 		self.branch_name = branch_name
+		# `commit_message` and `pr_title` are accepted for backward compatibility
+		# with the previous PR-creating runner; this runner no longer commits,
+		# pushes, or opens pull requests, so the values are ignored.
 		self.commit_message = commit_message
 		self.pr_title = pr_title
 		self.executor = executor or CommandExecutor()
@@ -148,7 +158,6 @@ class ValidationRefreshRunner:
 	def process_repository(self, repository: str, workspace_root: Path) -> RefreshResult:
 		result = RefreshResult(repository=repository, outcome="error", branch=self.branch_name)
 		repo_dir = workspace_root / repository.replace("/", "__")
-		owner = repository.split("/", 1)[0]
 
 		if not REPO_NAME_RE.match(repository):
 			result.diagnostics.append(f"invalid_repository_name: {repository}")
@@ -179,7 +188,10 @@ class ValidationRefreshRunner:
 		pipeline_green, diagnostics = self._run_refresh_pipeline(repo_dir, manifest_path)
 		result.diagnostics.extend(diagnostics)
 
-		if not self._repository_has_changes(repo_dir):
+		has_changes = self._repository_has_changes(repo_dir)
+		result.changed = has_changes
+
+		if not has_changes:
 			if pipeline_green:
 				result.outcome = "skipped"
 				result.diagnostics.append("no_changes_detected")
@@ -188,34 +200,12 @@ class ValidationRefreshRunner:
 				result.diagnostics.append("pipeline_failed_without_changes")
 			return result
 
-		result.changed = True
-		try:
-			self._commit_and_push(repo_dir)
-		except CommandFailure as exc:
-			result.diagnostics.append(_format_command_failure("commit_push", exc))
-			return result
-
-		pr_green = pipeline_green
-		if default_branch_diag and pr_green:
-			pr_green = False
-			result.diagnostics.append("default_branch_lookup_degraded_forced_red")
-		try:
-			pr_number, pr_url, auto_merge_enabled = self._upsert_refresh_pr(
-				repository=repository,
-				owner=owner,
-				default_branch=default_branch,
-				green=pr_green,
-				diagnostics=result.diagnostics,
-			)
-			result.pr_number = pr_number
-			result.pr_url = pr_url
-			if pr_green and not auto_merge_enabled:
-				pr_green = False
-		except CommandFailure as exc:
-			result.diagnostics.append(_format_command_failure("pull_request", exc))
-			return result
-
-		result.outcome = "green" if pr_green else "red"
+		# Drift detected: consumer repo's checked-in validation assets diverge
+		# from what the current templates would render. The runner intentionally
+		# does NOT push or open a PR — consumer repos render assets on demand
+		# during their own validation flow. The drift is recorded for monitoring.
+		result.diagnostics.append("validation_assets_drifted_no_push")
+		result.outcome = "green" if pipeline_green else "red"
 		return result
 
 	def _resolve_default_branch(self, repository: str) -> tuple[str, str | None]:
@@ -317,163 +307,6 @@ class ValidationRefreshRunner:
 		)
 		return bool((proc.stdout or "").strip())
 
-	def _commit_and_push(self, repo_dir: Path) -> None:
-		self.executor.run(["git", "config", "user.name", "coding-workflows[bot]"], cwd=repo_dir)
-		self.executor.run(["git", "config", "user.email", "coding-workflows-bot@users.noreply.github.com"], cwd=repo_dir)
-		self.executor.run(["gh", "auth", "setup-git"], cwd=repo_dir)
-		self.executor.run(["git", "add", "-A"], cwd=repo_dir)
-		if not self._repository_has_changes(repo_dir):
-			raise CommandFailure(
-				command=("git", "commit", "-m", self.commit_message),
-				cwd=str(repo_dir),
-				returncode=1,
-				stdout="",
-				stderr="nothing_to_commit",
-			)
-		self.executor.run(["git", "commit", "-m", self.commit_message], cwd=repo_dir)
-		self.executor.run(["git", "push", "--force-with-lease", "--set-upstream", "origin", self.branch_name], cwd=repo_dir)
-
-	def _upsert_refresh_pr(
-		self,
-		*,
-		repository: str,
-		owner: str,
-		default_branch: str,
-		green: bool,
-		diagnostics: list[str],
-	) -> tuple[int, str, bool]:
-		pr_body = _build_pr_body(green=green, branch_name=self.branch_name, diagnostics=diagnostics)
-		head_ref = f"{owner}:{self.branch_name}"
-		list_proc = self.executor.run(
-			[
-				"gh",
-				"pr",
-				"list",
-				"--repo",
-				repository,
-				"--state",
-				"open",
-				"--head",
-				head_ref,
-				"--json",
-				"number,url,isDraft",
-				"--limit",
-				"1",
-			]
-		)
-		existing_prs = _load_json_list(list_proc.stdout)
-		existing_was_draft = False
-		created_new_pr = False
-
-		if existing_prs:
-			existing = existing_prs[0]
-			pr_number_value = existing.get("number")
-			if pr_number_value is None:
-				raise CommandFailure(
-					command=("gh", "pr", "list", "--repo", repository),
-					cwd=None,
-					returncode=1,
-					stdout=list_proc.stdout,
-					stderr="missing_pr_number",
-				)
-			pr_number = int(pr_number_value)
-			pr_url = str(existing.get("url") or "")
-			is_draft = bool(existing.get("isDraft"))
-			self.executor.run(
-				[
-					"gh",
-					"pr",
-					"edit",
-					str(pr_number),
-					"--repo",
-					repository,
-					"--title",
-					self.pr_title,
-					"--body",
-					pr_body,
-				]
-			)
-			if green and is_draft:
-				self.executor.run(["gh", "pr", "ready", str(pr_number), "--repo", repository], check=False)
-			elif (not green) and (not is_draft):
-				self.executor.run(["gh", "pr", "ready", "--undo", str(pr_number), "--repo", repository], check=False)
-			existing_was_draft = is_draft
-		else:
-			created_new_pr = True
-			create_command = [
-				"gh",
-				"pr",
-				"create",
-				"--repo",
-				repository,
-				"--base",
-				default_branch,
-				"--head",
-				head_ref,
-				"--title",
-				self.pr_title,
-				"--body",
-				pr_body,
-			]
-			if not green:
-				create_command.append("--draft")
-			create_proc = self.executor.run(create_command)
-			pr_url = _extract_url(create_proc.stdout)
-			pr_number = _extract_pr_number(pr_url)
-			if pr_number is None:
-				raise CommandFailure(
-					command=tuple(create_command),
-					cwd=None,
-					returncode=1,
-					stdout=create_proc.stdout,
-					stderr="unable_to_parse_pr_number",
-				)
-
-		auto_merge_enabled = False
-		if green:
-			try:
-				self.executor.run(
-					[
-						"gh",
-						"pr",
-						"merge",
-						str(pr_number),
-						"--repo",
-						repository,
-						"--squash",
-						"--auto",
-					]
-				)
-				auto_merge_enabled = True
-			except CommandFailure as exc:
-				diagnostics.append(_format_command_failure("auto_merge", exc))
-				undo_ready = created_new_pr or existing_was_draft
-				if undo_ready:
-					self.executor.run(
-						["gh", "pr", "ready", "--undo", str(pr_number), "--repo", repository],
-						check=False,
-					)
-					diagnostics.append("auto_merge_enable_failed_fallback_to_draft")
-
-		if green and not auto_merge_enabled:
-			final_pr_body = _build_pr_body(green=False, branch_name=self.branch_name, diagnostics=diagnostics)
-			self.executor.run(
-				[
-					"gh",
-					"pr",
-					"edit",
-					str(pr_number),
-					"--repo",
-					repository,
-					"--title",
-					self.pr_title,
-					"--body",
-					final_pr_body,
-				]
-			)
-
-		return pr_number, pr_url, auto_merge_enabled
-
 
 def load_target_repositories(repos_file: Path) -> list[str]:
 	if not repos_file.is_file():
@@ -551,17 +384,17 @@ def parse_args() -> argparse.Namespace:
 	parser.add_argument(
 		"--branch-name",
 		default="ai/validation-refresh",
-		help="Branch name used for refresh commits",
+		help="Local branch name used inside the temp clone during render/lint/self-test",
 	)
 	parser.add_argument(
 		"--commit-message",
 		default="chore(validation): refresh validation assets",
-		help="Commit message used for refresh commits",
+		help="Deprecated, no-op: kept for backward compatibility with prior runner CLI",
 	)
 	parser.add_argument(
 		"--pr-title",
 		default="chore(validation): refresh validation assets",
-		help="Pull request title for refresh updates",
+		help="Deprecated, no-op: kept for backward compatibility with prior runner CLI",
 	)
 	return parser.parse_args()
 
@@ -606,53 +439,6 @@ def main() -> int:
 			temporary_root.cleanup()
 
 	return 1 if any(result.outcome == "error" for result in results) else 0
-
-
-def _extract_url(stdout_text: str) -> str:
-	for line in (stdout_text or "").splitlines():
-		candidate = line.strip()
-		if candidate.startswith("http://") or candidate.startswith("https://"):
-			return candidate
-	return (stdout_text or "").strip()
-
-
-def _extract_pr_number(pr_url: str) -> int | None:
-	match = PR_NUMBER_RE.search(pr_url.strip())
-	if match is None:
-		return None
-	return int(match.group("number"))
-
-
-def _build_pr_body(*, green: bool, branch_name: str, diagnostics: list[str]) -> str:
-	lines = [
-		"## Validation Refresh",
-		"",
-		f"- Branch: `{branch_name}`",
-		"- Source: validation-refresh workflow in this repository",
-	]
-	if green:
-		lines.append("- Status: green (render, lint, and self-test passed)")
-	else:
-		lines.append("- Status: red (one or more refresh checks failed)")
-
-	if diagnostics:
-		lines.extend(["", "### Diagnostics"])
-		for item in diagnostics:
-			lines.append(f"- {item}")
-	return "\n".join(lines) + "\n"
-
-
-def _load_json_list(stdout_text: str) -> list[dict[str, Any]]:
-	text = (stdout_text or "").strip()
-	if not text:
-		return []
-	try:
-		payload = json.loads(text)
-	except json.JSONDecodeError:
-		return []
-	if not isinstance(payload, list):
-		return []
-	return [item for item in payload if isinstance(item, dict)]
 
 
 def _format_command_failure(stage: str, failure: CommandFailure) -> str:

--- a/scripts/validation_refresh_runner.py
+++ b/scripts/validation_refresh_runner.py
@@ -246,15 +246,16 @@ class ValidationRefreshRunner:
 		self.executor.run(["gh", "repo", "clone", repository, str(repo_dir)])
 
 	def _checkout_refresh_branch(self, repo_dir: Path, default_branch: str) -> None:
-		remote_branch = self.executor.run(
-			["git", "ls-remote", "--heads", "origin", f"refs/heads/{self.branch_name}"],
+		# Drift monitoring always compares the rendered output against the
+		# consumer repo's default branch. We deliberately ignore any existing
+		# `origin/<branch_name>` that may linger from the previous PR-based
+		# flow — otherwise drift against the default branch can be hidden by
+		# a stale refresh branch. `branch_name` is now only a local label.
+		self.executor.run(["git", "fetch", "origin", default_branch], cwd=repo_dir)
+		self.executor.run(
+			["git", "checkout", "-B", self.branch_name, f"origin/{default_branch}"],
 			cwd=repo_dir,
 		)
-		start_ref = f"origin/{self.branch_name}" if (remote_branch.stdout or "").strip() else f"origin/{default_branch}"
-		self.executor.run(["git", "fetch", "origin", default_branch], cwd=repo_dir)
-		if start_ref == f"origin/{self.branch_name}":
-			self.executor.run(["git", "fetch", "origin", self.branch_name], cwd=repo_dir)
-		self.executor.run(["git", "checkout", "-B", self.branch_name, start_ref], cwd=repo_dir)
 
 	def _run_refresh_pipeline(self, repo_dir: Path, manifest_path: Path) -> tuple[bool, list[str]]:
 		diagnostics: list[str] = []

--- a/tests/test_validation_refresh_runner.py
+++ b/tests/test_validation_refresh_runner.py
@@ -86,6 +86,14 @@ slots:
 	)
 
 
+def _make_runner(executor: FakeExecutor, branch: str) -> "refresh_runner.ValidationRefreshRunner":
+	return refresh_runner.ValidationRefreshRunner(
+		source_root=REPO_ROOT,
+		branch_name=branch,
+		executor=executor,
+	)
+
+
 def test_load_target_repositories_deduplicates_and_validates() -> None:
 	with tempfile.TemporaryDirectory(prefix="validation-refresh-load-") as td:
 		repos_path = Path(td) / "consumer_repos.json"
@@ -114,7 +122,7 @@ def test_load_target_repositories_deduplicates_and_validates() -> None:
 			raise AssertionError("expected ValueError for malformed JSON")
 
 
-def test_process_repository_green_existing_pr_promotes_and_enables_auto_merge() -> None:
+def test_process_repository_green_drift_records_no_push_diagnostic() -> None:
 	with tempfile.TemporaryDirectory(prefix="validation-refresh-green-") as td:
 		workspace = Path(td) / "work"
 		workspace.mkdir(parents=True, exist_ok=True)
@@ -137,41 +145,25 @@ def test_process_repository_green_existing_pr_promotes_and_enables_auto_merge() 
 				PlannedCall(("python3", str(REPO_ROOT / "scripts" / "validation_lint.py"))),
 				PlannedCall(("bash", str(REPO_ROOT / "scripts" / "validate_driver.sh"))),
 				PlannedCall(("git", "status"), stdout=" M validation/tests/00_canary.sh\n"),
-				PlannedCall(("git", "config", "user.name")),
-				PlannedCall(("git", "config", "user.email")),
-				PlannedCall(("gh", "auth", "setup-git")),
-				PlannedCall(("git", "add", "-A")),
-				PlannedCall(("git", "status"), stdout=" M validation/tests/00_canary.sh\n"),
-				PlannedCall(("git", "commit", "-m")),
-				PlannedCall(("git", "push", "--force-with-lease", "--set-upstream", "origin", branch)),
-				PlannedCall(
-					("gh", "pr", "list"),
-					stdout='[{"number":42,"url":"https://github.com/octo/demo-repo/pull/42","isDraft":true}]',
-				),
-				PlannedCall(("gh", "pr", "edit", "42")),
-				PlannedCall(("gh", "pr", "ready", "42"), check=False),
-				PlannedCall(("gh", "pr", "merge", "42")),
 			]
 		)
 
-		runner = refresh_runner.ValidationRefreshRunner(
-			source_root=REPO_ROOT,
-			branch_name=branch,
-			commit_message="chore(validation): refresh validation assets",
-			pr_title="chore(validation): refresh validation assets",
-			executor=executor,
-		)
+		runner = _make_runner(executor, branch)
 		result = runner.process_repository(repository, workspace)
 
 		assert result.outcome == "green"
 		assert result.changed is True
-		assert result.pr_number == 42
-		assert result.pr_url == "https://github.com/octo/demo-repo/pull/42"
-		assert result.diagnostics == []
+		assert "validation_assets_drifted_no_push" in result.diagnostics
+		assert result.pr_number is None
+		assert result.pr_url is None
+		# Confirm we never invoked any gh pr / git commit / git push commands.
+		assert all(cmd[:2] != ["gh", "pr"] for cmd, _cwd, _check, _env in executor.seen)
+		assert all(cmd[:2] != ["git", "commit"] for cmd, _cwd, _check, _env in executor.seen)
+		assert all(cmd[:2] != ["git", "push"] for cmd, _cwd, _check, _env in executor.seen)
 		executor.assert_consumed()
 
 
-def test_process_repository_red_new_draft_pr_with_diagnostics() -> None:
+def test_process_repository_red_pipeline_failure_with_drift_records_no_push() -> None:
 	with tempfile.TemporaryDirectory(prefix="validation-refresh-red-") as td:
 		workspace = Path(td) / "work"
 		workspace.mkdir(parents=True, exist_ok=True)
@@ -196,149 +188,20 @@ def test_process_repository_red_new_draft_pr_with_diagnostics() -> None:
 					stderr="lint failed",
 				),
 				PlannedCall(("git", "status"), stdout=" M validation/tests/00_canary.sh\n"),
-				PlannedCall(("git", "config", "user.name")),
-				PlannedCall(("git", "config", "user.email")),
-				PlannedCall(("gh", "auth", "setup-git")),
-				PlannedCall(("git", "add", "-A")),
-				PlannedCall(("git", "status"), stdout=" M validation/tests/00_canary.sh\n"),
-				PlannedCall(("git", "commit", "-m")),
-				PlannedCall(("git", "push", "--force-with-lease", "--set-upstream", "origin", branch)),
-				PlannedCall(("gh", "pr", "list"), stdout="[]"),
-				PlannedCall(("gh", "pr", "create"), stdout="https://github.com/octo/demo-repo/pull/52\n"),
 			]
 		)
 
-		runner = refresh_runner.ValidationRefreshRunner(
-			source_root=REPO_ROOT,
-			branch_name=branch,
-			commit_message="chore(validation): refresh validation assets",
-			pr_title="chore(validation): refresh validation assets",
-			executor=executor,
-		)
+		runner = _make_runner(executor, branch)
 		result = runner.process_repository(repository, workspace)
 
 		assert result.outcome == "red"
 		assert result.changed is True
-		assert result.pr_number == 52
 		assert any("lint_failed" in line for line in result.diagnostics)
-		create_commands = [cmd for cmd, _cwd, _check, _env in executor.seen if cmd[:3] == ["gh", "pr", "create"]]
-		assert len(create_commands) == 1
-		assert "--draft" in create_commands[0]
-		executor.assert_consumed()
-
-
-def test_process_repository_green_auto_merge_failure_falls_back_to_red() -> None:
-	with tempfile.TemporaryDirectory(prefix="validation-refresh-merge-") as td:
-		workspace = Path(td) / "work"
-		workspace.mkdir(parents=True, exist_ok=True)
-		repository = "octo/demo-repo"
-		repo_dir = workspace / "octo__demo-repo"
-		branch = "ai/validation-refresh"
-
-		def on_clone(_command: list[str], _cwd: Path | None) -> None:
-			_write_manifest(repo_dir)
-
-		executor = FakeExecutor(
-			[
-				PlannedCall(("gh", "repo", "view"), stdout="main\n"),
-				PlannedCall(("gh", "repo", "clone"), callback=on_clone),
-				PlannedCall(("git", "ls-remote"), stdout=""),
-				PlannedCall(("git", "fetch", "origin", "main")),
-				PlannedCall(("git", "checkout", "-B", branch, "origin/main")),
-				PlannedCall(("python3", str(REPO_ROOT / "scripts" / "render_validation_templates.py"))),
-				PlannedCall(("python3", str(REPO_ROOT / "scripts" / "validation_lint.py"))),
-				PlannedCall(("bash", str(REPO_ROOT / "scripts" / "validate_driver.sh"))),
-				PlannedCall(("git", "status"), stdout=" M validation/tests/00_canary.sh\n"),
-				PlannedCall(("git", "config", "user.name")),
-				PlannedCall(("git", "config", "user.email")),
-				PlannedCall(("gh", "auth", "setup-git")),
-				PlannedCall(("git", "add", "-A")),
-				PlannedCall(("git", "status"), stdout=" M validation/tests/00_canary.sh\n"),
-				PlannedCall(("git", "commit", "-m")),
-				PlannedCall(("git", "push", "--force-with-lease", "--set-upstream", "origin", branch)),
-				PlannedCall(
-					("gh", "pr", "list"),
-					stdout='[{"number":77,"url":"https://github.com/octo/demo-repo/pull/77","isDraft":false}]',
-				),
-				PlannedCall(("gh", "pr", "edit", "77")),
-				PlannedCall(("gh", "pr", "merge", "77"), returncode=1, stderr="auto-merge unavailable"),
-				PlannedCall(("gh", "pr", "edit", "77")),
-			]
-		)
-
-		runner = refresh_runner.ValidationRefreshRunner(
-			source_root=REPO_ROOT,
-			branch_name=branch,
-			commit_message="chore(validation): refresh validation assets",
-			pr_title="chore(validation): refresh validation assets",
-			executor=executor,
-		)
-		result = runner.process_repository(repository, workspace)
-
-		assert result.outcome == "red"
-		assert result.pr_number == 77
-		assert any("auto_merge_failed" in line for line in result.diagnostics)
-		assert "auto_merge_enable_failed_fallback_to_draft" not in result.diagnostics
-		assert result.diagnostics
-		edit_commands = [cmd for cmd, _cwd, _check, _env in executor.seen if cmd[:3] == ["gh", "pr", "edit"]]
-		assert len(edit_commands) == 2
-		ready_commands = [cmd for cmd, _cwd, _check, _env in executor.seen if cmd[:3] == ["gh", "pr", "ready"]]
-		assert len(ready_commands) == 0
-		executor.assert_consumed()
-
-
-def test_process_repository_green_new_pr_auto_merge_failure_falls_back_to_red_draft() -> None:
-	with tempfile.TemporaryDirectory(prefix="validation-refresh-new-merge-") as td:
-		workspace = Path(td) / "work"
-		workspace.mkdir(parents=True, exist_ok=True)
-		repository = "octo/demo-repo"
-		repo_dir = workspace / "octo__demo-repo"
-		branch = "ai/validation-refresh"
-
-		def on_clone(_command: list[str], _cwd: Path | None) -> None:
-			_write_manifest(repo_dir)
-
-		executor = FakeExecutor(
-			[
-				PlannedCall(("gh", "repo", "view"), stdout="main\n"),
-				PlannedCall(("gh", "repo", "clone"), callback=on_clone),
-				PlannedCall(("git", "ls-remote"), stdout=""),
-				PlannedCall(("git", "fetch", "origin", "main")),
-				PlannedCall(("git", "checkout", "-B", branch, "origin/main")),
-				PlannedCall(("python3", str(REPO_ROOT / "scripts" / "render_validation_templates.py"))),
-				PlannedCall(("python3", str(REPO_ROOT / "scripts" / "validation_lint.py"))),
-				PlannedCall(("bash", str(REPO_ROOT / "scripts" / "validate_driver.sh"))),
-				PlannedCall(("git", "status"), stdout=" M validation/tests/00_canary.sh\n"),
-				PlannedCall(("git", "config", "user.name")),
-				PlannedCall(("git", "config", "user.email")),
-				PlannedCall(("gh", "auth", "setup-git")),
-				PlannedCall(("git", "add", "-A")),
-				PlannedCall(("git", "status"), stdout=" M validation/tests/00_canary.sh\n"),
-				PlannedCall(("git", "commit", "-m")),
-				PlannedCall(("git", "push", "--force-with-lease", "--set-upstream", "origin", branch)),
-				PlannedCall(("gh", "pr", "list"), stdout="[]"),
-				PlannedCall(("gh", "pr", "create"), stdout="https://github.com/octo/demo-repo/pull/88\n"),
-				PlannedCall(("gh", "pr", "merge", "88"), returncode=1, stderr="auto-merge unavailable"),
-				PlannedCall(("gh", "pr", "ready", "--undo", "88"), check=False),
-				PlannedCall(("gh", "pr", "edit", "88")),
-			]
-		)
-
-		runner = refresh_runner.ValidationRefreshRunner(
-			source_root=REPO_ROOT,
-			branch_name=branch,
-			commit_message="chore(validation): refresh validation assets",
-			pr_title="chore(validation): refresh validation assets",
-			executor=executor,
-		)
-		result = runner.process_repository(repository, workspace)
-
-		assert result.outcome == "red"
-		assert result.pr_number == 88
-		assert result.pr_url == "https://github.com/octo/demo-repo/pull/88"
-		assert "auto_merge_enable_failed_fallback_to_draft" in result.diagnostics
-		ready_commands = [cmd for cmd, _cwd, _check, _env in executor.seen if cmd[:3] == ["gh", "pr", "ready"]]
-		assert len(ready_commands) == 1
+		assert "validation_assets_drifted_no_push" in result.diagnostics
+		assert result.pr_number is None
+		assert all(cmd[:2] != ["gh", "pr"] for cmd, _cwd, _check, _env in executor.seen)
+		assert all(cmd[:2] != ["git", "commit"] for cmd, _cwd, _check, _env in executor.seen)
+		assert all(cmd[:2] != ["git", "push"] for cmd, _cwd, _check, _env in executor.seen)
 		executor.assert_consumed()
 
 
@@ -367,18 +230,13 @@ def test_process_repository_no_changes_skips_pr_operations() -> None:
 			]
 		)
 
-		runner = refresh_runner.ValidationRefreshRunner(
-			source_root=REPO_ROOT,
-			branch_name=branch,
-			commit_message="chore(validation): refresh validation assets",
-			pr_title="chore(validation): refresh validation assets",
-			executor=executor,
-		)
+		runner = _make_runner(executor, branch)
 		result = runner.process_repository(repository, workspace)
 
 		assert result.outcome == "skipped"
 		assert result.changed is False
 		assert "no_changes_detected" in result.diagnostics
+		assert "validation_assets_drifted_no_push" not in result.diagnostics
 		assert all(cmd[:2] != ["gh", "pr"] for cmd, _cwd, _check, _env in executor.seen)
 		executor.assert_consumed()
 
@@ -408,13 +266,7 @@ def test_process_repository_pipeline_unsets_github_tokens() -> None:
 			]
 		)
 
-		runner = refresh_runner.ValidationRefreshRunner(
-			source_root=REPO_ROOT,
-			branch_name=branch,
-			commit_message="chore(validation): refresh validation assets",
-			pr_title="chore(validation): refresh validation assets",
-			executor=executor,
-		)
+		runner = _make_runner(executor, branch)
 		runner.process_repository(repository, workspace)
 
 		pipeline_commands = {
@@ -446,7 +298,6 @@ def test_process_repository_bootstraps_manifest_for_manifestless_repo() -> None:
 			.strip()
 		)
 		bootstrapped_untracked_status = "?? .ai/validate.yml\n?? scripts/run_validation_repo_checks.sh\n"
-		bootstrapped_staged_status = "A  .ai/validate.yml\nA  scripts/run_validation_repo_checks.sh\n"
 
 		def on_clone(_command: list[str], _cwd: Path | None) -> None:
 			repo_dir.mkdir(parents=True, exist_ok=True)
@@ -462,34 +313,18 @@ def test_process_repository_bootstraps_manifest_for_manifestless_repo() -> None:
 				PlannedCall(("python3", str(REPO_ROOT / "scripts" / "validation_lint.py"))),
 				PlannedCall(("bash", str(REPO_ROOT / "scripts" / "validate_driver.sh"))),
 				PlannedCall(("git", "status"), stdout=bootstrapped_untracked_status),
-				PlannedCall(("git", "config", "user.name")),
-				PlannedCall(("git", "config", "user.email")),
-				PlannedCall(("gh", "auth", "setup-git")),
-				PlannedCall(("git", "add", "-A")),
-				PlannedCall(("git", "status"), stdout=bootstrapped_staged_status),
-				PlannedCall(("git", "commit", "-m")),
-				PlannedCall(("git", "push", "--force-with-lease", "--set-upstream", "origin", branch)),
-				PlannedCall(("gh", "pr", "list"), stdout="[]"),
-				PlannedCall(("gh", "pr", "create"), stdout="https://github.com/octo/demo-repo/pull/99\n"),
-				PlannedCall(("gh", "pr", "merge", "99")),
 			]
 		)
 
-		runner = refresh_runner.ValidationRefreshRunner(
-			source_root=REPO_ROOT,
-			branch_name=branch,
-			commit_message="chore(validation): refresh validation assets",
-			pr_title="chore(validation): refresh validation assets",
-			executor=executor,
-		)
+		runner = _make_runner(executor, branch)
 		result = runner.process_repository(repository, workspace)
 
 		assert result.outcome == "green"
 		assert result.changed is True
-		assert result.pr_number == 99
-		assert result.pr_url == "https://github.com/octo/demo-repo/pull/99"
-		assert f"manifest_bootstrapped_from: examples/validation-fixtures/python-repo-checks.yml" in result.diagnostics
-		assert f"repo_check_entry_seeded: scripts/run_validation_repo_checks.sh" in result.diagnostics
+		assert "validation_assets_drifted_no_push" in result.diagnostics
+		assert result.pr_number is None
+		assert "manifest_bootstrapped_from: examples/validation-fixtures/python-repo-checks.yml" in result.diagnostics
+		assert "repo_check_entry_seeded: scripts/run_validation_repo_checks.sh" in result.diagnostics
 		assert "no_changes_detected" not in result.diagnostics
 
 		bootstrapped_manifest = (repo_dir / ".ai" / "validate.yml").read_text(encoding="utf-8").strip()
@@ -497,6 +332,12 @@ def test_process_repository_bootstraps_manifest_for_manifestless_repo() -> None:
 		entry_script = repo_dir / "scripts" / "run_validation_repo_checks.sh"
 		assert entry_script.is_file()
 		assert os.access(entry_script, os.X_OK)
+		# No commit/push/PR commands should be issued — onboarding stubs are
+		# rendered into the temp clone for monitoring only; the consumer repo
+		# pulls them in during its own validation flow.
+		assert all(cmd[:2] != ["gh", "pr"] for cmd, _cwd, _check, _env in executor.seen)
+		assert all(cmd[:2] != ["git", "commit"] for cmd, _cwd, _check, _env in executor.seen)
+		assert all(cmd[:2] != ["git", "push"] for cmd, _cwd, _check, _env in executor.seen)
 		executor.assert_consumed()
 
 

--- a/tests/test_validation_refresh_runner.py
+++ b/tests/test_validation_refresh_runner.py
@@ -137,10 +137,8 @@ def test_process_repository_green_drift_records_no_push_diagnostic() -> None:
 			[
 				PlannedCall(("gh", "repo", "view"), stdout="main\n"),
 				PlannedCall(("gh", "repo", "clone"), callback=on_clone),
-				PlannedCall(("git", "ls-remote"), stdout="abc refs/heads/ai/validation-refresh\n"),
 				PlannedCall(("git", "fetch", "origin", "main")),
-				PlannedCall(("git", "fetch", "origin", branch)),
-				PlannedCall(("git", "checkout", "-B", branch, f"origin/{branch}")),
+				PlannedCall(("git", "checkout", "-B", branch, "origin/main")),
 				PlannedCall(("python3", str(REPO_ROOT / "scripts" / "render_validation_templates.py"))),
 				PlannedCall(("python3", str(REPO_ROOT / "scripts" / "validation_lint.py"))),
 				PlannedCall(("bash", str(REPO_ROOT / "scripts" / "validate_driver.sh"))),
@@ -156,10 +154,18 @@ def test_process_repository_green_drift_records_no_push_diagnostic() -> None:
 		assert "validation_assets_drifted_no_push" in result.diagnostics
 		assert result.pr_number is None
 		assert result.pr_url is None
-		# Confirm we never invoked any gh pr / git commit / git push commands.
+		# Confirm we never invoked any gh pr / git commit / git push commands,
+		# and never consulted the remote `<branch_name>` ref (drift monitoring
+		# always baselines on the default branch, ignoring any leftover refresh
+		# branch from the previous PR-based flow).
 		assert all(cmd[:2] != ["gh", "pr"] for cmd, _cwd, _check, _env in executor.seen)
 		assert all(cmd[:2] != ["git", "commit"] for cmd, _cwd, _check, _env in executor.seen)
 		assert all(cmd[:2] != ["git", "push"] for cmd, _cwd, _check, _env in executor.seen)
+		assert all(cmd[:2] != ["git", "ls-remote"] for cmd, _cwd, _check, _env in executor.seen)
+		assert not any(
+			cmd[:3] == ["git", "fetch", "origin"] and len(cmd) > 3 and cmd[3] == branch
+			for cmd, _cwd, _check, _env in executor.seen
+		)
 		executor.assert_consumed()
 
 
@@ -178,7 +184,6 @@ def test_process_repository_red_pipeline_failure_with_drift_records_no_push() ->
 			[
 				PlannedCall(("gh", "repo", "view"), stdout="main\n"),
 				PlannedCall(("gh", "repo", "clone"), callback=on_clone),
-				PlannedCall(("git", "ls-remote"), stdout=""),
 				PlannedCall(("git", "fetch", "origin", "main")),
 				PlannedCall(("git", "checkout", "-B", branch, "origin/main")),
 				PlannedCall(("python3", str(REPO_ROOT / "scripts" / "render_validation_templates.py"))),
@@ -220,7 +225,6 @@ def test_process_repository_no_changes_skips_pr_operations() -> None:
 			[
 				PlannedCall(("gh", "repo", "view"), stdout="main\n"),
 				PlannedCall(("gh", "repo", "clone"), callback=on_clone),
-				PlannedCall(("git", "ls-remote"), stdout=""),
 				PlannedCall(("git", "fetch", "origin", "main")),
 				PlannedCall(("git", "checkout", "-B", branch, "origin/main")),
 				PlannedCall(("python3", str(REPO_ROOT / "scripts" / "render_validation_templates.py"))),
@@ -256,7 +260,6 @@ def test_process_repository_pipeline_unsets_github_tokens() -> None:
 			[
 				PlannedCall(("gh", "repo", "view"), stdout="main\n"),
 				PlannedCall(("gh", "repo", "clone"), callback=on_clone),
-				PlannedCall(("git", "ls-remote"), stdout=""),
 				PlannedCall(("git", "fetch", "origin", "main")),
 				PlannedCall(("git", "checkout", "-B", branch, "origin/main")),
 				PlannedCall(("python3", str(REPO_ROOT / "scripts" / "render_validation_templates.py"))),
@@ -306,7 +309,6 @@ def test_process_repository_bootstraps_manifest_for_manifestless_repo() -> None:
 			[
 				PlannedCall(("gh", "repo", "view"), stdout="main\n"),
 				PlannedCall(("gh", "repo", "clone"), callback=on_clone),
-				PlannedCall(("git", "ls-remote"), stdout=""),
 				PlannedCall(("git", "fetch", "origin", "main")),
 				PlannedCall(("git", "checkout", "-B", branch, "origin/main")),
 				PlannedCall(("python3", str(REPO_ROOT / "scripts" / "render_validation_templates.py"))),

--- a/tests/test_validation_refresh_workflow_contract.py
+++ b/tests/test_validation_refresh_workflow_contract.py
@@ -22,8 +22,12 @@ def test_validation_refresh_workflow_invokes_runner_with_auth() -> None:
 	content = WORKFLOW_PATH.read_text(encoding="utf-8")
 	assert "scripts/validation_refresh_runner.py" in content
 	assert "GH_TOKEN: ${{ secrets.GH_PAT }}" in content
-	assert "pull-requests: write" in content
-	assert "contents: write" in content
+	# The runner is read-only against consumer repos: no commits, pushes, or
+	# pull requests are produced, so the workflow must NOT request write perms
+	# that imply otherwise.
+	assert "pull-requests: write" not in content
+	assert "contents: write" not in content
+	assert "contents: read" in content
 	assert "--summary-json" in content
 
 


### PR DESCRIPTION
## Summary
- Stop the validation-refresh workflow from creating `chore(validation): refresh validation assets` draft / ready PRs (and the underlying commits/pushes) in consumer repos.
- The runner still clones each consumer repo, renders validation assets, and runs lint + self-test against the temp clone for drift monitoring; drift is reported via the new `validation_assets_drifted_no_push` diagnostic instead of producing a PR.
- Consumers are expected to render validation assets on demand inside their own validation flow, so pre-shipping a refresh PR is unnecessary.

## Notable changes
- `scripts/validation_refresh_runner.py`: removed `_commit_and_push` / `_upsert_refresh_pr` and the helpers they used (`_build_pr_body`, `_extract_url`, `_extract_pr_number`, `_load_json_list`, `PR_NUMBER_RE`). `process_repository` now reports `green` / `red` / `skipped` / `error` based on render+lint+self-test only. CLI flags `--commit-message` / `--pr-title` and the constructor params of the same name are kept as accepted no-ops for backward compatibility.
- `.github/workflows/validation-refresh.yml`: downgraded `permissions:` to `contents: read` and dropped `pull-requests: write` since the workflow no longer pushes or opens PRs anywhere.
- `tests/test_validation_refresh_runner.py`: rewrote PR-flow tests to assert that `gh pr` / `git commit` / `git push` are never invoked; new green/red drift cases assert `validation_assets_drifted_no_push`.
- `tests/test_validation_refresh_workflow_contract.py`: asserts the workflow does NOT request `pull-requests: write` / `contents: write` and does request `contents: read`.
- `README.md` (Validation Refresh Automation section): rewrote PR behavior copy to describe drift-only reporting.

## Test plan
- [x] `python3 tests/test_validation_refresh_runner.py` — 6/6 pass
- [x] `python3 tests/test_validation_refresh_workflow_contract.py` — 3/3 pass
- [x] `python3 -m py_compile scripts/validation_refresh_runner.py`
- [ ] Next scheduled `validation-refresh.yml` run produces a summary with no PR creation calls and surfaces drift via the new diagnostic where it exists.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGmt4MfcsoPRwpbtKGa2JF)_