### PR TITLE
revert(prompts): un-namespace Serena/Git MCP refs in agents.md + codex_system_instructions.md

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -23,24 +23,24 @@ Reduce token usage by using Serena's LSP-backed semantic tools instead of full-f
 Rules:
 - ALWAYS use Serena semantic tools over full-file reads.
 - NEVER read an entire file if symbol tools suffice.
-- NEVER rewrite an entire file if `mcp__serena__replace_symbol_body` or `mcp__serena__insert_after_symbol` can do it.
+- NEVER rewrite an entire file if `replace_symbol_body` or `insert_after_symbol` can do it.
 
 ### Reading code (use INSTEAD of cat/read):
-- `mcp__serena__get_symbols_overview` — file structure (classes, functions, exports)
-- `mcp__serena__find_symbol` — jump to a symbol definition
-- `mcp__serena__find_referencing_symbols` — find all callers/usages
-- `mcp__serena__search_for_pattern` — regex search (replaces grep)
+- `get_symbols_overview` — file structure (classes, functions, exports)
+- `find_symbol` — jump to a symbol definition
+- `find_referencing_symbols` — find all callers/usages
+- `search_for_pattern` — regex search (replaces grep)
 
 ### Editing code (use INSTEAD of full-file writes):
-- `mcp__serena__replace_symbol_body` — replace a function/class body
-- `mcp__serena__insert_after_symbol` / `mcp__serena__insert_before_symbol` — add code around a symbol
-- `mcp__serena__rename_symbol` — rename across codebase (LSP refactor)
+- `replace_symbol_body` — replace a function/class body
+- `insert_after_symbol` / `insert_before_symbol` — add code around a symbol
+- `rename_symbol` — rename across codebase (LSP refactor)
 
 ### Workflow:
-1. `mcp__serena__get_symbols_overview` → understand file structure
-2. `mcp__serena__find_symbol` → drill into specific functions
-3. `mcp__serena__find_referencing_symbols` → understand change impact
-4. Edit with `mcp__serena__replace_symbol_body` / `mcp__serena__insert_after_symbol` — NOT full-file rewrites
+1. `get_symbols_overview` → understand file structure
+2. `find_symbol` → drill into specific functions
+3. `find_referencing_symbols` → understand change impact
+4. Edit with `replace_symbol_body` / `insert_after_symbol` — NOT full-file rewrites
 
 ### Search result limits:
 - Serena results may truncate at ~29k chars. Do NOT re-run via shell grep. Instead narrow the query or split into targeted lookups.

--- a/codex_system_instructions.md
+++ b/codex_system_instructions.md
@@ -23,24 +23,24 @@ Reduce token usage by using Serena's LSP-backed semantic tools instead of full-f
 Rules:
 - ALWAYS use Serena semantic tools over full-file reads.
 - NEVER read an entire file if symbol tools suffice.
-- NEVER rewrite an entire file if `mcp__serena__replace_symbol_body` or `mcp__serena__insert_after_symbol` can do it.
+- NEVER rewrite an entire file if `replace_symbol_body` or `insert_after_symbol` can do it.
 
 ### Reading code (use INSTEAD of cat/read):
-- `mcp__serena__get_symbols_overview` — file structure (classes, functions, exports)
-- `mcp__serena__find_symbol` — jump to a symbol definition
-- `mcp__serena__find_referencing_symbols` — find all callers/usages
-- `mcp__serena__search_for_pattern` — regex search (replaces grep)
+- `get_symbols_overview` — file structure (classes, functions, exports)
+- `find_symbol` — jump to a symbol definition
+- `find_referencing_symbols` — find all callers/usages
+- `search_for_pattern` — regex search (replaces grep)
 
 ### Editing code (use INSTEAD of full-file writes):
-- `mcp__serena__replace_symbol_body` — replace a function/class body
-- `mcp__serena__insert_after_symbol` / `mcp__serena__insert_before_symbol` — add code around a symbol
-- `mcp__serena__rename_symbol` — rename across codebase (LSP refactor)
+- `replace_symbol_body` — replace a function/class body
+- `insert_after_symbol` / `insert_before_symbol` — add code around a symbol
+- `rename_symbol` — rename across codebase (LSP refactor)
 
 ### Workflow:
-1. `mcp__serena__get_symbols_overview` → understand file structure
-2. `mcp__serena__find_symbol` → drill into specific functions
-3. `mcp__serena__find_referencing_symbols` → understand change impact
-4. Edit with `mcp__serena__replace_symbol_body` / `mcp__serena__insert_after_symbol` — NOT full-file rewrites
+1. `get_symbols_overview` → understand file structure
+2. `find_symbol` → drill into specific functions
+3. `find_referencing_symbols` → understand change impact
+4. Edit with `replace_symbol_body` / `insert_after_symbol` — NOT full-file rewrites
 
 ### Search result limits:
 - Serena results may truncate at ~29k chars. Do NOT re-run via shell grep. Instead narrow the query or split into targeted lookups.
@@ -64,7 +64,7 @@ Rules:
 Use Git MCP in review/edit flows to fetch scoped, on-demand git context when available.
 
 Rules:
-- Prefer targeted Git MCP queries (`mcp__git__git_status`, `mcp__git__git_diff`, `mcp__git__git_show`, `mcp__git__git_log`, `mcp__git__git_branch`) over broad git context dumps.
+- Prefer targeted Git MCP queries (`git_status`, `git_diff`, `git_show`, `git_log`, `git_branch`) over broad git context dumps.
 - Keep Git MCP usage read-oriented in review/edit flows.
 - Keep existing preloaded diff/context artifacts as fallback when Git MCP is unavailable or disabled.
 - If Git MCP is unavailable or errors, continue with the existing fallback artifacts.


### PR DESCRIPTION
## Summary

Continues beeab62 (#1965)'s partial revert of PR #1711's namespacing pass. Run 25247210528 (5/02 stable smoke, post-beeab62) failed Phase 4b "Verify editor removed bait line": review_autofix run 25247372376 completed `success` but the editor produced a noop and never moved the PR head off the bait commit.

## Why beeab62 alone wasn't enough

beeab62 reverted only `prompts/serena-efficiency-block.txt`, with the explicit framing "are left as-is so we can isolate whether the efficiency-block specifically is the lever that matters." Empirically it was not.

review_autofix's editor static prefix bundles **both** of the following into the prompt at `review_autofix.yml:1240-1252`:
- `codex_system_instructions.md` (Serena section, via `awk '/^## Serena \(MCP\) Semantic Tooling/{flag=1} /^## 0\./{flag=0} flag{print}'`)
- `agents.md` (full file)

Pre-this-PR, those two files together contributed **25 namespaced refs** (12 in agents.md, 13 in codex_system_instructions.md's editor-included slice) — an order of magnitude more than the 1 file beeab62 reverted. So the same noop-without-invoke pattern beeab62's commit message described stayed live for review_autofix specifically.

## Diagnosis evidence (from run 25247210528 e2e-smoke-test job log)

- Bait commit `4894e60` pushed to PR #1973 head branch.
- Review run #25247372376 reached step "Apply fixes with editor model", ran ~11min, then jumped directly to "Record review run completion in memory" — no "Commit changes" / "Push autofix" step ran.
- Review run conclusion: `success`. PR head SHA never advanced past the bait. PR `mergeable_state=dirty`, `additions=2 / deletions=1` across all commits.
- Phase 4b "Verify editor removed bait line": `##[error]Editor failed to remove bait line E2E_EDITOR_BAIT_25247210528` — the canary file still contained the bait line at the end.
- This pattern matches `EDITOR_NOOP_SUSPICIOUS=true` skipping the commit/push gates (`review_autofix.yml:3334`+).

## What this PR does

Mechanical un-namespacing of the Serena/Git MCP refs in `agents.md` and `codex_system_instructions.md`, mirroring beeab62's treatment of `serena-efficiency-block.txt` (which was byte-identical to `73e737a4f` after that rewrite):

- `mcp__serena__X` → `X`
- `mcp__git__X` → `X`

Result: 0 namespaced refs left in either file. PR #1926 (`d79c906`)'s operator-runbook split is preserved — the diff only touches Serena/Git MCP tool references, not the structural trim that #1926 added.

## What this PR deliberately does NOT touch

The other three files PR #1711 namespaced (`.github/workflows/clarify.yml`, `plan.yml`, `implement.yml`) are left as-is. Those feed clarify/plan/implement, not review_autofix, so isolating the review_autofix surface first preserves an experimental signal: if smoke goes green after this PR, that's strong evidence the review_autofix editor was the only thing the namespacing was breaking.

## Test plan

- [ ] Re-run Test & Mark Stable Release on the merge commit. Expected: `e2e-smoke-test` Phase 4b passes (editor removes bait line + pushes a fix commit).
- [ ] If still failing, the next isolation step is the implement.yml namespacing (smoke-implement uses different prompt path).

🤖 https://claude.ai/code/session_011tJLUvaa2kaFiUJNXEYj4F

---
_Generated by [Claude Code](https://claude.ai/code/session_011tJLUvaa2kaFiUJNXEYj4F)_