### PR TITLE
fix(review): recover consolidator blocks truncated before END marker

### DIFF
--- a/scripts/review_parse_consolidator.sh
+++ b/scripts/review_parse_consolidator.sh
@@ -521,8 +521,21 @@ while IFS= read -r line || [ -n "${line}" ]; do
 done < "${CONSOLIDATOR_RAW_FILE}"
 
 if [ "${block_open}" -eq 1 ]; then
-	dropped_unknown_reason=$((dropped_unknown_reason + 1))
+	# Recover blocks where the consolidator emitted the open marker plus
+	# required fields but truncated before `=== END ISSUE NNN ===` (observed
+	# with openai/gpt-5.4-mini @ reasoning=medium on minimal canary diffs;
+	# see analysis/e2e-smoke-failure-25212177682.md). Without recovery the
+	# parser drops the block, falls back to passthrough+unclassified, and
+	# the editor downweights the finding. Always count the missing close
+	# marker in unmatched_markers so consolidator quality stays observable.
 	unmatched_markers=$((unmatched_markers + 1))
+	if [ -n "${block_file}" ] && [ -n "${block_lines}" ]; then
+		process_block "${block_id}"
+	else
+		dropped_unknown_reason=$((dropped_unknown_reason + 1))
+	fi
+	block_open=0
+	reset_block
 fi
 
 if [ "${marker_open_count}" -eq 0 ]; then

--- a/tests/fixtures/review_pipeline/consolidator_unterminated_block.txt
+++ b/tests/fixtures/review_pipeline/consolidator_unterminated_block.txt
@@ -1,0 +1,17 @@
+=== ISSUE 001 ===
+FILE: src/module.py
+LINES: 2-3
+LENS: CORRECTNESS & LOGIC
+SEVERITY: high
+FLAGGED_BY: reviewer_alpha, reviewer_beta
+CLASSIFICATION: must-fix
+EVIDENCE:
+  reviewer_alpha> "saw bug"
+  reviewer_beta> "same anchor"
+CURRENT_CODE:
+  if x == None:
+    return
+SUGGESTED_APPROACH:
+  Use is None check.
+NOTES:
+  consolidator truncated before `=== END ISSUE NNN ===` here

--- a/tests/test_review_parse_consolidator.py
+++ b/tests/test_review_parse_consolidator.py
@@ -131,6 +131,19 @@ def test_anchor_mismatch_tags_line_unverified_and_preserves_passthrough() -> Non
 		assert "=== ISSUE PASSTHROUGH 004 ===" in issues
 
 
+def test_unterminated_block_is_recovered_at_eof() -> None:
+	with tempfile.TemporaryDirectory() as td:
+		result, runtime = _run_parser(Path(td), "consolidator_unterminated_block.txt")
+		assert result.returncode == 0, result.stderr
+		stats = _load_kv_file(runtime / "parser_stats.txt")
+		issues = (runtime / "review_issues.txt").read_text(encoding="utf-8")
+		assert stats["parsed_blocks"] == "1"
+		assert stats["dropped_unknown_reason"] == "0"
+		assert "=== ISSUE 001 ===" in issues
+		assert "CLASSIFICATION: must-fix" in issues
+		assert "=== END ISSUE 001 ===" in issues
+
+
 def test_fail_open_when_no_markers_emits_passthrough_anchors() -> None:
 	with tempfile.TemporaryDirectory() as td:
 		result, runtime = _run_parser(Path(td), "consolidator_garbled.txt", failopen="1")


### PR DESCRIPTION
## Summary
- Recover consolidator blocks that get truncated before `=== END ISSUE NNN ===` so the editor sees the structured `must-fix` finding instead of a passthrough `unclassified`.
- Adds a fixture + regression test (`test_unterminated_block_is_recovered_at_eof`) that locks in the recovery behavior.

## Root cause
e2e-smoke-test job [run 25212177682](https://github.com/shubhodeep1/coding-workflows/actions/runs/25212177682) failed Phase 4b with `Editor failed to remove bait line E2E_EDITOR_BAIT_25212177682`. Upstream review_autofix run #25212403764 ran 6 editor attempts (3 + 3-retry) and each returned empty stdout. The cause was inside the consolidator → editor handoff:

- `openai/gpt-5.4-mini @ reasoning=medium` (the consolidator) emitted a structurally complete `=== ISSUE 001 ===` block — `FILE`, `LINES`, `LENS`, `SEVERITY`, `FLAGGED_BY` (6 reviewers), `CLASSIFICATION: must-fix`, `EVIDENCE`, `CURRENT_CODE`, `SUGGESTED_APPROACH`, `NOTES` — but truncated before emitting `=== END ISSUE 001 ===`.
- `scripts/review_parse_consolidator.sh:519-522` saw the unmatched open marker, incremented `unmatched_markers=1` + `dropped_unknown_reason=1`, and threw the block away. The reviewer-bundle anchor at `tests/e2e_smoke_canary.txt:4` then fell to the passthrough path with `CLASSIFICATION: unclassified`.
- `openai/gpt-5.3-codex` (the editor) downweighted the unclassified passthrough — across all 6 attempts (13–30k tokens each) it exited with empty stdout. The editor pushed nothing; the bait stayed on the PR head; Phase 4b failed correctly.

Same downstream symptom as run 25126757724 ([analysis/e2e-smoke-failure-25126757724.md](https://github.com/shubhodeep1/coding-workflows/blob/main/analysis/e2e-smoke-failure-25126757724.md)) but a different upstream shape — that incident had no structured block at all, this one had a complete-but-unterminated block.

## Fix
At EOF, if a block is still open and has the minimum-required fields (`FILE` + `LINES`), call `process_block` to emit the structured issue instead of dropping it. `unmatched_markers` is still incremented so consolidator quality stays observable in telemetry; only `dropped_unknown_reason` no longer fires for this recoverable case.

Verified locally by replaying the actual failure input through the patched parser:
```
parsed_blocks=1 passthrough_blocks=4 unmatched_markers=1 dropped_unknown_reason=0
=== ISSUE 001 ===
FILE: tests/e2e_smoke_canary.txt
…
CLASSIFICATION: must-fix
…
=== END ISSUE 001 ===
```

## Test plan
- [x] `python3 tests/test_review_parse_consolidator.py` — 7/7 pass (new + existing)
- [x] `python3 tests/test_review_pipeline_integration.py` — 3/3 pass
- [x] `python3 tests/test_review_issue_ledger.py` — 10/10 pass
- [x] `python3 tests/test_detect_editor_changes_lost.py` — pass
- [x] Replay failing input from review_autofix run 25212403764 against patched parser → block now recovers with `CLASSIFICATION: must-fix` intact
- [ ] Re-run the e2e smoke gate to confirm the editor consumes the recovered block end-to-end

https://claude.ai/code/session_01Xa3mDauTDYAqassNxNEaWx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xa3mDauTDYAqassNxNEaWx)_