### PR TITLE
fix(workflow-log-analysis): bump api-redundancy timeout 60m → 90m

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -2607,9 +2607,16 @@ jobs:
     # still in "Plan update → Draft" phase), so api-redundancy was
     # bumped to 90m. Sum of in-step DEADLINEs below (workflow-log-analysis
     # 12000 + validation-refresh 2400 + update_workflows 600 +
-    # memory-maintenance 900 = 15900s ≈ 265m) plus a 15m headroom for
-    # runner queueing and step setup.
-    timeout-minutes: 280
+    # memory-maintenance 900 = 15900s ≈ 265m). This job also spends
+    # additional wall time outside those DEADLINE windows on prerequisite
+    # validation, checkout, and the per-phase run-soft-error-analyzer
+    # composite actions (each waits up to wait_for_completion_secs=120s
+    # and then runs an OpenRouter call via scripts/analyze_soft_errors.py;
+    # log1 of run #25200117236 observed ~40s for one phase, so 4 phases
+    # under OpenRouter latency variance can plausibly reach 8–12m), so
+    # keep extra headroom for that work as well as runner queueing and
+    # step setup. Per Copilot review on PR #1842.
+    timeout-minutes: 330
     env:
       GH_TOKEN: ${{ secrets.GH_PAT }}
       TEST_REPO: ${{ inputs.test_repo || github.repository }}

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -2597,16 +2597,19 @@ jobs:
     runs-on: ubuntu-latest
     # 45m was sized for the original 2-job workflow-log-analysis. The
     # workflow now has four sequential jobs (collect-logs 25m,
-    # analyze-commit-notify 30m, deep-audit 45m, api-redundancy 60m —
-    # ceiling ~160m), and run #25088541089 cancelled at 30m 16s on
+    # analyze-commit-notify 30m, deep-audit 45m, api-redundancy 90m —
+    # ceiling ~190m), and run #25088541089 cancelled at 30m 16s on
     # `deep-audit` (its previous 30m timeout-minutes), so deep-audit
     # was bumped to 45m in workflow-log-analysis.yml:603. Run #25115192726
     # then cancelled at 30m 19s on api-redundancy with that job's prior
-    # 30m cap, so api-redundancy was bumped to 60m. Sum of in-step
-    # DEADLINEs below (workflow-log-analysis 10200 + validation-refresh
-    # 2400 + update_workflows 600 + memory-maintenance 900 = 14100s ≈
-    # 235m) plus a 15m headroom for runner queueing and step setup.
-    timeout-minutes: 250
+    # 30m cap, so api-redundancy was bumped to 60m. Run #25200117236
+    # cancelled at 60m 11s on api-redundancy with that 60m cap (Codex
+    # still in "Plan update → Draft" phase), so api-redundancy was
+    # bumped to 90m. Sum of in-step DEADLINEs below (workflow-log-analysis
+    # 12000 + validation-refresh 2400 + update_workflows 600 +
+    # memory-maintenance 900 = 15900s ≈ 265m) plus a 15m headroom for
+    # runner queueing and step setup.
+    timeout-minutes: 280
     env:
       GH_TOKEN: ${{ secrets.GH_PAT }}
       TEST_REPO: ${{ inputs.test_repo || github.repository }}
@@ -2648,15 +2651,17 @@ jobs:
         # step instead of cancelling all sibling steps in the job.
         # Sized to the workflow-log-analysis 4-job sequential worst-case
         # (collect-logs 25m + analyze-commit-notify 30m + deep-audit
-        # 45m + api-redundancy 60m = 160m) plus a 15m runner-queue +
+        # 45m + api-redundancy 90m = 190m) plus a 15m runner-queue +
         # step-setup buffer; release v1.0.113 watcher exited at 28m
         # while deep-audit was still running, run #25088541089
         # cancelled at 30m 16s on deep-audit with its prior 30m cap,
-        # and run #25115192726 cancelled at 30m 19s on api-redundancy
-        # with its prior 30m cap (now 60m, see workflow-log-analysis.yml).
-        # Per Copilot review on PR #1742: the previous 95m setting
-        # could still time out a healthy run that hit the worst case.
-        timeout-minutes: 175
+        # run #25115192726 cancelled at 30m 19s on api-redundancy with
+        # its 30m cap, and run #25200117236 cancelled at 60m 11s on
+        # api-redundancy with its 60m cap (now 90m, see workflow-log-
+        # analysis.yml). Per Copilot review on PR #1742: the previous
+        # 95m setting could still time out a healthy run that hit the
+        # worst case.
+        timeout-minutes: 205
         env:
           WF_FILE: workflow-log-analysis.yml
           INPUTS: '{"lookback_days":"1","repos_override":"${{ inputs.test_repo || github.repository }}"}'
@@ -2668,10 +2673,10 @@ jobs:
             --field lookback_days=1 \
             --field repos_override="${TEST_REPO}" \
             --field alert_msg_level=SILENT
-          # 10200s (170m) covers the 160m worst-case audit chain
+          # 12000s (200m) covers the 190m worst-case audit chain
           # (collect-logs 25m + analyze-commit-notify 30m + deep-audit
-          # 45m + api-redundancy 60m) plus a 10m buffer for runner
-          # queueing between jobs. Step timeout-minutes above (175m)
+          # 45m + api-redundancy 90m) plus a 10m buffer for runner
+          # queueing between jobs. Step timeout-minutes above (205m)
           # is the outer cap that attributes a hang to this step.
           # Bumped 7200 → 8400 after deep-audit's per-job cap was
           # raised 30m → 45m in workflow-log-analysis.yml:603 (run
@@ -2679,7 +2684,11 @@ jobs:
           # Bumped 8400 → 10200 after api-redundancy's per-job cap was
           # raised 30m → 60m (run #25115192726 cancelled at 30m 19s
           # on api-redundancy with its prior 30m cap).
-          DEADLINE=$(( $(date +%s) + 10200 ))
+          # Bumped 10200 → 12000 after api-redundancy's per-job cap was
+          # raised 60m → 90m (run #25200117236 cancelled at 60m 11s on
+          # api-redundancy with its prior 60m cap, Codex still in "Plan
+          # update → Draft" phase).
+          DEADLINE=$(( $(date +%s) + 12000 ))
           NEW_ID=""
           while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
             NEW_ID=$(gh api "repos/${TEST_REPO}/actions/workflows/${WF_FILE}/runs?per_page=10" \

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -935,10 +935,17 @@ jobs:
     # Bumped 30 → 60 after run 25115192726 cancelled at 30m19s on this job
     # — Codex was still mid-analysis ("considering whether I can combine
     # findings from two separate call sites") when the 30m cap fired and
-    # emitted `##[error]The operation was canceled.`. The orphan-workflows
-    # poller's outer DEADLINE in test-and-mark-stable.yml (dispatch step)
-    # still covers the new 60m cap with plenty of headroom.
-    timeout-minutes: 60
+    # emitted `##[error]The operation was canceled.`. Bumped 60 → 90 after
+    # run 25200117236 cancelled at 60m 11s — Codex (gpt-5.4 reasoning
+    # effort xhigh) was still in the "Plan update … → Draft final markdown
+    # section" phase (had not started generating output) when the 60m cap
+    # fired. Audit-prompt input size has not grown materially since the
+    # 30 → 60 bump (report file 51 KB this run vs. 33–58 KB pre-bump);
+    # the structural cause is xhigh deliberation latency variance, which
+    # the 60m cap couldn't absorb. The orphan-workflows poller's outer
+    # DEADLINE in test-and-mark-stable.yml (dispatch step) still covers
+    # the new 90m cap with headroom.
+    timeout-minutes: 90
     outputs:
       api_redundancy_status: ${{ steps.api_redundancy.outputs.api_redundancy_status }}
     env:


### PR DESCRIPTION
## Summary

`workflow-log-analysis` run **#25200117236** cancelled at exactly **60 min 11 s** on the `api-redundancy` job — Codex (`openai/gpt-5.4`, reasoning effort `xhigh`) was still in the *"Plan update → Draft final markdown section"* phase (had not begun emitting output) when the runner timeout fired with `##[error]The operation was canceled.`. This cascaded into the `orphan-workflows-test` failure observed in the parent `Test & Mark Stable Release` run #25200104592 (which simply observed and reported the dispatched run's `cancelled` conclusion).

This is the **same** structural failure mode that triggered the prior 30 → 60 bump (run #25115192726 cancelled at 30 m 19 s with Codex still mid-analysis). The cap shifted but did not eliminate the failure.

## Root cause

`xhigh` deliberation latency variance for the API-call-consolidation prompt exceeds the cap. Confirmed **not** an input-size regression: the audit input (the in-progress report file) was 51 KB this run, well within the historical 33–58 KB range observed before the 30 → 60 bump. The cap is structurally undersized for the model + reasoning-effort combination.

Per owner direction, `THINKING_LEVEL_ANALYSIS` stays at `xhigh` (the audit pass needs the depth) — fix is on the cap side.

## Changes

**Commit 1 (`5da4c14`) — primary fix:**
- **`.github/workflows/workflow-log-analysis.yml`** — `api-redundancy` `timeout-minutes: 60 → 90`. Comment block updated to cite this run and record that input size is not the driver.
- **`.github/workflows/test-and-mark-stable.yml`** — three coupled bumps so the `orphan-workflows-test` watcher continues to outlast the worst-case audit chain:
  - dispatch step `DEADLINE`: `10200s → 12000s` (170 m → 200 m; covers new 190 m worst-case chain + 10 m buffer)
  - dispatch step `timeout-minutes`: `175 → 205`
  - `orphan-workflows-test` job-level `timeout-minutes`: `250 → 280`
- All four comment blocks at the bumped sites updated so the cite-by-run-id audit trail of cap bumps stays accurate.

**Commit 2 (`6a5f99d`) — addresses Copilot review:**
- **`.github/workflows/test-and-mark-stable.yml`** — further bumped `orphan-workflows-test` job-level `timeout-minutes: 280 → 330` and enriched the comment math to enumerate analyzer wall-time contributors. The prior 280 was sized as `sum-of-DEADLINEs (15900 s ≈ 265 m) + 15 m headroom`, which didn't account for the per-phase `run-soft-error-analyzer` composite actions (each waits up to `wait_for_completion_secs=120s` and then runs an OpenRouter call via `scripts/analyze_soft_errors.py` — log1 of run #25200117236 observed ~40 s for one phase, so 4 phases under OpenRouter latency variance can plausibly reach 8-12 m). New 330 = 265 m DEADLINE sum + 65 m headroom for analyzer calls, checkout, prereq validation, runner queueing, and step setup.

**Net effect on `orphan-workflows-test` job-level cap: 250 → 330** (across both commits).

No other behavior changed. `THINKING_LEVEL_ANALYSIS`, `MAX_CODEX_ATTEMPTS`, `WORKFLOW_LOG_ANALYSIS_MODEL`, and Codex stream/retry settings are all untouched.

## Test plan

- [ ] On the next `Test & Mark Stable Release` dispatch, confirm `orphan-workflows-test` does **not** cancel at the previous 175 m step cap or 250 m job cap.
- [ ] Confirm `workflow-log-analysis`'s `api-redundancy` job either completes within 90 m or, if it cancels, attribute the new failure to the new cap (not to the watcher's outer cap timing out first).
- [ ] If `api-redundancy` ever completes within ≪ 90 m on three consecutive runs, consider whether the cap can be relaxed back; if it cancels at 90 m on a future run, the next move is to revisit `THINKING_LEVEL_ANALYSIS` (currently held at `xhigh`) rather than further cap inflation.

https://claude.ai/code/session_014zTjWBKwBaT84gUjff4r8p
