### PR TITLE
feat(workflow-log-analysis): mini-summarize unselected runs to widen coverage

### DIFF
--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -288,16 +288,19 @@ jobs:
           # Validate `vars`-sourced numeric inputs in-shell so a typo like
           # vars.WORKFLOW_LOG_SUMMARY_MAX_RUNS="abc" doesn't crash argparse
           # before the Python script can emit a fail-open ::warning:: +
-          # AI_MEMORY_TELEMETRY. Pattern matches MAX_CODEX_ATTEMPTS validation
-          # later in this workflow.
+          # AI_MEMORY_TELEMETRY. Pattern matches the `^[0-9]+$` shell guard
+          # used for MAX_CODEX_ATTEMPTS/CODEX_RETRY_BACKOFF_BASE_SECS later
+          # in this workflow — negatives are rejected here (the script
+          # treats 0 as "skip", so non-negative integers are the full
+          # accepted range).
           max_summaries="${WORKFLOW_LOG_SUMMARY_MAX_RUNS}"
           token_budget="${WORKFLOW_LOG_SUMMARY_TOKEN_BUDGET}"
-          if ! [[ "${max_summaries}" =~ ^-?[0-9]+$ ]]; then
-            echo "::warning::Invalid WORKFLOW_LOG_SUMMARY_MAX_RUNS='${WORKFLOW_LOG_SUMMARY_MAX_RUNS}'; falling back to 100."
+          if ! [[ "${max_summaries}" =~ ^[0-9]+$ ]]; then
+            echo "::warning::Invalid WORKFLOW_LOG_SUMMARY_MAX_RUNS='${WORKFLOW_LOG_SUMMARY_MAX_RUNS}' (must be a non-negative integer); falling back to 100."
             max_summaries="100"
           fi
-          if ! [[ "${token_budget}" =~ ^-?[0-9]+$ ]]; then
-            echo "::warning::Invalid WORKFLOW_LOG_SUMMARY_TOKEN_BUDGET='${WORKFLOW_LOG_SUMMARY_TOKEN_BUDGET}'; falling back to 1500000."
+          if ! [[ "${token_budget}" =~ ^[0-9]+$ ]]; then
+            echo "::warning::Invalid WORKFLOW_LOG_SUMMARY_TOKEN_BUDGET='${WORKFLOW_LOG_SUMMARY_TOKEN_BUDGET}' (must be a non-negative integer); falling back to 1500000."
             token_budget="1500000"
           fi
 

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -265,6 +265,30 @@ jobs:
           name: workflow-log-output
           path: ${{ runner.temp }}/workflow-log-output
 
+      - name: Summarize unselected runs (gpt-5.4-mini)
+        id: summarize_unselected
+        # Fail-open contract: this step widens analyzer coverage by adding
+        # `log_summary` fields to runs that the collector did not deep-dive,
+        # but it must never block the Codex pass. Errors only emit warnings.
+        continue-on-error: true
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          WORKFLOW_LOG_SUMMARY_MODEL: ${{ vars.WORKFLOW_LOG_SUMMARY_MODEL || 'openai/gpt-5.4-mini' }}
+          WORKFLOW_LOG_SUMMARY_MAX_RUNS: ${{ vars.WORKFLOW_LOG_SUMMARY_MAX_RUNS || '100' }}
+          WORKFLOW_LOG_SUMMARY_TOKEN_BUDGET: ${{ vars.WORKFLOW_LOG_SUMMARY_TOKEN_BUDGET || '1500000' }}
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: |
+          set -euo pipefail
+          if [ ! -f workflow_log_report.json ]; then
+            echo "::warning::workflow_log_report.json not present; skipping mini summarization."
+            exit 0
+          fi
+          python3 scripts/summarize_unselected_runs.py \
+            --report workflow_log_report.json \
+            --max-summaries "${WORKFLOW_LOG_SUMMARY_MAX_RUNS}" \
+            --token-budget "${WORKFLOW_LOG_SUMMARY_TOKEN_BUDGET}"
+
       - name: Run workflow log analysis
         id: analyze
         env:

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -284,10 +284,27 @@ jobs:
             echo "::warning::workflow_log_report.json not present; skipping mini summarization."
             exit 0
           fi
+
+          # Validate `vars`-sourced numeric inputs in-shell so a typo like
+          # vars.WORKFLOW_LOG_SUMMARY_MAX_RUNS="abc" doesn't crash argparse
+          # before the Python script can emit a fail-open ::warning:: +
+          # AI_MEMORY_TELEMETRY. Pattern matches MAX_CODEX_ATTEMPTS validation
+          # later in this workflow.
+          max_summaries="${WORKFLOW_LOG_SUMMARY_MAX_RUNS}"
+          token_budget="${WORKFLOW_LOG_SUMMARY_TOKEN_BUDGET}"
+          if ! [[ "${max_summaries}" =~ ^-?[0-9]+$ ]]; then
+            echo "::warning::Invalid WORKFLOW_LOG_SUMMARY_MAX_RUNS='${WORKFLOW_LOG_SUMMARY_MAX_RUNS}'; falling back to 100."
+            max_summaries="100"
+          fi
+          if ! [[ "${token_budget}" =~ ^-?[0-9]+$ ]]; then
+            echo "::warning::Invalid WORKFLOW_LOG_SUMMARY_TOKEN_BUDGET='${WORKFLOW_LOG_SUMMARY_TOKEN_BUDGET}'; falling back to 1500000."
+            token_budget="1500000"
+          fi
+
           python3 scripts/summarize_unselected_runs.py \
             --report workflow_log_report.json \
-            --max-summaries "${WORKFLOW_LOG_SUMMARY_MAX_RUNS}" \
-            --token-budget "${WORKFLOW_LOG_SUMMARY_TOKEN_BUDGET}"
+            --max-summaries "${max_summaries}" \
+            --token-budget "${token_budget}"
 
       - name: Run workflow log analysis
         id: analyze

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 *.pyc
 .venv/
+.coverage
 
 .serena/
 

--- a/prompts/mode-workflow-analysis.txt
+++ b/prompts/mode-workflow-analysis.txt
@@ -10,6 +10,8 @@ You will receive telemetry assembled from workflow-log folders, including:
 
 If analysis input is a workflow-log folder, read `summary.json` first, then inspect `errors/`, `slow/`, and `recent/` for targeted evidence.
 
+For runs outside the collector's deep-dive set (no `log_excerpts`, no folder under `errors|slow|recent/`), check the `log_summary` field on the run row in `analysis_context.json`. These are gpt-5.4-mini summaries of unselected runs, added to widen coverage; treat them as evidence-grade for outcome, warnings, retries, and any quoted token/API/AI_MEMORY_TELEMETRY signals, but verify high-stakes claims against the deep-dive logs when possible.
+
 Your task is to produce a concrete, evidence-first optimization report covering:
 - Speed Optimizations
 - Cost Optimizations

--- a/scripts/analyze_workflow_logs.py
+++ b/scripts/analyze_workflow_logs.py
@@ -182,7 +182,7 @@ def load_input_data(args: argparse.Namespace) -> dict[str, Any]:
 
 
 def _normalized_run_view(run: dict[str, Any]) -> dict[str, Any]:
-	return {
+	view: dict[str, Any] = {
 		"repository": run.get("repository"),
 		"run_id": run.get("run_id") or run.get("id"),
 		"workflow_name": run.get("workflow_name") or run.get("workflow"),
@@ -194,6 +194,13 @@ def _normalized_run_view(run: dict[str, Any]) -> dict[str, Any]:
 		"created_at": run.get("created_at"),
 		"failure_point": run.get("failure_point") or {},
 	}
+	# `log_summary` is populated by scripts/summarize_unselected_runs.py for
+	# runs outside the collector's deep-dive top-15. Carry it through so the
+	# Codex analysis pass can cite signals from coverage-widened runs.
+	log_summary = run.get("log_summary")
+	if isinstance(log_summary, str) and log_summary.strip():
+		view["log_summary"] = log_summary
+	return view
 
 
 def _summarize_runs(runs: list[dict[str, Any]]) -> dict[str, Any]:

--- a/scripts/summarize_unselected_runs.py
+++ b/scripts/summarize_unselected_runs.py
@@ -213,12 +213,24 @@ def select_targets(runs: list[dict[str, Any]], max_summaries: int) -> list[dict[
 
 
 def _truncate_step(content: str, head_chars: int, tail_chars: int) -> str:
-	"""Keep head + tail of a single step log, preserving error context at the end."""
+	"""Keep head + tail of a single step log, preserving error context at the end.
+
+	Both bounds may be 0; we slice explicitly because Python's
+	`content[-0:]` evaluates to `content[0:]` (the full string), which would
+	silently defeat truncation when `tail_chars == 0`.
+	"""
 	if len(content) <= head_chars + tail_chars:
 		return content
-	head = content[:head_chars]
-	tail = content[-tail_chars:]
-	return f"{head}\n... [truncated {len(content) - head_chars - tail_chars} chars] ...\n{tail}"
+	head = content[:head_chars] if head_chars > 0 else ""
+	tail = content[-tail_chars:] if tail_chars > 0 else ""
+	marker = f"... [truncated {len(content) - head_chars - tail_chars} chars] ..."
+	if head and tail:
+		return f"{head}\n{marker}\n{tail}"
+	if head:
+		return f"{head}\n{marker}"
+	if tail:
+		return f"{marker}\n{tail}"
+	return marker
 
 
 def build_summary_input(
@@ -264,8 +276,15 @@ def build_summary_input(
 	budget = char_cap - len(marker)
 	if budget <= 0:
 		return marker[:char_cap]
+	if budget == 1:
+		# Only one slot left after the marker — give it to the head.
+		return text[:1] + marker
+	# Strict invariant: head_size + tail_size == budget so the result is
+	# exactly char_cap chars long (head + marker + tail). The previous
+	# `max(..., 1)` clamp on tail_size could push the total over by one
+	# when head_size already consumed the entire budget.
 	head_size = max(budget // 3, 1)
-	tail_size = max(budget - head_size, 1)
+	tail_size = budget - head_size
 	return text[:head_size] + marker + text[-tail_size:]
 
 
@@ -497,7 +516,11 @@ def main(argv: list[str] | None = None) -> int:
 		timeout_seconds=args.timeout_seconds,
 		max_output_tokens=args.max_output_tokens,
 	)
-	archive_cache: dict[tuple[str, int], bytes | Exception] = {}
+	# No archive cache: this script visits each (repo, run_id) at most once,
+	# so the collector's payload-bytes cache (collect_workflow_logs.py:777-779)
+	# would only retain hundreds of MB of log archives for no benefit. A
+	# per-run fetch with `cache=None` keeps memory bounded by a single
+	# archive at a time.
 
 	for index, run in enumerate(targets):
 		if stats["tokens_used"] >= args.token_budget:
@@ -509,7 +532,7 @@ def main(argv: list[str] | None = None) -> int:
 		run_id = _to_int(run.get("run_id"), 0)
 		try:
 			archive_bytes = collector._fetch_run_log_archive(
-				repository, run_id, token=gh_token, cache=archive_cache
+				repository, run_id, token=gh_token, cache=None
 			)
 			full_logs = collector.extract_full_logs(archive_bytes)
 		except Exception as exc:  # noqa: BLE001 — fail-open per run

--- a/scripts/summarize_unselected_runs.py
+++ b/scripts/summarize_unselected_runs.py
@@ -121,7 +121,11 @@ def _warn(message: str) -> None:
 def _is_run_eligible(run: Any) -> bool:
 	if not isinstance(run, dict):
 		return False
-	if run.get("log_summary"):
+	# Treat whitespace-only `log_summary` as missing so a prior empty write
+	# doesn't permanently block re-summarization (analyzer also drops blanks
+	# in `_normalized_run_view`).
+	log_summary = run.get("log_summary")
+	if isinstance(log_summary, str) and log_summary.strip():
 		return False
 	excerpts = run.get("log_excerpts")
 	if isinstance(excerpts, list) and excerpts:
@@ -170,6 +174,11 @@ def build_summary_input(
 	total approaches `char_cap`. If still over the cap, the assembled text is
 	itself head/tail-truncated to fit.
 	"""
+	# Defensive clamps so a misconfigured CLI flag or env override can't
+	# produce unbounded output: char_cap >= 1, per-step bounds >= 0.
+	char_cap = max(int(char_cap), 1)
+	per_step_head = max(int(per_step_head), 0)
+	per_step_tail = max(int(per_step_tail), 0)
 	parts: list[str] = []
 	total = 0
 	for step in full_logs:
@@ -299,7 +308,10 @@ def _write_json_atomic(path: Path, payload: Any) -> None:
 
 def _emit_telemetry(stats: dict[str, Any]) -> None:
 	stats_with_op = {"op": SUMMARIZER_TELEMETRY_OP, **stats}
-	print(f"AI_MEMORY_TELEMETRY: {json.dumps(stats_with_op, sort_keys=True)}", file=sys.stderr)
+	print(
+		f"AI_MEMORY_TELEMETRY: {json.dumps(stats_with_op, ensure_ascii=True, sort_keys=True)}",
+		file=sys.stderr,
+	)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -419,10 +431,12 @@ def main(argv: list[str] | None = None) -> int:
 	)
 	archive_cache: dict[tuple[str, int], Any] = {}
 
-	for run in targets:
+	for index, run in enumerate(targets):
 		if stats["tokens_used"] >= args.token_budget:
-			stats["skipped_budget_exhausted"] += 1
-			continue
+			# Account for the current run plus everything after it in one shot,
+			# then bail — no point fetching log archives we won't summarize.
+			stats["skipped_budget_exhausted"] += len(targets) - index
+			break
 		repository = str(run.get("repository") or "")
 		run_id = _to_int(run.get("run_id"), 0)
 		try:

--- a/scripts/summarize_unselected_runs.py
+++ b/scripts/summarize_unselected_runs.py
@@ -262,7 +262,6 @@ def build_summary_input(
 	per_step_head = max(int(per_step_head), 0)
 	per_step_tail = max(int(per_step_tail), 0)
 	parts: list[str] = []
-	total = 0
 	for step in full_logs:
 		name = str(step.get("step_name") or "unknown_step")
 		content = str(step.get("content") or "")
@@ -271,10 +270,13 @@ def build_summary_input(
 		body = _truncate_step(content, per_step_head, per_step_tail)
 		block = f"=== STEP: {name} ===\n{body}\n"
 		parts.append(block)
-		total += len(block)
-		if total >= char_cap * 2:
-			# Hard cut so we don't blow up memory if a run has thousands of steps.
-			break
+	# Don't `break` early on the assembled length: log archives are sorted
+	# earliest-first, so cutting off mid-stream would usually drop the late
+	# steps (often the failing step + final warnings) that carry the most
+	# signal. Each step is already head/tail-truncated, so memory stays
+	# bounded (~per_step_head + per_step_tail per step), and the run-level
+	# truncation below preserves both the head and tail of the assembled
+	# text — meaning late steps survive into the summary input.
 	text = "".join(parts)
 	if len(text) <= char_cap:
 		return text

--- a/scripts/summarize_unselected_runs.py
+++ b/scripts/summarize_unselected_runs.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""Summarize unselected workflow runs via gpt-5.4-mini to widen analysis coverage.
+
+Runs as an optional pre-step of the Codex analysis pass in
+`.github/workflows/workflow-log-analysis.yml`. The collector writes per-step
+`log_excerpts` only for the top-15 "notable" runs (failures, retries, slow)
+plus a small successful-run sample (~7%); every other run in the window has
+metadata but no log content. This script picks up to `--max-summaries` of
+those unselected runs (newest-first), fetches each run's log archive from
+GitHub, and asks gpt-5.4-mini for a terse per-run summary that preserves the
+signals the downstream analyzer Codex pass looks for (outcome, failure step,
+warnings, token/API hot-spots, AI_MEMORY_TELEMETRY lines, retries).
+
+The summary is written into the run row as `log_summary` plus a
+`log_summary_meta` field. The script is fail-open: missing creds, archive
+fetch errors, or model errors skip the affected run with a warning instead of
+failing the job, and the token budget caps total spend per collection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(REPO_ROOT) not in sys.path:
+	sys.path.insert(0, str(REPO_ROOT))
+
+
+DEFAULT_MODEL = "openai/gpt-5.4-mini"
+DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+DEFAULT_MAX_SUMMARIES = 100
+DEFAULT_TOKEN_BUDGET = 1_500_000
+DEFAULT_PER_RUN_INPUT_CHARS = 12_000
+DEFAULT_OUTPUT_TOKENS = 500
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 60
+DEFAULT_PER_STEP_HEAD_CHARS = 1_000
+DEFAULT_PER_STEP_TAIL_CHARS = 4_000
+
+SUMMARIZER_TELEMETRY_OP = "summarize_unselected_runs"
+
+
+SYSTEM_PROMPT = (
+	"You are a concise log summarizer for an AI-powered GitHub Actions workflow analyzer.\n"
+	"Given the step logs of a single workflow run, extract the signals the analyzer needs to spot\n"
+	"reliability, cost, and performance regressions, and emit a terse summary in markdown bullets.\n"
+	"\n"
+	"Required signals (include only those actually present in the logs):\n"
+	"- Outcome (success/failure/cancelled) and the failing step name if any\n"
+	"- Notable warnings (deprecation, cache invalidation, secondary rate limit)\n"
+	"- Token usage / model usage lines (e.g. tokens_used=..., model=openai/...)\n"
+	"- AI_MEMORY_TELEMETRY: lines (preserve verbatim, max 3)\n"
+	"- GH API call hot-spots (high call counts, HTTP 429, secondary rate limit)\n"
+	"- MCP/Serena tool patterns (broad reads, repeated lookups, onboarding fired)\n"
+	"- Retry/backoff events with attempt counts\n"
+	"- Performance outliers (single steps that dominate runtime)\n"
+	"\n"
+	"Constraints:\n"
+	"- Maximum 12 bullets, each under 30 words.\n"
+	"- No preamble, no closing summary, no headings.\n"
+	"- If a signal is absent, omit the bullet (do NOT say 'no X observed').\n"
+	"- Quote concrete numbers and step names verbatim from the logs.\n"
+)
+
+
+def _load_collector_module() -> Any:
+	"""Import collect_workflow_logs without exposing it as a runtime hard dep.
+
+	The collector pulls in `ai_memory_lib`; we still want this script to fail
+	open if that import surface ever moves. Loading via `importlib.util` lets
+	us catch ModuleNotFoundError and degrade gracefully (the caller will then
+	skip summarization and emit a warning).
+	"""
+	spec = importlib.util.spec_from_file_location(
+		"_collect_workflow_logs", SCRIPTS_DIR / "collect_workflow_logs.py"
+	)
+	if spec is None or spec.loader is None:
+		raise ModuleNotFoundError("scripts/collect_workflow_logs.py spec unavailable")
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+def _to_int(value: Any, default: int = 0) -> int:
+	try:
+		return int(value)
+	except (TypeError, ValueError):
+		return default
+
+
+def _parse_iso8601(value: str | None) -> datetime | None:
+	if not value:
+		return None
+	normalized = value.strip()
+	if normalized.endswith("Z"):
+		normalized = normalized[:-1] + "+00:00"
+	try:
+		dt = datetime.fromisoformat(normalized)
+	except ValueError:
+		return None
+	if dt.tzinfo is None:
+		return dt.replace(tzinfo=timezone.utc)
+	return dt.astimezone(timezone.utc)
+
+
+def _warn(message: str) -> None:
+	print(f"::warning::{message}", file=sys.stderr)
+
+
+def _is_run_eligible(run: Any) -> bool:
+	if not isinstance(run, dict):
+		return False
+	if run.get("log_summary"):
+		return False
+	excerpts = run.get("log_excerpts")
+	if isinstance(excerpts, list) and excerpts:
+		return False
+	if not run.get("repository"):
+		return False
+	if _to_int(run.get("run_id"), 0) <= 0:
+		return False
+	return True
+
+
+def select_targets(runs: list[dict[str, Any]], max_summaries: int) -> list[dict[str, Any]]:
+	if max_summaries <= 0:
+		return []
+	candidates = [run for run in runs if _is_run_eligible(run)]
+	# Newest-first by created_at; stable secondary on run_id desc to keep ties deterministic.
+	candidates.sort(
+		key=lambda r: (
+			_parse_iso8601(r.get("created_at")) or datetime.min.replace(tzinfo=timezone.utc),
+			_to_int(r.get("run_id"), 0),
+		),
+		reverse=True,
+	)
+	return candidates[:max_summaries]
+
+
+def _truncate_step(content: str, head_chars: int, tail_chars: int) -> str:
+	"""Keep head + tail of a single step log, preserving error context at the end."""
+	if len(content) <= head_chars + tail_chars:
+		return content
+	head = content[:head_chars]
+	tail = content[-tail_chars:]
+	return f"{head}\n... [truncated {len(content) - head_chars - tail_chars} chars] ...\n{tail}"
+
+
+def build_summary_input(
+	full_logs: list[dict[str, str]],
+	*,
+	char_cap: int,
+	per_step_head: int = DEFAULT_PER_STEP_HEAD_CHARS,
+	per_step_tail: int = DEFAULT_PER_STEP_TAIL_CHARS,
+) -> str:
+	"""Assemble step logs into a single bounded prompt input.
+
+	Each step is head/tail-truncated, then steps are concatenated until the
+	total approaches `char_cap`. If still over the cap, the assembled text is
+	itself head/tail-truncated to fit.
+	"""
+	parts: list[str] = []
+	total = 0
+	for step in full_logs:
+		name = str(step.get("step_name") or "unknown_step")
+		content = str(step.get("content") or "")
+		if not content:
+			continue
+		body = _truncate_step(content, per_step_head, per_step_tail)
+		block = f"=== STEP: {name} ===\n{body}\n"
+		parts.append(block)
+		total += len(block)
+		if total >= char_cap * 2:
+			# Hard cut so we don't blow up memory if a run has thousands of steps.
+			break
+	text = "".join(parts)
+	if len(text) <= char_cap:
+		return text
+	head_size = max(char_cap // 3, 1)
+	tail_size = max(char_cap - head_size, 1)
+	return text[:head_size] + "\n... [run-level truncation] ...\n" + text[-tail_size:]
+
+
+def _format_user_message(run: dict[str, Any], logs_text: str) -> str:
+	failure_point = run.get("failure_point") or {}
+	failure_block = ""
+	if failure_point.get("step_name") or failure_point.get("job_name"):
+		failure_block = (
+			f"Failing job/step (collector-detected): "
+			f"{failure_point.get('job_name') or 'unknown'} / "
+			f"{failure_point.get('step_name') or 'unknown'}\n"
+		)
+	return (
+		f"Run: {run.get('repository')} #{run.get('run_id')}\n"
+		f"Workflow: {run.get('workflow_name') or 'unknown'} "
+		f"(family={run.get('workflow_family') or 'unknown'})\n"
+		f"Outcome: {run.get('conclusion') or 'unknown'}, "
+		f"duration={_to_int(run.get('duration_seconds'), 0)}s, "
+		f"attempt={_to_int(run.get('run_attempt'), 1)}, "
+		f"retries={_to_int(run.get('retries'), 0)}\n"
+		f"{failure_block}"
+		f"\nStep logs (truncated):\n{logs_text}"
+	)
+
+
+class OpenRouterSummarizer:
+	"""Thin wrapper for OpenRouter chat-completions calls."""
+
+	def __init__(
+		self,
+		api_key: str,
+		*,
+		model: str,
+		base_url: str,
+		timeout_seconds: int,
+		max_output_tokens: int,
+	) -> None:
+		self.api_key = api_key
+		self.model = model
+		self.base_url = base_url.rstrip("/")
+		self.timeout_seconds = timeout_seconds
+		self.max_output_tokens = max_output_tokens
+
+	def summarize(
+		self, run: dict[str, Any], logs_text: str
+	) -> tuple[str, int]:
+		body = json.dumps(
+			{
+				"model": self.model,
+				"messages": [
+					{"role": "system", "content": SYSTEM_PROMPT},
+					{"role": "user", "content": _format_user_message(run, logs_text)},
+				],
+				"max_tokens": self.max_output_tokens,
+				"temperature": 0.0,
+			}
+		).encode("utf-8")
+		request = urllib.request.Request(
+			f"{self.base_url}/chat/completions",
+			data=body,
+			headers={
+				"Authorization": f"Bearer {self.api_key}",
+				"Content-Type": "application/json",
+				"X-Title": "workflow-log-summarize-unselected-runs",
+			},
+			method="POST",
+		)
+		try:
+			with urllib.request.urlopen(request, timeout=self.timeout_seconds) as resp:
+				raw = resp.read().decode("utf-8")
+		except urllib.error.HTTPError as exc:
+			detail = ""
+			try:
+				detail = exc.read().decode("utf-8", errors="replace")[:300]
+			except Exception:  # noqa: BLE001
+				pass
+			raise RuntimeError(f"chat/completions HTTP {exc.code}: {detail}") from exc
+		except urllib.error.URLError as exc:
+			raise RuntimeError(f"chat/completions connection error: {exc}") from exc
+		try:
+			payload = json.loads(raw)
+		except json.JSONDecodeError as exc:
+			raise RuntimeError(f"chat/completions invalid JSON: {exc}") from exc
+		choices = payload.get("choices") or []
+		if not choices:
+			raise RuntimeError("chat/completions empty choices")
+		content = ((choices[0] or {}).get("message") or {}).get("content") or ""
+		content = content.strip()
+		if not content:
+			raise RuntimeError("chat/completions empty content")
+		usage = payload.get("usage") or {}
+		tokens_used = _to_int(usage.get("total_tokens"), 0)
+		if tokens_used <= 0:
+			tokens_used = _to_int(usage.get("prompt_tokens"), 0) + _to_int(
+				usage.get("completion_tokens"), 0
+			)
+		return content, max(tokens_used, 0)
+
+
+def _write_json_atomic(path: Path, payload: Any) -> None:
+	path.parent.mkdir(parents=True, exist_ok=True)
+	tmp_path = path.with_suffix(path.suffix + ".tmp")
+	tmp_path.write_text(
+		json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8"
+	)
+	tmp_path.replace(path)
+
+
+def _emit_telemetry(stats: dict[str, Any]) -> None:
+	stats_with_op = {"op": SUMMARIZER_TELEMETRY_OP, **stats}
+	print(f"AI_MEMORY_TELEMETRY: {json.dumps(stats_with_op, sort_keys=True)}", file=sys.stderr)
+
+
+def build_parser() -> argparse.ArgumentParser:
+	parser = argparse.ArgumentParser(
+		description=(
+			"Summarize unselected workflow runs via gpt-5.4-mini and write log_summary "
+			"fields back into workflow_log_report.json."
+		)
+	)
+	parser.add_argument("--report", required=True, help="Path to workflow_log_report.json")
+	parser.add_argument(
+		"--max-summaries",
+		type=int,
+		default=DEFAULT_MAX_SUMMARIES,
+		help="Cap on additional runs to summarize (default 100).",
+	)
+	parser.add_argument(
+		"--token-budget",
+		type=int,
+		default=DEFAULT_TOKEN_BUDGET,
+		help="Hard cap on total tokens spent across mini calls (default 1.5M).",
+	)
+	parser.add_argument(
+		"--per-run-char-cap",
+		type=int,
+		default=DEFAULT_PER_RUN_INPUT_CHARS,
+		help="Max prompt characters per run after step head/tail truncation.",
+	)
+	parser.add_argument("--model", default=None, help="OpenRouter model id (default gpt-5.4-mini).")
+	parser.add_argument("--base-url", default=DEFAULT_BASE_URL, help="OpenRouter base URL.")
+	parser.add_argument(
+		"--timeout-seconds",
+		type=int,
+		default=DEFAULT_REQUEST_TIMEOUT_SECONDS,
+		help="HTTP timeout per mini call.",
+	)
+	parser.add_argument(
+		"--max-output-tokens",
+		type=int,
+		default=DEFAULT_OUTPUT_TOKENS,
+		help="max_tokens for each mini summary (default 500).",
+	)
+	return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+	parser = build_parser()
+	args = parser.parse_args(argv)
+
+	report_path = Path(args.report)
+	if not report_path.exists():
+		_warn(f"report {report_path} not found; skipping summarization")
+		return 0
+
+	api_key = (os.getenv("OPENROUTER_API_KEY") or "").strip()
+	gh_token = (os.getenv("GH_TOKEN") or "").strip()
+	model = (os.getenv("WORKFLOW_LOG_SUMMARY_MODEL") or args.model or DEFAULT_MODEL).strip()
+
+	stats: dict[str, Any] = {
+		"targeted": 0,
+		"summarized": 0,
+		"skipped_fetch_error": 0,
+		"skipped_summary_error": 0,
+		"skipped_budget_exhausted": 0,
+		"skipped_disabled": 0,
+		"tokens_used": 0,
+		"model": model,
+		"started_at": datetime.now(timezone.utc).isoformat(),
+	}
+
+	if not api_key:
+		_warn("OPENROUTER_API_KEY not set; skipping summarization (fail-open)")
+		stats["skipped_disabled"] = 1
+		_emit_telemetry(stats)
+		return 0
+	if not gh_token:
+		_warn("GH_TOKEN not set; skipping summarization (fail-open)")
+		stats["skipped_disabled"] = 1
+		_emit_telemetry(stats)
+		return 0
+	if args.max_summaries <= 0 or args.token_budget <= 0:
+		_warn("max_summaries or token_budget <= 0; skipping summarization")
+		stats["skipped_disabled"] = 1
+		_emit_telemetry(stats)
+		return 0
+
+	try:
+		report = json.loads(report_path.read_text(encoding="utf-8"))
+	except (OSError, json.JSONDecodeError) as exc:
+		_warn(f"failed to read report {report_path}: {exc}")
+		_emit_telemetry(stats)
+		return 0
+	if not isinstance(report, dict) or not isinstance(report.get("runs"), list):
+		_warn("report missing 'runs' array; skipping summarization")
+		_emit_telemetry(stats)
+		return 0
+
+	try:
+		collector = _load_collector_module()
+	except Exception as exc:  # noqa: BLE001 — fail-open contract
+		_warn(f"unable to load collector helpers ({exc}); skipping summarization")
+		_emit_telemetry(stats)
+		return 0
+
+	targets = select_targets(report["runs"], args.max_summaries)
+	stats["targeted"] = len(targets)
+	if not targets:
+		_emit_telemetry(stats)
+		return 0
+
+	summarizer = OpenRouterSummarizer(
+		api_key,
+		model=model,
+		base_url=args.base_url,
+		timeout_seconds=args.timeout_seconds,
+		max_output_tokens=args.max_output_tokens,
+	)
+	archive_cache: dict[tuple[str, int], Any] = {}
+
+	for run in targets:
+		if stats["tokens_used"] >= args.token_budget:
+			stats["skipped_budget_exhausted"] += 1
+			continue
+		repository = str(run.get("repository") or "")
+		run_id = _to_int(run.get("run_id"), 0)
+		try:
+			archive_bytes = collector._fetch_run_log_archive(
+				repository, run_id, token=gh_token, cache=archive_cache
+			)
+			full_logs = collector.extract_full_logs(archive_bytes)
+		except Exception as exc:  # noqa: BLE001 — fail-open per run
+			_warn(f"log archive fetch failed for {repository}#{run_id}: {exc}")
+			stats["skipped_fetch_error"] += 1
+			continue
+		logs_text = build_summary_input(full_logs, char_cap=args.per_run_char_cap)
+		if not logs_text.strip():
+			stats["skipped_fetch_error"] += 1
+			continue
+		try:
+			summary, tokens_used = summarizer.summarize(run, logs_text)
+		except Exception as exc:  # noqa: BLE001 — fail-open per run
+			_warn(f"mini summary failed for {repository}#{run_id}: {exc}")
+			stats["skipped_summary_error"] += 1
+			# Tiny pause so a flaky upstream doesn't burn the budget instantly.
+			time.sleep(0.25)
+			continue
+		run["log_summary"] = summary
+		run["log_summary_meta"] = {
+			"model": model,
+			"tokens_used": tokens_used,
+			"input_chars": len(logs_text),
+			"created_at": datetime.now(timezone.utc).isoformat(),
+		}
+		stats["summarized"] += 1
+		stats["tokens_used"] += tokens_used
+
+	stats["finished_at"] = datetime.now(timezone.utc).isoformat()
+
+	try:
+		_write_json_atomic(report_path, report)
+	except OSError as exc:
+		_warn(f"failed to write report {report_path}: {exc}")
+		_emit_telemetry(stats)
+		return 0
+
+	_emit_telemetry(stats)
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/scripts/summarize_unselected_runs.py
+++ b/scripts/summarize_unselected_runs.py
@@ -430,7 +430,13 @@ def build_parser() -> argparse.ArgumentParser:
 		"--token-budget",
 		type=int,
 		default=DEFAULT_TOKEN_BUDGET,
-		help="Hard cap on total tokens spent across mini calls (default 1.5M).",
+		help=(
+			"Best-effort cap on total tokens spent across mini calls. The script "
+			"performs a pre-flight estimate (input_chars/4 + max_output_tokens) "
+			"and stops scheduling new requests once the budget would be "
+			"exceeded; actual token usage from a final call may still overshoot "
+			"the target slightly (default 1.5M)."
+		),
 	)
 	parser.add_argument(
 		"--per-run-char-cap",
@@ -455,6 +461,20 @@ def build_parser() -> argparse.ArgumentParser:
 	return parser
 
 
+def _first_non_blank(*candidates: Any) -> str | None:
+	"""Return the first string candidate that is not None/empty/whitespace.
+
+	`os.getenv("X")` returning `"   "` is truthy in Python, so a naive
+	`os.getenv("X") or default` skips the fallback and yields whitespace
+	that later strips to `""`. This helper picks the first candidate that
+	carries actual content after stripping.
+	"""
+	for value in candidates:
+		if isinstance(value, str) and value.strip():
+			return value.strip()
+	return None
+
+
 def main(argv: list[str] | None = None) -> int:
 	parser = build_parser()
 	args = parser.parse_args(argv)
@@ -466,7 +486,9 @@ def main(argv: list[str] | None = None) -> int:
 
 	api_key = (os.getenv("OPENROUTER_API_KEY") or "").strip()
 	gh_token = (os.getenv("GH_TOKEN") or "").strip()
-	model = (os.getenv("WORKFLOW_LOG_SUMMARY_MODEL") or args.model or DEFAULT_MODEL).strip()
+	model = _first_non_blank(
+		os.getenv("WORKFLOW_LOG_SUMMARY_MODEL"), args.model, DEFAULT_MODEL
+	) or DEFAULT_MODEL
 
 	stats: dict[str, Any] = {
 		"targeted": 0,
@@ -558,6 +580,15 @@ def main(argv: list[str] | None = None) -> int:
 			# fetch errors from "nothing to summarize".
 			stats["skipped_empty_logs"] += 1
 			continue
+		# Pre-flight token estimate using the same formula as the
+		# `_extract_tokens_used` fallback (~4 chars/token + max output).
+		# Skipping over-budget runs here keeps overshoot bounded — the
+		# alternative is per-call after-the-fact accounting that can blow
+		# past the cap on a single large summary.
+		estimated_tokens = (len(logs_text) // 4) + max(args.max_output_tokens, 0)
+		if stats["tokens_used"] + estimated_tokens > args.token_budget:
+			stats["skipped_budget_exhausted"] += len(targets) - index
+			break
 		try:
 			summary, tokens_used = summarizer.summarize(run, logs_text)
 		except Exception as exc:  # noqa: BLE001 — fail-open per run

--- a/scripts/summarize_unselected_runs.py
+++ b/scripts/summarize_unselected_runs.py
@@ -429,7 +429,7 @@ def main(argv: list[str] | None = None) -> int:
 		timeout_seconds=args.timeout_seconds,
 		max_output_tokens=args.max_output_tokens,
 	)
-	archive_cache: dict[tuple[str, int], Any] = {}
+	archive_cache: dict[tuple[str, int], bytes | Exception] = {}
 
 	for index, run in enumerate(targets):
 		if stats["tokens_used"] >= args.token_budget:

--- a/scripts/summarize_unselected_runs.py
+++ b/scripts/summarize_unselected_runs.py
@@ -159,7 +159,13 @@ def _to_int(value: Any, default: int = 0) -> int:
 		return default
 
 
-def _parse_iso8601(value: str | None) -> datetime | None:
+def _parse_iso8601(value: Any) -> datetime | None:
+	# Defensive type guard: callers pass run.get("created_at") through a
+	# sort key, so a malformed (non-string) value would otherwise raise
+	# AttributeError on .strip() and abort summarization for the whole
+	# window. Treat anything non-stringy as "no timestamp".
+	if not isinstance(value, str):
+		return None
 	if not value:
 		return None
 	normalized = value.strip()
@@ -190,7 +196,11 @@ def _is_run_eligible(run: Any) -> bool:
 	excerpts = run.get("log_excerpts")
 	if isinstance(excerpts, list) and excerpts:
 		return False
-	if not run.get("repository"):
+	# Repository must be a non-empty, non-whitespace string. The collector
+	# normally produces "owner/repo", but we guard against malformed rows
+	# so they don't reach _fetch_run_log_archive with an empty target.
+	repository = run.get("repository")
+	if not isinstance(repository, str) or not repository.strip():
 		return False
 	if _to_int(run.get("run_id"), 0) <= 0:
 		return False

--- a/scripts/summarize_unselected_runs.py
+++ b/scripts/summarize_unselected_runs.py
@@ -92,6 +92,66 @@ def _load_collector_module() -> Any:
 	return module
 
 
+def _load_normalize_usage() -> Any:
+	"""Import openrouter_prompt_cache.normalize_usage if available.
+
+	Reusing the existing helper keeps token-budget accounting consistent with
+	the rest of the OpenRouter call-sites (it handles `prompt_tokens_details`,
+	`input_token_details`, and other variant shapes that some providers
+	return). If the helper can't be loaded we fall back to a local parser.
+	"""
+	try:
+		spec = importlib.util.spec_from_file_location(
+			"_openrouter_prompt_cache", SCRIPTS_DIR / "openrouter_prompt_cache.py"
+		)
+		if spec is None or spec.loader is None:
+			return None
+		module = importlib.util.module_from_spec(spec)
+		spec.loader.exec_module(module)
+		return getattr(module, "normalize_usage", None)
+	except Exception:  # noqa: BLE001 — fail-open: fall back to local parser
+		return None
+
+
+_NORMALIZE_USAGE = _load_normalize_usage()
+
+
+def _extract_tokens_used(
+	usage: Any, *, input_chars: int, max_output_tokens: int
+) -> int:
+	"""Best-effort token accounting that always returns a positive number.
+
+	Order of preference:
+	1. `normalize_usage()` from openrouter_prompt_cache (handles nested shapes).
+	2. Flat `total_tokens` / sum of `prompt_tokens` + `completion_tokens`.
+	3. Conservative estimate `input_chars/4 + max_output_tokens` so the
+	   token budget keeps advancing even if a provider omits `usage` entirely.
+	"""
+	usage_dict = usage if isinstance(usage, dict) else {}
+	if _NORMALIZE_USAGE is not None:
+		try:
+			normalized = _NORMALIZE_USAGE(usage_dict) or {}
+		except Exception:  # noqa: BLE001
+			normalized = {}
+		total = normalized.get("total_tokens")
+		if isinstance(total, int) and total > 0:
+			return total
+		prompt = normalized.get("prompt_tokens") or 0
+		completion = normalized.get("completion_tokens") or 0
+		if (prompt or completion) and isinstance(prompt, int) and isinstance(completion, int):
+			return max(prompt + completion, 0)
+	flat_total = _to_int(usage_dict.get("total_tokens"), 0)
+	if flat_total > 0:
+		return flat_total
+	flat_sum = _to_int(usage_dict.get("prompt_tokens"), 0) + _to_int(
+		usage_dict.get("completion_tokens"), 0
+	)
+	if flat_sum > 0:
+		return flat_sum
+	# ~4 chars/token is the OpenAI rule-of-thumb; conservative for English logs.
+	return max(input_chars // 4 + max(max_output_tokens, 0), 1)
+
+
 def _to_int(value: Any, default: int = 0) -> int:
 	try:
 		return int(value)
@@ -196,9 +256,17 @@ def build_summary_input(
 	text = "".join(parts)
 	if len(text) <= char_cap:
 		return text
-	head_size = max(char_cap // 3, 1)
-	tail_size = max(char_cap - head_size, 1)
-	return text[:head_size] + "\n... [run-level truncation] ...\n" + text[-tail_size:]
+	# Run-level truncation must keep len(result) <= char_cap *including* the
+	# marker, so we subtract the marker length from the head/tail budget. If
+	# `char_cap` is smaller than the marker itself, return a marker prefix
+	# so we still don't exceed the cap.
+	marker = "\n... [run-level truncation] ...\n"
+	budget = char_cap - len(marker)
+	if budget <= 0:
+		return marker[:char_cap]
+	head_size = max(budget // 3, 1)
+	tail_size = max(budget - head_size, 1)
+	return text[:head_size] + marker + text[-tail_size:]
 
 
 def _format_user_message(run: dict[str, Any], logs_text: str) -> str:
@@ -288,13 +356,12 @@ class OpenRouterSummarizer:
 		content = content.strip()
 		if not content:
 			raise RuntimeError("chat/completions empty content")
-		usage = payload.get("usage") or {}
-		tokens_used = _to_int(usage.get("total_tokens"), 0)
-		if tokens_used <= 0:
-			tokens_used = _to_int(usage.get("prompt_tokens"), 0) + _to_int(
-				usage.get("completion_tokens"), 0
-			)
-		return content, max(tokens_used, 0)
+		tokens_used = _extract_tokens_used(
+			payload.get("usage"),
+			input_chars=len(logs_text),
+			max_output_tokens=self.max_output_tokens,
+		)
+		return content, tokens_used
 
 
 def _write_json_atomic(path: Path, payload: Any) -> None:
@@ -374,6 +441,7 @@ def main(argv: list[str] | None = None) -> int:
 		"targeted": 0,
 		"summarized": 0,
 		"skipped_fetch_error": 0,
+		"skipped_empty_logs": 0,
 		"skipped_summary_error": 0,
 		"skipped_budget_exhausted": 0,
 		"skipped_disabled": 0,
@@ -450,7 +518,10 @@ def main(argv: list[str] | None = None) -> int:
 			continue
 		logs_text = build_summary_input(full_logs, char_cap=args.per_run_char_cap)
 		if not logs_text.strip():
-			stats["skipped_fetch_error"] += 1
+			# The fetch succeeded — the archive was just empty/unsupported.
+			# Count it separately so telemetry can distinguish transient
+			# fetch errors from "nothing to summarize".
+			stats["skipped_empty_logs"] += 1
 			continue
 		try:
 			summary, tokens_used = summarizer.summarize(run, logs_text)

--- a/scripts/summarize_unselected_runs.py
+++ b/scripts/summarize_unselected_runs.py
@@ -124,8 +124,8 @@ def _extract_tokens_used(
 	Order of preference:
 	1. `normalize_usage()` from openrouter_prompt_cache (handles nested shapes).
 	2. Flat `total_tokens` / sum of `prompt_tokens` + `completion_tokens`.
-	3. Conservative estimate `input_chars/4 + max_output_tokens` so the
-	   token budget keeps advancing even if a provider omits `usage` entirely.
+	3. Conservative estimate `input_chars/4 + max_output_tokens` so the token
+	budget keeps advancing even if a provider omits `usage` entirely.
 	"""
 	usage_dict = usage if isinstance(usage, dict) else {}
 	if _NORMALIZE_USAGE is not None:

--- a/tests/test_summarize_unselected_runs.py
+++ b/tests/test_summarize_unselected_runs.py
@@ -120,6 +120,18 @@ def test_select_targets_zero_cap_returns_empty():
 	assert summarizer.select_targets(runs, max_summaries=0) == []
 
 
+def test_select_targets_treats_whitespace_log_summary_as_missing():
+	runs = [
+		{"repository": "a/b", "run_id": 1, "created_at": "2026-01-01T00:00:00Z", "log_summary": "   "},
+		{"repository": "a/b", "run_id": 2, "created_at": "2026-01-02T00:00:00Z", "log_summary": ""},
+		{"repository": "a/b", "run_id": 3, "created_at": "2026-01-03T00:00:00Z", "log_summary": "real"},
+	]
+	picked = summarizer.select_targets(runs, max_summaries=10)
+	# Whitespace-only and empty are treated as missing → eligible. Real text
+	# is treated as already summarized → skipped.
+	assert sorted(r["run_id"] for r in picked) == [1, 2]
+
+
 # ---------- build_summary_input ------------------------------------------
 
 
@@ -153,6 +165,17 @@ def test_build_summary_input_skips_empty_steps():
 	text = summarizer.build_summary_input(logs, char_cap=10_000)
 	assert "STEP: real" in text
 	assert "STEP: empty" not in text
+
+
+def test_build_summary_input_clamps_non_positive_char_cap():
+	logs = [{"step_name": "build", "content": "X" * 5_000}]
+	# A misconfigured char_cap=0 must not produce unbounded output; the
+	# defensive clamp upgrades it to 1, so the result is bounded by the
+	# truncation marker plus 1 char of head + 1 char of tail.
+	text = summarizer.build_summary_input(logs, char_cap=0, per_step_head=10, per_step_tail=10)
+	marker = "\n... [run-level truncation] ...\n"
+	assert len(text) <= len(marker) + 2
+	assert "[run-level truncation]" in text
 
 
 # ---------- _format_user_message + truncation helper ---------------------
@@ -310,6 +333,69 @@ def test_main_writes_summary_when_summarizer_succeeds(monkeypatch=None):
 	assert row["log_summary"].startswith("- success")
 	assert row["log_summary_meta"]["tokens_used"] == 42
 	assert row["log_summary_meta"]["model"]
+
+
+def test_main_breaks_loop_when_token_budget_exhausted():
+	"""After a single mini call exceeds the budget, remaining runs must be
+	accounted for in `skipped_budget_exhausted` in one shot — not iterated."""
+	with tempfile.TemporaryDirectory() as tmp:
+		report = Path(tmp) / "report.json"
+		_write_report(
+			report,
+			{
+				"runs": [
+					{
+						"repository": "a/b",
+						"run_id": i,
+						"created_at": f"2026-04-{i:02d}T00:00:00Z",
+					}
+					for i in range(1, 6)  # 5 eligible runs
+				]
+			},
+		)
+		fetch_calls = {"n": 0}
+		summarize_calls = {"n": 0}
+
+		class _FakeCollector:
+			@staticmethod
+			def _fetch_run_log_archive(repo, run_id, *, token, cache=None):
+				fetch_calls["n"] += 1
+				return b"<archive bytes>"
+
+			@staticmethod
+			def extract_full_logs(_archive):
+				return [{"step_name": "build", "content": "ok"}]
+
+		class _BudgetEatingSummarizer:
+			def __init__(self, *_a, **_k):
+				pass
+
+			def summarize(self, *_a, **_k):
+				summarize_calls["n"] += 1
+				# First call alone consumes the entire budget.
+				return ("- summary", 10_000)
+
+		original_loader = summarizer._load_collector_module
+		original_klass = summarizer.OpenRouterSummarizer
+		summarizer._load_collector_module = lambda: _FakeCollector
+		summarizer.OpenRouterSummarizer = _BudgetEatingSummarizer
+		try:
+			with _env(OPENROUTER_API_KEY="orkey", GH_TOKEN="ghs_test"), _capture_std():
+				rc = summarizer.main(
+					["--report", str(report), "--token-budget", "5000"]
+				)
+			written = json.loads(report.read_text(encoding="utf-8"))
+		finally:
+			summarizer._load_collector_module = original_loader
+			summarizer.OpenRouterSummarizer = original_klass
+
+	assert rc == 0
+	# Exactly one summary written; loop must not continue calling the
+	# summarizer or fetching archives once budget exceeded.
+	assert summarize_calls["n"] == 1
+	assert fetch_calls["n"] == 1
+	summarized_count = sum(1 for r in written["runs"] if r.get("log_summary"))
+	assert summarized_count == 1
 
 
 def test_main_fail_open_when_summarizer_raises():

--- a/tests/test_summarize_unselected_runs.py
+++ b/tests/test_summarize_unselected_runs.py
@@ -106,6 +106,40 @@ def test_select_targets_requires_repo_and_run_id():
 	assert [r["run_id"] for r in picked] == [7]
 
 
+def test_select_targets_rejects_whitespace_or_non_string_repository():
+	runs = [
+		{"repository": "   ", "run_id": 1, "created_at": "2026-01-01T00:00:00Z"},
+		{"repository": "", "run_id": 2, "created_at": "2026-01-02T00:00:00Z"},
+		{"repository": 42, "run_id": 3, "created_at": "2026-01-03T00:00:00Z"},
+		{"repository": "a/b", "run_id": 4, "created_at": "2026-01-04T00:00:00Z"},
+	]
+	picked = summarizer.select_targets(runs, max_summaries=10)
+	# Only the last row has a usable repository string.
+	assert [r["run_id"] for r in picked] == [4]
+
+
+def test_select_targets_tolerates_non_string_created_at_in_sort_key():
+	"""A malformed `created_at` (int / dict / None) must not raise — it just
+	sorts as 'no timestamp' instead of aborting the whole window."""
+	runs = [
+		{"repository": "a/b", "run_id": 1, "created_at": 12345},
+		{"repository": "a/b", "run_id": 2, "created_at": {"not": "a string"}},
+		{"repository": "a/b", "run_id": 3, "created_at": None},
+		{"repository": "a/b", "run_id": 4, "created_at": "2026-04-01T00:00:00Z"},
+	]
+	# Must not raise; the well-formed row should sort newest among them.
+	picked = summarizer.select_targets(runs, max_summaries=10)
+	assert {r["run_id"] for r in picked} == {1, 2, 3, 4}
+	assert picked[0]["run_id"] == 4
+
+
+def test_parse_iso8601_returns_none_for_non_string_inputs():
+	assert summarizer._parse_iso8601(None) is None
+	assert summarizer._parse_iso8601(12345) is None
+	assert summarizer._parse_iso8601({"not": "a string"}) is None
+	assert summarizer._parse_iso8601(["2026-01-01"]) is None
+
+
 def test_select_targets_caps_and_sorts_newest_first():
 	runs = [
 		{"repository": "a/b", "run_id": i, "created_at": f"2026-01-{i:02d}T00:00:00Z"}

--- a/tests/test_summarize_unselected_runs.py
+++ b/tests/test_summarize_unselected_runs.py
@@ -153,8 +153,17 @@ def test_build_summary_input_run_level_truncation_when_assembled_exceeds_cap():
 	text = summarizer.build_summary_input(
 		logs, char_cap=5_000, per_step_head=1_000, per_step_tail=2_000
 	)
-	assert len(text) <= 5_000 + len("\n... [run-level truncation] ...\n")
+	# Strict cap: total length INCLUDING the truncation marker must fit
+	# within `char_cap`. This matches the --per-run-char-cap CLI contract.
+	assert len(text) <= 5_000
 	assert "[run-level truncation]" in text
+
+
+def test_build_summary_input_when_cap_smaller_than_marker_returns_marker_prefix():
+	# Pathological tiny cap (< marker length): we still must not exceed it.
+	logs = [{"step_name": "s", "content": "X" * 100}]
+	text = summarizer.build_summary_input(logs, char_cap=10, per_step_head=5, per_step_tail=5)
+	assert len(text) <= 10
 
 
 def test_build_summary_input_skips_empty_steps():
@@ -169,13 +178,42 @@ def test_build_summary_input_skips_empty_steps():
 
 def test_build_summary_input_clamps_non_positive_char_cap():
 	logs = [{"step_name": "build", "content": "X" * 5_000}]
-	# A misconfigured char_cap=0 must not produce unbounded output; the
-	# defensive clamp upgrades it to 1, so the result is bounded by the
-	# truncation marker plus 1 char of head + 1 char of tail.
+	# A misconfigured char_cap=0 is clamped to 1, and the strict cap means
+	# the returned text fits in 1 character (marker truncated to that).
 	text = summarizer.build_summary_input(logs, char_cap=0, per_step_head=10, per_step_tail=10)
-	marker = "\n... [run-level truncation] ...\n"
-	assert len(text) <= len(marker) + 2
-	assert "[run-level truncation]" in text
+	assert len(text) <= 1
+
+
+def test_extract_tokens_used_prefers_normalized_total():
+	got = summarizer._extract_tokens_used(
+		{"total_tokens": 123, "prompt_tokens": 100, "completion_tokens": 23},
+		input_chars=4_000,
+		max_output_tokens=500,
+	)
+	assert got == 123
+
+
+def test_extract_tokens_used_sums_prompt_and_completion_when_total_missing():
+	got = summarizer._extract_tokens_used(
+		{"prompt_tokens": 80, "completion_tokens": 20},
+		input_chars=4_000,
+		max_output_tokens=500,
+	)
+	assert got == 100
+
+
+def test_extract_tokens_used_falls_back_when_usage_missing():
+	# When the provider omits `usage` entirely, the fallback estimate must
+	# still return a positive number so --token-budget keeps advancing.
+	got = summarizer._extract_tokens_used(None, input_chars=4_000, max_output_tokens=500)
+	assert got >= 1
+	# Conservative estimate: input_chars/4 + max_output_tokens.
+	assert got == 4_000 // 4 + 500
+
+
+def test_extract_tokens_used_falls_back_on_empty_usage_dict():
+	got = summarizer._extract_tokens_used({}, input_chars=2_000, max_output_tokens=400)
+	assert got == 2_000 // 4 + 400
 
 
 # ---------- _format_user_message + truncation helper ---------------------
@@ -333,6 +371,55 @@ def test_main_writes_summary_when_summarizer_succeeds(monkeypatch=None):
 	assert row["log_summary"].startswith("- success")
 	assert row["log_summary_meta"]["tokens_used"] == 42
 	assert row["log_summary_meta"]["model"]
+
+
+def test_main_counts_empty_archive_as_skipped_empty_logs_not_fetch_error():
+	"""When extract_full_logs returns nothing summarizable, the run must be
+	counted as skipped_empty_logs (fetch succeeded, archive was empty),
+	not skipped_fetch_error (transient/unrecoverable fetch failure)."""
+	with tempfile.TemporaryDirectory() as tmp:
+		report = Path(tmp) / "report.json"
+		_write_report(
+			report,
+			{
+				"runs": [
+					{"repository": "a/b", "run_id": 1, "created_at": "2026-04-30T00:00:00Z"}
+				]
+			},
+		)
+
+		class _EmptyArchiveCollector:
+			@staticmethod
+			def _fetch_run_log_archive(repo, run_id, *, token, cache=None):
+				return b""
+
+			@staticmethod
+			def extract_full_logs(_archive):
+				return []  # empty -> logs_text is blank
+
+		class _ShouldNotBeCalledSummarizer:
+			def __init__(self, *_a, **_k):
+				pass
+
+			def summarize(self, *_a, **_k):  # pragma: no cover — guarded by empty path
+				raise AssertionError("summarize() must not be called for empty archives")
+
+		original_loader = summarizer._load_collector_module
+		original_klass = summarizer.OpenRouterSummarizer
+		summarizer._load_collector_module = lambda: _EmptyArchiveCollector
+		summarizer.OpenRouterSummarizer = _ShouldNotBeCalledSummarizer
+		try:
+			with _env(OPENROUTER_API_KEY="orkey", GH_TOKEN="ghs_test"), _capture_std() as (_out, err):
+				rc = summarizer.main(["--report", str(report)])
+			err_text = err.getvalue()
+		finally:
+			summarizer._load_collector_module = original_loader
+			summarizer.OpenRouterSummarizer = original_klass
+
+	assert rc == 0
+	# Telemetry line includes skipped_empty_logs=1 and skipped_fetch_error=0.
+	assert '"skipped_empty_logs": 1' in err_text
+	assert '"skipped_fetch_error": 0' in err_text
 
 
 def test_main_breaks_loop_when_token_budget_exhausted():

--- a/tests/test_summarize_unselected_runs.py
+++ b/tests/test_summarize_unselected_runs.py
@@ -574,6 +574,117 @@ def test_main_does_not_pass_archive_cache_so_payload_bytes_arent_retained():
 	)
 
 
+def test_first_non_blank_skips_whitespace_and_non_strings():
+	# Whitespace-only candidates must NOT be picked, so the env-var fallback
+	# chain doesn't yield an empty model after .strip().
+	assert summarizer._first_non_blank("  ", "", None, "real") == "real"
+	assert summarizer._first_non_blank(None, 42, "  ", "x") == "x"
+	# All blank → None so callers can fall through to the literal default.
+	assert summarizer._first_non_blank("  ", "", None) is None
+
+
+def test_main_uses_default_model_when_env_var_is_whitespace_only():
+	"""WORKFLOW_LOG_SUMMARY_MODEL='   ' is truthy in Python, so a naive
+	`os.getenv() or default` would skip the fallback and call OpenRouter
+	with model=''. Assert the helper falls through to DEFAULT_MODEL."""
+	with tempfile.TemporaryDirectory() as tmp:
+		report = Path(tmp) / "report.json"
+		_write_report(
+			report,
+			{"runs": [{"repository": "a/b", "run_id": 1, "created_at": "2026-04-01T00:00:00Z"}]},
+		)
+		captured_models: list[str] = []
+
+		class _FakeCollector:
+			@staticmethod
+			def _fetch_run_log_archive(repo, run_id, *, token, cache=None):
+				return b"<archive>"
+
+			@staticmethod
+			def extract_full_logs(_archive):
+				return [{"step_name": "build", "content": "ok"}]
+
+		class _ModelSpyingSummarizer:
+			def __init__(self, *_args, model=None, **_kw):
+				captured_models.append(model)
+
+			def summarize(self, *_a, **_k):
+				return ("- ok", 10)
+
+		original_loader = summarizer._load_collector_module
+		original_klass = summarizer.OpenRouterSummarizer
+		summarizer._load_collector_module = lambda: _FakeCollector
+		summarizer.OpenRouterSummarizer = _ModelSpyingSummarizer
+		try:
+			with _env(
+				OPENROUTER_API_KEY="orkey",
+				GH_TOKEN="ghs_test",
+				WORKFLOW_LOG_SUMMARY_MODEL="   ",
+			), _capture_std():
+				rc = summarizer.main(["--report", str(report)])
+		finally:
+			summarizer._load_collector_module = original_loader
+			summarizer.OpenRouterSummarizer = original_klass
+
+	assert rc == 0
+	assert captured_models, "summarizer was never instantiated"
+	assert captured_models[0] == summarizer.DEFAULT_MODEL
+
+
+def test_main_skips_run_when_preflight_estimate_would_exceed_budget():
+	"""Pre-flight check must skip a run whose estimated tokens would push
+	the total over the budget, instead of letting a single call overshoot."""
+	with tempfile.TemporaryDirectory() as tmp:
+		report = Path(tmp) / "report.json"
+		_write_report(
+			report,
+			{
+				"runs": [
+					{"repository": "a/b", "run_id": i, "created_at": f"2026-04-{i:02d}T00:00:00Z"}
+					for i in range(1, 4)
+				]
+			},
+		)
+		summarize_calls = {"n": 0}
+
+		class _FakeCollector:
+			@staticmethod
+			def _fetch_run_log_archive(repo, run_id, *, token, cache=None):
+				return b"<archive>"
+
+			@staticmethod
+			def extract_full_logs(_archive):
+				# Generate enough content that input_chars/4 alone exceeds
+				# the configured token budget.
+				return [{"step_name": "build", "content": "X" * 12_000}]
+
+		class _NeverCalledSummarizer:
+			def __init__(self, *_a, **_k):
+				pass
+
+			def summarize(self, *_a, **_k):
+				summarize_calls["n"] += 1
+				return ("- ok", 10)
+
+		original_loader = summarizer._load_collector_module
+		original_klass = summarizer.OpenRouterSummarizer
+		summarizer._load_collector_module = lambda: _FakeCollector
+		summarizer.OpenRouterSummarizer = _NeverCalledSummarizer
+		try:
+			# Tiny budget; input alone (~3000 tokens estimated) exceeds it.
+			with _env(OPENROUTER_API_KEY="orkey", GH_TOKEN="ghs_test"), _capture_std():
+				rc = summarizer.main(
+					["--report", str(report), "--token-budget", "100"]
+				)
+		finally:
+			summarizer._load_collector_module = original_loader
+			summarizer.OpenRouterSummarizer = original_klass
+
+	assert rc == 0
+	# Pre-flight should reject every run before any summarize() call.
+	assert summarize_calls["n"] == 0
+
+
 def test_main_breaks_loop_when_token_budget_exhausted():
 	"""After a single mini call exceeds the budget, remaining runs must be
 	accounted for in `skipped_budget_exhausted` in one shot — not iterated."""

--- a/tests/test_summarize_unselected_runs.py
+++ b/tests/test_summarize_unselected_runs.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Tests for scripts/summarize_unselected_runs.py.
+
+Coverage:
+  * select_targets: filters runs already covered by deep-dive log_excerpts or a
+    prior log_summary, requires repo+run_id, sorts newest-first, and respects
+    the cap.
+  * build_summary_input: per-step head/tail truncation and run-level fallback
+    truncation when the assembled text still exceeds the cap.
+  * _normalized_run_view (in analyze_workflow_logs): carries log_summary
+    through to analysis_context.json when present.
+  * main(): fail-open paths — missing report, missing creds, missing 'runs'
+    array all return 0 and emit telemetry instead of raising.
+
+Run via the CI coverage gate pattern (no pytest dependency):
+  python3 -m coverage run tests/test_summarize_unselected_runs.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "summarize_unselected_runs.py"
+ANALYZER_PATH = REPO_ROOT / "scripts" / "analyze_workflow_logs.py"
+if str(REPO_ROOT) not in sys.path:
+	sys.path.insert(0, str(REPO_ROOT))
+
+
+def _load_module(name: str, path: Path):
+	spec = importlib.util.spec_from_file_location(name, path)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+summarizer = _load_module("summarize_unselected_runs", SCRIPT_PATH)
+analyzer = _load_module("analyze_workflow_logs", ANALYZER_PATH)
+
+
+@contextlib.contextmanager
+def _capture_std():
+	out, err = io.StringIO(), io.StringIO()
+	with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+		yield out, err
+
+
+@contextlib.contextmanager
+def _env(**overrides):
+	original = {key: os.environ.get(key) for key in overrides}
+	try:
+		for key, value in overrides.items():
+			if value is None:
+				os.environ.pop(key, None)
+			else:
+				os.environ[key] = value
+		yield
+	finally:
+		for key, value in original.items():
+			if value is None:
+				os.environ.pop(key, None)
+			else:
+				os.environ[key] = value
+
+
+# ---------- select_targets ------------------------------------------------
+
+
+def test_select_targets_skips_runs_with_excerpts_or_existing_summary():
+	runs = [
+		{"repository": "a/b", "run_id": 1, "created_at": "2026-01-01T00:00:00Z"},
+		{
+			"repository": "a/b",
+			"run_id": 2,
+			"created_at": "2026-01-02T00:00:00Z",
+			"log_excerpts": [{"step_name": "x", "excerpt": "..."}],
+		},
+		{
+			"repository": "a/b",
+			"run_id": 3,
+			"created_at": "2026-01-03T00:00:00Z",
+			"log_summary": "already summarized",
+		},
+		{"repository": "a/b", "run_id": 4, "created_at": "2026-01-04T00:00:00Z"},
+	]
+	picked = summarizer.select_targets(runs, max_summaries=10)
+	assert [r["run_id"] for r in picked] == [4, 1], picked
+
+
+def test_select_targets_requires_repo_and_run_id():
+	runs = [
+		{"run_id": 5, "created_at": "2026-01-01T00:00:00Z"},
+		{"repository": "a/b", "run_id": 0, "created_at": "2026-01-01T00:00:00Z"},
+		{"repository": "a/b", "run_id": 7, "created_at": "2026-01-01T00:00:00Z"},
+	]
+	picked = summarizer.select_targets(runs, max_summaries=10)
+	assert [r["run_id"] for r in picked] == [7]
+
+
+def test_select_targets_caps_and_sorts_newest_first():
+	runs = [
+		{"repository": "a/b", "run_id": i, "created_at": f"2026-01-{i:02d}T00:00:00Z"}
+		for i in range(1, 8)
+	]
+	picked = summarizer.select_targets(runs, max_summaries=3)
+	assert [r["run_id"] for r in picked] == [7, 6, 5]
+
+
+def test_select_targets_zero_cap_returns_empty():
+	runs = [{"repository": "a/b", "run_id": 1, "created_at": "2026-01-01T00:00:00Z"}]
+	assert summarizer.select_targets(runs, max_summaries=0) == []
+
+
+# ---------- build_summary_input ------------------------------------------
+
+
+def test_build_summary_input_per_step_head_tail_truncation():
+	long_content = "A" * 2000 + "MIDDLE" + "Z" * 4000
+	logs = [{"step_name": "build", "content": long_content}]
+	text = summarizer.build_summary_input(
+		logs, char_cap=20_000, per_step_head=500, per_step_tail=1_000
+	)
+	assert text.startswith("=== STEP: build ===\n")
+	assert "A" * 500 in text
+	assert "Z" * 1_000 in text
+	assert "MIDDLE" not in text  # middle dropped
+	assert "[truncated" in text
+
+
+def test_build_summary_input_run_level_truncation_when_assembled_exceeds_cap():
+	logs = [{"step_name": f"s{i}", "content": "X" * 6_000} for i in range(10)]
+	text = summarizer.build_summary_input(
+		logs, char_cap=5_000, per_step_head=1_000, per_step_tail=2_000
+	)
+	assert len(text) <= 5_000 + len("\n... [run-level truncation] ...\n")
+	assert "[run-level truncation]" in text
+
+
+def test_build_summary_input_skips_empty_steps():
+	logs = [
+		{"step_name": "empty", "content": ""},
+		{"step_name": "real", "content": "hello world"},
+	]
+	text = summarizer.build_summary_input(logs, char_cap=10_000)
+	assert "STEP: real" in text
+	assert "STEP: empty" not in text
+
+
+# ---------- _format_user_message + truncation helper ---------------------
+
+
+def test_truncate_step_returns_short_content_unchanged():
+	assert summarizer._truncate_step("short", 100, 100) == "short"
+
+
+def test_format_user_message_includes_failure_point_when_present():
+	run = {
+		"repository": "owner/repo",
+		"run_id": 42,
+		"workflow_name": "Plan",
+		"workflow_family": "plan",
+		"conclusion": "failure",
+		"duration_seconds": 120,
+		"run_attempt": 2,
+		"retries": 1,
+		"failure_point": {"job_name": "build", "step_name": "compile"},
+	}
+	msg = summarizer._format_user_message(run, "logs go here")
+	assert "owner/repo #42" in msg
+	assert "build / compile" in msg
+	assert "logs go here" in msg
+
+
+# ---------- analyzer carries log_summary through ------------------------
+
+
+def test_normalized_run_view_carries_log_summary():
+	run = {
+		"repository": "a/b",
+		"run_id": 7,
+		"workflow_name": "Plan",
+		"log_summary": "- failure on step X\n- 429 from openrouter",
+	}
+	view = analyzer._normalized_run_view(run)
+	assert view["log_summary"].startswith("- failure")
+
+
+def test_normalized_run_view_omits_log_summary_when_blank():
+	view = analyzer._normalized_run_view({"repository": "a/b", "run_id": 1, "log_summary": "  "})
+	assert "log_summary" not in view
+
+
+# ---------- main() fail-open paths --------------------------------------
+
+
+def _write_report(path: Path, payload: dict) -> None:
+	path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_main_returns_zero_when_report_missing():
+	with tempfile.TemporaryDirectory() as tmp:
+		report = Path(tmp) / "absent.json"
+		with _capture_std() as (_out, err):
+			rc = summarizer.main(["--report", str(report)])
+	assert rc == 0
+	assert "not found" in err.getvalue()
+
+
+def test_main_returns_zero_when_openrouter_key_missing():
+	with tempfile.TemporaryDirectory() as tmp:
+		report = Path(tmp) / "report.json"
+		_write_report(report, {"runs": [{"repository": "a/b", "run_id": 1}]})
+		with _env(OPENROUTER_API_KEY="", GH_TOKEN="ghs_test"), _capture_std() as (_out, err):
+			rc = summarizer.main(["--report", str(report)])
+	assert rc == 0
+	assert "OPENROUTER_API_KEY" in err.getvalue()
+	assert "AI_MEMORY_TELEMETRY" in err.getvalue()
+
+
+def test_main_returns_zero_when_gh_token_missing():
+	with tempfile.TemporaryDirectory() as tmp:
+		report = Path(tmp) / "report.json"
+		_write_report(report, {"runs": []})
+		with _env(OPENROUTER_API_KEY="orkey", GH_TOKEN=""), _capture_std() as (_out, err):
+			rc = summarizer.main(["--report", str(report)])
+	assert rc == 0
+	assert "GH_TOKEN" in err.getvalue()
+
+
+def test_main_returns_zero_when_runs_field_missing():
+	with tempfile.TemporaryDirectory() as tmp:
+		report = Path(tmp) / "report.json"
+		_write_report(report, {"summary": {}})
+		with _env(OPENROUTER_API_KEY="orkey", GH_TOKEN="ghs_test"), _capture_std() as (_out, err):
+			rc = summarizer.main(["--report", str(report)])
+	assert rc == 0
+	assert "missing 'runs' array" in err.getvalue()
+
+
+def test_main_returns_zero_with_zero_max_summaries():
+	with tempfile.TemporaryDirectory() as tmp:
+		report = Path(tmp) / "report.json"
+		_write_report(report, {"runs": [{"repository": "a/b", "run_id": 1}]})
+		with _env(OPENROUTER_API_KEY="orkey", GH_TOKEN="ghs_test"), _capture_std() as (_out, err):
+			rc = summarizer.main(["--report", str(report), "--max-summaries", "0"])
+	assert rc == 0
+
+
+def test_main_writes_summary_when_summarizer_succeeds(monkeypatch=None):
+	"""End-to-end happy path with both collector + summarizer monkey-patched."""
+	with tempfile.TemporaryDirectory() as tmp:
+		report = Path(tmp) / "report.json"
+		_write_report(
+			report,
+			{
+				"runs": [
+					{
+						"repository": "a/b",
+						"run_id": 9,
+						"created_at": "2026-04-30T00:00:00Z",
+						"workflow_name": "Plan",
+						"conclusion": "success",
+					}
+				]
+			},
+		)
+
+		# Stub out the collector loader so we don't need ai_memory_lib.
+		class _FakeCollector:
+			@staticmethod
+			def _fetch_run_log_archive(repo, run_id, *, token, cache=None):
+				return b"<archive bytes>"
+
+			@staticmethod
+			def extract_full_logs(_archive):
+				return [{"step_name": "build", "content": "ok"}]
+
+		original_loader = summarizer._load_collector_module
+		summarizer._load_collector_module = lambda: _FakeCollector
+
+		# Stub the OpenRouter client so we don't hit the network.
+		class _FakeSummarizer:
+			def __init__(self, *_a, **_k):
+				pass
+
+			def summarize(self, _run, _text):
+				return ("- success in 1s", 42)
+
+		original_klass = summarizer.OpenRouterSummarizer
+		summarizer.OpenRouterSummarizer = _FakeSummarizer
+		try:
+			with _env(OPENROUTER_API_KEY="orkey", GH_TOKEN="ghs_test"), _capture_std():
+				rc = summarizer.main(["--report", str(report)])
+			assert rc == 0
+			written = json.loads(report.read_text(encoding="utf-8"))
+		finally:
+			summarizer._load_collector_module = original_loader
+			summarizer.OpenRouterSummarizer = original_klass
+
+	row = written["runs"][0]
+	assert row["log_summary"].startswith("- success")
+	assert row["log_summary_meta"]["tokens_used"] == 42
+	assert row["log_summary_meta"]["model"]
+
+
+def test_main_fail_open_when_summarizer_raises():
+	with tempfile.TemporaryDirectory() as tmp:
+		report = Path(tmp) / "report.json"
+		_write_report(
+			report,
+			{
+				"runs": [
+					{
+						"repository": "a/b",
+						"run_id": 11,
+						"created_at": "2026-04-30T00:00:00Z",
+					}
+				]
+			},
+		)
+
+		class _FakeCollector:
+			@staticmethod
+			def _fetch_run_log_archive(repo, run_id, *, token, cache=None):
+				return b"<archive bytes>"
+
+			@staticmethod
+			def extract_full_logs(_archive):
+				return [{"step_name": "build", "content": "ok"}]
+
+		class _FlakySummarizer:
+			def __init__(self, *_a, **_k):
+				pass
+
+			def summarize(self, *_a, **_k):
+				raise RuntimeError("simulated upstream 503")
+
+		original_loader = summarizer._load_collector_module
+		original_klass = summarizer.OpenRouterSummarizer
+		summarizer._load_collector_module = lambda: _FakeCollector
+		summarizer.OpenRouterSummarizer = _FlakySummarizer
+		try:
+			with _env(OPENROUTER_API_KEY="orkey", GH_TOKEN="ghs_test"), _capture_std() as (_out, err):
+				rc = summarizer.main(["--report", str(report)])
+			err_text = err.getvalue()
+			written = json.loads(report.read_text(encoding="utf-8"))
+		finally:
+			summarizer._load_collector_module = original_loader
+			summarizer.OpenRouterSummarizer = original_klass
+
+	assert rc == 0
+	assert "simulated upstream 503" in err_text
+	# Run row must remain unchanged (no log_summary written) under fail-open.
+	assert "log_summary" not in written["runs"][0]
+
+
+# ---------- script-mode entry point --------------------------------------
+
+
+def main() -> int:
+	test_funcs = sorted(
+		(name, obj)
+		for name, obj in globals().items()
+		if name.startswith("test_") and callable(obj)
+	)
+	failures: list[tuple[str, BaseException]] = []
+	for name, func in test_funcs:
+		try:
+			func()
+		except BaseException as exc:  # noqa: BLE001
+			failures.append((name, exc))
+			print(f"FAIL: {name}: {exc!r}", file=sys.stderr)
+		else:
+			print(f"PASS: {name}")
+	if failures:
+		print(f"\n{len(failures)} of {len(test_funcs)} tests failed.", file=sys.stderr)
+		return 1
+	print(f"\n{len(test_funcs)} tests passed.")
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_summarize_unselected_runs.py
+++ b/tests/test_summarize_unselected_runs.py
@@ -193,6 +193,24 @@ def test_build_summary_input_run_level_truncation_when_assembled_exceeds_cap():
 	assert "[run-level truncation]" in text
 
 
+def test_build_summary_input_preserves_late_step_signal_in_tail():
+	"""Regression: previously an early `break` at total>=char_cap*2 dropped
+	late steps entirely. The run-level truncation now keeps both ends, so
+	the failing-step content at the bottom of the archive must survive."""
+	logs = [
+		{"step_name": f"step{i:03d}", "content": f"step{i:03d}-body " * 200}
+		for i in range(40)
+	]
+	# Append a sentinel as the final step (mirrors the failing step / final
+	# warnings that the analyzer needs).
+	logs.append({"step_name": "final", "content": "FAILING_STEP_SENTINEL " * 50})
+	text = summarizer.build_summary_input(
+		logs, char_cap=8_000, per_step_head=200, per_step_tail=400
+	)
+	assert "FAILING_STEP_SENTINEL" in text
+	assert len(text) <= 8_000
+
+
 def test_build_summary_input_when_cap_smaller_than_marker_returns_marker_prefix():
 	# Pathological tiny cap (< marker length): we still must not exceed it.
 	logs = [{"step_name": "s", "content": "X" * 100}]
@@ -518,7 +536,7 @@ def test_main_does_not_pass_archive_cache_so_payload_bytes_arent_retained():
 				]
 			},
 		)
-		seen_cache_args: list[Any] = []
+		seen_cache_args: list[object] = []
 
 		class _CacheSpyingCollector:
 			@staticmethod

--- a/tests/test_summarize_unselected_runs.py
+++ b/tests/test_summarize_unselected_runs.py
@@ -166,6 +166,28 @@ def test_build_summary_input_when_cap_smaller_than_marker_returns_marker_prefix(
 	assert len(text) <= 10
 
 
+def test_build_summary_input_strict_cap_at_marker_plus_one():
+	# Regression: when budget==1 (char_cap == len(marker)+1), the previous
+	# `max(budget - head_size, 1)` clamp produced char_cap+1 chars.
+	marker = "\n... [run-level truncation] ...\n"
+	char_cap = len(marker) + 1
+	logs = [{"step_name": "s", "content": "X" * 1_000}]
+	text = summarizer.build_summary_input(
+		logs, char_cap=char_cap, per_step_head=10, per_step_tail=10
+	)
+	assert len(text) <= char_cap
+
+
+def test_build_summary_input_strict_cap_at_marker_plus_two():
+	marker = "\n... [run-level truncation] ...\n"
+	char_cap = len(marker) + 2
+	logs = [{"step_name": "s", "content": "X" * 1_000}]
+	text = summarizer.build_summary_input(
+		logs, char_cap=char_cap, per_step_head=10, per_step_tail=10
+	)
+	assert len(text) <= char_cap
+
+
 def test_build_summary_input_skips_empty_steps():
 	logs = [
 		{"step_name": "empty", "content": ""},
@@ -221,6 +243,31 @@ def test_extract_tokens_used_falls_back_on_empty_usage_dict():
 
 def test_truncate_step_returns_short_content_unchanged():
 	assert summarizer._truncate_step("short", 100, 100) == "short"
+
+
+def test_truncate_step_handles_tail_chars_zero_without_falling_back_to_full_string():
+	"""Python `content[-0:]` evaluates to `content[0:]` (the full string).
+	The truncator must guard against that so per_step_tail=0 actually drops
+	the tail instead of silently returning the entire content."""
+	content = "X" * 1_000
+	out = summarizer._truncate_step(content, head_chars=10, tail_chars=0)
+	# Should be head + marker only — never the full 1000-char content.
+	assert content not in out
+	assert out.startswith("X" * 10)
+	assert "[truncated 990 chars]" in out
+
+
+def test_truncate_step_handles_head_chars_zero():
+	content = "Y" * 500
+	out = summarizer._truncate_step(content, head_chars=0, tail_chars=20)
+	assert content not in out
+	assert out.endswith("Y" * 20)
+
+
+def test_truncate_step_returns_marker_only_when_both_bounds_zero():
+	out = summarizer._truncate_step("Z" * 100, head_chars=0, tail_chars=0)
+	assert "Z" not in out
+	assert "[truncated" in out
 
 
 def test_format_user_message_includes_failure_point_when_present():
@@ -420,6 +467,59 @@ def test_main_counts_empty_archive_as_skipped_empty_logs_not_fetch_error():
 	# Telemetry line includes skipped_empty_logs=1 and skipped_fetch_error=0.
 	assert '"skipped_empty_logs": 1' in err_text
 	assert '"skipped_fetch_error": 0' in err_text
+
+
+def test_main_does_not_pass_archive_cache_so_payload_bytes_arent_retained():
+	"""The collector caches payload bytes by (repo, run_id) when given a
+	cache dict; for a script that fetches each run exactly once that just
+	leaks log archives. Verify cache=None is passed."""
+	with tempfile.TemporaryDirectory() as tmp:
+		report = Path(tmp) / "report.json"
+		_write_report(
+			report,
+			{
+				"runs": [
+					{"repository": "a/b", "run_id": 1, "created_at": "2026-04-01T00:00:00Z"},
+					{"repository": "a/b", "run_id": 2, "created_at": "2026-04-02T00:00:00Z"},
+				]
+			},
+		)
+		seen_cache_args: list[Any] = []
+
+		class _CacheSpyingCollector:
+			@staticmethod
+			def _fetch_run_log_archive(repo, run_id, *, token, cache=None):
+				seen_cache_args.append(cache)
+				return b"<archive>"
+
+			@staticmethod
+			def extract_full_logs(_archive):
+				return [{"step_name": "build", "content": "ok"}]
+
+		class _NoopSummarizer:
+			def __init__(self, *_a, **_k):
+				pass
+
+			def summarize(self, *_a, **_k):
+				return ("- ok", 10)
+
+		original_loader = summarizer._load_collector_module
+		original_klass = summarizer.OpenRouterSummarizer
+		summarizer._load_collector_module = lambda: _CacheSpyingCollector
+		summarizer.OpenRouterSummarizer = _NoopSummarizer
+		try:
+			with _env(OPENROUTER_API_KEY="orkey", GH_TOKEN="ghs_test"), _capture_std():
+				rc = summarizer.main(["--report", str(report)])
+		finally:
+			summarizer._load_collector_module = original_loader
+			summarizer.OpenRouterSummarizer = original_klass
+
+	assert rc == 0
+	assert len(seen_cache_args) == 2
+	assert all(arg is None for arg in seen_cache_args), (
+		f"expected cache=None for every fetch to avoid retaining log-archive bytes, "
+		f"got: {seen_cache_args!r}"
+	)
 
 
 def test_main_breaks_loop_when_token_budget_exhausted():


### PR DESCRIPTION
## Summary

- Adds `scripts/summarize_unselected_runs.py`: an optional pre-pass that picks up to **100 newest unselected runs** (those with no `log_excerpts` because they fell outside the collector's deep-dive top-15), fetches each run's GH log archive, and asks **gpt-5.4-mini** for a terse per-run summary covering outcome, failing step, warnings, retries, token/API hot-spots, and any `AI_MEMORY_TELEMETRY:` lines.
- Writes `log_summary` + `log_summary_meta` back into the run rows in `workflow_log_report.json`. `analyze_workflow_logs.py:_normalized_run_view` now carries `log_summary` through to `analysis_context.json`, and `prompts/mode-workflow-analysis.txt` tells Codex to consult those summaries for runs without folder-level evidence.
- Wires the new step into `analyze-commit-notify` between the artifact downloads and the existing `analyze_workflow_logs.py` call, gated `continue-on-error: true`. Repo-overridable via `vars.WORKFLOW_LOG_SUMMARY_MODEL / _MAX_RUNS / _TOKEN_BUDGET` (defaults: `openai/gpt-5.4-mini`, 100 runs, 1.5M tokens).

## Why

The collector's quick-index excerpts are capped at 4 000 chars per step, but the analyzer Codex pass already reads the full untruncated step logs from the `workflow-log-output` artifact — so the 4 000-char cap doesn't lose signal for the top-15 deep-dive runs. The actual blind spot was every run **outside** the top-15, which had only metadata. Mini-summarizing those at ~3 000-token input × 500-token output per run closes that gap without competing with the main Codex pass for tokens.

## Fail-open posture (matches §15 GH-API hygiene)

- Missing `OPENROUTER_API_KEY` or `GH_TOKEN` → skip with `::warning::`, exit 0.
- Archive fetch error or mini call error → skip the run, keep going.
- Token budget exceeded → stop summarizing remaining runs, exit 0.
- Step itself runs `continue-on-error: true`, so the analysis job is never blocked.

## Test plan

- [x] `python3 tests/test_summarize_unselected_runs.py` — 18 new tests pass (selection, head/tail truncation, run-level fallback truncation, fail-open paths, monkey-patched happy/sad e2e, normalized-view propagation).
- [x] `python3 tests/test_analyze_workflow_logs.py` — 15 existing tests still pass after the `_normalized_run_view` change.
- [x] `python3 tests/test_collect_workflow_logs.py` — 22 existing collector tests still pass.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/workflow-log-analysis.yml'))"` — workflow YAML parses cleanly.
- [ ] Dispatch the workflow with a small `lookback_days` and confirm `analysis_context.json` contains `log_summary` fields and the mini step's `AI_MEMORY_TELEMETRY` line shows non-zero `summarized` and `tokens_used` within budget.

https://claude.ai/code/session_01We3u9ws8WJiUckGforqvka

---
_Generated by [Claude Code](https://claude.ai/code/session_01We3u9ws8WJiUckGforqvka)_