### PR TITLE
revert(implement): remove EDIT TOOL DISCIPLINE block (regressed smoke tests)

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -932,17 +932,6 @@ jobs:
             handles commit and diff reporting separately.
           - Do NOT emit progress/status messages. Output ONLY repository changes.
 
-          EDIT TOOL DISCIPLINE (MANDATORY — prevents announce-without-editing stalls):
-          - Make every repository edit via `apply_patch` or the equivalent Serena edit
-            tool (mcp__serena__replace_symbol_body, mcp__serena__insert_after_symbol,
-            mcp__serena__insert_before_symbol). Do NOT shell out to `sed`/`awk`/`rg`
-            with literal special characters — they routinely fail shell quoting and
-            waste the entire attempt without producing a diff.
-          - Once you have located the file and lines to change, go straight to the
-            edit. Do NOT keep exploring. Announcing "I'll now apply_patch …" without
-            actually invoking the tool counts as a failed attempt and trips the
-            stuck-in-exploration bail.
-
           CONFLICT DETECTION:
           - Flag any factual conflicts between the implementation plan and the actual
             codebase (e.g., a function name in the plan doesn't match the code, a file


### PR DESCRIPTION
## Summary

Reverts the EDIT TOOL DISCIPLINE block from `.github/workflows/implement.yml` (added by PR #1906 / 11bfcd8). The block correlates exactly with a 100% smoke-test regression boundary.

## Evidence

**Before #1906 (5/01 02:58 → 13:11Z):** 7 consecutive alt-model E2E smoke implements succeeded (#1830, #1845, #1856, #1867, #1875, #1888, #1897), each in 4–7K tokens via:

```
exec /bin/bash -lc "printf 'status: ok\n…' > tests/e2e_smoke_canary.txt"
```
or `cat <<EOF > …` heredocs.

**After #1906 (5/01 17:00 → 5/02 05:42Z):** 5 consecutive alt-model E2E smoke implements failed (#1908, #1916, #1929, #1934, #1943) with `Codex bailed: 2 consecutive attempts with no actionable output`:

| Issue | Run | Tokens (a1 / a2) | Failure mode |
| --- | --- | --- | --- |
| #1908 | 25224028373 | 4,502 / — | silent exit after `serena.activate_project` |
| #1943 | 25245077011 | 24,112 / 13,534 | `"I'll … apply a direct patch"` announce-without-invoke |

Intermediate fixes (PR #1933 `MODEL_REASONING_EFFORT=low`, PR #1940 revert to `xhigh`) toggled reasoning effort but didn't address the prompt change; failure rate stayed at ~100%.

## Why removing the block restores success

The EDIT TOOL DISCIPLINE block instructs Codex to use `apply_patch` / Serena edit tools and forbids `sed`/`awk`/`rg` shell-out. The OpenRouter `gpt-5.3-codex` agent on this micro-task either fails to invoke `apply_patch` (announces it then stops) or exits silently. Removing the block lets the model fall back to the working `exec /bin/bash -lc printf` heredoc pattern that produced 7 consecutive successes.

## What's preserved

- Retry-prompt nudge at L1130 (added in 8998e46, present during all 7 successes; only fires after attempt 1 fails) — kept as-is.
- Broadened `ANNOUNCE_EDIT_REGEX` (also from #1906) — kept; it gates on `codex_delta is empty`, so successful exec-and-edit paths never trip it.
- `prompts/serena-efficiency-block.txt` — predates the regression; not touched.
- The issue.state=closed gating (the other half of #1906) — kept; unrelated to the regression.

## Test plan

- [ ] Trigger a fresh E2E smoke test cycle and confirm the alt-model implement succeeds (close issue #1943, let the next orchestrate-decompose-test cycle spawn a new one).
- [ ] Confirm Codex narrates `exec /bin/bash -lc "printf …"` or equivalent shell-write rather than announcing `apply_patch`.
- [ ] Confirm token count drops back to the 4–7K range for the smoke fixture.

https://claude.ai/code/session_01NXiUCc6ZV7Qkyc3XN6GTf5

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXiUCc6ZV7Qkyc3XN6GTf5)_