### PR TITLE
fix(gh_helpers): treat PAT-scoped 403 as permanent failure

### DIFF
--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -62,7 +62,8 @@ _gh_actions_escape()
 #     not on the issue; retrying just burns API budget.)
 #   * HTTP 404 Not Found             (resource doesn't exist)
 #   * HTTP 422 Unprocessable Entity  (validation / already-exists)
-#   * "Resource not accessible by integration"  (token scope)
+#   * "Resource not accessible by integration"      (GITHUB_TOKEN scope)
+#   * "Resource not accessible by personal access token" (PAT scope)
 #
 # Returns 0 (true) if the text indicates such a failure.
 # Conservative on purpose — only matches conditions that retrying
@@ -70,7 +71,7 @@ _gh_actions_escape()
 # ---------------------------------------------------------------
 _is_gh_permanent_failure()
 {
-	printf '%s' "$1" | grep -qiE "['\"][^'\"]+['\"] not found|gh: Not Found|HTTP 404|404 Not Found|status code 404|HTTP 422|Resource not accessible by integration"
+	printf '%s' "$1" | grep -qiE "['\"][^'\"]+['\"] not found|gh: Not Found|HTTP 404|404 Not Found|status code 404|HTTP 422|Resource not accessible by (integration|personal access token)"
 }
 
 # ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

`_is_gh_permanent_failure` in `scripts/gh_helpers.sh` recognized `"Resource not accessible by integration"` (GITHUB_TOKEN scope failures) but not the PAT variant `"Resource not accessible by personal access token"`. When a workflow ran with a PAT lacking a required scope, every gh call burned the full retry budget (1 + 2 + 4 + 8 + 16 s) and emitted `::error::` even when the caller intentionally fails open.

## Root cause

In the failing job (PR #2770 / run `25245285005` of `tele-funtoken-msg-scoring`), the check-runs collection step issued:

```
gh api --paginate --slurp repos/shubhodeep1/tele-funtoken-msg-scoring/commits/<sha>/check-runs?per_page=100
```

The PAT lacked `Checks:read`, so each attempt returned HTTP 403 with `gh: Resource not accessible by personal access token`. The regex at `scripts/gh_helpers.sh:73` only matched the integration variant, so `gh_retry` retried 5×, then emitted `::error::gh command failed after 5 attempts: …`. The caller (`review_autofix.yml`'s check-runs step) caught the non-zero return and set `_final_status="api_error"`, but the spurious red annotation remained on an otherwise green job.

## Fix

Extend the alternation so PAT-scoped 403s short-circuit to a single `::warning::` and return immediately, the same way integration-scoped 403s already do.

## Test plan

- [x] Manual: source the helper and invoke `_is_gh_permanent_failure` against both variants — PAT and integration both classify as permanent; transient errors still classify as retryable.
- [ ] Re-run a `review_autofix` job whose PAT lacks `Checks:read` and confirm only `::warning::` appears (no `::error::`, no 31 s retry burn).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYmARzzELHVU4HdSNcjzS1)_