### PR TITLE
revert(prompts): un-namespace Serena MCP refs in clarify/plan/implement.yml

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -650,18 +650,18 @@ jobs:
 
           SERENA MCP EFFICIENCY (MANDATORY):
           {{SERENA_EFFICIENCY_BLOCK_READ_ONLY}}
-          - LARGE FILES (>5000 lines): Skip mcp__serena__get_symbols_overview entirely — it will
+          - LARGE FILES (>5000 lines): Skip get_symbols_overview entirely — it will
             exceed character limits and waste a tool call. Use shell rg with | head -n N
-            first to locate relevant functions, then use mcp__serena__find_symbol or targeted sed reads.
+            first to locate relevant functions, then use find_symbol or targeted sed reads.
           - Serena search responses are truncated at ~29,000 characters. If
-            mcp__serena__get_symbols_overview is truncated, retry ONCE with max_answer_chars=29000
-            before falling back to shell. Do NOT retry mcp__serena__search_for_pattern — narrow
+            get_symbols_overview is truncated, retry ONCE with max_answer_chars=29000
+            before falling back to shell. Do NOT retry search_for_pattern — narrow
             scope instead. Never fall back to shell grep/rg with the same patterns.
-          - NARROW SEARCH SCOPE: When using mcp__serena__search_for_pattern, target a specific
+          - NARROW SEARCH SCOPE: When using search_for_pattern, target a specific
             directory or file — never search the entire repo with a broad pattern.
-            Bad:  mcp__serena__search_for_pattern("crash", "ft.games", "**/*.{py,html,js}")
-            Good: mcp__serena__search_for_pattern("animateCrash|riseFrameId", "ft.games/static/crash.js")
-            If you need to locate files first, use mcp__serena__find_file with a specific mask.
+            Bad:  search_for_pattern("crash", "ft.games", "**/*.{py,html,js}")
+            Good: search_for_pattern("animateCrash|riseFrameId", "ft.games/static/crash.js")
+            If you need to locate files first, use find_file with a specific mask.
 
           EFFICIENCY RULES (MANDATORY — reduces token waste):
           - Read ONLY the specific lines/symbols you need. Do NOT read entire files or
@@ -669,7 +669,7 @@ jobs:
             ranges (e.g. sed -n '10,30p') instead of full-file reads.
           - Never read the same file region twice. Plan your reads upfront. When reading
             multiple nearby ranges, merge them into ONE wider range instead of separate calls.
-          - Prefer Serena MCP tools (mcp__serena__get_symbols_overview, mcp__serena__find_symbol) over raw file reads
+          - Prefer Serena MCP tools (get_symbols_overview, find_symbol) over raw file reads
             when available — they return only relevant symbols with far fewer tokens.
           - When a Serena search hits its character limit, do NOT fall back to shell grep/rg
             with the same patterns. Refine the Serena query or narrow the scope instead.
@@ -678,8 +678,8 @@ jobs:
           - Batch shell searches with && or ;.
           - When searching for multiple terms (e.g., game names, route patterns), batch
             into ONE shell rg call with alternation (rg 'term1|term2|term3') rather than
-            making separate Serena MCP calls to mcp__serena__find_file or
-            mcp__serena__search_for_pattern for each term.
+            making separate Serena MCP calls to find_file or
+            search_for_pattern for each term.
           - After a Serena search returns empty results, do NOT retry with a slightly
             different regex. Switch to shell rg with broader patterns instead.
           - Do NOT map the full implementation surface. Only inspect code to the extent
@@ -693,21 +693,21 @@ jobs:
 
           EFFICIENT TOOL CALL EXAMPLES (study before starting):
           WASTEFUL (burns budget on broad, overlapping queries):
-            1. mcp__serena__search_for_pattern("user", "src")  ← broad term on broad directory, huge result
-            2. mcp__serena__search_for_pattern("@app.route('/foo')", "app.py")  ← too-literal regex, misses dynamic routes
+            1. search_for_pattern("user", "src")  ← broad term on broad directory, huge result
+            2. search_for_pattern("@app.route('/foo')", "app.py")  ← too-literal regex, misses dynamic routes
             3. Same search retried with a slightly different regex  ← overlapping retry wastes a call
-            4. mcp__serena__list_dir on directories unrelated to the issue  ← unnecessary exploration
+            4. list_dir on directories unrelated to the issue  ← unnecessary exploration
             5. shell: sed -n '1,200p' some_file  ← reading 200 lines when 20-30 would suffice
             6. Searching db/schema/contract files for a pure UI/frontend issue  ← wrong scope
             7. sed -n '100,200p' f then sed -n '180,250p' f  ← overlapping ranges; use sed -n '100,250p' once
-            8. 4× mcp__serena__find_file("*term1*"), mcp__serena__find_file("*term2*")…  ← use one rg 'term1|term2|…' call instead
+            8. 4× find_file("*term1*"), find_file("*term2*")…  ← use one rg 'term1|term2|…' call instead
           EFFICIENT (targeted, batched, minimal):
-            1. mcp__serena__activate_project → mcp__serena__get_symbols_overview("src/main_module.py")  ← see all functions at once
-            2. mcp__serena__find_symbol("handle_request", "src/main_module.py")  ← jump to exact function
+            1. activate_project → get_symbols_overview("src/main_module.py")  ← see all functions at once
+            2. find_symbol("handle_request", "src/main_module.py")  ← jump to exact function
             3. shell: sed -n '120,140p' src/main_module.py  ← read only the 20 lines you need
-            4. mcp__serena__search_for_pattern("EDGE_CONFIG|rate_limit|payout", "src/main_module.py")  ← one query, specific terms
+            4. search_for_pattern("EDGE_CONFIG|rate_limit|payout", "src/main_module.py")  ← one query, specific terms
             5. shell: rg -l 'ClassName' src/ && sed -n '50,70p' src/found_file.py  ← batched with &&
-          Rule of thumb: 1 mcp__serena__activate_project + 1 mcp__serena__get_symbols_overview + 2-3 mcp__serena__find_symbol/mcp__serena__search_for_pattern
+          Rule of thumb: 1 activate_project + 1 get_symbols_overview + 2-3 find_symbol/search_for_pattern
           calls should cover most clarification needs. If you're past 10 tool calls,
           you are likely over-exploring.
 
@@ -736,7 +736,7 @@ jobs:
           3. Ask only essential questions needed for implementation.
           4. Use repo documentation only; no external web searches.
           5. If external APIs/services are likely required, review their official API docs and identify the expected endpoints and parameters so planning can include concrete call details for an offline editor.
-          6. Use Serena MCP tools (mcp__serena__get_symbols_overview, mcp__serena__find_symbol) when available to explore
+          6. Use Serena MCP tools (get_symbols_overview, find_symbol) when available to explore
              the codebase efficiently. This helps you understand code structure with fewer tokens.
              If Serena tools are unavailable, fall back to normal file reads.
           7. Flag any factual conflicts between the issue description and the codebase

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -920,7 +920,7 @@ jobs:
             request large ranges speculatively. Use Serena symbol tools or targeted line
             ranges (e.g. sed -n '10,30p') instead of full-file reads.
           - Never read the same file region twice. Plan your reads upfront.
-          - Prefer Serena MCP tools (mcp__serena__get_symbols_overview, mcp__serena__find_symbol) over raw file reads
+          - Prefer Serena MCP tools (get_symbols_overview, find_symbol) over raw file reads
             when available — they return only relevant symbols with far fewer tokens.
           - When a Serena search hits its character limit, do NOT fall back to shell grep/rg
             with the same patterns. Refine the Serena query or narrow the scope instead.
@@ -1104,7 +1104,7 @@ jobs:
               # attempts). Codex CLI prints `exec\n<cmd> in <cwd> <status>:`
               # so awk pairs each `exec` line with the following command
               # line. Long commands (>500 chars — typical for serialized
-              # MCP calls like `mcp__serena__find_symbol` with a long
+              # MCP calls like `find_symbol` with a long
               # body arg) are truncated to 500 chars + `…[truncated]`
               # rather than dropped, so the model still sees that the
               # call was tried even if the full args are clipped. Dedup

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -826,10 +826,10 @@ jobs:
 
           SERENA MCP EFFICIENCY (MANDATORY):
           {{SERENA_EFFICIENCY_BLOCK_READ_ONLY}}
-          - For large files (>5000 lines), use mcp__serena__get_symbols_overview with depth=0 first to
-            get a high-level map, then drill into specific symbols with mcp__serena__find_symbol.
+          - For large files (>5000 lines), use get_symbols_overview with depth=0 first to
+            get a high-level map, then drill into specific symbols with find_symbol.
             Do NOT use depth=1+ on very large files — it will exceed character limits.
-          - When mcp__serena__search_for_pattern returns "answer is too long", NARROW the query (target
+          - When search_for_pattern returns "answer is too long", NARROW the query (target
             a single function/class name or a specific subdirectory). Do NOT retry the same
             broad pattern or fall back to shell grep/rg with equivalent patterns.
 
@@ -854,7 +854,7 @@ jobs:
             request large ranges speculatively. Use Serena symbol tools or targeted line
             ranges (e.g. sed -n '10,30p') instead of full-file reads.
           - Never read the same file region twice. Plan your reads upfront.
-          - Prefer Serena MCP tools (mcp__serena__get_symbols_overview, mcp__serena__find_symbol) over raw file reads
+          - Prefer Serena MCP tools (get_symbols_overview, find_symbol) over raw file reads
             when available — they return only relevant symbols with far fewer tokens.
           - When a Serena search hits its character limit, do NOT fall back to shell grep/rg
             with the same patterns. Refine the Serena query or narrow the scope instead.


### PR DESCRIPTION
## Summary

Completes the partial revert chain started in PR #1965 (beeab62) and continued in PR #1974 (b0d1ed8), which mechanically reverted PR #1711's bare→namespaced MCP tool rename (`mcp__serena__X` / `mcp__git__X` → `X`) for the files bundled into the review_autofix editor's static prefix. PRs #1965/#1974 explicitly deferred clarify.yml/plan.yml/implement.yml to isolate signal; this commit completes that revert.

Triggered by analysis of run 25253051580 (PR #1992 closing #1986), where the review_autofix editor at `reasoning=low` (per PR #1984's smoke override) still produced empty output across 4 attempts despite making successful bare-name Serena calls — confirming the static-prefix reverts landed correctly, but leaving the implement-side namespacing as the only remaining PR #1711 surface.

## Changes

- `.github/workflows/clarify.yml`: 20 refs un-namespaced
- `.github/workflows/plan.yml`: 4 refs un-namespaced
- `.github/workflows/implement.yml`: 2 refs un-namespaced (1 in prompt, 1 in workflow comment)

Mechanical edit: `mcp__serena__X` → `X`, `mcp__git__X` → `X`. Codex CLI v0.114's router accepts both bare and namespaced forms, so this is router-safe.

## Files audited but NOT changed

- `scripts/serena_efficiency_report.py` — regex parser; `(?:mcp__serena__|serena[./])` accepts both forms by design and must continue to parse historical logs.
- `scripts/review_run_reviewers.sh` — single namespaced ref inside a historical comment block (cites PR #1742 / run 25084895203). Non-load-bearing.
- `serena_implementation_plan.md` — historical implementation-plan doc; not bundled into any prompt.

## Part (a): mirror PR #1948 on review_autofix — audit-only

Audited for `apply_patch`-mandatory phrasing on the review_autofix editor surface. **No changes needed**, verified clean:

- `scripts/review_apply_fixes.sh`: `EDITOR EXECUTION GUARDRAILS` reads only *"you may read and modify repository files directly as needed"*. No apply_patch-mandatory clause.
- `.github/workflows/review_autofix.yml` editor static block (assembled from `unattended_llm_system_instructions.md`, `codex_system_instructions.md` Serena+Code-Style sections, `agents.md`, README.md trim, `probably_unnecessary_but_read_if_stuck.md` pointer): no apply_patch-mandatory clause.
- `prompts/serena-efficiency-block.txt`'s "Prefer Serena edit tools over full-file rewrites" line is byte-identical to the 4/23 known-good pre-#1711 form (per PR #1965's revert) — not part of the regression.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` passes on all three modified workflow files
- [x] `grep -c "mcp__serena__\|mcp__git__"` returns `0` in all three files
- [ ] Next E2E smoke run on `[E2E Smoke Test]` issue — observe whether editor empty-output rate at `reasoning=low` recovers
- [ ] If empty-output persists, fall back to deterministic shell write for the smoke canary case (option (c) from the prior analysis)

https://claude.ai/code/session_01UxmVRWnXTyCKrF2P4o51qr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxmVRWnXTyCKrF2P4o51qr)_