### PR TITLE
fix(smoke): raise editor reasoning from low to medium for smoke runs

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1825,10 +1825,10 @@ jobs:
           fi
 
           if [ "$IS_SMOKE" = "true" ]; then
-            # Reasoning overrides for smoke runs: both reviewers and editor
-            # are pinned to low.
+            # Reasoning overrides for smoke runs.
+            # Reviewers are pinned to low; editor is pinned to medium.
             #
-            # History of reasoning levels on smoke runs (editor + reviewer):
+            # History of reasoning levels on smoke runs (editor):
             #   low  → run 25254574828: OSCILLATION GUARD activated because the
             #           bait commit appeared in LAST_RUN_DIFF (since fixed at
             #           L2249-2260 to only walk [ai-autofix] commits — bait
@@ -1843,22 +1843,28 @@ jobs:
             #           documented at the "Resolve merge conflicts" step below).
             #           Reviewer manifest validation then fails because the editor
             #           lists aggregate files instead of individual reviewer files.
-            # low is safe because LAST_RUN_DIFF excludes bait commits (so the
-            # oscillation guard cannot activate on a smoke run), and low is
-            # sufficient for both spotting and removing a single bait line.
+            #   low   → run 25308327160 (gate run 25308071039): gpt-5.3-codex at
+            #           reasoning=low also exits rc=0 with empty stdout on all
+            #           3 attempts per round (same failure mode as none — pattern
+            #           extends across both none and low for this model+task).
+            #           "low is sufficient" assumption was wrong.
+            # medium is the only untried level; reviewers stay at low (all 6
+            # succeeded on attempt 1 at low in run 25308327160). LAST_RUN_DIFF
+            # already excludes bait commits so the oscillation guard cannot
+            # fire regardless of editor reasoning level.
             # Non-smoke PRs continue to use the workflow defaults
             # (THINKING_LEVEL_REVIEWER / THINKING_LEVEL_EDITOR).
             echo "REVIEWER_REASONING_EFFORT=low" >> "$GITHUB_ENV"
-            echo "EDITOR_REASONING_EFFORT=low" >> "$GITHUB_ENV"
+            echo "EDITOR_REASONING_EFFORT=medium" >> "$GITHUB_ENV"
             # Patch the already-written Codex config so the reviewer phase
             # (which copies ~/.codex/config.toml into each reviewer's
             # isolated CODEX_HOME) picks up the low override. Without this
             # sed the reviewer codex config would still hold the medium value
             # baked in by the "Create Codex config" step that ran earlier.
             # The editor phase re-patches the config in "Switch reasoning effort
-            # for editor" using EDITOR_REASONING_EFFORT=low (set above).
+            # for editor" using EDITOR_REASONING_EFFORT=medium (set above).
             sed -i 's/^model_reasoning_effort = ".*"/model_reasoning_effort = "low"/' ~/.codex/config.toml
-            echo "🔬 Smoke test PR detected — overriding reviewer + editor reasoning to low (Phase 4b fix)"
+            echo "🔬 Smoke test PR detected — reviewer reasoning=low, editor reasoning=medium (Phase 4b fix)"
             # Suppress per-phase Telegram alerts; the test-and-mark-stable
             # gate emits a single combined pass/fail notification at the
             # end via raw curl. SILENT > CRITICAL so all levels filter.

--- a/tests/test_review_autofix_reasoning_schedule.py
+++ b/tests/test_review_autofix_reasoning_schedule.py
@@ -4,7 +4,9 @@
 The cycle-based schedule machinery (REVIEW_REASONING_SCHEDULE,
 REVIEW_AUTODOWNGRADE_DISABLED) has been removed. Non-smoke-test runs use
 the configured THINKING_LEVEL_* for every cycle. Smoke test runs override
-reasoning to ``low`` for both reviewer and editor phases.
+reviewer reasoning to ``low`` and editor reasoning to ``medium`` (split
+introduced after run 25308327160 showed gpt-5.3-codex at reasoning=low
+produces empty output — same failure mode as reasoning=none).
 """
 
 from __future__ import annotations
@@ -32,11 +34,15 @@ def test_no_cycle_selector_step() -> None:
 	assert "schedule_source" not in wf
 
 
-def test_smoke_test_forces_none_reasoning() -> None:
+def test_smoke_test_reasoning_split() -> None:
+	"""Smoke runs pin reviewer to low and editor to medium (split since run 25308327160)."""
 	wf = _workflow()
 	assert 'REVIEWER_REASONING_EFFORT=low' in wf
-	assert 'EDITOR_REASONING_EFFORT=low' in wf
+	assert 'EDITOR_REASONING_EFFORT=medium' in wf
+	# The reviewer-config sed still patches to low; editor re-patches separately.
 	assert 'model_reasoning_effort = "low"' in wf
+	# Ensure the old all-low assignment is gone.
+	assert 'EDITOR_REASONING_EFFORT=low' not in wf
 
 
 def test_editor_switch_replaces_any_reasoning_value() -> None:


### PR DESCRIPTION
## Summary

- `gpt-5.3-codex` at `reasoning=low` (review run 25308327160, gate run 25308071039) produces empty stdout on all 3 attempts per round — identical failure mode to `reasoning=none` (run 25305535590). The "low is sufficient" assumption was wrong.
- Raises `EDITOR_REASONING_EFFORT` from `low` to `medium` for E2E smoke runs. Reviewers stay at `low` (all 6 succeeded on attempt 1 in the failing run).
- `medium` is the only reasoning level not yet tried for this model+task; oscillation guard is not a concern since `LAST_RUN_DIFF` already excludes non-`[ai-autofix]` commits.

## Root cause evidence

| Reasoning | Run | Outcome |
|-----------|-----|---------|
| `xhigh` | 25249170035 | budget burns on tool calls + reasoning summaries → empty output |
| `none` | 25305535590 | rc=0, empty stdout, all attempts |
| `low` | 25308327160 | rc=0, empty stdout, all attempts (this failure) |
| `medium` | — | untried |

Gate run 25308071039 failed at Phase 4b (`verify-bait-removed`) with `bait_remained` after the editor produced no output and left `# E2E_EDITOR_BAIT_25308071039` in `tests/e2e_smoke_canary.txt`. All 6 reviewers correctly flagged the bait line; the failure was solely in the editor not applying the fix.

## Test plan

- [ ] Next E2E smoke run should complete Phase 4b (editor removes bait line from `tests/e2e_smoke_canary.txt`)
- [ ] Verify `EDITOR_REASONING_EFFORT=medium` appears in the review run log for smoke PRs
- [ ] Verify reviewers still use `reasoning=low` (unchanged)

https://claude.ai/code/session_01BcB2CQuhaMkyzkqu53atN3

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcB2CQuhaMkyzkqu53atN3)_