### PR TITLE
fix(review_autofix): scope LAST_RUN_DIFF to actual ai-autofix commits

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2260,13 +2260,32 @@ jobs:
           fi
           git show --stat HEAD > "${LAST_COMMIT_STAT_FILE}" || true
 
-          if git rev-parse HEAD~1 >/dev/null 2>&1; then
-            git diff "HEAD~1...HEAD" > "${LAST_RUN_DIFF_FILE}" || true
-            git diff --name-only "HEAD~1...HEAD" > "${LAST_RUN_CHANGED_FILES_FILE}" || true
-            git diff --stat "HEAD~1...HEAD" > "${LAST_RUN_DIFF_STAT_FILE}" || true
+          # LAST_RUN_DIFF must reflect actual prior AI autofix work on PR head,
+          # not whatever HEAD~1 happens to be. The downstream OSCILLATION GUARD
+          # in the editor prompt (scripts/review_apply_fixes.sh:441-462) tells
+          # the model to leave any hunk visible in LAST_RUN_DIFF alone unless
+          # it can attach a "regression fingerprint" + "runtime failure path".
+          # The previous unconditional `git diff HEAD~1...HEAD` fed the editor
+          # the diff of impl commits, smoke-test bait commits, and manual
+          # pushes — falsely tripping the guardrail on first-iteration runs.
+          # Smoke run 25254574828 hit this: bait commit was at HEAD,
+          # last_run_diff showed the bait line, OSCILLATION GUARD activated,
+          # editor produced empty output across 6 attempts (3 + 3 retry) at
+          # reasoning=low → Phase 4b bait-removed verification failed.
+          # Walk back recent commits and only use the diff of the most recent
+          # `[ai-autofix]`/`[judge-fix]` commit, matching the existing prefix
+          # convention used by review_apply_fixes.sh:2838 and the iteration
+          # counter at line 2096-2105.
+          LAST_AUTOFIX_SHA="$(git log --format='%H%x09%s' -n 50 2>/dev/null \
+            | awk -F'\t' '$2 ~ /^\[(ai-autofix|judge-fix)\]/ { print $1; exit }' \
+            || true)"
+          if [ -n "${LAST_AUTOFIX_SHA}" ] && git rev-parse "${LAST_AUTOFIX_SHA}^" >/dev/null 2>&1; then
+            git diff "${LAST_AUTOFIX_SHA}^...${LAST_AUTOFIX_SHA}" > "${LAST_RUN_DIFF_FILE}" || true
+            git diff --name-only "${LAST_AUTOFIX_SHA}^...${LAST_AUTOFIX_SHA}" > "${LAST_RUN_CHANGED_FILES_FILE}" || true
+            git diff --stat "${LAST_AUTOFIX_SHA}^...${LAST_AUTOFIX_SHA}" > "${LAST_RUN_DIFF_STAT_FILE}" || true
           else
-            echo "Initial run — no previous commit" > "${LAST_RUN_DIFF_FILE}"
-            echo "Initial run — no previous commit" > "${LAST_RUN_CHANGED_FILES_FILE}"
+            echo "No previous AI autofix run on PR head" > "${LAST_RUN_DIFF_FILE}"
+            echo "No previous AI autofix run on PR head" > "${LAST_RUN_CHANGED_FILES_FILE}"
             echo "FIRST_RUN_NO_PREVIOUS_AI_CHANGES" > "${LAST_RUN_DIFF_STAT_FILE}"
           fi
 

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2273,10 +2273,15 @@ jobs:
           # editor produced empty output across 6 attempts (3 + 3 retry) at
           # reasoning=low → Phase 4b bait-removed verification failed.
           # Walk back recent commits and only use the diff of the most recent
-          # `[ai-autofix]`/`[judge-fix]` commit, matching the existing prefix
-          # convention used by review_apply_fixes.sh:2838 and the iteration
-          # counter at line 2096-2105.
-          LAST_AUTOFIX_SHA="$(git log --format='%H%x09%s' -n 50 2>/dev/null \
+          # `[ai-autofix]`/`[judge-fix]` commit on the PR head's first-parent
+          # chain, matching the iteration counter at line 2096-2105 and the
+          # in-step retry gate further down in this file (see the
+          # `_prior_autofix_count` block in the `Apply fixes with editor model`
+          # step). `--first-parent` is load-bearing: without it, `git log`
+          # walks merged-in history and could pick up an unrelated autofix
+          # commit from base (e.g. a `[ai-autofix]` commit on `main` pulled
+          # in by a merge), polluting LAST_RUN_DIFF on a first-iteration PR.
+          LAST_AUTOFIX_SHA="$(git log --first-parent --format='%H%x09%s' -n 50 2>/dev/null \
             | awk -F'\t' '$2 ~ /^\[(ai-autofix|judge-fix)\]/ { print $1; exit }' \
             || true)"
           if [ -n "${LAST_AUTOFIX_SHA}" ] && git rev-parse "${LAST_AUTOFIX_SHA}^" >/dev/null 2>&1; then

--- a/analysis/workflow-optimization-2026-05-02-9.md
+++ b/analysis/workflow-optimization-2026-05-02-9.md
@@ -664,3 +664,140 @@ Additional cross-cutting notes from the audit:
 | Code modularization | 5-6 | Medium |
 | Expression size reduction | 0 | Small |
 | Medium/Low fixes | 2-4 | Small |
+
+## API Call Consolidation & Dead-Call Analysis (2026-05-02)
+
+### Safety Tag Legend
+`SAFE_TO_MERGE` means the overlap is fully proven statically and can be implemented directly without changing filters, retry/error behavior, concurrency, or cache contracts. `NEEDS_VERIFICATION` means the consolidation/reuse is plausible but one or more of those proofs are missing. `RISKY_SKIP` means the call sits in retry/poll/race-defense/judge logic (or another explicitly protected path), so it should be surfaced for humans but not auto-implemented.
+
+### Consolidation Candidates (MERGE-###)
+
+#### MERGE-001 — `orchestrate_clarify_respond` re-reads the same child/tracking issues across two steps
+- **ID** — `MERGE-001`
+- **Safety tag** — `NEEDS_VERIFICATION`
+- **File path and line ranges** — `.github/workflows/orchestrate_clarify_respond.yml:61-76`; `.github/workflows/orchestrate_clarify_respond.yml:418-429`
+- **Current call count** — `4` on the orchestrator-managed path when `TRACKING_NUM` is present (`GET issue` + `GET tracking issue` + `GET issue` + `GET tracking issue`); `2` when no tracking issue is parsed.
+- **Proposed call count** — `2` on the tracking path; `1` on the no-tracking path.
+- **Endpoint(s)** — `GET /repos/{repo}/issues/{ISSUE_NUMBER}`; `GET /repos/{repo}/issues/{TRACKING_NUM}`
+- **Evidence** — The first step already fetches the full child issue payload, then separately fetches the tracking issue title. A later step refetches the same child issue and the same tracking issue for body text:
+```bash
+ISSUE_PAYLOAD="$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}")"
+ISSUE_BODY="$(printf '%s' "${ISSUE_PAYLOAD}" | jq -r '.body // ""')"
+ISSUE_TITLE="$(printf '%s' "${ISSUE_PAYLOAD}" | jq -r '.title // ""')"
+...
+TRACKING_TITLE="$(gh api "repos/${{ github.repository }}/issues/${TRACKING_NUM}" --jq '.title // ""' 2>/dev/null || echo "")"
+```
+
+```bash
+ISSUE_META="$(gh_retry gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}")"
+ISSUE_BODY="$(printf '%s' "${ISSUE_META}" | jq -r '.body // ""')"
+ISSUE_TITLE="$(printf '%s' "${ISSUE_META}" | jq -r '.title // ""')"
+...
+TRACKING_BODY="$(gh_retry gh api "repos/${{ github.repository }}/issues/${TRACKING_NUM}" --jq '.body // ""')"
+```
+- **Proposed fix** — In `Check orchestrator metadata`, persist the full child issue JSON and, when `TRACKING_NUM` is present, fetch the full tracking issue JSON once (not title-only) into a job-local cache file under `${RUNNER_TEMP}`. Update `Fetch issue and tracking context` to read those cached payloads first and fall back to `gh_retry gh api` only when the cache file is missing or invalid.
+- **Safety rationale** — `NEEDS_VERIFICATION` because the calls are in separate workflow steps with different error-handling semantics (`gh api` vs `gh_retry`) and there are many intervening steps, so freshness and failure behavior are not statically identical.
+- **Downstream signal** — Verify that no step between `Check orchestrator metadata` and `Fetch issue and tracking context` relies on fresher issue/tracking title/body, and that reusing the earlier snapshot preserves current fail-fast/fail-open behavior before consolidating.
+
+### Redundant Re-Fetch (REUSE-###)
+
+#### REUSE-001 — `review_rb_judge.sh` refetches PR title/body already serialized by `Collect PR metadata`
+- **ID** — `REUSE-001`
+- **Safety tag** — `NEEDS_VERIFICATION`
+- **File path and line ranges** — `.github/workflows/review_autofix.yml:1371-1385`; `scripts/review_rb_judge.sh:153-156`
+- **Current call count** — `2` on the judge fallback path where `closingIssuesReferences` is empty (`1` earlier PR fetch in `Collect PR metadata` + `1` later PR fetch in `review_rb_judge.sh`).
+- **Proposed call count** — `1` on that path.
+- **Endpoint(s)** — `GET /repos/{repo}/pulls/{PR_NUMBER}`
+- **Evidence** — `review_autofix.yml` already fetches the PR and writes `PR_META_FILE`; the judge later re-hits the same PR endpoint only to rebuild `title + body`:
+```bash
+gh_retry "${PR_PAYLOAD_FILE}" api repos/${{ github.repository }}/pulls/"${PR_NUMBER}"
+...
+jq '{
+  title: (.title // ""),
+  body: (.body // ""),
+  baseRefName: (.base.ref // ""),
+  headRefName: (.head.ref // ""),
+  headRepoFullName: (.head.repo.full_name // "")
+}' "${PR_PAYLOAD_FILE}" > "${PR_META_FILE}"
+```
+
+```bash
+if [ -z "${ISSUE_NUMBERS}" ]; then
+  PR_DATA="$(_safe_gh_jq "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.title + " " + (.body // "")' || echo "")"
+  REPOSITORY_ESCAPED="${REPOSITORY//./\\.}"
+  ISSUE_NUMBERS="$(echo "${PR_DATA}" | grep -oiE ... )"
+fi
+```
+- **Proposed fix** — In `scripts/review_rb_judge.sh`, read `PR_DATA` from `${PR_META_FILE}` first with `jq -r '[.title // "", .body // ""] | join(" ")'`, and keep the existing `_safe_gh_jq "repos/.../pulls/${PR_NUMBER}"` only as a cache-miss / parse-failure fallback.
+- **Safety rationale** — `NEEDS_VERIFICATION` because the judge may run long after metadata collection, so a human-edited PR title/body could diverge from the cached snapshot, and the `force_rb_judge` path must still guarantee `PR_META_FILE` exists.
+- **Downstream signal** — Verify that every `review_rb_judge.sh` invocation occurs after `Collect PR metadata` and leaves `PR_META_FILE` intact, including `force_rb_judge=true`; then switch the judge fallback to `PR_META_FILE`-first with the live PR GET kept only for cache-miss recovery.
+
+#### REUSE-002 — post-merge validate dispatch can use existing `pr_title` / `pr_body` inputs before hitting `/pulls/{PR_NUMBER}`
+- **ID** — `REUSE-002`
+- **Safety tag** — `NEEDS_VERIFICATION`
+- **File path and line ranges** — `.github/workflows/internal-review.yml:55-63`; `.github/workflows/review_autofix.yml:478-486`
+- **Current call count** — `2` on the GraphQL-empty merged-PR fallback path (`1` GraphQL call + `1` REST PR fetch).
+- **Proposed call count** — `1` on that path when caller inputs are populated; retain `2` as fallback only when inputs are blank.
+- **Endpoint(s)** — `POST /graphql` for `closingIssuesReferences`; `GET /repos/{repo}/pulls/{PR_NUMBER}`
+- **Evidence** — The wrapper already passes PR title/body into the reusable workflow, but the fallback path still re-fetches them from the PR endpoint:
+```yaml
+with:
+  pr_number: ${{ github.event.inputs.pr_number || github.event.pull_request.number || '' }}
+  pr_title: >-
+    ${{ github.event_name != 'workflow_dispatch' && format('{0}', github.event.pull_request.title) || '' }}
+  pr_body: >-
+    ${{ github.event_name != 'workflow_dispatch' && format('{0}', github.event.pull_request.body) || '' }}
+```
+
+```bash
+issue_nodes_json="$(gh api graphql ...)"
+if [ -z "${issue_nodes_json}" ] || [ "${issue_nodes_json}" = "[]" ]; then
+  pr_data="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.title + " " + (.body // "")' 2>/dev/null || echo "")"
+  ...
+fi
+```
+- **Proposed fix** — In `post-merge-validate-dispatch`, add env bindings for `PR_TITLE_INPUT: ${{ inputs.pr_title }}` and `PR_BODY_INPUT: ${{ inputs.pr_body }}`. Build `pr_data="${PR_TITLE_INPUT} ${PR_BODY_INPUT}"` first, and only call `gh api "repos/.../pulls/${PR_NUMBER}"` if both inputs are empty/whitespace.
+- **Safety rationale** — `NEEDS_VERIFICATION` because `review_autofix.yml` can also be entered by `workflow_dispatch` or future wrappers that leave those inputs blank, and event-snapshot PR text may differ from live PR text if someone edits the PR after the workflow is triggered.
+- **Downstream signal** — Verify that every merged-PR caller in this repo populates `pr_title` and `pr_body` for `review_autofix.yml`, and confirm that event-snapshot PR text is acceptable for fallback issue discovery; only then gate the live PR GET behind a blank-input fallback.
+
+### Dead Calls (DEAD-API-###)
+
+#### DEAD-API-001 — standalone conflict sweep fetches `default_branch` and never reads it
+- **ID** — `DEAD-API-001`
+- **Safety tag** — `RISKY_SKIP`
+- **File path and line ranges** — `scripts/orchestrate_poll_process.sh:11405-11405`
+- **Current call count** — `1`
+- **Proposed call count** — `0`
+- **Endpoint(s)** — `GET /repos/{repo}`
+- **Evidence** — The tail block fetches `DEFAULT_BRANCH` immediately before the standalone conflict loop, but the remainder of the block consumes only `S_PR`, `S_HEAD`, `S_BASE`, `S_PR_JSON`, `S_STATE`, `S_HEAD_REF`, `S_MERGEABLE_STATE`, and `S_HEAD_SHA`; the file ends at line `11478` with no `${DEFAULT_BRANCH}` read after the assignment:
+```bash
+CONFLICT_SWEEP_FIXED=0
+DEFAULT_BRANCH="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}" --jq '.default_branch' || echo "main")"
+
+for (( sidx=0; sidx<STANDALONE_COUNT; sidx++ )); do
+  S_PR="$(echo "${STANDALONE_PRS}" | jq -r ".[${sidx}].number")"
+  S_HEAD="$(echo "${STANDALONE_PRS}" | jq -r ".[${sidx}].headRefName")"
+  S_BASE="$(echo "${STANDALONE_PRS}" | jq -r ".[${sidx}].baseRefName")"
+  ...
+done
+```
+- **Proposed fix** — Remove the `DEFAULT_BRANCH=` fetch from this terminal standalone-conflict-sweep block, unless a reviewer decides to wire the variable into future branch-targeting logic in the same block.
+- **Safety rationale** — `RISKY_SKIP` because the dead call is inside `scripts/orchestrate_poll_process.sh`, which this audit contract treats as a race-defense path that must not be auto-implemented.
+- **Downstream signal** — Do not auto-remove this from `orchestrate_poll_process.sh`; manually confirm no EOF-adjacent trap, sourced helper, or pending conflict-recovery branch logic depends on `DEFAULT_BRANCH`, then remove the fetch in a human-reviewed patch only.
+
+### Cross-References to Deep Audit Section
+- `BATCH-001`: `RISKY_SKIP` — Real batching opportunity, but it sits in `review_rb_judge.sh`, a judge/decision path where auto-implementation could alter recovery semantics.
+- `API-001`: `NEEDS_VERIFICATION` — Earlier orchestrator classification is likely reusable, but the later alert gate must preserve the same fail-open behavior across GraphQL and REST fallback branches.
+- `API-002`: `RISKY_SKIP` — The repeated PR snapshots live in `scripts/orchestrate_poll_process.sh` final-merge polling, which explicitly defends against mutable upstream state.
+- `BATCH-002`: `RISKY_SKIP` — The stalled-autofix recovery probes are in `scripts/orchestrate_poll_process.sh`; cache reuse there needs manual validation against run-visibility delays and existing log contracts.
+
+### Summary Counts
+
+| Tag | Count | IDs |
+|---|---:|---|
+| SAFE_TO_MERGE | 0 | — |
+| NEEDS_VERIFICATION | 3 | MERGE-001, REUSE-001, REUSE-002 |
+| RISKY_SKIP | 1 | DEAD-API-001 |
+
+### Implement-Stage Handoff
+- No SAFE_TO_MERGE findings in this pass.

--- a/analysis/workflow-optimization-2026-05-02-9.md
+++ b/analysis/workflow-optimization-2026-05-02-9.md
@@ -1,0 +1,546 @@
+## Executive Summary
+
+- **The biggest end-to-end drag is `review_autofix`, especially on comment-only Claude-branch reviews.** Deep-dive runs `25253939361` (`1066s`), `25253051580` (`1284s`), and `25253094074` (`2062s`) all spent 17–34 minutes in review flows, even when logs show the path was effectively “reviewer panel + comment-only” or had long setup/checkout spans. **Estimated impact:** save 12–20 minutes on affected runs. **Confidence:** high.
+
+- **`test_and_mark_stable` is currently the highest-severity reliability issue.** All 3 completed runs in the window failed at `e2e-smoke-test / Phase 4b: Verify editor removed bait line` (`25247210528`, `25249170035`, `25252918179`), and the canary still contained `E2E_EDITOR_BAIT_*`. A related note in run `25254373266` also says review editor output stayed empty across attempts on PR `#1992`. **Estimated impact:** remove a 50% workflow-family failure rate and avoid 74–108 minute failed release tests. **Confidence:** high.
+
+- **`workflow_log_analysis` is the largest clear token-cost hotspot.** `summarize_unselected_runs` used `116,787` to `237,335` tokens per sampled pass (avg `164,825` across 8 telemetry entries), and run `25252928519` logged `304,969` tokens in its API redundancy pass. **Estimated impact:** 100k–200k+ token savings per analysis run with low-risk scope reduction/delta reuse. **Confidence:** high.
+
+- **Implement failures are wasting tokens despite strong Serena adoption.** Failed implement runs `25245077011`, `25245085089`, and `25246727158` consumed about `37,646`, `29,529`, and `18,600` tokens respectively before bailing with “2 consecutive attempts with no actionable output,” even though one run reports `254` Serena calls and `98%` Serena efficiency. **Estimated impact:** cut failed-attempt token burn by ~30k per bad run and improve success rate. **Confidence:** high.
+
+- **Git fetch scope is broader than needed in several fast-control workflows.** `orchestrate_poll` (`25254213178`), `promote_main_to_stable` (`25254375144`), and `forward_merge_stable_to_main` (`25254380023`) all use `fetch-depth: 0` or full `refs/heads/* + refs/tags/*` fetches, pulling many branch/tag refs for jobs that mostly need main/stable state. **Estimated impact:** 5–35 seconds per run, especially on no-work poll cycles. **Confidence:** high.
+
+- **Prompt cache is enabled but not measurable enough to optimize confidently yet.** Logs show `OPENROUTER_PROMPT_CACHE_DISABLED: false`, but sampled cache probe lines report `cache_creation_input_tokens=na` and `cache_read_input_tokens=na`. **Estimated impact:** instrumentation first, then moderate latency/token savings on retries and repeated review prompts. **Confidence:** medium.
+
+## Speed Optimizations
+
+Ranked by expected end-to-end latency reduction.
+
+### 1. Shrink the `review_autofix` comment-only path
+- **Evidence:**  
+  - Run `25253939361` took `1066s`; log summary says `AUTOFIX_GATE_CLAUDE_BRANCH_REVIEW ... running reviewer panel + comment-only path; editor/commit/judge/auto-merge skipped.`  
+  - Run `25253051580` took `1284s`; `review.codex-agent` dominated from `13:32:06` to `13:53:16`.  
+  - Run `25253094074` took `2062s`; log summary says checkout/setup in `review codex-agent` spanned roughly `13:53:22` to `14:08:35`.
+- **Root cause:** Expensive reviewer-panel execution and heavy setup are still happening on paths that are intentionally non-mutating.
+- **Exact change:**  
+  - Add a lighter review mode for `AUTOFIX_GATE_CLAUDE_BRANCH_REVIEW` / comment-only paths:
+    - use 1–2 reviewer models instead of the full pool,
+    - lower reasoning from `xhigh` to `medium` for comment-only review,
+    - skip editor bootstrap and any judge-side prep that is irrelevant when no patch/merge is possible,
+    - short-circuit artifact/setup steps not used by comment-only output.
+- **Estimated time savings:** `12–20 minutes` on affected runs.
+- **Implementation risk:** **Medium.** Safe if scoped only to comment-only/non-merge paths; avoid changing full autofix/merge behavior.
+
+### 2. Narrow `orchestrate_poll` checkout/fetch scope on no-work cycles
+- **Evidence:**  
+  - Run `25254213178` (`48s`) and `25253748231` (`43s`) were dominated by `poll/Checkout repository`.  
+  - Deep log shows `fetch-depth: 0` plus `git fetch ... +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags*`.
+- **Root cause:** Poller is paying for full-graph fetches even when it only needs current workflow support files and active issue state.
+- **Exact change:**  
+  - Switch the repo checkout in `orchestrate_poll` to shallow/targeted fetch by default.
+  - Fetch only the specific refs actually needed for the poll decision path.
+  - Keep a fallback full fetch only when a downstream script explicitly requires history/tags.
+- **Estimated time savings:** `20–35s` per no-work poll run.
+- **Implementation risk:** **Low-Medium.** Verify no hidden dependency on tag/history traversal in `orchestrate_poll_process.sh`.
+
+### 3. Stop full branch/tag enumeration in `promote` and `forward-merge`
+- **Evidence:**  
+  - `25254375144` and `25254380023` both used `fetch-depth: 0` and full ref fetches.  
+  - Logs show many unrelated `claude/*` branches and numerous tags being fetched.
+- **Root cause:** Control-plane jobs are using repository-wide fetch patterns for branch comparisons and version resolution.
+- **Exact change:**  
+  - For `forward_merge_stable_to_main`, fetch only `stable` and `main`.
+  - For `promote_main_to_stable`, fetch `main`, `stable`, and tags only when version resolution needs them.
+  - Avoid `+refs/heads/*` in these jobs.
+- **Estimated time savings:** `5–10s` per run.
+- **Implementation risk:** **Low.**
+
+### 4. Reduce `workflow_log_analysis` scope for repeated runs
+- **Evidence:**  
+  - Workflow family average duration is `4617s`, p50 `4428s`, with sampled runs at `4028–6075s`.  
+  - `summarize_unselected_runs` spans about `2–3 minutes` inside sampled runs.
+- **Root cause:** The analyzer is repeatedly summarizing large sets of runs and re-running expensive sections even when many runs are unchanged.
+- **Exact change:**  
+  - Reuse prior per-run summaries for unchanged run IDs.
+  - Skip summarization for already-summarized unselected runs unless the source logs changed.
+  - Prioritize failing/slow/new runs first; cap routine success-run expansion.
+- **Estimated time savings:** `2–10 minutes` per analysis run, depending on repeat overlap.
+- **Implementation risk:** **Low.**
+
+### 5. Trim duplicate setup/cleanup work in failed `implement` runs
+- **Evidence:**  
+  - Failed implement runs show repeated Serena prompt blocks, repeated MCP startup, and repeated git post-job cleanup.  
+  - `25246727158` still emitted `254` Serena calls before failure.
+- **Root cause:** Retry attempts repeat nearly the full setup stack before the agent makes no edit.
+- **Exact change:**  
+  - Reuse initialized runtime/session state across retry attempts within a run.
+  - Stop re-injecting the full Serena instruction block on every retry.
+  - Early-abort after first no-change attempt for fully specified one-file smoke tasks.
+- **Estimated time savings:** `30–90s` per failed implement run.
+- **Implementation risk:** **Medium.** Needs care to preserve retry correctness.
+
+## Cost Optimizations
+
+Ranked by expected token and/or dollar savings.
+
+### 1. Cap and de-duplicate `workflow_log_analysis` summarization
+- **Evidence:**  
+  - `summarize_unselected_runs` telemetry used:
+    - `154,202` tokens,
+    - `116,787`,
+    - `153,540`,
+    - `237,335`,
+    - `190,564`,
+    - `156,314` (and repeats in other sampled runs).  
+  - Average across 8 sampled telemetry entries: about `164,825` tokens/run.
+  - Run `25252928519` also logged `304,969` tokens in the API-redundancy pass.
+- **Root cause:** High-volume re-summarization of unselected runs and large secondary analysis passes.
+- **Exact change:**  
+  - Persist run-summary artifacts by run ID and reuse them.
+  - Only summarize newly observed runs or runs whose deep-dive status changed.
+  - Lower the default unselected-run target below `100` unless failure coverage is thin.
+- **Estimated savings:** `100k–200k+ tokens` per analysis run.
+- **Quality-risk notes:** Low if failures/slow/outliers stay prioritized.
+
+### 2. Downshift reviewer-model fanout on comment-only review paths
+- **Evidence:**  
+  - Comment-only review path in `25253939361` still took `1066s`.  
+  - Similar review jobs expose large reviewer pools: `REVIEWER_MODELS` includes six providers in recent runs like `25254373300` and `25253039282`.
+- **Root cause:** The same multi-model panel appears to be used even when the workflow cannot auto-edit or auto-merge.
+- **Exact change:**  
+  - For comment-only paths, use a reduced reviewer set or a single fast primary reviewer plus optional fallback.
+  - Lower reasoning from `xhigh` to `medium` on non-patch flows.
+- **Estimated savings:** Likely the largest review-token reduction; exact token totals were not emitted, but duration suggests material savings.
+- **Quality-risk notes:** Medium. Keep the full panel for merge-affecting paths; only trim non-mutating review modes.
+
+### 3. Fix retry-prompt inflation in failed `implement` runs
+- **Evidence:**  
+  - `25245077011`: `24,112 + 13,534 = 37,646` tokens before bail.  
+  - `25245085089`: `5,380 + 24,149 = 29,529`.  
+  - `25246727158`: `4,466 + 14,134 = 18,600`.  
+  - Total across 3 failed runs: about `85,775` tokens with no successful edit.
+- **Root cause:** Retries repeat large static instructions and setup despite highly deterministic tasks.
+- **Exact change:**  
+  - Add a “minimal retry prompt” mode that reuses stable context and appends only delta diagnostics.
+  - For one-file, fully specified tasks, stop after first announced-edit-without-change and route to diagnosis.
+- **Estimated savings:** `10k–30k tokens` per failed implement run.
+- **Quality-risk notes:** Low-Medium. Keep full retries for ambiguous multi-file tasks only.
+
+### 4. Make prompt-cache prefixes stable across retries
+- **Evidence:**  
+  - Cache is enabled (`OPENROUTER_PROMPT_CACHE_DISABLED: false`), but observed cache probe lines show `cache_creation_input_tokens=na` and `cache_read_input_tokens=na`.  
+  - Implement failure logs show repeated large Serena/system instruction blocks across attempts.
+- **Root cause:** Cache instrumentation is incomplete, and retry prompts likely vary early in the prefix. This is an inference from the repeated attempt scaffolding.
+- **Exact change:**  
+  - Freeze a static prompt prefix for implement/review retries.
+  - Move attempt counters, failure diagnostics, and ephemeral metadata to the end of the prompt.
+  - Emit real cache read/create token counters on every cache-enabled call.
+- **Estimated savings:** Not measurable from current logs; likely moderate on retry-heavy flows.
+- **Quality-risk notes:** Low if prompt semantics stay identical.
+
+### 5. Avoid unnecessary full-history fetches in control workflows
+- **Evidence:** Full fetches in `orchestrate_poll`, `promote`, and `forward_merge`.
+- **Root cause:** Over-fetching burns network/runtime; indirectly raises runner cost.
+- **Exact change:** Shallow targeted fetch by default.
+- **Estimated savings:** Small dollar impact, moderate cumulative savings due to high run frequency.
+- **Quality-risk notes:** Low.
+
+## Reliability Improvements
+
+Ranked by expected failure-rate or rerun-rate reduction.
+
+### 1. Fix `review_autofix` empty-output behavior on smoke-test editor paths
+- **Failure evidence:**  
+  - All 3 `test_and_mark_stable` failures (`25247210528`, `25249170035`, `25252918179`) stopped at `e2e-smoke-test / Phase 4b: Verify editor removed bait line`.  
+  - In `25252918179`, the canary still contained `# E2E_EDITOR_BAIT_25252918179`.  
+  - `25254373266` includes a note referencing analysis of run `25253051580`, stating the `review_autofix` editor at `reasoning=low` produced empty output across 4 attempts on PR `#1992`.
+- **Root cause category:** AI execution failure / agent non-action on deterministic edit.
+- **Exact fix:**  
+  - Add a smoke-test-specific review profile:
+    - force a patch-capable editor path,
+    - disable comment-only downgrade for smoke PRs carrying the editor-bait marker,
+    - raise reasoning only for the smoke editor substep if low reasoning is implicated,
+    - fail fast when the editor returns announced-edit-without-change on bait-removal tasks.
+- **Expected reliability impact:** High; should address the `50%` failure rate in `test_and_mark_stable` and turn long failures into deterministic pass/fail earlier.
+- **Rollback/fail-open considerations:** Keep existing generic review path as fallback; scope changes to bait-marked smoke PRs first.
+
+### 2. Add retry/backoff to `actionlint` install
+- **Failure evidence:**  
+  - CI run `25249161547` failed in `lint / Install actionlint` because `curl` returned `502`.
+- **Root cause category:** External fetch flake.
+- **Exact fix:**  
+  - Wrap the tarball download in retry/backoff with checksum verification preserved.
+  - Optionally cache the verified binary/tarball per version.
+- **Expected reliability impact:** Removes a class of transient CI failures with near-zero behavior change.
+- **Rollback/fail-open considerations:** Fail closed if checksum mismatches; fail open is not appropriate here.
+
+### 3. Reduce support-script ref drift
+- **Failure evidence:**  
+  - `issue_pr_status` runs `25254373266` and `25253471403` warn: `Support checkout ref ... is unavailable; using main.`
+- **Root cause category:** Workflow-to-support-script version mismatch.
+- **Exact fix:**  
+  - Validate support ref existence before dispatching dependent workflows, or materialize support files from the same commit as the workflow whenever possible.
+- **Expected reliability impact:** Medium; lowers silent drift between workflow revision and helper scripts.
+- **Rollback/fail-open considerations:** Preserve current `main` fallback, but surface an explicit metric and warning count.
+
+### 4. Upgrade deprecated Node-20-based actions
+- **Failure evidence:**  
+  - `workflow_log_analysis` emitted `Node.js 20 is deprecated ... actions/download-artifact@v4 forced to run on Node.js 24`.  
+  - `copilot_pull_request_reviewer` logs also showed `Buffer()` deprecation warnings.
+- **Root cause category:** Toolchain deprecation risk.
+- **Exact fix:**  
+  - Upgrade deprecated action versions and remove Node-20-bound revisions.
+- **Expected reliability impact:** Medium long-term; avoids future hard failures when compatibility shims are removed.
+- **Rollback/fail-open considerations:** Low-risk version bumps with pinning.
+
+### 5. Preserve memory-helper availability for run-end bookkeeping
+- **Failure evidence:**  
+  - Cancelled `review_autofix` runs `25253930796`, `25253454529`, and `25253449112` warn: `memory helper script missing; skipping run-end failure event`.
+- **Root cause category:** Observability/bookkeeping gap.
+- **Exact fix:**  
+  - Stage memory helper scripts before any branch-specific cleanup path and make the run-end event emitter independent of optional review artifacts.
+- **Expected reliability impact:** Low-Medium direct workflow impact, but important for postmortem accuracy and idempotency.
+- **Rollback/fail-open considerations:** Keep fail-open behavior if helpers are truly unavailable.
+
+## AI Memory Health
+
+- **Telemetry coverage:** Observed in sampled deep-dive logs; `96` valid `AI_MEMORY_TELEMETRY` JSON entries.
+- **Operation mix:**  
+  - `record-run-event`: `40`  
+  - `retrieve`: `15`  
+  - `processed-command-check`: `14`  
+  - `processed-command-claim`: `13`  
+  - `summarize_unselected_runs`: `8`  
+  - `compact`: `4`  
+  - `record-candidate`: `2`
+
+### Retrieve effectiveness
+- **Hit rate:** `13 / 15 = 86.7%`
+- **Average `estimated_tokens`:** `42.9`
+- **`keyword_method` distribution:**  
+  - `plain`: `13`  
+  - `none`: `2`  
+  - `llm`: `0`
+- **Roles:**  
+  - `implementation`: `13` retrieves  
+  - `reviewer`: `2` retrieves
+
+### Flags
+- **Zero-record retrieves:** `2`, both reviewer retrieves in workflow-log-analysis sampled runs (`25246650500`, `25246056978`), each with `keyword_method: none` and `estimated_tokens: 0`.
+- **`fail_open: true`:** none observed.
+- **`enabled: false`:** none observed.
+- **High push retry counts:** 2 entries with `push_attempts: 2`, both on `record-run-event` failures, including implement run `25246727158`.
+
+### Assessment
+- Memory is **working well for implement flows**: high retrieve hit rate, low token footprint, no disabled/fail-open noise.
+- Memory is **not helping reviewer/workflow-analysis retrieval** in the sampled runs: reviewer fetches returned zero records and never used `llm` keywording.
+
+### Recommendation
+- Add a reviewer-specific retrieval strategy before heavy review/log-analysis passes:
+  - try `plain` first,
+  - escalate to `llm` keyword extraction on zero-hit review paths,
+  - emit the token budget alongside retrieve telemetry so budget use can be judged directly.
+
+## GH API Call Audit
+
+### Highest-volume / highest-redundancy patterns
+
+1. **Implement re-fetches the same issue repeatedly**
+   - **Evidence:** Failed implement logs (`25245077011`, `25245085089`, `25246727158`) show:
+     - initial `GET /issues/{ISSUE_NUMBER}` for state/labels,
+     - another `GET /issues/{ISSUE_NUMBER}` to write `ISSUE_META_FILE`,
+     - later guarded label re-fetches,
+     - paginated comment fetches.
+   - **Root cause:** Early and later steps independently fetch overlapping issue metadata.
+   - **Exact change:** Cache the first full issue payload locally and reuse it for labels/state/body consumers within the run.
+   - **Estimated call-count reduction:** 1 guaranteed issue GET removed per non-skipped implement run; more on fallback paths.
+   - **Rate-limit risk reduction:** Moderate across high-frequency issue workflows.
+
+2. **Issue/PR status sync still falls back from GraphQL batching to per-issue REST**
+   - **Evidence:** In `25254373266`, `issue_pr_status` uses batched `closingIssuesReferences(first: 50)` and a batched orchestrator query, but still has per-issue fallback body/label reads.
+   - **Root cause:** Partial batching; downstream steps re-derive facts already available earlier.
+   - **Exact change:** Export orchestrator-managed classification from the first GraphQL pass and reuse it in merged-alert/finalization steps.
+   - **Estimated call-count reduction:** 1–N issue GETs per merged PR, depending on linked issue count.
+   - **Rate-limit risk reduction:** Medium.
+
+3. **`cancel_on_pr_close` scans `/actions/runs` and checks `/rate_limit` even on no-op runs**
+   - **Evidence:** `25254373292` and `25253471399` both call `_rl_wait()` with `/rate_limit` support and query `/actions/runs`, even when no matching runs exist.
+   - **Root cause:** Defensive retry wrapper is always armed on a mostly empty-path workflow.
+   - **Exact change:**  
+     - Keep fail-open retry logic, but defer `/rate_limit` probing until an actual rate-limit response occurs.  
+     - Avoid duplicate run-list scans if the first filtered query is empty.
+   - **Estimated call-count reduction:** Small per run, meaningful due to frequent lifecycle triggers.
+   - **Rate-limit risk reduction:** Low-Medium.
+
+4. **`review_autofix` post-merge validate dispatch re-fetches PR metadata after GraphQL linked-issue lookup**
+   - **Evidence:** `25254373300` step `Dispatch standalone validate...` runs GraphQL for `closingIssuesReferences`, then falls back to `GET /pulls/{PR_NUMBER}` for title/body text.
+   - **Root cause:** Linked-issue resolution and PR metadata resolution are split.
+   - **Exact change:** Reuse preloaded PR metadata artifact or include fallback-needed fields earlier in the run.
+   - **Estimated call-count reduction:** 1 PR GET on fallback path.
+   - **Rate-limit risk reduction:** Low.
+
+### Cross-reference to repo API hygiene rules
+The repo already documents:
+- **mandatory batching,**
+- **cycle-local caches,**
+- **fail-open behavior.**
+
+Observed behavior partially follows that standard, but sampled logs show the remaining gaps are mostly **reuse gaps**, not absence of policy. The next wins are to:
+- export earlier batched results to later steps,
+- avoid re-reading issue/PR bodies inside the same job,
+- preserve fail-open semantics when removing redundant reads.
+
+### Deep-audit corroboration
+`workflow_log_analysis` run `25252928519` produced:
+- `0` `SAFE_TO_MERGE` findings,
+- `5` `NEEDS_VERIFICATION` findings (`MERGE-001`, `MERGE-002`, `REUSE-001`, `REUSE-002`, `REUSE-003`),
+- `1` `RISKY_SKIP` (`MERGE-003`).
+
+That matches the sampled telemetry: there are clear reuse opportunities, but most need careful rollout because they sit near fallback logic or pagination semantics.
+
+## MCP & Serena Efficiency
+
+### What is working
+- Failed implement run `25246727158` shows **strong Serena adoption**:
+  - `254` Serena tool calls,
+  - reported **`98%` Serena efficiency**,
+  - top tools: `replace_symbol_body (40)`, `insert_after_symbol (40)`, `get_symbols_overview (33)`, `find_symbol (33)`, `find_referencing_symbols (28)`,
+  - estimated tokens `~19,050` with Serena vs `~162,100` without.
+- The agent correctly uses `serena.activate_project(...)` directly and does **not** show onboarding calls in sampled logs.
+
+### Inefficiencies observed
+1. **High tool churn without a successful edit**
+   - **Evidence:** `25246727158` still ended with “2 consecutive attempts with no actionable output” despite 254 Serena calls.
+   - **Issue:** Navigation was efficient, but execution got stuck in explore/edit-announcement loops.
+
+2. **Repeated large Serena instruction blocks per retry**
+   - **Evidence:** Failed implement logs repeat the full “Serena (MCP) Semantic Tooling” and “SERENA MCP EFFICIENCY (MANDATORY)” blocks before multiple attempts.
+   - **Issue:** Good rules are being re-sent too often.
+
+3. **Tool-usage stats file missing even when Serena was clearly used**
+   - **Evidence:** `25246727158` says `No Serena tool usage stats found`, then later generates a Serena efficiency report showing 254 calls.
+   - **Issue:** Reporting path is inconsistent, which makes automated efficiency monitoring noisy.
+
+### Concrete changes
+- **Early no-change circuit breaker:**  
+  When a fully specified task shows “announced edit/apply_patch but produced no file changes” on attempt 1, switch from full retry to targeted diagnosis instead of re-running the same large tool-guidance stack.
+- **Retry prompt compaction:**  
+  Send the Serena policy block once, then retry with delta-only instructions.
+- **Stabilize Serena stats emission:**  
+  Ensure `.serena/tool_usage_stats.json` is written before cleanup/reporting so run-end monitoring reflects actual usage.
+- **Increase safe parallelism in read phase:**  
+  For complex review paths, batch initial symbol lookups (`get_symbols_overview`, `find_symbol`, `find_referencing_symbols`) before the first edit decision rather than interleaving many tiny reads.
+
+### Net assessment
+- **Serena itself is not the bottleneck.**  
+  In sampled failures, Serena use was high-quality; the waste came from **agent retry behavior** and **prompt churn**, not from broad raw-file reads.
+
+## Prompt Cache & Memory System
+
+### Prompt cache
+- **Observed state:** Enabled in sampled runs (`OPENROUTER_PROMPT_CACHE_DISABLED: false`).
+- **Observed problem:** Cache effectiveness is not measurable because sampled cache probe lines report:
+  - `cache_creation_input_tokens=na`
+  - `cache_read_input_tokens=na`
+- **Likely fragmentation causes (inference):**
+  - large repeated retry preambles,
+  - dynamic attempt counters and failure diagnostics inserted early,
+  - repeated Serena policy blocks.
+
+### Concrete cache improvements
+1. **Emit non-`na` cache metrics for every cache-enabled call**
+   - **Impact:** Enables actual hit-rate tracking; prerequisite for tuning.
+   - **Risk:** Low.
+
+2. **Freeze prompt prefixes across retries**
+   - **Impact:** Moderate token and latency savings on implement/review retries.
+   - **Risk:** Low.
+
+3. **Separate static tooling policy from run-specific diagnostics**
+   - **Impact:** Better cache locality and smaller retry prompts.
+   - **Risk:** Low.
+
+### Memory system
+- **Strength:** Memory retrieval for implement role is healthy and cheap.
+- **Weakness:** Reviewer/log-analysis retrieval showed 0-hit behavior in the sampled runs.
+- **Concrete improvements:**
+  - add reviewer-role keyword generation fallback,
+  - log token budgets with retrieves,
+  - flag zero-hit reviewer retrieves separately from implement retrieves.
+
+### Estimated impact
+- **Tokens:** moderate savings on retry-heavy runs; higher once cache metrics are measurable.
+- **Latency:** modest direct savings, larger on repeated failures/retries.
+- **Reliability:** better diagnosis when cache/memory are not helping.
+
+## Orchestrator Health
+
+### Observed health signals
+- **High skip volume but fast short-circuiting:**  
+  `clarify`, `plan`, `implement`, and `orchestrate_clarify_respond` all have p50 durations of `1s`, which suggests gating is cheap and mostly server-side.
+- **No stuck terminal loops surfaced in sampled orchestrate runs.**
+- **Poller completes reliably:**  
+  `orchestrate_poll` success rate is strong in the sample; sampled runs recorded `poll_started` and `poll_completed` ledger events.
+- **But control-plane overhead is still visible:**  
+  no-work `orchestrate_poll` runs still take `43–49s`.
+
+### Recurring pain points
+1. **Review path ambiguity on Claude branches**
+   - Long comment-only reviews are operationally expensive and hard to distinguish from meaningful work.
+
+2. **Support-ref fallback drift**
+   - Warnings about unavailable support refs undermine confidence that the run used the intended helper version.
+
+3. **Run-end bookkeeping occasionally missing**
+   - Missing memory helper scripts mean some failure events are never recorded.
+
+### Smallest safe mitigations
+- Add explicit metrics for:
+  - comment-only review count,
+  - support-ref fallback count,
+  - missing run-end bookkeeping count,
+  - no-change retry bails in implement/review.
+- Add a dedicated “no-op control-path” optimization mode for poll/promote/merge flows.
+
+### Indicators to track
+- `% of review_autofix runs that are comment-only`
+- `median duration of comment-only review_autofix`
+- `% of implement runs ending in no-actionable-output bail`
+- `support checkout ref unavailable` warning count
+- `memory helper missing` warning count
+- `orchestrate_poll` no-work median duration
+
+## Pipeline Flow Bottlenecks
+
+Ordered by end-to-end impact.
+
+1. **Review/autofix compute bottleneck**
+   - Dominant in the current window.
+   - Affects implement → review → validate progression most.
+   - Includes multi-model reviewer overhead, setup cost, and long comment-only reviews.
+
+2. **Release validation loop bottleneck**
+   - `test_and_mark_stable` runs are both long and failing.
+   - The loop reaches late-stage Phase 4 before discovering bait removal did not happen, wasting most of the run.
+
+3. **Workflow-log-analysis compute cost**
+   - Not on the critical product path, but it is a major background drain on tokens and runner time.
+
+4. **Queue + fetch overhead on control workflows**
+   - Poll/promote/forward-merge all pay checkout and runner-start cost disproportionate to their logic.
+
+5. **Retry overhead in implement**
+   - Small in duration compared with review, but significant in wasted tokens and failed smoke runs.
+
+### Bottleneck fixes by impact
+1. **Slim comment-only review paths**
+2. **Make smoke-test bait-removal path deterministic**
+3. **De-duplicate workflow-log-analysis summaries**
+4. **Use targeted/shallow fetch in poll/promote/merge**
+5. **Short-circuit deterministic implement failures earlier**
+
+## Per-Repo Breakdown
+
+### shubhodeep1/coding-workflows
+
+**Top bottlenecks**
+- `review_autofix` long-tail runs (`p95 1685.4s`; examples up to `2062s`)
+- `test_and_mark_stable` failures and 67–108 minute durations
+- `workflow_log_analysis` long/costly background passes
+- unnecessary full-history fetches in control-plane workflows
+
+**Top failure modes**
+- Smoke-test bait line not removed (`25247210528`, `25249170035`, `25252918179`)
+- `implement` empty-output / announced-edit-without-change bails (`25245077011`, `25245085089`, `25246727158`)
+- transient external download failure in CI (`25249161547`, actionlint tarball `502`)
+
+**Highest-cost drivers**
+- `workflow_log_analysis` summarization and API-redundancy passes
+- long multi-model `review_autofix` runs
+- repeated retry prompts on implement failures
+
+**Top 3 prioritized actions**
+1. **Create a lightweight `review_autofix` mode for comment-only Claude-branch reviews.**
+2. **Fix the smoke-test editor path so bait-removal reviews cannot degrade into empty-output/comment-only behavior.**
+3. **Add run-ID-based reuse/delta summarization in `workflow_log_analysis` to cut 100k–200k tokens per analysis run.**
+
+## Metrics Appendix
+
+### Repository-level run summary
+
+| Repository | Total runs | Success | Failure | Cancelled | Other | Failure rate | Avg duration (s) | p50 (s) | p95 (s) |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| shubhodeep1/coding-workflows | 1000 | 285 | 7 | 40 | 668 | 0.7% | 132.4 | 1.0 | 615.0 |
+
+### Workflow-family summary
+
+| Workflow family | Total runs | Success | Failure | Cancelled | Avg duration (s) | p50 (s) | p95 (s) | Key note |
+|---|---:|---:|---:|---:|---:|---:|---:|---|
+| ci | 63 | 62 | 1 | 0 | 597.4 | 609.0 | 643.9 | Stable but ~10m baseline; one actionlint download flake |
+| implement | 181 | 23 | 3 | 7 | 31.6 | 1.0 | 219.0 | Most runs skipped; sampled failures were empty-output bails |
+| review_autofix | 62 | 32 | 0 | 29 | 369.2 | 47.0 | 1685.4 | Largest latency hotspot |
+| test_and_mark_stable | 6 | 0 | 3 | 3 | 4115.3 | 4043.0 | 6422.3 | Worst reliability hotspot |
+| orchestrate_poll | 19 | 19 | 0 | 0 | 43.1 | 43.0 | 48.1 | No-work polls still expensive |
+| workflow_log_analysis | 6 | 5 | 0 | 1 | 4617.0 | 4428.0 | 6025.0 | Major background cost center |
+| plan | 181 | 26 | 0 | 0 | 13.4 | 1.0 | 144.0 | Mostly skipped |
+| clarify | 217 | 30 | 0 | 0 | 19.8 | 1.0 | 128.2 | Mostly skipped |
+| validation_refresh | 3 | 3 | 0 | 0 | 210.7 | 220.0 | 220.0 | `refresh` dominates runtime |
+
+### Notable failed runs
+
+| Run ID | Workflow family | Duration (s) | Failure point |
+|---|---|---:|---|
+| 25252918179 | test_and_mark_stable | 4457 | `e2e-smoke-test / Phase 4b: Verify editor removed bait line` |
+| 25249170035 | test_and_mark_stable | 6255 | `e2e-smoke-test / Phase 4b: Verify editor removed bait line` |
+| 25247210528 | test_and_mark_stable | 6478 | `e2e-smoke-test / Phase 4b: Verify editor removed bait line` |
+| 25246727158 | implement | 184 | `implement / Run Codex implementation` |
+| 25245085089 | implement | 188 | `implement / Run Codex implementation` |
+| 25245077011 | implement | 176 | `implement / Run Codex implementation` |
+| 25249161547 | ci | 13 | `lint / Install actionlint` |
+
+### Sampled token metrics
+
+| Source | Sample count | Token metric |
+|---|---:|---:|
+| `workflow_log_analysis` `summarize_unselected_runs` telemetry | 8 | Avg `164,825` tokens/run |
+| `workflow_log_analysis` API redundancy pass (`25252928519`) | 1 | `304,969` tokens |
+| Failed implement run `25245077011` | 1 | `37,646` tokens across 2 attempts |
+| Failed implement run `25245085089` | 1 | `29,529` tokens across 2 attempts |
+| Failed implement run `25246727158` | 1 | `18,600` tokens across 2 attempts |
+
+### AI memory telemetry summary
+
+| Metric | Value |
+|---|---:|
+| Valid telemetry entries | 96 |
+| Retrieve count | 15 |
+| Retrieve hit rate | 86.7% |
+| Avg retrieve estimated tokens | 42.9 |
+| `keyword_method=plain` | 13 |
+| `keyword_method=none` | 2 |
+| `keyword_method=llm` | 0 |
+| Zero-record retrieves | 2 |
+| `fail_open: true` entries | 0 |
+| `enabled: false` entries | 0 |
+| High push-attempt entries (`>1`) | 2 |
+
+### Prompt-cache / cache signals
+
+| Signal | Observation |
+|---|---|
+| OpenRouter prompt cache enabled | Yes (`OPENROUTER_PROMPT_CACHE_DISABLED: false`) |
+| Cache hit/read token metrics | Not usable; observed as `na` in sampled cache probe lines |
+| Actions cache hits | Observed for `codex-v0.114.0` and `setup-uv-*` keys |
+| Memory compaction | Run `25254305081` archived `2914` candidates in ~14s |
+
+### GH API hotspot summary
+
+| Workflow / step | Observed hotspot |
+|---|---|
+| `implement / Run Codex implementation` | repeated `GET /issues/{ISSUE_NUMBER}` and paginated comment fetches |
+| `issue_pr_status / Update linked issue labels when PR closes` | `POST /graphql` for `closingIssuesReferences`, then per-issue REST fallback/lookups |
+| `review_autofix / Dispatch standalone validate...` | GraphQL linked-issue lookup + fallback `GET /pulls/{PR_NUMBER}` + `gh workflow run` |
+| `cancel_on_pr_close / Cancel queued/in-progress runs...` | `/actions/runs` scan plus `/rate_limit`-aware retry wrapper |
+| `test_and_mark_stable / Phase 4 wait/verify` | repeated Actions/PR polling in long-running smoke-test coordination |
+
+If you want, I can turn this into a prioritized implementation backlog with owner/team labels and a 1-week vs 1-month plan.

--- a/analysis/workflow-optimization-2026-05-02-9.md
+++ b/analysis/workflow-optimization-2026-05-02-9.md
@@ -544,3 +544,123 @@ Ordered by end-to-end impact.
 | `test_and_mark_stable / Phase 4 wait/verify` | repeated Actions/PR polling in long-running smoke-test coordination |
 
 If you want, I can turn this into a prioritized implementation backlog with owner/team labels and a 1-week vs 1-month plan.
+
+## Deep Audit — Workflows & Scripts (2026-05-02)
+
+### Section 1: Bug & Correctness Sweep
+
+#### SEC-001
+- **File path** — `scripts/tg_helpers.sh:167-187,332-350,395-421`
+- **Severity** — High
+- **Category tag** — `security`
+- **Description** — The Telegram cleanup helpers trust any GitHub issue comment whose body contains the hidden markers `<!-- tg_cleanup:... -->` or `<!-- tg_phase:... -->`. The selector at lines 184-187 and 397-398 does not verify `user.login`, and the cleanup loops at lines 332-350 and 401-421 will delete Telegram messages based on IDs parsed from those comment bodies. That means any user who can comment on the issue can forge a marker comment and cause the bot to attempt deletion of arbitrary Telegram message IDs.
+- **Recommended fix** — Only honor marker comments authored by a trusted identity (for example the workflow bot / `github-actions[bot]`) and reject all others in the jq filter. For stronger protection, embed a signed nonce/HMAC in the marker and verify it before deleting messages. Reuse the existing `curl_gh_api` path so marker validation and deletion stay rate-limit aware.
+
+#### CONSIST-001
+- **File path** — `.github/workflows/review_autofix.yml:3774-3783; scripts/review_rb_judge.sh:153-156; .github/workflows/issue_pr_status.yml:196-210`
+- **Severity** — Medium
+- **Category tag** — `consistency`
+- **Description** — `issue_pr_status.yml` already narrowed its fallback linker to explicit closing references only (`close|fix|resolve #N` or full repo issue URLs) to avoid the documented false-positive bug on prose mentions. `review_autofix.yml` and `review_rb_judge.sh` still use the older broad regex that matches generic `issue #99` / `issues/99` prose. That parser drift means review paths can still set `ai:ready-to-merge` or judge-close unrelated issues when a PR body references issue numbers in documentation/examples rather than as closing links.
+- **Recommended fix** — Extract one shared helper in `scripts/gh_helpers.sh`, e.g. `resolve_closing_issue_numbers_from_pr_text <repo> <title> <body>`, and make `review_autofix.yml` and `review_rb_judge.sh` use the same closing-only logic already implemented in `issue_pr_status.yml`. Prefer “no fallback match” over the older broad regex.
+
+### Section 2: GitHub API Call Redundancy Audit
+
+#### BATCH-001
+- **File path** — `scripts/review_rb_judge.sh:146-170`
+- **Severity** — Medium
+- **Category tag** — `api-batching`
+- **Description** — The judge first does one GraphQL `closingIssuesReferences` fetch to get linked issue numbers, then immediately loops over those numbers and performs per-issue REST reads to fetch bodies, even though only `FIRST_ISSUE_BODY` is consumed later. **Current call count:** `1 + N` (`1` GraphQL + up to `N` `GET /issues/{n}` calls). **Proposed call count:** `1` by extending the first GraphQL query to return `nodes { number body }` and selecting the first node directly.
+- **Recommended fix** — Fold `body` into the initial linked-issue GraphQL query and stop the per-issue REST loop. The batching pattern to extend is the repo’s existing alias/batched GraphQL style used in `scripts/orchestrate_poll_process.sh::_fetch_candidate_issue_details_graphql` and in `review_autofix.yml`’s linked-issue cache step.
+
+#### API-001
+- **File path** — `.github/workflows/issue_pr_status.yml:253-381,503-510`
+- **Severity** — Medium
+- **Category tag** — `api-redundancy`
+- **Description** — The workflow already classifies linked issues into `TRACKING_ISSUES` and `MANAGED_ISSUES` using a batched GraphQL query (and a conservative REST fallback), but the later Telegram-alert gate ignores that result and re-fetches each linked issue body one-by-one to rediscover whether the issue is orchestrator-managed. **Current call count:** `1` batched classification call **plus** up to `N` extra `GET /issues/{n}` body reads in the merged-alert step. **Proposed call count:** `1` classification call and `0` extra reads by exporting/reusing the earlier classification.
+- **Recommended fix** — Persist `TRACKING_ISSUES` / `MANAGED_ISSUES` or a single `HAS_ORCHESTRATED_ISSUE=true|false` flag into `$GITHUB_ENV` and consume that in the alert step. The batching pattern to extend is the workflow’s existing `ORCH_QUERY` alias batch; if you want to move it into a helper, mirror `scripts/orchestrate_poll_process.sh::_fetch_issue_labels_batch_graphql`.
+
+#### API-002
+- **File path** — `scripts/orchestrate_poll_process.sh:3412-3524`
+- **Severity** — Medium
+- **Category tag** — `api-redundancy`
+- **Description** — The final-merge path repeatedly queries the same PR endpoint for different fields from the same payload. It fetches state/merged once when `final_pr` already exists (2 reads), then re-fetches state/mergeable/merged before merge (3 reads), then re-fetches the same three fields again after a failed merge attempt (3 reads). **Current call count:** up to `8` reads of `GET /repos/{repo}/pulls/{final_pr}` per poll tick. **Proposed call count:** `2` (`1` snapshot before the decision, `1` refresh after merge attempt).
+- **Recommended fix** — Cache the pull response in a local JSON variable (or a tiny helper) and parse `state`, `mergeable`, and `merged_at` from that single blob. Refresh once after `gh pr merge`. This should follow the same cycle-local cache pattern already used elsewhere in this script (for example `_load_actions_runs_cached`).
+
+#### BATCH-002
+- **File path** — `scripts/orchestrate_poll_process.sh:5121-5137`
+- **Severity** — Medium
+- **Category tag** — `api-batching`
+- **Description** — The failed-autofix recovery path probes `ai-review.yml`, `internal-review.yml`, and `review_autofix.yml` with three separate `gh run list` calls for the same branch to find the latest failed completed run. **Current call count:** `3` list calls per stalled issue. **Proposed call count:** `0` extra calls if the path reuses the poll cycle’s cached Actions run snapshot, or `1` single `/actions/runs` snapshot filtered client-side if that cache is unavailable.
+- **Recommended fix** — Extend `_load_actions_runs_cached` so it indexes recent review/autofix runs by branch + workflow path, then use that cache here instead of looping `gh run list`. That matches the existing batching/caching pattern already documented for this script in `README.md`.
+
+### Section 3: Code Duplication & Modularization Opportunities
+
+#### DUP-001
+- **File path** — `.github/workflows/implement.yml:2414-2458; scripts/orchestrate_poll_process.sh:4661-4699`
+- **Severity** — Low
+- **Category tag** — `duplication`
+- **Description** — The “count consecutive no-op ancestors” walk is implemented twice with near-identical logic: parse `Re-issued from #N` from the issue body, fetch parent comments, look for the `produced no repository changes` marker, and stop on first miss. The duplication increases drift risk in a path that already exists specifically as a belt-and-braces guard against infinite reissue loops.
+- **Recommended fix** — Move the traversal into a shared helper, e.g. `count_noop_ancestors <repo> <issue_num> <max_depth> [marker]`, in `scripts/gh_helpers.sh` or a new `scripts/issue_helpers.sh`. Update both callers: the implement workflow’s “Handle no-op implementation” step and the orchestrator’s reissue paths.
+
+#### DUP-002
+- **File path** — `.github/workflows/review_autofix.yml:3774-3781; scripts/review_rb_judge.sh:153-156; .github/workflows/issue_pr_status.yml:196-210`
+- **Severity** — Low
+- **Category tag** — `duplication`
+- **Description** — PR-text-to-issue fallback parsing exists in at least three places, with two broader regex variants and one safer closing-only variant. This is both duplicated code and already-demonstrated policy drift.
+- **Recommended fix** — Create one helper in `scripts/gh_helpers.sh`, for example `extract_linked_issue_numbers_from_pr_text <repository> <title> <body> <mode>`, where `mode=closing_only` is the default. Update `review_autofix.yml`, `review_rb_judge.sh`, and `issue_pr_status.yml` to call the helper instead of carrying inline regexes.
+
+### Section 4: Expression Size Limit Risk Assessment
+
+No expression-size findings met the reporting threshold.
+
+- **Largest workflow file observed** — `review_autofix.yml` at `269,830` bytes, well below the `800 KB` warning threshold and the `1 MB` hard limit.
+- **Largest `${{ }}` body observed** — `229` characters (`.github/workflows/internal-review.yml:65`), far below the `15,000` / `18,000` risk thresholds.
+- **Result** — No `run:` or `if:` expressions in audited workflows are currently close to GitHub’s `21,000`-character template-expression limit.
+
+### Section 5: Cross-Cutting Concerns
+
+#### SHELL-001
+- **File path** — `scripts/tg_helpers.sh:335-350,405-421`
+- **Severity** — Low
+- **Category tag** — `shellcheck`
+- **Description** — The cleanup loops use `for tg_id in ${id_list}; do` after mutating `IFS=','`. That is a classic SC2086/word-splitting pattern on comment-derived data and still permits glob expansion before `tg_delete_msg` is called. A malformed or forged marker such as `*` or embedded whitespace would be expanded by the shell instead of being treated as data.
+- **Recommended fix** — Replace the unquoted loop with array parsing:
+  - `IFS=',' read -r -a tg_ids <<< "${id_list}"`
+  - `for tg_id in "${tg_ids[@]}"; do ... done`
+  - validate `[[ "${tg_id}" =~ ^[0-9]+$ ]]` before deletion.
+  This also hardens the path implicated by `SEC-001`.
+
+#### DEBT-001
+- **File path** — `.github/workflows/implement.yml:549-550,639-640,2278-2279,3201-3202; scripts/review_run_reviewers.sh:13-14; scripts/tg_helpers.sh:26-28`
+- **Severity** — Low
+- **Category tag** — `tech-debt`
+- **Description** — Multiple callers redefine `gh_retry` / `curl_gh_api` as simple pass-through wrappers whenever `scripts/gh_helpers.sh` fails to source. That silently disables the repo’s documented rate-limit handling, alerting, and circuit-breaker behavior at exactly the moment support-script drift is already happening, making failures harder to diagnose and behavior inconsistent across workflows.
+- **Recommended fix** — Add a small bootstrap layer, e.g. `scripts/bootstrap_gh_helpers.sh`, that either:
+  1. stages a known-good helper copy and exports the real functions, or
+  2. emits a single explicit `GH_HELPERS_MODE=passthrough` warning/telemetry flag.
+  Then make workflows consume that bootstrap consistently instead of redefining ad hoc fallback functions inline.
+
+Additional cross-cutting notes from the audit:
+- **TODO/FIXME/HACK markers** — none found in `.github/workflows/*.yml`, `scripts/*.sh`, or `scripts/*.py`.
+- **Dead code** — no clearly provable unused functions/steps were identified from static inspection alone without dynamic call data.
+
+### Section 6: Summary & Severity Matrix
+
+#### 6A. Findings Summary Table
+
+| Severity | Count | IDs |
+|---|---:|---|
+| Critical | 0 | — |
+| High | 1 | SEC-001 |
+| Medium | 5 | CONSIST-001, BATCH-001, API-001, API-002, BATCH-002 |
+| Low | 4 | DUP-001, DUP-002, SHELL-001, DEBT-001 |
+
+#### 6B. Estimated Remediation Scope
+
+| Category | Files Touched | Estimated Effort |
+|---|---:|---|
+| Critical/High bug fixes | 1-2 | Medium |
+| API call optimization | 3-4 | Medium |
+| Code modularization | 5-6 | Medium |
+| Expression size reduction | 0 | Small |
+| Medium/Low fixes | 2-4 | Small |

--- a/tests/e2e_smoke_canary.txt
+++ b/tests/e2e_smoke_canary.txt
@@ -1,3 +1,3 @@
 status: ok
-run_id: alt-25252918179
+run_id: alt-25254380200
 updated-by: ai-pipeline

--- a/tests/test_review_autofix_last_run_diff_oscillation_guard.py
+++ b/tests/test_review_autofix_last_run_diff_oscillation_guard.py
@@ -15,19 +15,23 @@ of release v1.1.0): the bait commit was at HEAD, the unconditional
 the editor at `reasoning=low` produced empty output across 6 attempts
 (3 + 3 retry), and Phase 4b's `bait_remained` verification correctly
 failed the smoke gate. The fix narrows the diff source to the most recent
-`[ai-autofix]`/`[judge-fix]` commit, matching the existing prefix
-convention used by `scripts/review_apply_fixes.sh:2838` and the
-`Count autofix iterations` step at line 2096-2105.
+`[ai-autofix]`/`[judge-fix]` commit on the PR head's first-parent chain,
+matching the existing prefix convention used by the
+`Count autofix iterations` step (`.github/workflows/review_autofix.yml`
+~line 2096-2105) and the in-step retry gate
+(`_prior_autofix_count` in the `Apply fixes with editor model` step).
 
-Three invariants must hold for the OSCILLATION GUARD not to false-trip:
+Four invariants must hold for the OSCILLATION GUARD not to false-trip:
 
 1. The diff source must be a walk-back to the most recent
    `[ai-autofix]`/`[judge-fix]` commit (awk regex on `git log`), NOT an
    unconditional `git diff HEAD~1...HEAD`.
-2. The fall-through placeholder must start with "No previous AI autofix"
+2. The walk must use `--first-parent` so merged-in autofix commits from
+   the base branch don't pollute LAST_RUN_DIFF on a first-iteration PR.
+3. The fall-through placeholder must start with "No previous AI autofix"
    so `scripts/review_run_reviewers.sh:249`'s sentinel-detection regex
    correctly classifies the run as the first iteration.
-3. The diff range must use `${SHA}^...${SHA}` so the autofix commit's own
+4. The diff range must use `${SHA}^...${SHA}` so the autofix commit's own
    diff is shown (not whatever HEAD~1 happens to be).
 """
 
@@ -69,8 +73,17 @@ def test_last_run_diff_walks_back_to_autofix_commit() -> None:
 	assert r"$2 ~ /^\[(ai-autofix|judge-fix)\]/" in block, (
 		"LAST_AUTOFIX_SHA walk must filter on the "
 		"`[ai-autofix]`/`[judge-fix]` commit-subject prefix. The same "
-		"regex is used by scripts/review_apply_fixes.sh:2838 — keep them "
-		"in lockstep."
+		"regex is used by the `_prior_autofix_count` block in the "
+		"`Apply fixes with editor model` step of this workflow — keep "
+		"them in lockstep so the OSCILLATION GUARD's diff source and "
+		"the in-step retry gate agree on what counts as a prior run."
+	)
+	assert "git log --first-parent" in block, (
+		"LAST_AUTOFIX_SHA walk is missing `--first-parent`. Without it, "
+		"`git log` walks merged-in history and could pick up an autofix "
+		"commit from the base branch (e.g. a `[ai-autofix]` on `main` "
+		"pulled in via merge), polluting LAST_RUN_DIFF on a "
+		"first-iteration PR."
 	)
 
 

--- a/tests/test_review_autofix_last_run_diff_oscillation_guard.py
+++ b/tests/test_review_autofix_last_run_diff_oscillation_guard.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Contract test for the LAST_RUN_DIFF generation in `review_autofix.yml`.
+
+The downstream OSCILLATION GUARD in the editor prompt
+(`scripts/review_apply_fixes.sh:441-462`) tells the model to leave any hunk
+visible in `last_run_diff.patch` alone unless it can attach a "regression
+fingerprint" + "runtime failure path". This guardrail is correct ONLY when
+the diff actually reflects prior AI autofix work; feeding it the diff of
+non-autofix commits (impl commits, smoke-test bait commits, manual pushes)
+falsely trips the guard and causes the editor to silently bail out.
+
+That regression was observed on review_autofix run 25254574828 (smoke gate
+of release v1.1.0): the bait commit was at HEAD, the unconditional
+`git diff HEAD~1...HEAD` fed the bait line into `last_run_diff.patch`,
+the editor at `reasoning=low` produced empty output across 6 attempts
+(3 + 3 retry), and Phase 4b's `bait_remained` verification correctly
+failed the smoke gate. The fix narrows the diff source to the most recent
+`[ai-autofix]`/`[judge-fix]` commit, matching the existing prefix
+convention used by `scripts/review_apply_fixes.sh:2838` and the
+`Count autofix iterations` step at line 2096-2105.
+
+Three invariants must hold for the OSCILLATION GUARD not to false-trip:
+
+1. The diff source must be a walk-back to the most recent
+   `[ai-autofix]`/`[judge-fix]` commit (awk regex on `git log`), NOT an
+   unconditional `git diff HEAD~1...HEAD`.
+2. The fall-through placeholder must start with "No previous AI autofix"
+   so `scripts/review_run_reviewers.sh:249`'s sentinel-detection regex
+   correctly classifies the run as the first iteration.
+3. The diff range must use `${SHA}^...${SHA}` so the autofix commit's own
+   diff is shown (not whatever HEAD~1 happens to be).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REVIEW_AUTOFIX = REPO_ROOT / ".github" / "workflows" / "review_autofix.yml"
+
+
+def _review_autofix_text() -> str:
+	return REVIEW_AUTOFIX.read_text(encoding="utf-8")
+
+
+def _generate_diff_block(text: str) -> str:
+	"""Return the body of the `Generate diff context` step."""
+	marker = "- name: Generate diff context"
+	start = text.find(marker)
+	assert start != -1, "Missing `Generate diff context` step in review_autofix.yml"
+	next_step = text.find("\n      - name:", start + len(marker))
+	assert next_step != -1, "Could not bound the `Generate diff context` step"
+	return text[start:next_step]
+
+
+def test_last_run_diff_walks_back_to_autofix_commit() -> None:
+	"""The diff source must be the most recent `[ai-autofix]`/`[judge-fix]`
+	commit, not an unconditional `HEAD~1...HEAD` diff. Without this walk,
+	the smoke gate's bait commit (or any non-autofix commit at HEAD)
+	leaks into `last_run_diff.patch` and false-trips the OSCILLATION
+	GUARD downstream."""
+	block = _generate_diff_block(_review_autofix_text())
+	assert "LAST_AUTOFIX_SHA=" in block, (
+		"`Generate diff context` step is missing the LAST_AUTOFIX_SHA "
+		"walk-back. Reverting to unconditional `git diff HEAD~1...HEAD` "
+		"re-introduces the run-25254574828 OSCILLATION GUARD false-trip."
+	)
+	assert r"$2 ~ /^\[(ai-autofix|judge-fix)\]/" in block, (
+		"LAST_AUTOFIX_SHA walk must filter on the "
+		"`[ai-autofix]`/`[judge-fix]` commit-subject prefix. The same "
+		"regex is used by scripts/review_apply_fixes.sh:2838 — keep them "
+		"in lockstep."
+	)
+
+
+def test_last_run_diff_uses_caret_dotdotdot_range() -> None:
+	"""The diff range must be `${SHA}^...${SHA}` so it shows the autofix
+	commit's own changes against its parent. A range against HEAD would
+	leak any post-autofix commits (manual pushes, bait) back into the
+	diff and re-introduce the OSCILLATION GUARD false-trip."""
+	block = _generate_diff_block(_review_autofix_text())
+	assert '"${LAST_AUTOFIX_SHA}^...${LAST_AUTOFIX_SHA}"' in block, (
+		"LAST_RUN_DIFF must diff `${SHA}^...${SHA}` to scope the diff to "
+		"the autofix commit alone. Any other range can leak unrelated "
+		"commits into the editor's OSCILLATION GUARD context."
+	)
+
+
+def test_last_run_diff_no_unconditional_head1_diff() -> None:
+	"""The unconditional `git diff HEAD~1...HEAD` must not be present.
+	That was the regression-source: it fed the smoke gate's bait commit
+	(authored as `[E2E Smoke Test] inject editor bait line ...`, NOT
+	`[ai-autofix]`) into the editor's OSCILLATION GUARD context."""
+	block = _generate_diff_block(_review_autofix_text())
+	assert 'git diff "HEAD~1...HEAD"' not in block, (
+		"`Generate diff context` step still has the unconditional "
+		'`git diff "HEAD~1...HEAD"` for LAST_RUN_DIFF. This is exactly '
+		"the regression that caused review_autofix run 25254574828 to "
+		"silently no-op against the smoke-test bait commit."
+	)
+
+
+def test_last_run_diff_placeholder_matches_first_iteration_sentinel() -> None:
+	"""The fall-through placeholder must begin with "No previous AI autofix"
+	so `scripts/review_run_reviewers.sh:249`'s
+	`^(No previous AI autofix|Initial run — no previous commit)` regex
+	correctly flips IS_FIRST_ITERATION=true. Without this, reviewers get
+	the iteration-2 prompt on a fresh smoke PR, which is also wrong."""
+	block = _generate_diff_block(_review_autofix_text())
+	assert '"No previous AI autofix run on PR head" > "${LAST_RUN_DIFF_FILE}"' in block, (
+		"LAST_RUN_DIFF_FILE placeholder must start with `No previous AI autofix` "
+		"so review_run_reviewers.sh's first-iteration sentinel regex matches."
+	)
+	# The stat-file sentinel must remain intact for downstream consumers.
+	assert '"FIRST_RUN_NO_PREVIOUS_AI_CHANGES" > "${LAST_RUN_DIFF_STAT_FILE}"' in block, (
+		"LAST_RUN_DIFF_STAT_FILE sentinel `FIRST_RUN_NO_PREVIOUS_AI_CHANGES` "
+		"is part of the cross-script contract and must be preserved."
+	)
+
+
+if __name__ == "__main__":
+	test_last_run_diff_walks_back_to_autofix_commit()
+	test_last_run_diff_uses_caret_dotdotdot_range()
+	test_last_run_diff_no_unconditional_head1_diff()
+	test_last_run_diff_placeholder_matches_first_iteration_sentinel()
+	print("All LAST_RUN_DIFF OSCILLATION GUARD contract tests passed.")


### PR DESCRIPTION
## Summary

- Release v1.1.0 / e2e-smoke-test failed at Phase 4b (`Editor failed to remove bait line E2E_EDITOR_BAIT_25254380200`). Reasoning-effort overrides from PR #1984 / #1993 took effect — the editor ran at `low` per `review_autofix` run 25254574828 — yet still produced empty output across 6 attempts (3 primary + 3 in-step retry).
- Direct review_autofix run 25254574828 evidence (job 74051788318): consolidator emitted a clean `CLASSIFICATION: must-fix` issue with 6 reviewers flagging it (so the prior `analysis/e2e-smoke-failure-25126757724.md` "passthrough/unclassified" hypothesis does NOT apply here). The editor read all the inputs, saw the bait at L4 of the canary via `nl -ba`, then exited cleanly with empty stdout — no `apply_patch`, no Edit, no Write.
- Root cause: `last_run_diff.patch` contained the bait line as a `+1` hunk because `.github/workflows/review_autofix.yml:2263-2271` unconditionally ran `git diff HEAD~1...HEAD`. The bait commit (`[E2E Smoke Test] inject editor bait line ...`) leaked into LAST_RUN_DIFF as if it were a "previous AI autofix run", and the OSCILLATION GUARD block in the editor prompt (`scripts/review_apply_fixes.sh:441-462`) correctly told the model not to re-modify previously-changed hunks without a regression fingerprint + runtime failure path. The model followed the guardrail and bailed.
- Fix: walk back the last 50 commits and use `${SHA}^...${SHA}` for the most recent `[ai-autofix]`/`[judge-fix]` commit (same prefix regex already used by the iteration counter at line 2096-2105 and by `scripts/review_apply_fixes.sh:2838`). If no autofix commit is found, write a "No previous AI autofix run on PR head" placeholder that matches `scripts/review_run_reviewers.sh:249`'s first-iteration sentinel regex.
- Side effect: production runs where someone manually pushed on top of an autofix commit now correctly see the autofix's actual diff (`HEAD~2...HEAD~1`) instead of the manual push's diff. For the common case (HEAD itself is the autofix commit) `${SHA}^...${SHA}` reduces to the existing `HEAD~1...HEAD` semantics — no behavior change for production iteration 2+.

## Test plan

- [x] Local repro: 3 git fixtures (smoke / iteration 2 / manual-push-on-top) all classify correctly with the new walk-back logic.
- [x] `tests/test_review_autofix_last_run_diff_oscillation_guard.py` — 4 contract invariants locked down (walk-back present, prefix regex matches existing convention, `${SHA}^...${SHA}` range used, placeholder matches first-iteration sentinel).
- [x] All other review_autofix contract tests still pass: `test_review_autofix_editor_noop_cascade_contract.py`, `test_review_autofix_phase_transition_contract.py`, `test_review_autofix_reasoning_schedule.py`, `test_review_autofix_merge_precheck.py`, `test_detect_editor_changes_lost.py`.
- [x] YAML loads cleanly via `yaml.safe_load`.
- [ ] e2e-smoke-test gate must pass on next release run (requires a real autofix invocation against a smoke PR — not reproducible locally).

## Notes for reviewers

- Backwards compatibility (CLAUDE.md §6): `LAST_RUN_DIFF_FILE` / `LAST_RUN_CHANGED_FILES_FILE` / `LAST_RUN_DIFF_STAT_FILE` variable names preserved; `FIRST_RUN_NO_PREVIOUS_AI_CHANGES` sentinel preserved; placeholder phrasing kept compatible with the existing `^(No previous AI autofix|Initial run — no previous commit)` regex in `scripts/review_run_reviewers.sh:249`.
- Minimal change set (CLAUDE.md §5): single block in `review_autofix.yml` plus a new contract test. No prompt edits, no script edits, no scope expansion. The OSCILLATION GUARD prompt itself is correct as-is — only its input was wrong.
- Why not include `[ai-merge-resolve]`: the existing `_prior_autofix_count` regex at `scripts/review_apply_fixes.sh:2838` only counts `[ai-autofix]`/`[judge-fix]`. Keeping the same prefix set here for consistency. If we ever want merge-resolve commits to also count toward the OSCILLATION GUARD's "previous AI autofix run", that should be a separate change applied in both places at once.

https://claude.ai/code/session_01NiDi36zsdkHRGkpk8wVRzU

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiDi36zsdkHRGkpk8wVRzU)_