### PR TITLE
Add SessionStart hook so cloud sessions can read GitHub Actions logs

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -54,10 +54,10 @@ verify_token() {
     return 0
   fi
 
-  if gh auth status >/dev/null 2>&1; then
+  if gh api /user --silent >/dev/null 2>&1; then
     log "gh authenticated OK; Actions logs are readable via 'gh run view --log'."
   else
-    log "WARNING: token is set but 'gh auth status' failed. Check scopes/expiry."
+    log "WARNING: 'gh api /user' failed. Token may be invalid, expired, or missing required permissions."
   fi
 }
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -20,24 +20,24 @@ install_gh() {
     return 0
   fi
 
-  local sudo=""
+  local sudo_cmd=()
   if [ "$(id -u)" -ne 0 ]; then
     if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-      sudo="sudo -n"
+      sudo_cmd=(sudo -n)
     else
       log "Insufficient privileges (not root and no passwordless sudo); skipping gh install."
       return 0
     fi
   fi
 
-  $sudo install -d -m 0755 /etc/apt/keyrings
+  "${sudo_cmd[@]}" install -d -m 0755 /etc/apt/keyrings
   curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-    | $sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
-  $sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+    | "${sudo_cmd[@]}" tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+  "${sudo_cmd[@]}" chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-    | $sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
-  $sudo apt-get update -y >/dev/null
-  $sudo apt-get install -y gh >/dev/null
+    | "${sudo_cmd[@]}" tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+  "${sudo_cmd[@]}" apt-get update -y >/dev/null
+  "${sudo_cmd[@]}" apt-get install -y gh >/dev/null
   log "gh installed: $(gh --version | head -n1)"
 }
 
@@ -54,10 +54,13 @@ verify_token() {
     return 0
   fi
 
-  if gh api /user --silent >/dev/null 2>&1; then
-    log "gh authenticated OK; Actions logs are readable via 'gh run view --log'."
+  # Probe the actual capability we care about: reading Actions runs in this
+  # repo. 'gh run list' resolves the repo from the git remote and exits
+  # non-zero if the token lacks actions:read.
+  if gh run list -L 1 >/dev/null 2>&1; then
+    log "gh authenticated; Actions logs are readable via 'gh run view --log <id>'."
   else
-    log "WARNING: 'gh api /user' failed. Token may be invalid, expired, or missing required permissions."
+    log "WARNING: 'gh run list' failed. Token may be invalid, expired, or missing actions:read for this repo."
   fi
 }
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code on the web. Local sessions are unaffected.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+log() { printf '[session-start] %s\n' "$*"; }
+
+install_gh() {
+  if command -v gh >/dev/null 2>&1; then
+    log "gh already installed: $(gh --version | head -n1)"
+    return 0
+  fi
+
+  log "Installing gh CLI..."
+  if ! command -v apt-get >/dev/null 2>&1; then
+    log "apt-get not available; skipping gh install."
+    return 0
+  fi
+
+  local sudo=""
+  if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
+    sudo="sudo"
+  fi
+
+  $sudo install -d -m 0755 /etc/apt/keyrings
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | $sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+  $sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | $sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+  $sudo apt-get update -y >/dev/null
+  $sudo apt-get install -y gh >/dev/null
+  log "gh installed: $(gh --version | head -n1)"
+}
+
+verify_token() {
+  if [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
+    log "WARNING: neither GH_TOKEN nor GITHUB_TOKEN is set."
+    log "  Add GH_TOKEN to your Claude Code cloud environment variables to enable"
+    log "  Actions log access (scopes: repo + workflow, or fine-grained actions:read)."
+    return 0
+  fi
+
+  if gh auth status >/dev/null 2>&1; then
+    log "gh authenticated OK; Actions logs are readable via 'gh run view --log'."
+  else
+    log "WARNING: token is set but 'gh auth status' failed. Check scopes/expiry."
+  fi
+}
+
+install_gh || log "gh install failed (non-fatal)"
+verify_token || true

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -21,8 +21,13 @@ install_gh() {
   fi
 
   local sudo=""
-  if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
-    sudo="sudo"
+  if [ "$(id -u)" -ne 0 ]; then
+    if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+      sudo="sudo -n"
+    else
+      log "Insufficient privileges (not root and no passwordless sudo); skipping gh install."
+      return 0
+    fi
   fi
 
   $sudo install -d -m 0755 /etc/apt/keyrings
@@ -41,6 +46,11 @@ verify_token() {
     log "WARNING: neither GH_TOKEN nor GITHUB_TOKEN is set."
     log "  Add GH_TOKEN to your Claude Code cloud environment variables to enable"
     log "  Actions log access (scopes: repo + workflow, or fine-grained actions:read)."
+    return 0
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    log "WARNING: token is set but 'gh' is not installed; skipping auth check."
     return 0
   fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- New `.claude/hooks/session-start.sh` installs the `gh` CLI on first cloud session and verifies `GH_TOKEN` (or `GITHUB_TOKEN`) is set, so Claude Code on the web can run `gh run view --log` and other Actions queries on its own.
- Wired up via `.claude/settings.json` `SessionStart` hook.
- Guarded by `CLAUDE_CODE_REMOTE=true` — local Claude Code sessions are unaffected (early `exit 0`).
- Idempotent: re-runs detect existing `gh` and skip install.

## How to use
1. Create a PAT (fine-grained recommended) with: `contents:read`, `actions:read`, `pull_requests:read` (add `:write` variants if Claude should comment / re-run workflows).
2. In claude.ai/code → environment → environment variables, add `GH_TOKEN=<pat>`.
3. Start a new cloud session — the hook installs `gh` and confirms auth.

## Test plan
- [x] `env -u CLAUDE_CODE_REMOTE ./.claude/hooks/session-start.sh` exits 0 silently (local mode no-op).
- [x] `CLAUDE_CODE_REMOTE=true ./.claude/hooks/session-start.sh` installs `gh` and warns when token is missing.
- [x] Re-running with `gh` already present hits the "already installed" branch (idempotent).
- [ ] After merge, start a fresh cloud session with `GH_TOKEN` set and confirm `gh auth status` passes and `gh run view --log <run-id>` works.

https://claude.ai/code/session_015zubBbgiyy8ZXTGk3wFQqs

---
_Generated by [Claude Code](https://claude.ai/code/session_015zubBbgiyy8ZXTGk3wFQqs)_