### PR TITLE
fix(implement): add plain-text file write guidance to prevent narrate-only failures

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1123,13 +1123,19 @@ jobs:
 
           Concretely on this attempt:
           - Use `apply_patch` (or the equivalent Serena edit tool) to make
-            edits, NOT `sed`/`grep` shell-out workarounds. `sed` and `rg`
-            with literal special characters routinely fail shell quoting
-            and waste the entire attempt.
-          - Do NOT read additional files until your first `apply_patch`
-            call has succeeded. Pick the file you understand best from
-            the plan, edit it first, verify the patch landed, and only
-            then expand scope.
+            edits. For plain-text files (.txt, .csv, canary files, data
+            files) with fully-specified content, a direct shell write is
+            equally valid and avoids apply_patch diff-format issues:
+              printf 'line1\nline2\nline3\n' > path/to/file.txt
+            Avoid `sed`/`rg` for content replacements — quoting is fragile.
+          - Do NOT read additional files until your first write tool call
+            has succeeded. Pick the file you understand best from
+            the plan, edit it first, verify the change landed on disk, and
+            only then expand scope.
+          - WARNING: describing or quoting the file's new content in your
+            response does NOT write it to disk. You MUST call a write tool
+            (apply_patch, printf shell exec, or Serena write) — the
+            file is unchanged until a tool call is actually executed.
 
           RETRY_EOF
                 if [ -n "${prior_exec_history}" ]; then
@@ -1138,7 +1144,8 @@ jobs:
                     "${prior_exec_history}" \
                     "" \
                     "Based on the above, you have already inspected the relevant files. Skip" \
-                    "re-exploration. Make the edits now using apply_patch / Serena edit tools." \
+                    "re-exploration. Make the edits now using apply_patch, printf shell exec," \
+                    "or Serena write tools. Do NOT narrate — call a write tool." \
                     ""
                 fi
                 cat "${CODEX_PROMPT_FILE}"

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1144,8 +1144,8 @@ jobs:
                     "${prior_exec_history}" \
                     "" \
                     "Based on the above, you have already inspected the relevant files. Skip" \
-                    "re-exploration. Make the edits now using apply_patch, printf shell exec," \
-                    "or Serena write tools. Do NOT narrate — call a write tool." \
+                    "re-exploration. Make the edits now using apply_patch, printf, or Serena write tools." \
+                    "Do NOT narrate — call a write tool." \
                     ""
                 fi
                 cat "${CODEX_PROMPT_FILE}"

--- a/codex_system_instructions.md
+++ b/codex_system_instructions.md
@@ -48,6 +48,12 @@ Rules:
 ### Fallback:
 - If Serena is unavailable or errors, fall back to normal file reads/writes. Do not stall.
 
+### Plain-text / non-code file exception:
+- Serena's symbol tools (`replace_symbol_body`, `insert_after_symbol`, etc.) operate on **code files** with parseable symbols. They do NOT apply to plain-text data files (`.txt`, `.csv`, canary files, lock files, etc.) — attempting to use them on such files will silently fail or error.
+- For plain-text files with fully specified content, use `apply_patch` **or** a direct shell write:
+  `printf 'line1\nline2\nline3\n' > path/to/file.txt`
+- **CRITICAL — text narration is NOT a write:** Generating a response that describes or quotes the file's new content does NOT modify the file on disk. The file is unchanged until a write tool is actually called (`apply_patch`, a shell `printf`/`tee`, or a Serena write tool). Every file edit MUST be executed via a tool call — never by narrating what you would write.
+
 ## Context7 Library Docs (OPTIONAL when available)
 
 Use Context7 only when library/framework API details are uncertain and current docs are needed.

--- a/tests/e2e_smoke_canary.txt
+++ b/tests/e2e_smoke_canary.txt
@@ -1,3 +1,3 @@
 status: ok
-run_id: 25271960656
+run_id: alt-25265920645
 updated-by: ai-pipeline

--- a/tests/e2e_smoke_canary.txt
+++ b/tests/e2e_smoke_canary.txt
@@ -1,3 +1,3 @@
 status: ok
-run_id: alt-25265920645
+run_id: 25271960656
 updated-by: ai-pipeline

--- a/tests/test_implement_post_codex_recovery.py
+++ b/tests/test_implement_post_codex_recovery.py
@@ -1222,8 +1222,11 @@ def test_retry_prompt_includes_exec_history_recap() -> None:
 	assert "DO NOT redo these — go straight to editing" in codex_block, (
 		"Recap header must instruct the model to skip re-exploration and edit"
 	)
-	assert "apply_patch / Serena edit tools" in codex_block, (
+	assert "apply_patch, printf, or Serena write tools" in codex_block, (
 		"Recap must point the model at the actual editing tools to use"
+	)
+	assert "Do NOT narrate — call a write tool" in codex_block, (
+		"Recap must reinforce that narrating is not the same as a tool call"
 	)
 
 	# (b) The awk parser must match the Codex CLI stderr format we


### PR DESCRIPTION
## Summary

Root-cause fix for the Codex implement loop's "narrate-only" failure mode (CI run [25272034874](https://github.com/shubhodeep1/coding-workflows/actions/runs/25272034874), issue #2014; also previously seen in run 25223836137 / issue #1909).

The Codex model (`gpt-5.3-codex` via openrouter) generated a chat-style description of the intended edit in **~1.6 seconds with zero tool calls** (MCP startup `06:33:33.902` → first output `06:33:35.493`), then bailed after 2 attempts via the `empty_streak` guard. Driver: `codex_system_instructions.md` §Serena says "ALWAYS use Serena tools" + "NEVER rewrite an entire file", but Serena's symbol tools are inapplicable to plain-text data files (no symbols to operate on). With no clear write path, the model narrated the result instead of executing it.

This PR does **not** modify the canary file — that earlier change has been reverted on this branch. The canary update will land separately. The fix here addresses the underlying loop failure so future canary-style tasks succeed on the first attempt.

## Changes

- `codex_system_instructions.md` — added "Plain-text / non-code file exception" subsection under §Serena, naming `printf` as an explicit valid write path and adding a CRITICAL note that text narration does NOT write to disk.
- `.github/workflows/implement.yml` — RETRY_EOF block now allows `printf >` for plain-text files alongside `apply_patch`/Serena, and adds a WARNING bullet that describing file content is not the same as calling a write tool. Prior-exec-history recap line updated similarly.
- `tests/test_implement_post_codex_recovery.py` — updated the `test_retry_prompt_includes_exec_history_recap` marker assertion to match the new wording, and added a second assertion pinning the "Do NOT narrate — call a write tool" reinforcement.

## Test plan

- [x] `test_retry_prompt_includes_exec_history_recap` substring assertions verified against current `implement.yml` (all 5 markers present).
- [ ] Next implement-mode run on a plain-text-file task succeeds without hitting `empty_streak`.

https://claude.ai/code/session_01TyXDxZhux1NzYofsS3LcfM