### PR TITLE
fix(review_autofix): pin conflict-resolver reasoning independent of editor smoke override

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3579,6 +3579,21 @@ jobs:
         timeout-minutes: 60
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
+          # Decoupled from EDITOR_REASONING_EFFORT: the smoke-test override
+          # ("Detect smoke test PR" step) sets editor reasoning to "none" so
+          # the single-line bait removal completes deterministically. That
+          # patches ~/.codex/config.toml, which the conflict resolver below
+          # would otherwise inherit. With reasoning=none gpt-5.3-codex hits
+          # the same empty-stdout failure mode documented on the editor step
+          # ("Switch reasoning effort for editor"): it runs one read tool
+          # call, exits cleanly with rc=0 and zero stdout, and the retry
+          # loop bails after MAX_ATTEMPTS with no edits. Observed on PR
+          # #2058 / run 25300219172 where the resolver was given a 1-line
+          # canary conflict, never wrote a final message, and the
+          # [ai-merge-resolve] commit was aborted. Pin the resolver to a
+          # workflow-controlled effort so the smoke override never starves
+          # it.
+          CONFLICT_RESOLVER_REASONING_EFFORT: ${{ vars.THINKING_LEVEL_CONFLICT_RESOLVER || 'medium' }}
         run: |
           set -euo pipefail
           bash "${SUPPORT_SCRIPTS_DIR}/review_conflict_resolve.sh"

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `THINKING_LEVEL_JUDGE` | `medium` | orchestrate_poll | Reasoning effort for judge evaluation |
 | `THINKING_LEVEL_CLARIFY_RESPOND` | `medium` | orchestrate_clarify_respond | Reasoning effort for auto-answering clarification questions |
 | `THINKING_LEVEL_VALIDATE` | `medium` | validate | Reasoning effort for runtime validation harness generation and diagnosis |
-| `THINKING_LEVEL_CONFLICT_RESOLVER` | `medium` | orchestrate_poll | Reasoning effort for the orchestrator's Codex-based merge conflict resolver |
+| `THINKING_LEVEL_CONFLICT_RESOLVER` | `medium` | orchestrate_poll, review_autofix | Reasoning effort for the Codex-based merge conflict resolver (orchestrator integration-sync runs and review_autofix's post-editor resolver step) |
 **Tool call budgets** — soft limits on the number of MCP + shell tool calls per phase. The LLM treats these as guidelines; it may exceed them for large refactors that span many files.
 
 | Variable | Default | Used By | Description |
@@ -891,7 +891,7 @@ See [`workflow-templates/`](workflow-templates/) in this repository for ready-to
 | `TOKEN_WARN_THRESHOLD_ORCHESTRATE` | `200000` | Token warning threshold for orchestration |
 | `THINKING_LEVEL_CLARIFY_RESPOND` | `medium` | Reasoning effort for auto-answering clarification questions |
 | `THINKING_LEVEL_VALIDATE` | `medium` | Reasoning effort for runtime validation harness generation and diagnosis |
-| `THINKING_LEVEL_CONFLICT_RESOLVER` | `medium` | Reasoning effort for the orchestrator's Codex-based merge conflict resolver |
+| `THINKING_LEVEL_CONFLICT_RESOLVER` | `medium` | Reasoning effort for the Codex-based merge conflict resolver (used by orchestrate_poll integration-sync and review_autofix's post-editor resolver step) |
 | `TOOL_CALL_BUDGET_CLARIFY_RESPOND` | `15` | Tool call budget for auto-answering clarification questions |
 | `TOKEN_WARN_THRESHOLD_CLARIFY_RESPOND` | `80000` | Token warning threshold for auto-answering clarification questions |
 | `SEMANTIC_CACHE_BACKEND` | `none` | Semantic cache backend selector for clarification workloads: `none`, `redis`, `sqlite-vec` |

--- a/scripts/review_conflict_resolve.sh
+++ b/scripts/review_conflict_resolve.sh
@@ -189,26 +189,46 @@ _resolver_reasoning_effort="${CONFLICT_RESOLVER_REASONING_EFFORT:-medium}"
 # (vars.THINKING_LEVEL_CONFLICT_RESOLVER) so an unexpected value would
 # corrupt the TOML or break sed under set -e. Mirrors the pattern used
 # in scripts/review_consolidate.sh for REVIEW_CONSOLIDATOR_REASONING.
+# Allowed levels match README.md ("Thinking levels"): xhigh|high|medium|none.
 case "${_resolver_reasoning_effort}" in
-  xhigh|high|medium|low|none) ;;
+  xhigh|high|medium|none) ;;
   *)
     echo "::warning::Invalid CONFLICT_RESOLVER_REASONING_EFFORT='${_resolver_reasoning_effort}'; falling back to medium."
     _resolver_reasoning_effort="medium"
     ;;
 esac
 _codex_config="${HOME}/.codex/config.toml"
+# Fail-open guard around the rewrite: a sed/grep failure (permissions,
+# unexpected file shape, missing GNU sed) should fall through to a
+# ::warning:: rather than abort the resolver step under set -e — same
+# spirit as the missing-config branch below. Robust grep/sed patterns
+# tolerate whitespace and quoting variants so a non-canonical config
+# (e.g. unquoted value, extra spaces) is still updated rather than
+# silently no-op'd, which would re-introduce the empty-stdout failure
+# this fix is meant to prevent. Post-edit verification reads the file
+# back and emits a warning if the resolver value is missing.
 if [ -f "${_codex_config}" ]; then
-  if grep -q '^model_reasoning_effort = ' "${_codex_config}"; then
-    sed -i "s/^model_reasoning_effort = \".*\"/model_reasoning_effort = \"${_resolver_reasoning_effort}\"/" "${_codex_config}"
+  _rewrite_ok=1
+  {
+    if grep -qE '^[[:space:]]*model_reasoning_effort[[:space:]]*=' "${_codex_config}"; then
+      sed -i "s|^[[:space:]]*model_reasoning_effort[[:space:]]*=.*|model_reasoning_effort = \"${_resolver_reasoning_effort}\"|" "${_codex_config}"
+    else
+      printf '\nmodel_reasoning_effort = "%s"\n' "${_resolver_reasoning_effort}" >> "${_codex_config}"
+    fi
+    if grep -qE '^[[:space:]]*model_reasoning_summary[[:space:]]*=' "${_codex_config}"; then
+      sed -i 's|^[[:space:]]*model_reasoning_summary[[:space:]]*=.*|model_reasoning_summary = "auto"|' "${_codex_config}"
+    else
+      sed -i '/^[[:space:]]*model_reasoning_effort[[:space:]]*=/a model_reasoning_summary = "auto"' "${_codex_config}"
+    fi
+  } || _rewrite_ok=0
+
+  if [ "${_rewrite_ok}" -eq 0 ]; then
+    echo "::warning::Codex config rewrite failed for ${_codex_config}; resolver will run with whatever reasoning the editor step left in place."
+  elif ! grep -qE "^model_reasoning_effort = \"${_resolver_reasoning_effort}\"$" "${_codex_config}"; then
+    echo "::warning::Codex config rewrite did not produce the expected model_reasoning_effort = \"${_resolver_reasoning_effort}\" line; resolver may run with stale reasoning."
   else
-    printf '\nmodel_reasoning_effort = "%s"\n' "${_resolver_reasoning_effort}" >> "${_codex_config}"
+    echo "Conflict resolver reasoning effort set to ${_resolver_reasoning_effort} (model_reasoning_summary=auto)."
   fi
-  if grep -q '^model_reasoning_summary = ' "${_codex_config}"; then
-    sed -i 's/^model_reasoning_summary = ".*"/model_reasoning_summary = "auto"/' "${_codex_config}"
-  else
-    sed -i '/^model_reasoning_effort = /a model_reasoning_summary = "auto"' "${_codex_config}"
-  fi
-  echo "Conflict resolver reasoning effort set to ${_resolver_reasoning_effort} (model_reasoning_summary=auto)."
 else
   echo "::warning::Codex config ${_codex_config} not found before resolver loop; reasoning effort override skipped."
 fi

--- a/scripts/review_conflict_resolve.sh
+++ b/scripts/review_conflict_resolve.sh
@@ -166,6 +166,41 @@ trap _resolver_exit_trap EXIT
 # ----------------------------------------------------------------------
 INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS=3
 RESOLVER_ATTEMPT_BASE_DIR="${RUNTIME_DIR}/resolver_attempt_base"
+
+# Pin the resolver's Codex reasoning effort independent of the editor's.
+# review_autofix.yml's "Detect smoke test PR" step rewrites
+# ~/.codex/config.toml's model_reasoning_effort to "none" (so the
+# single-line smoke-canary edit completes deterministically). The
+# conflict resolver runs against the same config and inherits that
+# value, which reliably trips the empty-stdout failure mode of
+# gpt-5.3-codex (documented on the editor step's
+# "Switch reasoning effort" block): one tool call, rc=0, zero output,
+# no final assistant message — the retry loop then exhausts and aborts
+# the [ai-merge-resolve] commit. PR #2058 / run 25300219172 hit this on
+# a 1-line canary conflict.
+#
+# Override config.toml here using CONFLICT_RESOLVER_REASONING_EFFORT
+# (set by the workflow step's env, defaults to "medium"). Also ensure
+# model_reasoning_summary = "auto" is present — same diagnostic +
+# anti-empty-stdout rationale as the editor step.
+_resolver_reasoning_effort="${CONFLICT_RESOLVER_REASONING_EFFORT:-medium}"
+_codex_config="${HOME}/.codex/config.toml"
+if [ -f "${_codex_config}" ]; then
+  if grep -q '^model_reasoning_effort = ' "${_codex_config}"; then
+    sed -i "s/^model_reasoning_effort = \".*\"/model_reasoning_effort = \"${_resolver_reasoning_effort}\"/" "${_codex_config}"
+  else
+    printf '\nmodel_reasoning_effort = "%s"\n' "${_resolver_reasoning_effort}" >> "${_codex_config}"
+  fi
+  if grep -q '^model_reasoning_summary = ' "${_codex_config}"; then
+    sed -i 's/^model_reasoning_summary = ".*"/model_reasoning_summary = "auto"/' "${_codex_config}"
+  else
+    sed -i '/^model_reasoning_effort = /a model_reasoning_summary = "auto"' "${_codex_config}"
+  fi
+  echo "Conflict resolver reasoning effort set to ${_resolver_reasoning_effort} (model_reasoning_summary=auto)."
+else
+  echo "::warning::Codex config ${_codex_config} not found before resolver loop; reasoning effort override skipped."
+fi
+
 RESOLVER_ATTEMPT_BASE_MISSING_FILE="${RUNTIME_DIR}/resolver_attempt_base_missing.txt"
 RESOLVER_RETRY_PROMPT_FILE="${RUNTIME_DIR}/resolver_retry_prompt.txt"
 RESOLVER_MARKER_VIOLATIONS_FILE="${RUNTIME_DIR}/resolver_marker_violations.txt"

--- a/scripts/review_conflict_resolve.sh
+++ b/scripts/review_conflict_resolve.sh
@@ -11,6 +11,11 @@
 #   RUNTIME_DIR                     Ephemeral per-run directory.
 #   CONFLICT_RESOLVER_PROMPT_FILE   Rendered resolver prompt.
 #   CONFLICT_RESOLVER_SUMMARY_FILE  Path resolver summary is written to.
+#   CONFLICT_RESOLVER_REASONING_EFFORT  Reasoning level applied to ~/.codex/config.toml
+#                                   before the retry loop. One of xhigh|high|medium|none;
+#                                   defaults to medium. Decoupled from EDITOR_REASONING_EFFORT
+#                                   so the smoke-test override (which sets editor reasoning
+#                                   to "none") doesn't starve the resolver.
 #   MODEL_EDITOR                    Codex model id used for resolution.
 #   IS_WORKFLOW_SOURCE_REPO         "true" on the coding-workflows repo itself.
 #   SUPPORT_SCRIPTS_DIR             Path to check_resolver_diff.sh / verify_integration_fingerprints.py.

--- a/scripts/review_conflict_resolve.sh
+++ b/scripts/review_conflict_resolve.sh
@@ -231,6 +231,8 @@ if [ -f "${_codex_config}" ]; then
     echo "::warning::Codex config rewrite failed for ${_codex_config}; resolver will run with whatever reasoning the editor step left in place."
   elif ! grep -qE "^model_reasoning_effort = \"${_resolver_reasoning_effort}\"$" "${_codex_config}"; then
     echo "::warning::Codex config rewrite did not produce the expected model_reasoning_effort = \"${_resolver_reasoning_effort}\" line; resolver may run with stale reasoning."
+  elif ! grep -qE '^model_reasoning_summary = "auto"$' "${_codex_config}"; then
+    echo "::warning::Codex config rewrite did not produce the expected model_reasoning_summary = \"auto\" line; the anti-empty-stdout safeguard may be unset."
   else
     echo "Conflict resolver reasoning effort set to ${_resolver_reasoning_effort} (model_reasoning_summary=auto)."
   fi

--- a/scripts/review_conflict_resolve.sh
+++ b/scripts/review_conflict_resolve.sh
@@ -229,12 +229,21 @@ if [ -f "${_codex_config}" ]; then
 
   if [ "${_rewrite_ok}" -eq 0 ]; then
     echo "::warning::Codex config rewrite failed for ${_codex_config}; resolver will run with whatever reasoning the editor step left in place."
-  elif ! grep -qE "^model_reasoning_effort = \"${_resolver_reasoning_effort}\"$" "${_codex_config}"; then
-    echo "::warning::Codex config rewrite did not produce the expected model_reasoning_effort = \"${_resolver_reasoning_effort}\" line; resolver may run with stale reasoning."
-  elif ! grep -qE '^model_reasoning_summary = "auto"$' "${_codex_config}"; then
-    echo "::warning::Codex config rewrite did not produce the expected model_reasoning_summary = \"auto\" line; the anti-empty-stdout safeguard may be unset."
   else
-    echo "Conflict resolver reasoning effort set to ${_resolver_reasoning_effort} (model_reasoning_summary=auto)."
+    # Independent checks (not elif) so both mismatches surface together
+    # if the rewrite somehow produced neither expected line.
+    _verify_ok=1
+    if ! grep -qE "^model_reasoning_effort = \"${_resolver_reasoning_effort}\"$" "${_codex_config}"; then
+      echo "::warning::Codex config rewrite did not produce the expected model_reasoning_effort = \"${_resolver_reasoning_effort}\" line; resolver may run with stale reasoning."
+      _verify_ok=0
+    fi
+    if ! grep -qE '^model_reasoning_summary = "auto"$' "${_codex_config}"; then
+      echo "::warning::Codex config rewrite did not produce the expected model_reasoning_summary = \"auto\" line; the anti-empty-stdout safeguard may be unset."
+      _verify_ok=0
+    fi
+    if [ "${_verify_ok}" -eq 1 ]; then
+      echo "Conflict resolver reasoning effort set to ${_resolver_reasoning_effort} (model_reasoning_summary=auto)."
+    fi
   fi
 else
   echo "::warning::Codex config ${_codex_config} not found before resolver loop; reasoning effort override skipped."

--- a/scripts/review_conflict_resolve.sh
+++ b/scripts/review_conflict_resolve.sh
@@ -184,6 +184,18 @@ RESOLVER_ATTEMPT_BASE_DIR="${RUNTIME_DIR}/resolver_attempt_base"
 # model_reasoning_summary = "auto" is present — same diagnostic +
 # anti-empty-stdout rationale as the editor step.
 _resolver_reasoning_effort="${CONFLICT_RESOLVER_REASONING_EFFORT:-medium}"
+# Validate against known reasoning levels before interpolating into sed —
+# CONFLICT_RESOLVER_REASONING_EFFORT comes from a repo var
+# (vars.THINKING_LEVEL_CONFLICT_RESOLVER) so an unexpected value would
+# corrupt the TOML or break sed under set -e. Mirrors the pattern used
+# in scripts/review_consolidate.sh for REVIEW_CONSOLIDATOR_REASONING.
+case "${_resolver_reasoning_effort}" in
+  xhigh|high|medium|low|none) ;;
+  *)
+    echo "::warning::Invalid CONFLICT_RESOLVER_REASONING_EFFORT='${_resolver_reasoning_effort}'; falling back to medium."
+    _resolver_reasoning_effort="medium"
+    ;;
+esac
 _codex_config="${HOME}/.codex/config.toml"
 if [ -f "${_codex_config}" ]; then
   if grep -q '^model_reasoning_effort = ' "${_codex_config}"; then

--- a/tests/test_review_autofix_reasoning_schedule.py
+++ b/tests/test_review_autofix_reasoning_schedule.py
@@ -43,3 +43,15 @@ def test_editor_switch_replaces_any_reasoning_value() -> None:
 	wf = _workflow()
 	assert 'sed -i "s/^model_reasoning_effort = \\".*\\"/model_reasoning_effort = \\"${EDITOR_REASONING_EFFORT}\\"/" ~/.codex/config.toml' in wf
 	assert 'sed -i "s/model_reasoning_effort = \\"${REVIEWER_REASONING_EFFORT}\\"/model_reasoning_effort = \\"${EDITOR_REASONING_EFFORT}\\"/" ~/.codex/config.toml' not in wf
+
+
+def test_conflict_resolver_reasoning_env_wired() -> None:
+	"""Resolver step must pass CONFLICT_RESOLVER_REASONING_EFFORT to
+	review_conflict_resolve.sh so the smoke-test editor's reasoning=none
+	override doesn't starve the resolver (PR #2058 / run 25300219172).
+	"""
+	wf = _workflow()
+	assert "CONFLICT_RESOLVER_REASONING_EFFORT:" in wf
+	assert "vars.THINKING_LEVEL_CONFLICT_RESOLVER" in wf
+	resolver_script = (REPO_ROOT / "scripts" / "review_conflict_resolve.sh").read_text(encoding="utf-8")
+	assert "CONFLICT_RESOLVER_REASONING_EFFORT" in resolver_script

--- a/tests/test_review_autofix_reasoning_schedule.py
+++ b/tests/test_review_autofix_reasoning_schedule.py
@@ -55,3 +55,10 @@ def test_conflict_resolver_reasoning_env_wired() -> None:
 	assert "vars.THINKING_LEVEL_CONFLICT_RESOLVER" in wf
 	resolver_script = (REPO_ROOT / "scripts" / "review_conflict_resolve.sh").read_text(encoding="utf-8")
 	assert "CONFLICT_RESOLVER_REASONING_EFFORT" in resolver_script
+	# Validation must match README's documented levels (xhigh|high|medium|none)
+	# — `low` is not a documented level and must not be silently accepted.
+	assert "xhigh|high|medium|none)" in resolver_script
+	assert "xhigh|high|medium|low|none" not in resolver_script
+	# grep/sed must tolerate whitespace + unquoted variants so a non-canonical
+	# config doesn't silently no-op and leave the resolver on stale `none`.
+	assert "[[:space:]]*model_reasoning_effort[[:space:]]*=" in resolver_script


### PR DESCRIPTION
## Summary

The "Detect smoke test PR" step in `review_autofix.yml` sets `EDITOR_REASONING_EFFORT=none` and `sed`s `~/.codex/config.toml` so the editor's single-line bait removal completes deterministically. The later "Run Codex resolver" step shares that config file and inherits `reasoning=none`, which reliably trips gpt-5.3-codex's empty-stdout failure mode: one read tool call, `rc=0`, zero stdout, no final assistant message — the retry loop exhausts and aborts the `[ai-merge-resolve]` commit.

Observed on PR #2058 / run 25300219172 where the resolver was handed a 1-line canary conflict in `tests/e2e_smoke_canary.txt` and gave up after 3 attempts despite `prev markers=0, prev fingerprint_violations=0` (the soft-validation files were never populated because each attempt produced empty output and skipped validation).

## Fix

- Add `CONFLICT_RESOLVER_REASONING_EFFORT` to the resolver step env in `.github/workflows/review_autofix.yml` (defaults to `medium`, overridable via `vars.THINKING_LEVEL_CONFLICT_RESOLVER`).
- In `scripts/review_conflict_resolve.sh`, before the retry loop, `sed` `~/.codex/config.toml` to apply that effort, and re-assert `model_reasoning_summary = "auto"` (same anti-empty-stdout rationale the editor step already documents).

## Evidence-based

- `log-1 L16338`: resolver step started with `reasoning effort: none` (inherited from smoke override at `review_autofix.yml:1844-1851`).
- `log-1 L16398-16410, 16482-16488, 16560-16567`: each of the 3 codex attempts ran a single read (`sed -n` + `grep`) and emitted no further output.
- `log-1 L16413,16492`: retry messages report `prev markers=0, prev fingerprint_violations=0` because the empty-output branch in `review_conflict_resolve.sh:418-426` skips `_scan_residual_markers`/`_verify_fingerprints_soft`.
- `log-1 L16571-16572`: `Conflict resolver failed after retries.` → `Process completed with exit code 1`.
- `review_autofix.yml:1834-1845` comment-block already documents the same empty-stdout regression (run 25249170035 / PR #1982) for the editor at xhigh; the resolver hits the inverse at none.

## Test plan

- [ ] Re-run smoke-test workflow on a PR that creates a `tests/e2e_smoke_canary.txt` conflict; confirm resolver attempt 1 produces output and the `[ai-merge-resolve]` commit lands.
- [ ] Confirm non-smoke PRs are unaffected (default reasoning is unchanged at `medium`).
- [ ] Sanity-check that `~/.codex/config.toml` after the editor step is rewritten cleanly by the new `sed` block (no duplicate `model_reasoning_effort` lines).

https://claude.ai/code/session_01Cs8UvTboRgaxEALwtTrpG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cs8UvTboRgaxEALwtTrpG1)_