### PR TITLE
fix(implement): catch announce-edit on stderr + add overwrite/rewrite/replace to stuck-intent regex

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1010,6 +1010,35 @@ jobs:
           empty_streak=0
           empty_streak_threshold=2
 
+          # Stuck-intent / announce-edit detection regex. Matches phrasings
+          # the model uses to narrate an upcoming edit ("I'll apply the
+          # patch", "Applying the requested overwrite", etc.) without ever
+          # invoking the corresponding tool. Used in three places below:
+          # (a) when stdout has content but the worktree delta is empty
+          # (cmd_rc==0 + non-empty stdout branch), and (b)/(c) when stdout
+          # is empty but the per-attempt stderr log carries the same
+          # announce-edit narrative — Codex CLI in --full-auto exec mode
+          # streams agent narrative on stderr and only emits the final
+          # assistant message on stdout, so a model that announces the
+          # edit and then exits without calling apply_patch leaves stdout
+          # empty and the announce phrase only on stderr.
+          #
+          # Verb set extended for run 25223836137 (issue #1909) where
+          # Codex narrated "Applying the requested overwrite to <file>
+          # now, with no other file changes." PR #1906 covered
+          # patch/edit/implementation/change/fix/plan/update/modification
+          # but `overwrite`/`rewrite`/`replacement` were missing from the
+          # noun alternation, so the stuck-intent branch never fired and
+          # the diagnostic mis-classified the failure as "empty output".
+          # Likewise the verb list in the `i'll/will (now |…)` clauses
+          # now includes `overwrite|rewrite|replace`, and the
+          # `patching|editing` gerund pattern now includes
+          # `overwriting|rewriting|replacing|writing`. False positives
+          # don't regress correctness: the regex only fires on already-
+          # empty-delta attempts, so broadening strictly increases
+          # recall on a path that's already a confirmed no-op.
+          ANNOUNCE_EDIT_REGEX='(apply_patch|applying (a |an |the |this |requested |first |minimal |approved |implementation |new |my |our |proposed )*(patch|edit|implementation|change|fix|plan|update|modification|overwrite|rewrite|replacement)|(patching|editing|overwriting|rewriting|replacing|writing) `?[A-Za-z0-9_./-]+|i.?ll (now |first |then |next |only |just |go ahead and |proceed to )*(apply|patch|edit|update|modify|write|create|add|change|implement|fix|overwrite|rewrite|replace)|will (now |first |then |next |only |just |go ahead and |proceed to )*(apply|patch|edit|update|modify|write|create|add|change|implement|fix|overwrite|rewrite|replace))'
+
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "Codex implement attempt ${attempt}/${max_attempts}..."
 
@@ -1220,25 +1249,12 @@ jobs:
                 # is filtered out by the success-no-op regex above, so
                 # it never reaches this branch. Fail-open on grep error.
                 #
-                # Phrasing set extended for run 25215763575 (issue #1901)
-                # where Codex narrated "Applying the approved plan now
-                # with a minimal edit to <file>" / "Applying the requested
-                # minimal implementation now: I'll … patch <file>" — the
-                # original alternation set `(patch|edit)` after the
-                # adjective list, but Codex routinely reaches for
-                # synonyms like `plan` / `implementation` / `change` /
-                # `fix` / `update`, and the adjective set itself needs
-                # `approved`/`implementation`. Likewise the
-                # `i.?ll (now )?(apply|patch|edit|update)` clause now
-                # accepts more leading adverbs (`first`/`then`/`next`/
-                # `only`/`just`/`go ahead and`/`proceed to`) and the
-                # verb set adds `modify`/`write`/`create`/`add`/
-                # `change`/`implement`/`fix`. False positives don't
-                # regress correctness: this branch only fires when
-                # codex_delta is already empty, so broadening the
-                # regex strictly increases recall on a path that is
-                # already a confirmed no-op.
-                if grep -qEi '(apply_patch|applying (a |an |the |this |requested |first |minimal |approved |implementation |new |my |our |proposed )*(patch|edit|implementation|change|fix|plan|update|modification)|patching `?[A-Za-z0-9_./-]+|editing `?[A-Za-z0-9_./-]+|i.?ll (now |first |then |next |only |just |go ahead and |proceed to )*(apply|patch|edit|update|modify|write|create|add|change|implement|fix)|will (now |first |then |next |only |just |go ahead and |proceed to )*(apply|patch|edit|update|modify|write|create|add|change|implement|fix))' "${CODEX_OUTPUT_FILE}" 2>/dev/null; then
+                # Regex maintained as ANNOUNCE_EDIT_REGEX above the
+                # retry loop. False positives don't regress correctness:
+                # this branch only fires when codex_delta is already
+                # empty, so broadening strictly increases recall on a
+                # path that is already a confirmed no-op.
+                if grep -qEi "${ANNOUNCE_EDIT_REGEX}" "${CODEX_OUTPUT_FILE}" 2>/dev/null; then
                   echo "::warning::Codex announced an edit/apply_patch on attempt ${attempt} but produced no file changes — counting toward empty_streak."
                   attempt_was_empty=true
                 fi
@@ -1257,7 +1273,26 @@ jobs:
                   implement_succeeded=true
                   break
                 fi
-                echo "::warning::Codex returned empty output on attempt ${attempt}."
+                # Stuck-intent on stderr: when stdout is empty but the
+                # per-attempt stderr log carries an announce-edit
+                # phrasing, the model narrated the edit (visible to the
+                # operator in the workflow log) without ever invoking
+                # apply_patch — the same failure mode the stdout branch
+                # detects above, just with the narrative on a different
+                # stream. Codex CLI in --full-auto exec mode streams
+                # agent narrative on stderr and only writes the final
+                # assistant message on stdout, so a model that exits
+                # after one announce-and-tool-call sequence leaves
+                # stdout empty. Run 25223836137 (issue #1909): "Applying
+                # the requested overwrite to tests/e2e_smoke_canary.txt
+                # now, with no other file changes." appeared only on
+                # stderr; the stdout-only stuck-intent check missed it
+                # and the bail message mis-reported "empty output".
+                if [ -f "${attempt_log_file}" ] && grep -qEi "${ANNOUNCE_EDIT_REGEX}" "${attempt_log_file}" 2>/dev/null; then
+                  echo "::warning::Codex announced an edit/apply_patch on attempt ${attempt} (in stderr) but produced no file changes — counting toward empty_streak."
+                else
+                  echo "::warning::Codex returned empty output on attempt ${attempt}."
+                fi
                 attempt_was_empty=true
               fi
             else
@@ -1283,7 +1318,16 @@ jobs:
               # count as "non-empty" here but as "empty" in the
               # cmd_rc==0 branch (drift between the two paths).
               if ! grep -q '[^[:space:]]' "${CODEX_OUTPUT_FILE}" 2>/dev/null; then
-                echo "::warning::Codex exited with code $cmd_rc and returned empty output on attempt ${attempt}."
+                # Mirror the cmd_rc==0 + empty-stdout branch: surface a
+                # stderr-side announce-edit phrase in the diagnostic so
+                # watchdog-killed runs that left an announce-and-stop
+                # narrative on stderr don't get mis-classified as a
+                # plain empty-output failure.
+                if [ -f "${attempt_log_file}" ] && grep -qEi "${ANNOUNCE_EDIT_REGEX}" "${attempt_log_file}" 2>/dev/null; then
+                  echo "::warning::Codex exited with code $cmd_rc on attempt ${attempt} after announcing an edit/apply_patch (in stderr) but producing no file changes."
+                else
+                  echo "::warning::Codex exited with code $cmd_rc and returned empty output on attempt ${attempt}."
+                fi
                 attempt_was_empty=true
               else
                 echo "::warning::Codex exited with code $cmd_rc on attempt ${attempt}."


### PR DESCRIPTION
## Summary

Release v1.1.0 [run 25223836137](https://github.com/shubhodeep1/coding-workflows/actions/runs/25223836137) failed because the `e2e-smoke-test` and `e2e-alt-model-test` jobs both depend on the production implement workflow producing a PR for a trivial canary task, but Codex bailed in both runs with `Codex produced no actionable output 2 attempts in a row`.

**Root cause** (evidence-based):
- Codex narrated `Applying the requested overwrite to tests/e2e_smoke_canary.txt now, with no other file changes.` (issue #1909, attempts 1+2) and then exited without ever calling `apply_patch` — the same stuck-intent failure mode PR #1906 was meant to detect.
- PR #1906's regex (`patch|edit|implementation|change|fix|plan|update|modification`) didn't include `overwrite`, so the announce-edit branch never fired and the diagnostic mis-classified the failure as plain "empty output".
- Codex CLI in `--full-auto exec` mode streams agent narrative to **stderr** and only writes the final assistant message to **stdout**. The "Applying the requested overwrite" phrase lived only in `codex_log_attempt_<N>.txt`; the existing check ran against `CODEX_OUTPUT_FILE` (stdout) only. Stdout was empty, so the regex check never even ran.

The empty_streak counter still fired correctly (both empty-output and stuck-intent paths set `attempt_was_empty=true`), so the workflow bailed cleanly after 2 attempts without burning the full 5-attempt budget. This PR is a diagnostic-fidelity + pattern-recall improvement; it doesn't change correctness on the bail path.

**Note**: this fix does not address the underlying model behaviour (Codex-side stall after `serena.activate_project` returns Serena's "Skip onboarding … if you have not yet read the 'Serena Instructions Manual', do it now before continuing!" response). That stall is consistent across both `e2e-smoke-test` (issue #1909, `openai/gpt-5.3-codex`) and `e2e-alt-model-test` (issue #1908, also dispatched against `openai/gpt-5.3-codex` since the alt-model env var doesn't propagate into the production implement workflow). Re-running the release after the OpenRouter / model side stabilises is the immediate path forward; this PR makes the diagnostic accurate so future occurrences are classified correctly.

## Changes

- Extract the stuck-intent regex into `ANNOUNCE_EDIT_REGEX` shell variable defined once before the retry loop, then used in three places.
- Add `overwrite|rewrite|replacement` to the noun alternation.
- Add `overwrite|rewrite|replace` to the `i'll/will (now|first|…)` verb alternations.
- Add `overwriting|rewriting|replacing|writing` to the `patching|editing` gerund pattern.
- Both empty-stdout branches (`cmd_rc==0` and `cmd_rc!=0`) now also grep the per-attempt stderr log (`${attempt_log_file}`) for the same regex, so an announce-edit narrative on stderr lands on the correct `::warning::` line instead of the catch-all "empty output" message.

## Evidence trail

- Implement-job log (issue #1909) timestamps:
  - `17:06:34Z` — `Applying the requested overwrite to tests/e2e_smoke_canary.txt now, with no other file changes.` (stderr)
  - `17:06:58Z` — `tokens used 88,873` + `##[warning]Codex returned empty output on attempt 1.` (mis-classified)
  - `17:07:55Z` — `##[error]Codex bailed: 2 consecutive attempts with no actionable output …`
- `e2e-smoke-test` log: `17:08:50Z` — `##[error]All 1 implement workflow run(s) completed but no PR was created`.
- `e2e-alt-model-test` log: `18:15:45Z` — `##[error]Alt-model run timed out before reaching review stage` (the wait-loop's own auto-`/approved` retrigger kept the issue cycling through repeated stuck implement runs).

## Test plan

- [ ] Trigger another `test-and-mark-stable` run and confirm the implement workflow either succeeds (model recovered) or bails with `Codex announced an edit/apply_patch on attempt N (in stderr) but produced no file changes — counting toward empty_streak.` instead of the previous mis-classified `Codex returned empty output on attempt N`.
- [ ] Confirm a healthy implement run (model invokes `apply_patch` normally) is unaffected — the new regex/grep pair only fires when `codex_delta` is empty, so a successful patch path takes the existing `implement_succeeded=true; break` branch before either check runs.
- [ ] Confirm no false positives by reviewing the regex against the unit-style cases bundled in the commit message (already verified locally).

https://claude.ai/code/session_01HTuEf4ZdfKFWFAMjhLbhEL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTuEf4ZdfKFWFAMjhLbhEL)_