### PR TITLE
fix(workflows): gate clarify/plan/implement on issue.state=closed + harden codex stuck-intent detection

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -333,16 +333,32 @@ jobs:
             IS_FORCED_RECLARIFY="true"
           fi
 
+          # State gate: a closed issue should not produce side effects (label
+          # changes, /answer auto-post that triggers plan→implement). The
+          # orchestrate-decompose-test smoke (test-and-mark-stable.yml:3127)
+          # closes its child issues during cleanup and the trigger event
+          # payload may still show state=open if the close happened after
+          # the workflow was queued, so re-read state from the freshly
+          # fetched issue meta.
+          IS_CLOSED="false"
+          ISSUE_STATE="$(jq -r '.state // "open"' "${ISSUE_META_FILE}")"
+          if [ "${ISSUE_STATE}" = "closed" ]; then
+            IS_CLOSED="true"
+          fi
+
           SKIP_CODEX="false"
-          if [ "${IS_ORCHESTRATOR_MANAGED}" = "true" ] && [ "${IS_FORCED_RECLARIFY}" != "true" ]; then
+          if [ "${IS_CLOSED}" = "true" ]; then
+            SKIP_CODEX="true"
+          elif [ "${IS_ORCHESTRATOR_MANAGED}" = "true" ] && [ "${IS_FORCED_RECLARIFY}" != "true" ]; then
             SKIP_CODEX="true"
           fi
 
           echo "is_orchestrator_managed=${IS_ORCHESTRATOR_MANAGED}" >> "$GITHUB_OUTPUT"
           echo "is_forced_reclarify=${IS_FORCED_RECLARIFY}" >> "$GITHUB_OUTPUT"
+          echo "is_closed=${IS_CLOSED}" >> "$GITHUB_OUTPUT"
           echo "skip_codex=${SKIP_CODEX}" >> "$GITHUB_OUTPUT"
 
-          echo "::notice::clarify_route issue=${ISSUE_NUMBER} run_id=${RUN_ID} labels=${LABELS_CSV:-none} orchestrator_managed=${IS_ORCHESTRATOR_MANAGED} forced_reclarify=${IS_FORCED_RECLARIFY} skip_codex=${SKIP_CODEX}"
+          echo "::notice::clarify_route issue=${ISSUE_NUMBER} run_id=${RUN_ID} labels=${LABELS_CSV:-none} orchestrator_managed=${IS_ORCHESTRATOR_MANAGED} forced_reclarify=${IS_FORCED_RECLARIFY} is_closed=${IS_CLOSED} skip_codex=${SKIP_CODEX}"
 
       - name: Detect smoke test and tune LLM settings
         run: |
@@ -389,6 +405,7 @@ jobs:
           fi
 
       - name: Set clarification phase label
+        if: steps.clarify_route.outputs.is_closed != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
@@ -408,7 +425,7 @@ jobs:
           fi
 
       - name: Orchestrator-managed fast path
-        if: steps.clarify_route.outputs.skip_codex == 'true'
+        if: steps.clarify_route.outputs.skip_codex == 'true' && steps.clarify_route.outputs.is_closed != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -55,8 +55,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           set -euo pipefail
-          ISSUE_LABELS_JSON="$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}" --jq '[.labels[].name]')"
-          if printf '%s' "${ISSUE_LABELS_JSON}" | jq -e 'index("ai:implementing") != null' >/dev/null; then
+          # Fetch state alongside labels so a closed issue (e.g. cleanup-closed
+          # by the orchestrate-decompose-test smoke before the auto-approve
+          # comment fires the implement workflow) short-circuits before any
+          # Codex / install cost. Without the state gate, implement runs on
+          # the closed issue, posts a misleading "implementation-failed"
+          # diagnostics comment, and burns budget.
+          ISSUE_PAYLOAD="$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}" --jq '{state: (.state // "open"), labels: [.labels[].name]}')"
+          ISSUE_STATE="$(printf '%s' "${ISSUE_PAYLOAD}" | jq -r '.state')"
+          ISSUE_LABELS_JSON="$(printf '%s' "${ISSUE_PAYLOAD}" | jq -c '.labels')"
+          if [ "${ISSUE_STATE}" = "closed" ]; then
+            echo "Issue #${ISSUE_NUMBER} is closed. Skipping implementation steps."
+            echo "SKIP_IMPLEMENT=true" >> "$GITHUB_ENV"
+          elif printf '%s' "${ISSUE_LABELS_JSON}" | jq -e 'index("ai:implementing") != null' >/dev/null; then
             echo "Issue #${ISSUE_NUMBER} already has ai:implementing label. Another implement run is in progress. Skipping."
             echo "SKIP_IMPLEMENT=true" >> "$GITHUB_ENV"
           elif ! printf '%s' "${ISSUE_LABELS_JSON}" | jq -e 'index("ai:awaiting-approval") != null' >/dev/null; then
@@ -891,6 +902,17 @@ jobs:
             handles commit and diff reporting separately.
           - Do NOT emit progress/status messages. Output ONLY repository changes.
 
+          EDIT TOOL DISCIPLINE (MANDATORY — prevents announce-without-editing stalls):
+          - Make every repository edit via `apply_patch` or the equivalent Serena edit
+            tool (mcp__serena__replace_symbol_body, mcp__serena__insert_after_symbol,
+            mcp__serena__insert_before_symbol). Do NOT shell out to `sed`/`awk`/`rg`
+            with literal special characters — they routinely fail shell quoting and
+            waste the entire attempt without producing a diff.
+          - Once you have located the file and lines to change, go straight to the
+            edit. Do NOT keep exploring. Announcing "I'll now apply_patch …" without
+            actually invoking the tool counts as a failed attempt and trips the
+            stuck-in-exploration bail.
+
           CONFLICT DETECTION:
           - Flag any factual conflicts between the implementation plan and the actual
             codebase (e.g., a function name in the plan doesn't match the code, a file
@@ -1197,7 +1219,26 @@ jobs:
                 # conditional-verify phrasing (run 25206976031 attempt 1)
                 # is filtered out by the success-no-op regex above, so
                 # it never reaches this branch. Fail-open on grep error.
-                if grep -qEi '(apply_patch|applying (a |an |the |this |requested |first |minimal )(patch|edit)|patching `?[A-Za-z0-9_./-]+|editing `?[A-Za-z0-9_./-]+|i.?ll (now )?(apply|patch|edit|update)|will (now )?(apply|patch|edit|update))' "${CODEX_OUTPUT_FILE}" 2>/dev/null; then
+                #
+                # Phrasing set extended for run 25215763575 (issue #1901)
+                # where Codex narrated "Applying the approved plan now
+                # with a minimal edit to <file>" / "Applying the requested
+                # minimal implementation now: I'll … patch <file>" — the
+                # original alternation set `(patch|edit)` after the
+                # adjective list, but Codex routinely reaches for
+                # synonyms like `plan` / `implementation` / `change` /
+                # `fix` / `update`, and the adjective set itself needs
+                # `approved`/`implementation`. Likewise the
+                # `i.?ll (now )?(apply|patch|edit|update)` clause now
+                # accepts more leading adverbs (`first`/`then`/`next`/
+                # `only`/`just`/`go ahead and`/`proceed to`) and the
+                # verb set adds `modify`/`write`/`create`/`add`/
+                # `change`/`implement`/`fix`. False positives don't
+                # regress correctness: this branch only fires when
+                # codex_delta is already empty, so broadening the
+                # regex strictly increases recall on a path that is
+                # already a confirmed no-op.
+                if grep -qEi '(apply_patch|applying (a |an |the |this |requested |first |minimal |approved |implementation |new |my |our |proposed )*(patch|edit|implementation|change|fix|plan|update|modification)|patching `?[A-Za-z0-9_./-]+|editing `?[A-Za-z0-9_./-]+|i.?ll (now |first |then |next |only |just |go ahead and |proceed to )*(apply|patch|edit|update|modify|write|create|add|change|implement|fix)|will (now |first |then |next |only |just |go ahead and |proceed to )*(apply|patch|edit|update|modify|write|create|add|change|implement|fix))' "${CODEX_OUTPUT_FILE}" 2>/dev/null; then
                   echo "::warning::Codex announced an edit/apply_patch on attempt ${attempt} but produced no file changes — counting toward empty_streak."
                   attempt_was_empty=true
                 fi

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -1568,6 +1568,10 @@ jobs:
         run: |
           set -euo pipefail
           source scripts/gh_helpers.sh 2>/dev/null || true
+          # Fallback: if gh_helpers.sh failed to source, gh_retry would be
+          # undefined and the next call would fail under `set -euo pipefail`.
+          # Same pattern used by every other gh_retry caller in this file.
+          type gh_retry >/dev/null 2>&1 || gh_retry() { "$@"; }
 
           echo "auto_approved=false" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -379,6 +379,18 @@ jobs:
           fi
 
           # Reuse already-fetched issue metadata instead of a redundant API call
+          ISSUE_STATE="$(jq -r '.state // "open"' "${ISSUE_META_FILE}")"
+          if [ "${ISSUE_STATE}" = "closed" ]; then
+            # Closed issues should not progress through the pipeline. The
+            # orchestrate-decompose-test smoke closes its child issues in
+            # cleanup before the clarify→plan→implement chain finishes;
+            # without this gate, plan keeps running on the closed issue,
+            # posts the plan comment, and (when AUTO_IMPLEMENT_ON_CLEAR_PLAN
+            # is set) auto-approves implement to fire on a closed issue.
+            echo "Issue #${ISSUE_NUMBER} is closed. Skipping planning run."
+            echo "SKIP_PLAN=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
           ISSUE_LABELS_JSON="$(jq -c '[.labels[].name]' "${ISSUE_META_FILE}")"
           if printf '%s' "${ISSUE_LABELS_JSON}" | jq -e 'index("ai:planning") != null' >/dev/null; then
             echo "Issue #${ISSUE_NUMBER} is already in ai:planning phase."
@@ -1558,6 +1570,18 @@ jobs:
           source scripts/gh_helpers.sh 2>/dev/null || true
 
           echo "auto_approved=false" >> "$GITHUB_OUTPUT"
+
+          # Re-check state right before posting /approved: the issue may have
+          # been closed between the early validate-phase gate and now (the
+          # smoke test cleanup at test-and-mark-stable.yml:3127 races this
+          # path). Posting /approved on a closed issue triggers implement.yml
+          # on a dead issue and produces a misleading failure diagnostic.
+          CURRENT_STATE="$(gh_retry gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}" --jq '.state // "open"' 2>/dev/null || echo "open")"
+          if [ "${CURRENT_STATE}" = "closed" ]; then
+            echo "Issue #${ISSUE_NUMBER} is closed; skipping auto-approval comment."
+            exit 0
+          fi
+
           normalized_flag="$(printf '%s' "${AUTO_IMPLEMENT_ON_CLEAR_PLAN:-false}" | tr '[:upper:]' '[:lower:]' | xargs)"
           case "${normalized_flag}" in
             1|true|yes|on)


### PR DESCRIPTION
## Summary

Run 25215763575 (implement on issue #1901) failed because the
`orchestrate-decompose-test` smoke (`test-and-mark-stable.yml:3127`) closed
its child issues at 13:16:28Z while the clarify→plan→auto-approve→implement
pipeline kept running on the dead issue. Codex was invoked on a closed issue,
bailed after 2 attempts (`Codex produced no actionable output 2 attempts in a
row`), and a misleading `implementation-failed` diagnostics comment was
posted.

Two independent fixes:

**State gates** — three workflows now short-circuit on `issue.state == "closed"`:
- `implement.yml`: Precheck step fetches state alongside labels and skips if closed.
- `plan.yml`: Validate-planning-phase-label step skips on `state=closed`; the Auto-approve step re-checks state right before posting `/approved` (the smoke-test close races this path).
- `clarify.yml`: `Decide clarify route` emits `is_closed`; `Set clarification phase label` and `Orchestrator-managed fast path` (which posts the `/answer` comment that triggers plan) are gated on it.

**Codex stuck-intent hardening**:
- `implement.yml` inline prompt: new `EDIT TOOL DISCIPLINE` block tells the model to call `apply_patch` / Serena edit tools and to stop exploring once the file is located. Applies on attempt 1 (the existing retry-only nudge fired only after a no-op).
- `implement.yml` announce-edit detection regex broadened to recognise the phrasings observed in the failed run (`Applying the approved plan now`, `Applying the requested minimal implementation now: I'll … patch <file>`).

## Evidence trail

- Smoke close: `actions-results/.../cd473283-1364-5b43-8244-2f7497476de2/job-logs.txt` L312 `13:16:28.88 closed #1901` — `test-and-mark-stable.yml:3127-3181`.
- Auto-approve fired post-close: implement-job log L4934 `[2026-05-01T13:19:36Z] @shubhodeep1: /approved [auto-approved-by-plan]` — `plan.yml:1561-1575`.
- implement.yml started on closed issue: implement-job log L1, L33; L52-65 Precheck only checked labels, not state.
- Codex bailed on the closed issue: implement-job log L7008-7012 + L4945 / L6992 narrations.

## Test plan

- [ ] Watch the next `test-and-mark-stable` run; confirm the `orchestrate-decompose-test` smoke no longer triggers a downstream `ai:implementation-failed` diagnostic comment on the cleanup-closed child issues.
- [ ] Confirm `clarify_route` log line includes `is_closed=…` for any newly-opened issue.
- [ ] Confirm `Auto-approve clear plan` step skips with `Issue #N is closed; skipping auto-approval comment.` when manually closing an issue between plan-comment and auto-approve.
- [ ] Confirm an open-issue implement run still proceeds normally (regex broadening only fires on already-empty-delta path, so no regression on success path).

https://claude.ai/code/session_0138bDBzJ9MW4XRPwV7a1m4c

---
_Generated by [Claude Code](https://claude.ai/code/session_0138bDBzJ9MW4XRPwV7a1m4c)_