### PR TITLE
fix(test-and-mark-stable): pass --repo to gh workflow run in sync-to-main

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -4015,7 +4015,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
         run: |
           set -euo pipefail
-          gh workflow run forward-merge-stable-to-main.yml --ref stable
+          # --repo "${GITHUB_REPOSITORY}" is required: this job has no
+          # checkout step, so without it `gh workflow run` falls back to
+          # `git remote` detection and aborts with
+          # `fatal: not a git repository (or any of the parent directories): .git`.
+          gh workflow run forward-merge-stable-to-main.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref stable
           echo "Dispatched forward-merge-stable-to-main.yml on stable branch."
           echo "View runs: https://github.com/${GITHUB_REPOSITORY}/actions/workflows/forward-merge-stable-to-main.yml"
 


### PR DESCRIPTION
## Summary
- The `sync-to-main` job in `test-and-mark-stable.yml` has no checkout step, so `gh workflow run forward-merge-stable-to-main.yml --ref stable` falls back to `git remote` detection and aborts with `fatal: not a git repository (or any of the parent directories): .git` (exit code 1).
- Fix: pass `--repo "${GITHUB_REPOSITORY}"` to dispatch the workflow against the repo explicitly, matching every other `gh workflow run` call site in this file (and the comment at L1079–L1085 already documents the same requirement for the E2E review-dispatch path).

## Root cause
Job log (L29–L41) shows the sync-to-main step's only command is `gh workflow run forward-merge-stable-to-main.yml --ref stable`, with no preceding `actions/checkout`. `gh` then tries to derive the target repo from the local git context, fails with the "not a git repository" error, and exits non-zero.

## Test plan
- [ ] Next stable release run shows `sync-to-main` succeeds and the dispatched `forward-merge-stable-to-main.yml` run is visible in the Actions tab.
- [ ] No regressions in `test-and-mark-stable.yml` workflow validation (YAML parses; verified locally).

https://claude.ai/code/session_01Bs3Lww8Ucru21jgPbDRes1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bs3Lww8Ucru21jgPbDRes1)_