### PR TITLE
Condense /analyze-log slash command

### DIFF
--- a/.claude/commands/analyze-log.md
+++ b/.claude/commands/analyze-log.md
@@ -4,14 +4,14 @@ $ARGUMENTS
 
 ## Procedure
 
-1. **Fetch the log.** Use `curl --fail-with-body -sSL -o /tmp/<name>.log -w '%{http_code}\n' <url>` and check the status. Retry transient errors (5xx, 429, timeouts, DNS, connection reset) with exponential backoff (2s, 4s, 8s, 16s — max 4 tries). For GitHub Actions run/job URLs, use `mcp__github__get_workflow_run_logs` / `mcp__github__get_job_logs` instead — `curl` returns HTML.
+1. **Fetch the log.** Use `curl --fail-with-body -sSL -o /tmp/<name>.log -w '%{http_code}\n' <url>` and check the status. Retry transient errors (5xx, 429, timeouts, DNS, connection reset) with exponential backoff (up to 4 retries: 2s, 4s, 8s, 16s). Hard failures (401/403/404/410, auth-walled) → record the URL under `Artifacts needed` and stop only if it's the primary log. For GitHub Actions run/job URLs, use `mcp__github__get_workflow_run_logs` / `mcp__github__get_job_logs` instead — `curl` returns HTML. Reference log lines via `nl -ba /tmp/<name>.log` so `L<n>` citations are stable.
 2. **Read it end to end.** No skimming. Note errors, stack traces, exit codes, timeouts, dep mismatches, and any references (PRs, issues, SHAs, run IDs, artifact URLs).
 3. **Investigate.** Follow every relevant reference: PRs/issues via `mcp__github__pull_request_read` / `mcp__github__issue_read`; workflow YAML; `git blame` / `git log -p` on files in the stack trace; recent commits intersected with implicated files. Read the actual source — never guess at code.
 4. **Decide and act.** Apply the [Decision Rule](#decision-rule) below.
 
 ## Decision Rule
 
-After investigation, classify each finding as **EVIDENCE-BASED** (fully supported by log + code + repro) or **HYPOTHESIS** (plausible but unverified). Then:
+After investigation, classify each finding as **EVIDENCE-BASED** (fully supported by log + code, plus reproduction when feasible) or **HYPOTHESIS** (plausible but unverified). Then:
 
 - **All findings are EVIDENCE-BASED and no artifacts are missing** → design the fix, apply it, commit, push, open a PR. Do not ask. Report using the [Output Format](#output-format) afterward.
 - **Any HYPOTHESIS finding, missing artifact, or inaccessible resource that blocks root cause** → stop before editing. Report using the [Output Format](#output-format) and ask the user how to proceed.

--- a/.claude/commands/analyze-log.md
+++ b/.claude/commands/analyze-log.md
@@ -13,8 +13,8 @@ $ARGUMENTS
 
 After investigation, classify each finding as **EVIDENCE-BASED** (fully supported by log + code, plus reproduction when feasible) or **HYPOTHESIS** (plausible but unverified). Then:
 
-- **All findings are EVIDENCE-BASED and no artifacts are missing** → design the fix, apply it, verify it (re-run the repro / failing test when feasible), commit, push, open a PR. Do not ask. Report using the [Output Format](#output-format) afterward.
-- **Otherwise** (any HYPOTHESIS finding, any missing artifact, or any inaccessible resource) → stop before editing. Report using the [Output Format](#output-format) and ask the user how to proceed.
+- **All findings are EVIDENCE-BASED and no missing/inaccessible resource blocks root cause or fix verification** → design the fix, apply it, verify it (re-run the repro / failing test when feasible), commit, push, open a PR. Do not ask. Report using the [Output Format](#output-format) afterward. Non-blocking gaps (e.g. an inaccessible linked PR that doesn't affect the diagnosis) still get listed under `Artifacts needed` for transparency.
+- **Otherwise** (any HYPOTHESIS finding, or any missing/inaccessible resource that blocks root cause or fix verification) → stop before editing. Report using the [Output Format](#output-format) and ask the user how to proceed.
 - **Environmental failure** (service down, rate limit, runner outage) → no fix; say so explicitly.
 
 ## Output Format

--- a/.claude/commands/analyze-log.md
+++ b/.claude/commands/analyze-log.md
@@ -1,77 +1,49 @@
-Download the full log from the following URL and analyze it for errors, failures, and issues. Investigate to the depth required to identify the true root cause — follow every relevant reference (issues, PRs, related runner logs, related commits) and propose fixes only on evidence, never on speculation.
+Download the full log from the URL below, identify the root cause, and ship a fix.
 
 $ARGUMENTS
 
-## Steps
+## Procedure
 
-1. **Download the log** — Use `curl --fail-with-body -sSL -o <path> -w '%{http_code}\n' <url>` (or capture the status with `-w '%{http_code}'` separately) so HTTP errors are detected reliably; plain `curl -sL` exits 0 on 4xx/5xx and will silently download the server's error page. Save the body to a temporary file in `/tmp/` and verify the status code before treating the file as a log:
-   - `2xx` → proceed.
-   - `5xx`, `429`, network/timeout/connection-reset/DNS errors → transient; retry per the **Retry Rule** in the Rules section.
-   - `401`, `403`, `404`, `410` → hard failure; record the URL under **Inaccessible Resources** and follow the **Inaccessible resources** rule.
+1. **Fetch the log.** Use `curl --fail-with-body -sSL -o /tmp/<name>.log -w '%{http_code}\n' <url>` and check the status. Retry transient errors (5xx, 429, timeouts, DNS, connection reset) with exponential backoff (2s, 4s, 8s, 16s — max 4 tries). For GitHub Actions run/job URLs, use `mcp__github__get_workflow_run_logs` / `mcp__github__get_job_logs` instead — `curl` returns HTML.
+2. **Read it end to end.** No skimming. Note errors, stack traces, exit codes, timeouts, dep mismatches, and any references (PRs, issues, SHAs, run IDs, artifact URLs).
+3. **Investigate.** Follow every relevant reference: PRs/issues via `mcp__github__pull_request_read` / `mcp__github__issue_read`; workflow YAML; `git blame` / `git log -p` on files in the stack trace; recent commits intersected with implicated files. Read the actual source — never guess at code.
+4. **Decide and act.** Apply the [Decision Rule](#decision-rule) below.
 
-2. **Read the full log carefully** — Do not skim or summarize. Read the entire log from start to finish. Pay attention to:
-   - Error messages, stack traces, exceptions
-   - Failed assertions or test failures
-   - Exit codes, signal kills, OOM errors
-   - Timeout or connectivity failures
-   - Deprecation warnings that may have escalated to errors
-   - Mismatched dependency versions
-   - Environment or configuration issues
-   - References to PRs (`#1234`), issues, commit SHAs, branches, workflow run IDs, artifact URLs — these are leads to follow in Step 3.
+## Decision Rule
 
-3. **Expand the investigation** — Before proposing any fix, follow every relevant reference surfaced by the log. Do not stop at the log's surface:
-   - **PRs / issues** referenced in commit messages, branch names, or log output → fetch with `mcp__github__pull_request_read` / `mcp__github__issue_read`. Read description, comments, linked issues, recent reviews.
-   - **Workflow context** (for CI logs) → read the workflow YAML in `.github/workflows/`, the failing job's matrix entry, runner image, cache keys. Inspect related upstream/downstream jobs.
-   - **Other runs of the same workflow** → check whether the same failure appears on `main` and on related branches (regression vs. flake).
-   - **Failing files** in the stack trace → `git blame` and `git log -p -- <file>` to find the commit/PR that introduced the relevant code.
-   - **Recent commits** → intersect files changed in recent commits/PRs with files in the stack trace to identify the likely culprit change.
-   - **Retry transient errors when fetching from GitHub or any HTTP source** according to the **Retry Rule** in the Rules section. A transient blip is not an excuse to give up on the investigation.
+After investigation, classify each finding as **EVIDENCE-BASED** (fully supported by log + code + repro) or **HYPOTHESIS** (plausible but unverified). Then:
 
-4. **Identify every distinct issue** — List each unique issue. For each:
-   - Exact error message or log line (with line number in the saved log file)
-   - Root cause, not symptom
-   - Whether it is the primary failure or a cascading/secondary failure
+- **All findings are EVIDENCE-BASED and no artifacts are missing** → design the fix, apply it, commit, push, open a PR. Do not ask. Report using the [Output Format](#output-format) afterward.
+- **Any HYPOTHESIS finding, missing artifact, or inaccessible resource that blocks root cause** → stop before editing. Report using the [Output Format](#output-format) and ask the user how to proceed.
+- **Environmental failure** (service down, rate limit, runner outage) → no fix; say so explicitly.
 
-5. **Correlate to source code** — Locate the exact files and lines responsible. Use grep, paths from stack traces, and the references collected in Step 3. **Read the actual files.** Never guess at code structure or function signatures.
+## Output Format
 
-6. **Build the Evidence Ledger** — Every claim and every proposed fix must cite:
-   - Log line number(s) and exact text
-   - Source `file:line`
-   - Commit SHA or PR # that introduced the relevant code (when applicable)
-   - Test output or reproduction result (when applicable)
+Keep it tight. No prose padding.
 
-   No citation → no claim. No claim → no fix.
+```
+Summary: <1–2 lines: what failed, root cause>
 
-7. **Attempt reproduction** — Where feasible, run the failing test/command locally and record the result. A failure to reproduce is itself evidence (environment-specific, flake, cache-poisoned, runner-specific, etc.) — surface it; do not paper over it.
+Evidence-based:
+- <claim> — log L<n>: "<text>"; <file>:<line>; <SHA/PR if applicable>
 
-8. **Propose fixes — labeled by confidence** — For each proposed change:
-   - `EVIDENCE-BASED` — fully supported by log + code reading + (where applicable) reproduction. Apply per Claude Code's normal edit flow.
-   - `HYPOTHESIS` — plausible but unverified. Do **not** apply silently. Surface it, explain the gap, and ask before changing code.
+Hypothesis (if any):
+- <claim> — gap: <what's missing to confirm>
 
-9. **Final output structure** — Always produce, in this order:
-   - **Summary** (1–3 lines)
-   - **Evidence Ledger** (numbered)
-   - **Root Cause(s)** with confidence label
-   - **Proposed Fix(es)** with `file:line` and rationale
-   - **Inaccessible Resources** — exact URLs the user must open manually, with what's needed from each and what conclusion is blocked without it
-   - **Reproduction Result**
-   - **Open Questions** — surface any remaining ambiguity rather than guessing
+Artifacts needed (if any):
+- <exact URL or path> — <what's needed, what's blocked without it>
 
-10. **Cleanup** — Remove the temp log file from `/tmp/` when done.
+Fix: <applied / proposed>
+- <file>:<line> — <one-line rationale>
+```
+
+Omit empty sections. If the fix was applied and pushed, include the branch/PR link in the Fix line.
 
 ## Rules
 
-- Always download the complete log. Never truncate or skip sections.
-- **Retry Rule**: For transient HTTP/GitHub errors (5xx, 429, timeouts, connection resets, DNS failures), retry with exponential backoff (2s, 4s, 8s, 16s — up to 4 retries) before declaring failure. This applies to the initial log download **and** to every follow-up fetch (PRs, issues, workflow files, artifacts, related runs).
-- **Inaccessible resources** — If a resource is still unreachable after retries, or returns a hard failure (401, 403, 404, 410), or is auth-walled / expired / private, record it under **Inaccessible Resources**:
-  - The exact URL
-  - What is needed from it
-  - What conclusion is blocked without it
-
-  Stop that specific line of inquiry, but continue the broader analysis if the primary log is accessible and the root cause / proposed fix is still supported by available evidence. Do not make claims or propose fixes that depend on the inaccessible content — surface those gaps under **Open Questions** instead. Abort the analysis only if (a) the primary log itself is inaccessible, or (b) the missing resource blocks the root-cause conclusion.
-- **Use the GitHub MCP tools (`mcp__github__*`) for all GitHub interactions.** The `gh` CLI is not available in this environment. Repo scope is restricted to `shubhodeep1/coding-workflows`.
-- Prioritize the root cause — the first meaningful error in the log — over cascading failures.
-- If the log contains multiple independent failures, address each separately.
-- If a failure is environmental (service was down, rate limit, runner outage) and no code change can fix it, say so explicitly rather than proposing a workaround.
-- **Forbidden silent moves**: modifying tests to make them pass (unless the test is genuinely wrong, with evidence), broadening `except`/`catch` blocks, suppressing warnings, version-bumping without verified compatibility, adding retries to mask deterministic failures.
-- **No guessing.** Every diagnosis cites evidence; every fix is tied to a specific log line and source location. If you cannot find evidence, ask or surface the gap — do not invent it.
+- Download the complete log; never truncate.
+- Use `mcp__github__*` for all GitHub interactions (no `gh` CLI). Repo scope: `shubhodeep1/coding-workflows`.
+- No citation → no claim. No claim → no fix.
+- Forbidden silent moves: editing tests to pass without evidence the test is wrong, broadening `except`/`catch`, suppressing warnings, version-bumping without verified compatibility, adding retries to mask deterministic failures.
+- Address the root cause (first meaningful error), not cascading failures. Multiple independent failures → handle each separately.
+- Cleanup: delete the temp log from `/tmp/` when done.

--- a/.claude/commands/analyze-log.md
+++ b/.claude/commands/analyze-log.md
@@ -13,8 +13,8 @@ $ARGUMENTS
 
 After investigation, classify each finding as **EVIDENCE-BASED** (fully supported by log + code, plus reproduction when feasible) or **HYPOTHESIS** (plausible but unverified). Then:
 
-- **All findings are EVIDENCE-BASED and no artifacts are missing** → design the fix, apply it, commit, push, open a PR. Do not ask. Report using the [Output Format](#output-format) afterward.
-- **Any HYPOTHESIS finding, missing artifact, or inaccessible resource that blocks root cause** → stop before editing. Report using the [Output Format](#output-format) and ask the user how to proceed.
+- **All findings are EVIDENCE-BASED and no artifacts are missing** → design the fix, apply it, verify it (re-run the repro / failing test when feasible), commit, push, open a PR. Do not ask. Report using the [Output Format](#output-format) afterward.
+- **Otherwise** (any HYPOTHESIS finding, any missing artifact, or any inaccessible resource) → stop before editing. Report using the [Output Format](#output-format) and ask the user how to proceed.
 - **Environmental failure** (service down, rate limit, runner outage) → no fix; say so explicitly.
 
 ## Output Format


### PR DESCRIPTION
## Summary
- Trims `.claude/commands/analyze-log.md` from 78 to 49 lines by collapsing the 10-step procedure into 4 steps and the 7-section output template into a tight format.
- New output structure: `Summary` + `Evidence-based` + `Hypothesis` + `Artifacts needed` + `Fix`. Empty sections are omitted.
- Adds an explicit Decision Rule: when every finding is evidence-based and no artifacts are missing, design the fix, apply it, commit, and push without asking. Stop and report only when there is a HYPOTHESIS finding, missing artifact, inaccessible resource, or environmental failure.

## Test plan
- [ ] Run `/analyze-log <url>` against a CI log with a clean root cause and confirm it ships a fix without prompting.
- [ ] Run `/analyze-log <url>` against a log with ambiguous evidence and confirm it stops at the hypothesis stage and asks.
- [ ] Run `/analyze-log <url>` against a 404/auth-walled URL and confirm it surfaces the URL under `Artifacts needed` instead of guessing.

https://claude.ai/code/session_011H8tiQ2nafwDQuhByxvk8v

---
_Generated by [Claude Code](https://claude.ai/code/session_011H8tiQ2nafwDQuhByxvk8v)_