### PR TITLE
revert(prompts): un-namespace MCP refs in serena-efficiency-block.txt

### DIFF
--- a/prompts/serena-efficiency-block.txt
+++ b/prompts/serena-efficiency-block.txt
@@ -1,21 +1,21 @@
 [READ_ONLY]
 SERENA MCP EFFICIENCY (MANDATORY):
-- Do NOT call mcp__serena__onboarding, mcp__serena__initial_instructions, or mcp__serena__check_onboarding_performed.
-- Skip straight to mcp__serena__activate_project and then use tools directly.
-- Prefer mcp__serena__get_symbols_overview and mcp__serena__find_symbol over raw file reads.
-- Use mcp__serena__find_referencing_symbols for impact analysis when needed.
-- Use mcp__serena__search_for_pattern instead of shell grep/rg when Serena is available.
-- In review/edit flows, prefer targeted Git MCP fetches (`mcp__git__git_status`, `mcp__git__git_diff`, `mcp__git__git_show`, `mcp__git__git_log`, `mcp__git__git_branch`) when Git MCP is available.
+- Do NOT call onboarding, initial_instructions, or check_onboarding_performed.
+- Skip straight to activate_project and then use tools directly.
+- Prefer get_symbols_overview and find_symbol over raw file reads.
+- Use find_referencing_symbols for impact analysis when needed.
+- Use search_for_pattern instead of shell grep/rg when Serena is available.
+- In review/edit flows, prefer targeted Git MCP fetches (`git_status`, `git_diff`, `git_show`, `git_log`, `git_branch`) when Git MCP is available.
 - Keep existing preloaded diff/context artifacts as fallback when Git MCP is unavailable.
 - Never read the same file region twice. Plan reads upfront.
 - If Serena tools are unavailable or error, fall back to normal file operations.
 
 [READ_WRITE]
 SERENA MCP EFFICIENCY (MANDATORY):
-- Call mcp__serena__activate_project exactly once, then do NOT call mcp__serena__onboarding, mcp__serena__initial_instructions, or mcp__serena__check_onboarding_performed.
-- Prefer Serena read tools (mcp__serena__get_symbols_overview, mcp__serena__find_symbol, mcp__serena__find_referencing_symbols, mcp__serena__search_for_pattern) over full-file reads.
-- Prefer Serena edit tools (mcp__serena__replace_symbol_body, mcp__serena__insert_after_symbol, mcp__serena__insert_before_symbol, mcp__serena__rename_symbol) over full-file rewrites.
-- In review/edit flows, prefer targeted Git MCP fetches (`mcp__git__git_status`, `mcp__git__git_diff`, `mcp__git__git_show`, `mcp__git__git_log`, `mcp__git__git_branch`) when Git MCP is available.
+- Call activate_project exactly once, then do NOT call onboarding, initial_instructions, or check_onboarding_performed.
+- Prefer Serena read tools (get_symbols_overview, find_symbol, find_referencing_symbols, search_for_pattern) over full-file reads.
+- Prefer Serena edit tools (replace_symbol_body, insert_after_symbol, insert_before_symbol, rename_symbol) over full-file rewrites.
+- In review/edit flows, prefer targeted Git MCP fetches (`git_status`, `git_diff`, `git_show`, `git_log`, `git_branch`) when Git MCP is available.
 - Keep existing preloaded diff/context artifacts as fallback when Git MCP is unavailable.
 - Never read the same file region twice.
 - If Serena tools are unavailable or error, fall back to normal file operations.


### PR DESCRIPTION
## Summary

Partial revert of PR #1711 — restores `prompts/serena-efficiency-block.txt` only to its pre-#1711 form (bare MCP names: `activate_project`, `find_symbol`, `git_status`, …). The other five files #1711 touched are left as-is so we can isolate whether this single block is the lever that recovers the alt-model smoke success rate.

## Why

Run [25246727158](https://github.com/shubhodeep1/coding-workflows/actions/runs/25246727158) (issue #1959) failed with the `Codex bailed: 2 consecutive attempts with no actionable output` empty-streak bail despite PR #1948 already having reverted the EDIT TOOL DISCIPLINE block 39 minutes prior. Investigation against the 4/23 last-known-good SHA `73e737a4f` (8.9 days before this run) surfaced the following net delta on prompt content that affects model behaviour:

| Change | PR | Status |
|---|---|---|
| MCP tool refs renamed bare → `mcp__server__tool` | #1711 | **In place** ← this PR partially reverts |
| Codex CLI v0.114 → v0.125 → v0.114 | #1704 → #1729 | net zero |
| EDITOR_MAX_WALL 3300 → 7800s | (in-window) | in place |
| Retry-prompt nudge ("apply_patch / Serena edit tools, NOT sed/grep") | #1771 | in place; predates the 7 cited successes |
| EDIT TOOL DISCIPLINE attempt-1 block | #1906 → #1948 | reverted |
| MCP_HANDSHAKE_PROBE_ENABLED | #1799 | in place (helps, not hurts) |
| `agents.md` 93KB → 14KB (overflow split) | #1926 | in place (smaller prompt) |

#1711 was originally needed for Codex CLI v0.125's strict router. #1729 reverted the CLI to v0.114 (lenient router) but kept the rename, on the rationale that v0.114 accepts both forms. v0.114's router does in fact resolve both — the failing run shows the model successfully invoking bare `serena.activate_project` (log `L5005`) — but the rename appears to steer gpt-5.3-codex@xhigh away from the `printf … > tests/e2e_smoke_canary.txt` shell-out fallback that all 7 cited 5/01 alt-model smoke successes used (4-7K tokens, per #1948 commit message), and toward MCP-tool-shaped flows that announce `apply_patch` without invoking it.

Failing run signature:
- Attempt 1: 14,134 tokens, no file changes (silent exit after `serena.activate_project`)
- Attempt 2: 14k tokens, "Applying the requested direct patch to `tests/e2e_smoke_canary.txt` first, then I'll verify the exact file contents." → no tool call → empty-streak bail
- For comparison the cited 5/01 successes were 4-7K tokens via `exec /bin/bash -lc "printf … > tests/e2e_smoke_canary.txt"`

## Scope

Only one file changed:

- `prompts/serena-efficiency-block.txt` — both `[READ_ONLY]` and `[READ_WRITE]` sections un-namespaced. Now byte-identical to `73e737a4f:prompts/serena-efficiency-block.txt`.

Five other #1711 files (`agents.md`, `codex_system_instructions.md`, `.github/workflows/{clarify,plan,implement}.yml`) intentionally left namespaced — minimal change set, easy to roll back if this revert doesn't move the needle.

## Test plan

- [ ] Watch the next alt-model E2E smoke (`test-and-mark-stable.yml` `e2e-alt-model-test` job) — token count and outcome
- [ ] Compare attempt-1 token count against the cited 4-7K range from #1948 commit message
- [ ] If smoke recovers, broaden the partial revert in a follow-up PR
- [ ] If it doesn't, the next lever to try is the `MODEL_REASONING_EFFORT=low` smoke override (see #1933 / #1940 history) or capping `EDITOR_MAX_WALL` for smokes only

https://claude.ai/code/session_01XCD2DFmK4kYCkjiaiimm9b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jh9LMJJ9pS3EkBy6tCxP7C)_