### PR TITLE
fix(release): harden promote FF + forward-merge against silent no-ops and races

### DIFF
--- a/.github/workflows/forward-merge-stable-to-main.yml
+++ b/.github/workflows/forward-merge-stable-to-main.yml
@@ -189,10 +189,33 @@ jobs:
           # the bug fix wasn't actually propagated and the run looks
           # successful while consumers of main remain unfixed. Refresh
           # origin from the remote (don't trust local) and assert.
-          git fetch origin main stable
+          # Bounded retry on the verification fetch — propagation has
+          # already landed (the direct push succeeded); a transient
+          # transport blip on the verification fetch must not be
+          # reported as a propagation failure.
+          fetch_attempt=1
+          while [ "$fetch_attempt" -le 3 ]; do
+            if git fetch origin main stable 2>/tmp/_git_fetch_err; then
+              break
+            fi
+            if [ "$fetch_attempt" -eq 3 ]; then
+              echo "::error::Verification fetch failed after 3 attempts (push already succeeded — re-run when transport recovers)"
+              cat /tmp/_git_fetch_err >&2 2>/dev/null || true
+              exit 1
+            fi
+            backoff=$(( 2 ** fetch_attempt ))
+            echo "::warning::verification fetch failed (attempt ${fetch_attempt}/3), retrying in ${backoff}s…"
+            cat /tmp/_git_fetch_err >&2 2>/dev/null || true
+            sleep "${backoff}"
+            fetch_attempt=$((fetch_attempt + 1))
+          done
           if ! git merge-base --is-ancestor origin/stable origin/main; then
-            REMOTE_MAIN=$(git ls-remote origin refs/heads/main | awk '{print $1}')
-            REMOTE_STABLE=$(git ls-remote origin refs/heads/stable | awk '{print $1}')
+            # Use the just-fetched local origin/* refs for diagnostics
+            # rather than a fresh ls-remote — we already proved the
+            # remote is reachable in the fetch above, and rev-parse on
+            # local refs can't transiently fail and emit empty SHAs.
+            REMOTE_MAIN=$(git rev-parse origin/main 2>/dev/null || echo "?")
+            REMOTE_STABLE=$(git rev-parse origin/stable 2>/dev/null || echo "?")
             echo "::error::Push reported success but origin/main (${REMOTE_MAIN}) does not contain origin/stable (${REMOTE_STABLE}). Bug fixes may not be propagated."
             exit 1
           fi

--- a/.github/workflows/forward-merge-stable-to-main.yml
+++ b/.github/workflows/forward-merge-stable-to-main.yml
@@ -51,8 +51,34 @@ jobs:
         id: check
         run: |
           set -euo pipefail
-          git fetch origin stable
-          AHEAD=$(git rev-list --count main..origin/stable)
+          # Bounded retry on `git fetch` so a transient transport/auth
+          # blip can't drop the bug-fix propagation cycle. Stable→main
+          # propagation is the safety net for stable-only patches; if
+          # this workflow silently fails on a network flake, the next
+          # main-source release re-introduces already-fixed bugs.
+          fetch_attempt=1
+          while [ "$fetch_attempt" -le 3 ]; do
+            if git fetch origin stable main 2>/tmp/_git_fetch_err; then
+              break
+            fi
+            if [ "$fetch_attempt" -eq 3 ]; then
+              echo "::error::Failed to fetch origin/stable + origin/main after 3 attempts"
+              cat /tmp/_git_fetch_err >&2 2>/dev/null || true
+              exit 1
+            fi
+            backoff=$(( 2 ** fetch_attempt ))
+            echo "::warning::git fetch failed (attempt ${fetch_attempt}/3), retrying in ${backoff}s…"
+            cat /tmp/_git_fetch_err >&2 2>/dev/null || true
+            sleep "${backoff}"
+            fetch_attempt=$((fetch_attempt + 1))
+          done
+
+          # Compute ahead-count against `origin/main`, not local `main`.
+          # The checkout step pinned local main to whatever it was at
+          # workflow start; if main advanced concurrently between
+          # checkout and now, ahead-count off local main would be
+          # stale. origin/main was just refreshed by the fetch above.
+          AHEAD=$(git rev-list --count origin/main..origin/stable)
           echo "ahead=${AHEAD}" >> "$GITHUB_OUTPUT"
           if [ "${AHEAD}" = "0" ]; then
             echo "stable is fully merged into main — nothing to do"
@@ -71,6 +97,14 @@ jobs:
           bug fixes on the stable branch are also present on main.
           Source SHA: ${GITHUB_SHA}"
 
+          # Reset local main to origin/main right before merging.
+          # The checkout left local main at workflow-start state; if
+          # main advanced concurrently, merging on stale main would
+          # produce a non-fast-forward push that wastes a fallback PR
+          # for a race that a fresh merge would resolve.
+          git fetch origin stable main
+          git checkout -B main origin/main
+
           if ! git merge --no-ff origin/stable -m "${MSG}"; then
             echo "merge_status=conflict" >> "$GITHUB_OUTPUT"
             # Capture the conflicting file list BEFORE aborting so the
@@ -85,16 +119,66 @@ jobs:
             exit 0
           fi
 
-          # Push directly. If branch protection rejects the push, keep
-          # the local merge commit on HEAD so the PR-fallback step can
-          # push that commit to a dedicated branch — resetting here
-          # would discard the merge and the fallback PR would be a
-          # no-op.
-          if git push origin main; then
-            echo "merge_status=pushed" >> "$GITHUB_OUTPUT"
-          else
-            echo "merge_status=push_rejected" >> "$GITHUB_OUTPUT"
+          # Push directly with bounded retry. Distinguish three failure
+          # modes by inspecting stderr:
+          #   - branch-protection rejection → real push_rejected,
+          #     fall through to PR fallback (operator review needed).
+          #   - non-fast-forward (concurrent main push raced us) → the
+          #     local merge is now stale; classify as push_rejected so
+          #     the fallback PR opens against fresh main rather than
+          #     looping here. The PR will surface what diverged.
+          #   - transient transport/auth/5xx → retry with backoff.
+          # If branch protection rejects the push, keep the local
+          # merge commit on HEAD so the PR-fallback step can push it
+          # to a dedicated branch — resetting here would discard the
+          # merge and the fallback PR would be a no-op.
+          push_attempt=1
+          while [ "$push_attempt" -le 3 ]; do
+            set +e
+            git push origin main 2>/tmp/_git_push_err
+            push_rc=$?
+            set -e
+            if [ "$push_rc" -eq 0 ]; then
+              echo "merge_status=pushed" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if grep -qiE 'protected branch|non-fast-forward|\[rejected\]|! \[remote rejected\]' /tmp/_git_push_err 2>/dev/null; then
+              cat /tmp/_git_push_err >&2 2>/dev/null || true
+              echo "merge_status=push_rejected" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            cat /tmp/_git_push_err >&2 2>/dev/null || true
+            if [ "$push_attempt" -eq 3 ]; then
+              # Persistent non-classifiable failure — fall through to
+              # PR fallback rather than hard-failing the run, so the
+              # bug fix can still propagate via manual review.
+              echo "::warning::git push failed 3 times with non-classifiable error; falling back to PR"
+              echo "merge_status=push_rejected" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            backoff=$(( 2 ** push_attempt ))
+            echo "::warning::git push failed (attempt ${push_attempt}/3), retrying in ${backoff}s…"
+            sleep "${backoff}"
+            push_attempt=$((push_attempt + 1))
+          done
+
+      - name: Verify forward-merge landed on main
+        if: steps.direct.outputs.merge_status == 'pushed'
+        run: |
+          set -euo pipefail
+          # Defensive post-condition check. After a successful direct
+          # push, origin/main MUST contain origin/stable — otherwise
+          # the bug fix wasn't actually propagated and the run looks
+          # successful while consumers of main remain unfixed. Refresh
+          # origin from the remote (don't trust local) and assert.
+          git fetch origin main stable
+          if ! git merge-base --is-ancestor origin/stable origin/main; then
+            REMOTE_MAIN=$(git ls-remote origin refs/heads/main | awk '{print $1}')
+            REMOTE_STABLE=$(git ls-remote origin refs/heads/stable | awk '{print $1}')
+            echo "::error::Push reported success but origin/main (${REMOTE_MAIN}) does not contain origin/stable (${REMOTE_STABLE}). Bug fixes may not be propagated."
+            exit 1
           fi
+          echo "Verified: origin/main contains origin/stable — propagation complete"
 
       - name: Fallback — open PR for manual merge
         if: >-

--- a/.github/workflows/forward-merge-stable-to-main.yml
+++ b/.github/workflows/forward-merge-stable-to-main.yml
@@ -102,7 +102,25 @@ jobs:
           # main advanced concurrently, merging on stale main would
           # produce a non-fast-forward push that wastes a fallback PR
           # for a race that a fresh merge would resolve.
-          git fetch origin stable main
+          # Bounded retry mirrors the check-step fetch so a transient
+          # transport/auth blip here can't drop the propagation cycle
+          # either — both fetches are equally resilient.
+          fetch_attempt=1
+          while [ "$fetch_attempt" -le 3 ]; do
+            if git fetch origin stable main 2>/tmp/_git_fetch_err; then
+              break
+            fi
+            if [ "$fetch_attempt" -eq 3 ]; then
+              echo "::error::Failed to refresh origin/stable + origin/main after 3 attempts"
+              cat /tmp/_git_fetch_err >&2 2>/dev/null || true
+              exit 1
+            fi
+            backoff=$(( 2 ** fetch_attempt ))
+            echo "::warning::git fetch failed (attempt ${fetch_attempt}/3), retrying in ${backoff}s…"
+            cat /tmp/_git_fetch_err >&2 2>/dev/null || true
+            sleep "${backoff}"
+            fetch_attempt=$((fetch_attempt + 1))
+          done
           git checkout -B main origin/main
 
           if ! git merge --no-ff origin/stable -m "${MSG}"; then

--- a/.github/workflows/promote-main-to-stable.yml
+++ b/.github/workflows/promote-main-to-stable.yml
@@ -116,18 +116,61 @@ jobs:
         id: ff
         run: |
           set -euo pipefail
+          # Pre-check: `stable` MUST exist on origin as a branch. A naked
+          # `git push origin stable` from a detached HEAD (which is what
+          # `actions/checkout ref: stable` produces when only a `stable`
+          # tag exists) will silently match the tag refspec and report
+          # "Everything up-to-date" without moving any branch — the
+          # downstream release would then run against an unchanged
+          # commit. ls-remote --exit-code: 0 found, 2 absent, other =
+          # transport/auth/repo error.
+          set +e
+          git ls-remote --exit-code --heads origin stable >/dev/null 2>&1
+          rc=$?
+          set -e
+          case "$rc" in
+            0) ;;
+            2)
+              echo "::error::Origin has no 'stable' branch. The promote workflow requires a long-lived stable branch (consumers pin to the @stable tag, but the branch is what this workflow fast-forwards)."
+              echo "::error::Create it once with: git push origin <commit>:refs/heads/stable"
+              exit 1
+              ;;
+            *)
+              echo "::error::git ls-remote failed with exit code ${rc} (transport/auth/repo error). Refusing to proceed without a confirmed branch-present signal."
+              exit 1
+              ;;
+          esac
+
           BEFORE=$(git rev-parse HEAD)
           TARGET=$(git rev-parse origin/main)
           if [ "${BEFORE}" = "${TARGET}" ]; then
             echo "stable already at main's HEAD (${TARGET}) — no-op"
             echo "moved=false" >> "$GITHUB_OUTPUT"
-          else
-            git merge --ff-only origin/main
-            git push origin stable
-            echo "Fast-forwarded stable: ${BEFORE} → ${TARGET}"
-            echo "moved=true" >> "$GITHUB_OUTPUT"
+            echo "sha=${TARGET}" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+          git merge --ff-only origin/main
+          # Push HEAD explicitly to refs/heads/stable. Without the
+          # explicit refspec, `git push origin stable` from a detached
+          # HEAD resolves to the local `stable` tag (if present) and
+          # no-ops; the explicit `HEAD:refs/heads/stable` always
+          # targets the branch.
+          git push origin "HEAD:refs/heads/stable"
+
+          # Post-verify: confirm origin's stable branch actually moved
+          # to TARGET. Catches any path where the push appeared to
+          # succeed but the remote ref didn't advance (e.g. a server-
+          # side hook silently dropped the update, or an intermediate
+          # cache returned a stale OK).
+          REMOTE_AFTER=$(git ls-remote origin refs/heads/stable | awk '{print $1}')
+          if [ "${REMOTE_AFTER}" != "${TARGET}" ]; then
+            echo "::error::Push reported success but origin/stable is at ${REMOTE_AFTER}, expected ${TARGET}. Refusing to dispatch the release on stale state."
+            exit 1
+          fi
+          echo "Fast-forwarded stable: ${BEFORE} → ${TARGET} (verified on origin)"
+          echo "moved=true" >> "$GITHUB_OUTPUT"
+          echo "sha=${TARGET}" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch test-and-mark-stable on stable
         env:

--- a/.github/workflows/promote-main-to-stable.yml
+++ b/.github/workflows/promote-main-to-stable.yml
@@ -163,7 +163,34 @@ jobs:
           # succeed but the remote ref didn't advance (e.g. a server-
           # side hook silently dropped the update, or an intermediate
           # cache returned a stale OK).
-          REMOTE_AFTER=$(git ls-remote origin refs/heads/stable | awk '{print $1}')
+          # Bounded retry distinguishes a transient transport failure
+          # from a real ref mismatch — without it, a network blip
+          # would surface as "origin/stable is at <empty>, expected
+          # TARGET" instead of the underlying transport error.
+          ls_attempt=1
+          REMOTE_AFTER=""
+          while [ "$ls_attempt" -le 3 ]; do
+            set +e
+            git ls-remote origin refs/heads/stable >/tmp/_ls_remote_out 2>/tmp/_ls_remote_err
+            ls_rc=$?
+            set -e
+            if [ "$ls_rc" -eq 0 ]; then
+              REMOTE_AFTER=$(awk '{print $1}' /tmp/_ls_remote_out 2>/dev/null || true)
+              if [ -n "$REMOTE_AFTER" ]; then
+                break
+              fi
+            fi
+            if [ "$ls_attempt" -eq 3 ]; then
+              echo "::error::Post-push verification failed: git ls-remote could not return a SHA for refs/heads/stable after 3 attempts (rc=${ls_rc}). Cannot confirm origin/stable advanced — re-run after the transport issue resolves."
+              cat /tmp/_ls_remote_err >&2 2>/dev/null || true
+              exit 1
+            fi
+            backoff=$(( 2 ** ls_attempt ))
+            echo "::warning::git ls-remote failed (attempt ${ls_attempt}/3), retrying in ${backoff}s…"
+            cat /tmp/_ls_remote_err >&2 2>/dev/null || true
+            sleep "${backoff}"
+            ls_attempt=$((ls_attempt + 1))
+          done
           if [ "${REMOTE_AFTER}" != "${TARGET}" ]; then
             echo "::error::Push reported success but origin/stable is at ${REMOTE_AFTER}, expected ${TARGET}. Refusing to dispatch the release on stale state."
             exit 1


### PR DESCRIPTION
## Context

The 2026-04-30 11:45 `promote-main-to-stable` run (which led to v1.0.113) surfaced two related defects in the stable-release plumbing. Both fixes here.

Also a one-time repo-state change was made out-of-band before this PR: the `stable` **branch** has been created on `origin` (it was missing — only the `stable` **tag** existed). Workflow `actions/checkout@v5 ref: stable` now resolves to the branch (preferred over tags); consumer pins via `@stable` tag continue to work unchanged.

## Defects fixed

### 1. `promote-main-to-stable.yml` — silent no-op fast-forward

`actions/checkout ref: stable` produced a detached HEAD when `stable` existed only as a tag. `git push origin stable` then matched the local tag refspec and returned `Everything up-to-date` without moving any branch on origin. The script unconditionally echoed `Fast-forwarded stable: BEFORE → TARGET` regardless, so logs claimed success while `origin/stable` was unchanged. The release path only worked because `test-and-mark-stable.yml` independently force-moves the `stable` tag at the end — but the commit it tagged could (and did) drift from what promote claimed (the v1.0.113 release ended up at a commit ~46 minutes ahead of the supposed FF target).

**Fix**: pre-check origin has a `stable` branch via `git ls-remote --exit-code --heads`; push with explicit `HEAD:refs/heads/stable` refspec so the branch (not a colliding tag) is targeted; post-verify origin/stable advanced to TARGET before returning success.

### 2. `forward-merge-stable-to-main.yml` — propagation cycles could be dropped silently

Three thin spots:
- `git fetch origin stable` had no retry; a single transient transport/auth blip aborted the run with no propagation.
- "ahead" count was computed against local `main` (pinned by checkout at workflow start). Concurrent main advance → stale count and a wasted fallback PR for a race a fresh merge would resolve.
- `git push origin main` exit codes were collapsed into a single `push_rejected` regardless of whether the failure was branch protection (real rejection), non-fast-forward (race), or transient transport. Transients went straight to PR fallback instead of retrying.
- Successful direct-push had no post-condition check that `origin/main` actually contained `origin/stable`.

**Fix**: bounded retry + stderr capture on the initial fetch; compute ahead-count against `origin/main`; refresh and re-checkout main immediately before the merge to minimise the race window; classify push errors via stderr and retry transients with exponential backoff; add a post-success "Verify forward-merge landed on main" step that asserts `git merge-base --is-ancestor origin/stable origin/main` and hard-errors otherwise.

## Test plan

- [ ] Dry-run promote-main-to-stable with `dry_run=true` and confirm the FF step now exits 0 with `moved=false` if `stable` is already at main HEAD, or pushes via the explicit refspec and post-verify if not.
- [ ] Manually push a no-op commit to `stable` and verify forward-merge runs, the direct push succeeds, and the new "Verify forward-merge landed on main" step reports OK.
- [ ] Verify a forced transient failure (e.g. simulate a non-FF push) is now retried with backoff before falling back to PR.
- [ ] Confirm `actions/checkout ref: stable` in promote and downstream workflows continues to resolve to the new `stable` branch (not the existing `stable` tag) — branch refs win over tag refs in checkout's resolution order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SphUdbV8ET3vWFGrRWnPWf)_