### PR TITLE
fix(implement): drop reasoning effort to low for E2E smoke test runs

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -594,6 +594,16 @@ jobs:
             echo "🔬 Smoke test detected — suppressing per-phase Telegram alerts"
             echo "ALERT_MSG_LEVEL=SILENT" >> "$GITHUB_ENV"
             echo "IS_SMOKE_TEST=true" >> "$GITHUB_ENV"
+            # The smoke-canary task is a 3-line file overwrite — it does
+            # not need xhigh reasoning. At xhigh, gpt-5.3-codex has been
+            # observed announcing "Applying the required overwrite … using
+            # apply_patch" in its final assistant message and exiting
+            # without ever invoking the tool, tripping the empty_streak
+            # bail (run 25243564804 issue #1927; same pattern issue #1929).
+            # Drop reasoning to `low` for the smoke fixture so the model
+            # spends its budget on the apply_patch tool call instead of
+            # over-reasoning a trivial overwrite.
+            echo "MODEL_REASONING_EFFORT=low" >> "$GITHUB_ENV"
           fi
 
       - name: Fetch issue comments


### PR DESCRIPTION
## Summary

Two consecutive E2E smoke-canary implement runs (issues #1927 and #1929) failed with the same pattern: gpt-5.3-codex at `MODEL_REASONING_EFFORT=xhigh` announced an `apply_patch` edit in its final assistant message but never invoked the tool, tripping the `empty_streak >= 2` bail in the implement retry loop.

Evidence from the failing logs:

- **Issue #1927 / run 25243564804**
  - Attempt 1: only `serena.activate_project` called, then 23,331 tokens consumed and codex exited with empty stdout — no apply_patch, no edit.
  - Attempt 2 (with retry nudge): final stdout = `Applying the required overwrite to `tests/e2e_smoke_canary.txt` now using `apply_patch`.` — zero tool calls between Serena startup and exit, 21,294 tokens.
- **Issue #1929**
  - Attempt 1: said `Implementing the approved plan now by updating only `tests/e2e_smoke_canary.txt` …`, ran two read-only `serena.search_for_pattern` calls, exited with no edit.
  - Attempt 2: said `Applying the required file edit first via `apply_patch`, then I'll verify only that target file changed.` — no tool call, exited.

Both runs are on commit `d79c906` (the prior fix that split agents.md/README.md to reduce prompt size — that already-shipped fix did not unblock the smoke test).

## Fix

The smoke-canary task is a 3-line file overwrite. It does not need xhigh reasoning. Override `MODEL_REASONING_EFFORT=low` when the issue title carries the `[E2E Smoke Test]` prefix, piggybacking on the existing smoke-test detection step (`implement.yml:593`) so the override is in `$GITHUB_ENV` before the `Create Codex config` step writes `~/.codex/config.toml` (`implement.yml:813`).

Real implement runs (non-smoke issues) continue to use the workflow-level default of xhigh.

## Test plan

- [ ] Trigger a fresh `test-and-mark-stable` run and confirm the smoke-canary issue's implement workflow runs at `model_reasoning_effort = "low"`.
- [ ] Confirm `tests/e2e_smoke_canary.txt` is updated to the three required lines on attempt 1, no announce-without-edit warning, no empty_streak bail.
- [ ] Spot-check that a non-smoke issue's implement run still uses `xhigh` (no regression to other implement traffic).

https://claude.ai/code/session_01HpdBcrV3krngHXfniirS93

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpdBcrV3krngHXfniirS93)_