### PR TITLE
feat(release): minor-bump default for promote + TG alerts on forward-merge

### DIFF
--- a/.github/workflows/forward-merge-stable-to-main.yml
+++ b/.github/workflows/forward-merge-stable-to-main.yml
@@ -222,6 +222,7 @@ jobs:
           echo "Verified: origin/main contains origin/stable — propagation complete"
 
       - name: Fallback — open PR for manual merge
+        id: fallback
         if: >-
           steps.check.outputs.ahead != '0' &&
           (steps.direct.outputs.merge_status == 'conflict' ||
@@ -280,11 +281,20 @@ jobs:
           set -e
           if [ "${PR_RC}" -eq 0 ]; then
             echo "${PR_OUTPUT}"
+            # Capture the PR URL so the follow-up TG alert step can
+            # surface it. `gh pr create` prints the URL on its own
+            # line on success; grep for the first github.com URL to
+            # be tolerant of any preceding banner output.
+            PR_URL=$(printf '%s' "${PR_OUTPUT}" | grep -oE 'https://github\.com/[^[:space:]]+' | head -n1 || true)
+            echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+            echo "reason=${MERGE_STATUS}" >> "$GITHUB_OUTPUT"
           elif printf '%s' "${PR_OUTPUT}" | grep -qiE 'pull request for branch .* already exists'; then
             # Anchored to gh CLI's canonical phrasing: "a pull request
             # for branch <name> into branch <base> already exists". The
             # earlier looser pattern could match unrelated errors that
             # happened to mention "pull request" or "already exists".
+            # Don't re-alert: the original run that opened the PR
+            # already alerted, and a re-run shouldn't spam TG.
             echo "::warning::PR already exists for ${BRANCH} — treating as benign"
             echo "${PR_OUTPUT}"
           else
@@ -292,6 +302,43 @@ jobs:
             echo "${PR_OUTPUT}" >&2
             exit "${PR_RC}"
           fi
+
+      - name: Telegram alert — fallback PR opened
+        if: steps.fallback.outputs.pr_url != ''
+        env:
+          TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
+          TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID || '' }}
+          ALERT_MSG_LEVEL: ${{ vars.ALERT_MSG_LEVEL || 'DEBUG' }}
+          PR_URL: ${{ steps.fallback.outputs.pr_url }}
+          REASON: ${{ steps.fallback.outputs.reason }}
+        shell: bash
+        run: |
+          # Forward-merge is the safety net for stable→main propagation.
+          # When it falls back to a manual PR (conflict or branch
+          # protection), the bug fix is stuck on stable until a human
+          # resolves the PR. Surface that on TG so it doesn't sit
+          # unnoticed in GitHub email.
+          set -uo pipefail
+          if [ ! -f scripts/tg_helpers.sh ]; then
+            echo "::warning::tg_helpers.sh not found; skipping fallback PR TG alert"
+            exit 0
+          fi
+          # shellcheck disable=SC1091
+          source scripts/tg_helpers.sh
+
+          run_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          case "${REASON}" in
+            conflict)      reason_text="merge conflict" ;;
+            push_rejected) reason_text="branch protection / push rejected" ;;
+            *)             reason_text="${REASON}" ;;
+          esac
+
+          msg="forward-merge stable→main opened a fallback PR (${reason_text})"
+          msg+=$'\n'"PR: ${PR_URL}"
+          msg+=$'\n'"Run: ${run_url}"
+          msg+=$'\n'"Bug fixes on stable will not reach main until this PR is merged."
+
+          tg_send_msg "${msg}" "ERROR" >/dev/null || true
 
       - name: Summary
         if: always()
@@ -310,3 +357,58 @@ jobs:
           else
             echo "Result: unknown — see job logs"
           fi
+
+      - name: Telegram alert — hard failure
+        if: failure()
+        env:
+          TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
+          TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID || '' }}
+          ALERT_MSG_LEVEL: ${{ vars.ALERT_MSG_LEVEL || 'DEBUG' }}
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+        shell: bash
+        run: |
+          # Catch-all for hard failures (transport retries exhausted,
+          # post-push verification mismatch, fallback PR creation
+          # failure, etc.). Without this, a red run only surfaces via
+          # GitHub's default email — and forward-merge silently failing
+          # means stable bug fixes don't reach main, which the next
+          # main-source release would then re-introduce. Fire CRITICAL.
+          # Best-effort: missing tg_helpers.sh (e.g. an early checkout
+          # failure) degrades to a warning rather than masking the
+          # original failure.
+          set -uo pipefail
+          if [ ! -f scripts/tg_helpers.sh ]; then
+            echo "::warning::tg_helpers.sh not found; skipping hard-failure TG alert"
+            exit 0
+          fi
+          # shellcheck disable=SC1091
+          source scripts/tg_helpers.sh
+
+          run_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          workflow_name="${GITHUB_WORKFLOW:-forward-merge-stable-to-main}"
+
+          # Resolve the first failing step name via the GitHub API.
+          # Fail open: if the lookup fails or returns nothing, still
+          # send the alert without the step name rather than dropping
+          # the alert.
+          failing_step=""
+          if [ -n "${GH_TOKEN:-}" ]; then
+            jobs_json="$(curl -fsSL \
+              -H "Authorization: token ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT:-1}/jobs" 2>/dev/null || echo '')"
+            if [ -n "${jobs_json}" ]; then
+              failing_step="$(printf '%s' "${jobs_json}" \
+                | jq -r '.jobs[]?.steps[]? | select(.conclusion == "failure") | .name' 2>/dev/null \
+                | head -n1)"
+            fi
+          fi
+
+          msg="forward-merge stable→main hard failure: ${workflow_name}"
+          if [ -n "${failing_step}" ]; then
+            msg+=$'\n'"Failing step: ${failing_step}"
+          fi
+          msg+=$'\n'"Run: ${run_url}"
+          msg+=$'\n'"Bug fixes on stable may not propagate to main until resolved."
+
+          tg_send_msg "${msg}" "CRITICAL" >/dev/null || true

--- a/.github/workflows/forward-merge-stable-to-main.yml
+++ b/.github/workflows/forward-merge-stable-to-main.yml
@@ -24,6 +24,11 @@ name: Forward-merge stable to main
 permissions:
   contents: write
   pull-requests: write
+  # actions: read is required by the hard-failure TG alert step so
+  # the failing-step lookup against the Actions Jobs API works when
+  # GH_PAT is unset and we fall back to github.token. Without this,
+  # `failing_step` would always be empty on github.token-only runs.
+  actions: read
 
 concurrency:
   group: forward-merge-stable-to-main

--- a/.github/workflows/promote-main-to-stable.yml
+++ b/.github/workflows/promote-main-to-stable.yml
@@ -26,10 +26,12 @@ name: Promote main to stable
     inputs:
       version_tag:
         description: >
-          Semantic version tag (e.g. v1.5.0). Almost always required
-          for a promotion (since the typical case is a minor/major
-          bump). Leave blank to fall back to patch auto-increment
-          from the latest stable-reachable tag.
+          Semantic version tag (e.g. v1.5.0). Leave blank to
+          auto-increment the MINOR component from the latest
+          stable-reachable tag (vX.Y.Z → vX.(Y+1).0). The patch
+          component is reset to 0 — promotes are minor/major bumps
+          by definition; the patch-bump default in
+          test-and-mark-stable.yml is for the stable-only patch path.
         required: false
         type: string
         default: ""
@@ -199,24 +201,111 @@ jobs:
           echo "moved=true" >> "$GITHUB_OUTPUT"
           echo "sha=${TARGET}" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve version (compute next minor if not provided)
+        id: resolve_version
+        env:
+          INPUT_VERSION: ${{ inputs.version_tag }}
+        run: |
+          set -euo pipefail
+          # Promote runs are minor/major bumps by definition; the
+          # auto-bump path here computes vX.(Y+1).0 from the latest
+          # semver tag reachable from the just-fast-forwarded HEAD
+          # (== main HEAD). The patch-bump auto-resolver in
+          # test-and-mark-stable.yml is appropriate for the stable-
+          # only patch path; we override it here by passing an
+          # explicit version_tag through to the dispatch.
+          if [ -n "${INPUT_VERSION}" ]; then
+            if [[ ! "${INPUT_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Provided version '${INPUT_VERSION}' is invalid; must match vX.Y.Z"
+              exit 1
+            fi
+            echo "Using user-provided version: ${INPUT_VERSION}"
+            echo "version=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Refresh tags from origin BEFORE computing LATEST. Bounded
+          # retry tolerates transient network/auth flakes; persistent
+          # failure is a hard error since computing the next version
+          # on stale tag data could pick a colliding version.
+          fetch_attempt=1
+          while [ "$fetch_attempt" -le 3 ]; do
+            if git fetch --tags --force origin 2>/tmp/_git_fetch_err; then
+              break
+            fi
+            if [ "$fetch_attempt" -eq 3 ]; then
+              echo "::error::Failed to fetch remote tags after 3 attempts — refusing to compute next version on potentially stale tag data"
+              cat /tmp/_git_fetch_err >&2 2>/dev/null || true
+              exit 1
+            fi
+            backoff=$(( 2 ** fetch_attempt ))
+            echo "::warning::git fetch --tags failed (attempt ${fetch_attempt}/3), retrying in ${backoff}s…"
+            cat /tmp/_git_fetch_err >&2 2>/dev/null || true
+            sleep "${backoff}"
+            fetch_attempt=$((fetch_attempt + 1))
+          done
+
+          # Strict semver filter mirrors test-and-mark-stable.yml's
+          # resolver: the shell glob also matches prerelease tags
+          # (e.g. v1.4.2-beta.1) which would later break minor
+          # arithmetic on `cut -d. -f2` under `set -euo pipefail`.
+          LATEST=$(git tag --merged HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
+            | { grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; } \
+            | head -n1)
+
+          if [ -z "$LATEST" ]; then
+            NEXT="v1.0.0"
+            echo "No existing version tags reachable from HEAD. Defaulting to ${NEXT}"
+          else
+            MAJOR=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f1)
+            MINOR=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f2)
+            # Bump minor (patch resets to 0) and skip any candidate
+            # already in the local tag namespace (which mirrors origin
+            # after the fetch above). Bounded to 1000 iterations as a
+            # belt-and-braces guard.
+            NEXT=""
+            i=0
+            while [ "$i" -lt 1000 ]; do
+              MINOR=$((MINOR + 1))
+              CANDIDATE="v${MAJOR}.${MINOR}.0"
+              if ! git rev-parse "refs/tags/${CANDIDATE}" >/dev/null 2>&1; then
+                NEXT="$CANDIDATE"
+                break
+              fi
+              echo "Tag ${CANDIDATE} already exists — skipping"
+              i=$((i + 1))
+            done
+            if [ -z "$NEXT" ]; then
+              echo "::error::Could not find an unused minor tag after 1000 attempts starting from ${LATEST}"
+              exit 1
+            fi
+            echo "Latest reachable tag: ${LATEST} → next promote version: ${NEXT}"
+          fi
+
+          echo "version=${NEXT}" >> "$GITHUB_OUTPUT"
+
       - name: Dispatch test-and-mark-stable on stable
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          RESOLVED_VERSION: ${{ steps.resolve_version.outputs.version }}
         run: |
           set -euo pipefail
           # test-and-mark-stable.yml hard-rejects any dispatch ref
           # other than `stable`, so we MUST pass `--ref stable` here.
           # The release job tags the just-fast-forwarded commit on
           # stable and `gh release create` targets the stable branch.
+          # Passing `version_tag` explicitly overrides
+          # test-and-mark-stable.yml's auto-bump (which would patch-
+          # bump) — promote runs are minor/major by definition.
           gh workflow run test-and-mark-stable.yml \
             --ref stable \
-            -f version_tag="${{ inputs.version_tag }}" \
+            -f version_tag="${RESOLVED_VERSION}" \
             -f test_repo="${{ inputs.test_repo }}" \
             -f skip_e2e="${{ inputs.skip_e2e }}" \
             -f dry_run="${{ inputs.dry_run }}" \
             -f phase_timeout="${{ inputs.phase_timeout }}" \
             -f review_timeout="${{ inputs.review_timeout }}"
-          echo "Dispatched test-and-mark-stable.yml on stable branch."
+          echo "Dispatched test-and-mark-stable.yml on stable branch with version=${RESOLVED_VERSION}."
           echo "View runs: https://github.com/${GITHUB_REPOSITORY}/actions/workflows/test-and-mark-stable.yml"
 
       - name: Summary
@@ -225,6 +314,7 @@ jobs:
           echo "Promotion summary:"
           echo "  stable now at: ${{ steps.ff.outputs.sha }}"
           echo "  fast-forward moved: ${{ steps.ff.outputs.moved }}"
+          echo "  resolved version: ${{ steps.resolve_version.outputs.version }}"
           echo "  release pipeline dispatched on stable branch (see link above)"
           echo ""
           echo "The release run will tag, move the stable/vN pointers, create a"


### PR DESCRIPTION
## Summary

- **Minor-bump default for `promote-main-to-stable.yml`**: when `version_tag` is empty, auto-compute `vX.(Y+1).0` from the latest semver tag reachable from the just-fast-forwarded HEAD (== `main`). Promotes are minor/major bumps by definition; the patch-bump auto-resolver in `test-and-mark-stable.yml` stays the default for the stable-only patch path. Operator-supplied `version_tag` still wins.
- **Telegram alerts on forward-merge non-clean outcomes** (`forward-merge-stable-to-main.yml`):
  - **ERROR-level** alert when a fallback PR is opened (conflict or branch-protection rejection), with the PR URL and a note that bug fixes on `stable` won't reach `main` until the PR is merged.
  - **CRITICAL-level** catch-all on hard failure (transport retries exhausted, post-push verification mismatch, etc.) with the failing step name resolved via the GitHub API.
  - "PR already exists" path stays silent — the original run that opened it already alerted, so a re-run shouldn't spam TG.
  - Both alerts respect `ALERT_MSG_LEVEL` and degrade to a `::warning::` if `tg_helpers.sh` isn't on disk.

Together these close the silent-failure gap where stable-only bug fixes could sit on `stable` without ever propagating to `main`.

## Behaviour examples

| Scenario | Resolved version |
|---|---|
| Latest tag `v1.0.113`, promote dispatched with no `version_tag` | `v1.1.0` |
| Latest tag `v1.0.113`, promote dispatched with `version_tag=v2.0.0` | `v2.0.0` |
| After promote → stable patch dispatched on `stable` from `v1.1.0` | `v1.1.1` (unchanged — `test-and-mark-stable.yml` resolver) |

## Test plan

- [ ] Dry-run dispatch `promote-main-to-stable.yml` with no `version_tag` and confirm the resolver computes `vX.(Y+1).0` from the latest reachable tag.
- [ ] Dispatch with explicit `version_tag=v2.0.0` and confirm it passes through unchanged.
- [ ] Confirm `test-and-mark-stable.yml` receives the resolved version via `version_tag` input (visible in the dispatched run logs).
- [ ] Trigger a synthetic conflict on `stable` (e.g. push a stable-only commit that conflicts with `main`) and verify the fallback PR is opened AND a TG ERROR alert fires with the PR URL.
- [ ] Cause a hard failure (e.g. revoke `GH_PAT` temporarily on a fixture branch) and verify the TG CRITICAL alert fires with the failing step name.
- [ ] Verify the "PR already exists" path on a re-run does NOT re-alert.

https://claude.ai/code/session_01K2quRzRU7N2VRsA4Vx7LNL

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2quRzRU7N2VRsA4Vx7LNL)_