### PR TITLE
fix(e2e): dispatch internal-review.yml after bait push to bypass Bug B

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1076,7 +1076,15 @@ jobs:
           # Fail-soft: if dispatch fails, the synchronize event (when
           # it fires) still serves as the primary path; if neither
           # fires, wait-review surfaces no_review_triggered as before.
+          # --repo "${TEST_REPO}" is required because this job supports
+          # dispatching E2E against an arbitrary `inputs.test_repo`;
+          # without it, `gh workflow run` would target the default repo
+          # from the checkout/CLI context (shubhodeep1/coding-workflows
+          # itself, per the early checkout at line 316) instead of the
+          # repo we just pushed the bait commit to, leaving Phase 4
+          # still vulnerable to no_review_triggered.
           if gh workflow run "internal-review.yml" \
+              --repo "${TEST_REPO}" \
               --ref "${BRANCH}" \
               -f pr_number="${PR_NUMBER}" >/tmp/dispatch_resp.txt 2>&1; then
             echo "✓ Dispatched internal-review.yml on ${BRANCH} for PR #${PR_NUMBER} (Bug B fallback)"
@@ -1420,7 +1428,7 @@ jobs:
               # jq's `last` on an empty array yields the literal string
               # "null" rather than empty, so both branches are needed.
               if [ -n "${BAIT_SHA:-}" ] && { [ -z "${REVIEW_RUN:-}" ] || [ "${REVIEW_RUN}" = "null" ]; }; then
-                echo "::error::No review_autofix run with head_sha=${BAIT_SHA} ever appeared within ${REVIEW_TIMEOUT}m — neither the bait push's pull_request:synchronize event nor the Phase 3c workflow_dispatch fallback produced a review run"
+                echo "::error::No review workflow run (Internal: AI Review & Autofix) with head_sha=${BAIT_SHA} ever appeared within ${REVIEW_TIMEOUT}m — neither the bait push's pull_request:synchronize event nor the Phase 3c workflow_dispatch fallback produced a review run"
                 echo "status=no_review_triggered" >> "$GITHUB_OUTPUT"
                 echo "Diagnostic: workflow runs visible on branch ${PR_BRANCH}:" >&2
                 gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&per_page=20" \

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1056,6 +1056,35 @@ jobs:
           echo "marker=${BAIT_MARKER}" >> "$GITHUB_OUTPUT"
           echo "bait_sha=${BAIT_SHA}" >> "$GITHUB_OUTPUT"
 
+          # Defense-in-depth for "Bug B" (PR #1811): the Contents-API PUT
+          # above sometimes succeeds (commit + PR head pointer updated)
+          # without GitHub fanning out a `pull_request: synchronize`
+          # event, so internal-review.yml is never auto-triggered and
+          # wait-review (Phase 4) ages out at REVIEW_TIMEOUT minutes.
+          # Run 25204168842 was the most recent confirmed occurrence.
+          # Explicitly dispatch internal-review.yml against the PR
+          # branch so a review run with head_sha=BAIT_SHA always exists
+          # — workflow_dispatch resolves the ref's tip SHA at dispatch
+          # time, and we just pushed the bait commit there, so the
+          # dispatched run carries head_sha=BAIT_SHA and is matched by
+          # wait-review's pinned filter without any extra logic.
+          # The dispatch is keyed on a separate concurrency group (see
+          # internal-review.yml:48-50, `internal-review-dispatch-pr-N`),
+          # so if the synchronize event ever DID fire, both runs are
+          # serialised downstream by review_autofix.yml's `pr-autofix-N`
+          # group rather than racing — only one autofix proceeds.
+          # Fail-soft: if dispatch fails, the synchronize event (when
+          # it fires) still serves as the primary path; if neither
+          # fires, wait-review surfaces no_review_triggered as before.
+          if gh workflow run "internal-review.yml" \
+              --ref "${BRANCH}" \
+              -f pr_number="${PR_NUMBER}" >/tmp/dispatch_resp.txt 2>&1; then
+            echo "✓ Dispatched internal-review.yml on ${BRANCH} for PR #${PR_NUMBER} (Bug B fallback)"
+          else
+            echo "::warning::Could not dispatch internal-review.yml as Bug B fallback; relying on pull_request:synchronize event only"
+            cat /tmp/dispatch_resp.txt >&2 || true
+          fi
+
       # ── Phase 4: Wait for review/edit to complete ───────────────
       - name: "Phase 4: Wait for review & autofix to complete"
         id: wait-review
@@ -1138,8 +1167,18 @@ jobs:
             # page. Falls back to the legacy latest-by-created_at filter
             # only when the bait-injection step did not produce a SHA
             # (status=skipped path).
+            #
+            # The URL no longer pins event=pull_request: Phase 3c also
+            # dispatches internal-review.yml as a Bug B fallback, and
+            # those runs carry event=workflow_dispatch. Dropping the
+            # event filter from the URL lets head_sha=BAIT_SHA match
+            # both paths uniformly. (We still rely on the jq name match
+            # to avoid latching onto e.g. CI runs that happen to share
+            # the bait SHA.) The dispatched run's head_sha matches
+            # BAIT_SHA because we dispatch with --ref "${BRANCH}" and
+            # GitHub records the ref's tip SHA at dispatch time.
             if [ -n "${BAIT_SHA:-}" ]; then
-              REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&event=pull_request&per_page=100" \
+              REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&per_page=100" \
                 --jq "[.workflow_runs[] | select(.name | test(\"Review|review|autofix\"; \"i\")) | select(.head_sha == \"${BAIT_SHA}\")] | sort_by(.created_at) | last" || echo "")
             else
               REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&event=pull_request&per_page=5" \
@@ -1381,7 +1420,7 @@ jobs:
               # jq's `last` on an empty array yields the literal string
               # "null" rather than empty, so both branches are needed.
               if [ -n "${BAIT_SHA:-}" ] && { [ -z "${REVIEW_RUN:-}" ] || [ "${REVIEW_RUN}" = "null" ]; }; then
-                echo "::error::No review_autofix run with head_sha=${BAIT_SHA} ever appeared within ${REVIEW_TIMEOUT}m — bait push did not trigger downstream workflows"
+                echo "::error::No review_autofix run with head_sha=${BAIT_SHA} ever appeared within ${REVIEW_TIMEOUT}m — neither the bait push's pull_request:synchronize event nor the Phase 3c workflow_dispatch fallback produced a review run"
                 echo "status=no_review_triggered" >> "$GITHUB_OUTPUT"
                 echo "Diagnostic: workflow runs visible on branch ${PR_BRANCH}:" >&2
                 gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&per_page=20" \


### PR DESCRIPTION
## Summary

Run [25204168842](https://github.com/shubhodeep1/coding-workflows/actions/runs/25204168842) failed at Phase 4 with `status=no_review_triggered` after the full 30‑minute timeout. The bait commit was successfully created (`808a637…`, now PR #1851's head), but no `pull_request: synchronize` event fanned out, so `internal-review.yml` was never auto‑triggered.

This is the exact "Bug B" identified in [PR #1811](https://github.com/shubhodeep1/coding-workflows/pull/1811), which added the diagnostic that surfaced this failure but explicitly deferred the underlying GitHub‑side fan‑out fix to a "token-identity investigation." The diagnostic in this run confirmed the push identity is correct (author/committer = `shubhodeep1`, the GH_PAT owner — not `github-actions[bot]`), so the fan‑out failure isn't something we can resolve via PAT scope alone in code.

This PR sidesteps the synchronize‑event dependency entirely by also dispatching `internal-review.yml` via `workflow_dispatch` after a successful Contents‑API PUT. Because `gh workflow run --ref "${BRANCH}"` records the branch tip's SHA at dispatch time, and we just pushed the bait commit there, the dispatched run carries `head_sha=BAIT_SHA` — so `wait-review`'s existing pinned filter matches it without any extra logic.

## Changes

1. **`test-and-mark-stable.yml` Phase 3c (`inject-bait`)** — after the existing Contents‑API PUT succeeds, fail‑soft dispatch of `internal-review.yml` against the PR branch with `pr_number`. If the dispatch call itself fails, log a warning and continue; the synchronize event (when it fires) still serves as the primary path.

2. **`test-and-mark-stable.yml` Phase 4 (`wait-review`)** — drop `&event=pull_request` from the URL filter in the `BAIT_SHA`‑pinned branch (line 1142). Dispatched runs carry `event=workflow_dispatch`; the head_sha and name match in jq is already specific enough to reject unrelated runs that happen to share the bait SHA.

3. **Timeout error message** — clarify that both the `synchronize` event AND the Phase 3c `workflow_dispatch` fallback failed, so future `no_review_triggered` failures don't send investigators chasing the synchronize‑only path.

## Concurrency safety

`internal-review.yml:48-50` keys `workflow_dispatch` on `internal-review-dispatch-pr-{N}` — a different concurrency group from the `pull_request`‑event group `internal-review-{head_ref}`. So if the synchronize event ever DID fire (e.g. Bug B is later fixed), both runs are serialised downstream by `review_autofix.yml`'s `pr-autofix-{N}` group rather than racing — only one autofix proceeds. Verified against the existing dispatch pattern at `review_autofix.yml:4263-4266`, which uses the same approach.

## Test plan

- [ ] Trigger `test-and-mark-stable.yml` (release‑gate) and confirm Phase 3c logs `✓ Dispatched internal-review.yml on ai/issue-N for PR #N (Bug B fallback)` after the bait push diagnostic dump.
- [ ] Confirm Phase 4 `wait-review` matches the dispatched run via the `head_sha=BAIT_SHA` filter and `RUN_ID` is the dispatched run's ID (event = `workflow_dispatch`).
- [ ] Synthetic regression: temporarily remove the `gh workflow run` block and verify Phase 4 hits the (now‑updated) `neither the bait push's pull_request:synchronize event nor the Phase 3c workflow_dispatch fallback produced a review run` message — then restore.
- [ ] Verify `review_autofix.yml`'s `pr-autofix-{N}` concurrency correctly serialises the dispatched run with any synchronize‑triggered run that may also exist (only one autofix should proceed).

https://claude.ai/code/session_01PDLZpSkimwi82GtJr5zmC6


---
_Generated by [Claude Code](https://claude.ai/code/session_01PDLZpSkimwi82GtJr5zmC6)_