### PR TITLE
fix(e2e-smoke): pytest-based Phase 4b verification with retry budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,11 @@ jobs:
           python3 -m py_compile scripts/semantic_cache.py
           python3 -m py_compile scripts/check_workflow_script_refs.py
           # Phase 4b smoke-test fixture (only run from
-          # test-and-mark-stable.yml; py_compile catches syntax/import
-          # breakage in CI before it lands silently in the release path).
+          # test-and-mark-stable.yml). py_compile catches syntax-level
+          # breakage (parse errors, indentation) early in CI; it does
+          # NOT exercise imports, so import-time errors (e.g. missing
+          # pytest at runtime) still surface only when Phase 4b
+          # actually runs the test on the smoke runner.
           python3 -m py_compile tests/test_e2e_editor_smoke_canary.py
 
       - name: Orchestrate lib unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,10 @@ jobs:
           python3 -m py_compile scripts/analyze_workflow_logs.py
           python3 -m py_compile scripts/semantic_cache.py
           python3 -m py_compile scripts/check_workflow_script_refs.py
+          # Phase 4b smoke-test fixture (only run from
+          # test-and-mark-stable.yml; py_compile catches syntax/import
+          # breakage in CI before it lands silently in the release path).
+          python3 -m py_compile tests/test_e2e_editor_smoke_canary.py
 
       - name: Orchestrate lib unit tests
         run: |

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1482,23 +1482,29 @@ jobs:
           model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
           reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'none' }}
 
-      # ── Phase 4b: Verify the editor removed the bait commit ───
-      # Closes the loop on Phase 3c: confirms the reviewer→editor→commit
-      # pipeline actually fired by checking the canary on the post-review
-      # PR head no longer contains the bait marker AND that the editor
-      # pushed at least one commit on top of the bait.
+      # ── Phase 4b: Verify the editor restored the bait commit ──
+      # Confirms the reviewer→editor→commit pipeline actually fired by
+      # running the pytest assertions in tests/test_e2e_editor_smoke_canary.py
+      # against the canary fetched from the post-review PR head. The
+      # test asserts byte-for-byte match to the issue's 3-line spec
+      # (any value mangled, any line added/removed, any bait marker
+      # surviving = test fails).
       #
-      # Soft check (continue-on-error + WARN downgrade in the aggregator):
-      # the autofix editor model is flaky enough that this gate has been
-      # blocking unrelated releases. The diagnostic status (success /
-      # bait_remained / no_editor_commit / fetch_failed) is still emitted
-      # for visibility. Phase 3c's `pr_already_closed` is unaffected and
-      # remains hard-failing — that path signals a test-setup race, not
-      # editor reliability.
-      - name: "Phase 4b: Verify editor removed bait line"
+      # Hard-fail with retry budget: the autofix editor model is
+      # known-flaky (seven prior in-tree fixes targeting reasoning
+      # effort and prompt content; production runs hit empty-completion
+      # state non-deterministically). On first pytest failure we
+      # re-dispatch internal-review.yml against the bait commit and
+      # poll the new run for up to 10 minutes; if the second
+      # verification also fails we hard-fail this step. The retry
+      # absorbs single-shot model flakes without re-introducing the
+      # release-blocking failure mode that drove the soft-check
+      # detour. Phase 3c's `pr_already_closed` path is still
+      # hard-failing on its own (test-setup race, not editor
+      # reliability).
+      - name: "Phase 4b: Verify editor restored canary (pytest + retry)"
         id: verify-bait-removed
         if: steps.inject-bait.outputs.status == 'injected'
-        continue-on-error: true
         env:
           PR_NUMBER: ${{ steps.wait-implement.outputs.pr_number }}
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
@@ -1508,50 +1514,138 @@ jobs:
           set -euo pipefail
           BRANCH="ai/issue-${ISSUE_NUMBER}"
           CANARY_PATH="tests/e2e_smoke_canary.txt"
-          # Reconstruct the issue's exact 3-line target. Phase 3c
-          # corrupts every line of the canary plus adds extras; the
-          # editor must restore EXACTLY this content. The issue body
-          # at line ~347 hardcodes `run_id: ${RUN_ID}` where RUN_ID =
-          # GITHUB_RUN_ID, so the same value works on both sides.
-          EXPECTED=$(printf 'status: ok\nrun_id: %s\nupdated-by: ai-pipeline\n' "${GITHUB_RUN_ID}")
+          # The pytest test reconstructs the issue's exact 3-line target
+          # from E2E_EXPECTED_RUN_ID. Issue body at line ~347 hardcodes
+          # `run_id: ${RUN_ID}` where RUN_ID = GITHUB_RUN_ID, so the
+          # same value works on both sides.
+          export E2E_EXPECTED_RUN_ID="${GITHUB_RUN_ID}"
+          export E2E_CANARY_FILE="${RUNNER_TEMP:-/tmp}/e2e_canary_fetched.txt"
 
-          # Re-fetch canary on the (post-review) PR head.
-          BLOB=$(gh api "repos/${TEST_REPO}/contents/${CANARY_PATH}?ref=${BRANCH}" 2>/dev/null || echo "")
-          if [ -z "${BLOB}" ]; then
+          python3 -m pip install --quiet pytest >/dev/null 2>&1 || {
+            echo "::warning::pip install pytest failed; trying apt fallback"
+            sudo apt-get install -y --no-install-recommends python3-pytest >/dev/null 2>&1 || true
+          }
+
+          fetch_canary_to_tmp() {
+            # NOTE: do NOT use `blob=$(gh api ... || echo "")` — on
+            # non-zero exit, `gh api` writes the error JSON body
+            # (e.g. `{"message":"Not Found",...}`) to stdout, which
+            # would land in $blob as a valid-looking but bogus
+            # response. Capture exit status separately and require
+            # the .content field to be present before returning OK.
+            local blob_path="${RUNNER_TEMP:-/tmp}/e2e_canary_blob.json"
+            : > "${blob_path}"
+            local rc=0
+            gh api "repos/${TEST_REPO}/contents/${CANARY_PATH}?ref=${BRANCH}" \
+              > "${blob_path}" 2>/dev/null || rc=$?
+            if [ "${rc}" -ne 0 ] || [ ! -s "${blob_path}" ]; then
+              return 1
+            fi
+            # Validate response schema before trusting it.
+            local content_b64
+            content_b64=$(jq -r '.content // empty' "${blob_path}")
+            if [ -z "${content_b64}" ]; then
+              return 1
+            fi
+            printf '%s' "${content_b64}" | tr -d '\n' | base64 -d > "${E2E_CANARY_FILE}" 2>/dev/null || return 1
+            return 0
+          }
+
+          run_pytest() {
+            python3 -m pytest tests/test_e2e_editor_smoke_canary.py -v --no-header
+          }
+
+          # ── Attempt 1 ──────────────────────────────────────────────
+          echo "─── Phase 4b attempt 1: fetch + pytest ───"
+          if ! fetch_canary_to_tmp; then
             echo "::error::Could not re-fetch ${CANARY_PATH} after review — branch may be gone"
             echo "status=fetch_failed" >> "$GITHUB_OUTPUT"
             exit 1
           fi
-          DECODED=$(echo "${BLOB}" | jq -r '.content // empty' | tr -d '\n' | base64 -d 2>/dev/null || echo "")
-          if echo "${DECODED}" | grep -qF "${BAIT_MARKER}"; then
-            echo "::error::Editor failed to remove bait marker ${BAIT_MARKER}. Canary contents:"
-            printf '%s\n' "${DECODED}"
-            echo "status=bait_remained" >> "$GITHUB_OUTPUT"
+          if run_pytest; then
+            echo "✓ Canary verification passed on first attempt"
+            # Confirm the editor pushed at least one commit on top of the bait.
+            PR_HEAD=$(gh api "repos/${TEST_REPO}/pulls/${PR_NUMBER}" --jq '.head.sha // ""' 2>/dev/null || echo "")
+            if [ "${PR_HEAD}" = "${BAIT_SHA}" ]; then
+              echo "::error::PR head is still the bait commit — editor did not push a fix commit"
+              echo "status=no_editor_commit" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
+            echo "✓ Editor produced commit(s) past the bait (PR head: ${PR_HEAD:0:7}, bait: ${BAIT_SHA:0:7})"
+            echo "status=success" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::warning::Phase 4b first attempt failed — re-dispatching review_autofix and retrying once"
+
+          # ── Retry: redispatch internal-review.yml on the bait commit ──
+          # Mirrors the Phase 3c fallback dispatch (lines ~1101-1109),
+          # which uses internal-review.yml as the public entry-point that
+          # gates into review_autofix.yml without an `[ai-autofix]` self-
+          # trigger guard.
+          if ! gh workflow run "internal-review.yml" \
+              --repo "${TEST_REPO}" \
+              --ref "${BRANCH}" \
+              -f pr_number="${PR_NUMBER}" >/tmp/retry_dispatch.txt 2>&1; then
+            echo "::error::Retry dispatch failed; cannot recover"
+            cat /tmp/retry_dispatch.txt >&2 || true
+            echo "status=retry_dispatch_failed" >> "$GITHUB_OUTPUT"
             exit 1
           fi
-          if [ "${DECODED}" != "${EXPECTED}" ]; then
-            echo "::error::Canary content does not match the issue's required 3-line spec."
-            echo "Expected:"
-            printf '%s' "${EXPECTED}" | sed 's/^/  /'
-            echo "Actual:"
-            printf '%s' "${DECODED}" | sed 's/^/  /'
+          echo "✓ Retry dispatch sent — polling for the new review run"
+
+          # Poll for the new review run on the bait SHA. Skip the run
+          # we already saw via wait-review by recording its id (if
+          # available) and matching .head_sha + greater-than created_at.
+          PRIOR_REVIEW_RUN="${{ steps.wait-review.outputs.review_run_id }}"
+          DEADLINE=$(( $(date +%s) + 600 ))  # 10 minutes
+          RETRY_RUN_ID=""
+          while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
+            sleep 15
+            CANDIDATES=$(gh api "repos/${TEST_REPO}/actions/workflows/internal-review.yml/runs?event=workflow_dispatch&per_page=10" \
+              --jq ".workflow_runs[] | select(.head_sha == \"${BAIT_SHA}\") | select(.id != ${PRIOR_REVIEW_RUN:-0}) | \"\(.id) \(.status) \(.conclusion // \"null\")\"" 2>/dev/null || echo "")
+            if [ -z "${CANDIDATES}" ]; then
+              echo "  (no new review run yet)"
+              continue
+            fi
+            # Pick the latest candidate id
+            RETRY_RUN_ID=$(echo "${CANDIDATES}" | tail -n 1 | awk '{print $1}')
+            RETRY_STATUS=$(echo "${CANDIDATES}" | tail -n 1 | awk '{print $2}')
+            RETRY_CONCL=$(echo "${CANDIDATES}" | tail -n 1 | awk '{print $3}')
+            echo "  retry run #${RETRY_RUN_ID}: status=${RETRY_STATUS} conclusion=${RETRY_CONCL}"
+            if [ "${RETRY_STATUS}" = "completed" ]; then
+              break
+            fi
+          done
+
+          if [ -z "${RETRY_RUN_ID}" ] || [ "${RETRY_STATUS:-}" != "completed" ]; then
+            echo "::error::Retry review run did not complete within 10 minutes"
+            echo "status=retry_timeout" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          # ── Attempt 2 ──────────────────────────────────────────────
+          echo "─── Phase 4b attempt 2: re-fetch + pytest after retry ───"
+          if ! fetch_canary_to_tmp; then
+            echo "::error::Could not re-fetch ${CANARY_PATH} after retry"
+            echo "status=fetch_failed_after_retry" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          if ! run_pytest; then
+            echo "::error::Canary verification still failed after retry — editor is broken or model fully unavailable"
             echo "status=spec_mismatch" >> "$GITHUB_OUTPUT"
             exit 1
           fi
-          echo "✓ Canary restored to the issue's exact 3-line spec"
+          echo "✓ Canary verification passed on retry"
 
-          # Confirm the editor pushed at least one commit on top of the bait.
-          COMMITS_AFTER=$(gh api "repos/${TEST_REPO}/commits?sha=${BRANCH}&per_page=20" \
-            --jq "[.[] | select(.sha != \"${BAIT_SHA}\") | .sha] | length" 2>/dev/null || echo "0")
-          # The PR head SHA should differ from the bait SHA.
           PR_HEAD=$(gh api "repos/${TEST_REPO}/pulls/${PR_NUMBER}" --jq '.head.sha // ""' 2>/dev/null || echo "")
           if [ "${PR_HEAD}" = "${BAIT_SHA}" ]; then
-            echo "::error::PR head is still the bait commit — editor did not push a fix commit"
+            echo "::error::PR head is still the bait commit after retry — editor did not push a fix commit"
             echo "status=no_editor_commit" >> "$GITHUB_OUTPUT"
             exit 1
           fi
-          echo "✓ Editor produced commit(s) past the bait (PR head: ${PR_HEAD:0:7}, bait: ${BAIT_SHA:0:7})"
-          echo "status=success" >> "$GITHUB_OUTPUT"
+          echo "✓ Editor produced commit(s) past the bait on retry (PR head: ${PR_HEAD:0:7}, bait: ${BAIT_SHA:0:7})"
+          echo "status=success_after_retry" >> "$GITHUB_OUTPUT"
 
       # ── Phase 5: Orchestrator script integration test ──────────
       - name: Checkout repository for integration tests
@@ -2404,12 +2498,18 @@ jobs:
             echo "  ✗ Editor Bait. FAILED (pr_already_closed) — PR was merged/closed before bait injection; editor never invoked. See Phase 3c log."
             PASSED=false
           elif [ "$BAIT_VERIFIED" = "success" ]; then
-            echo "  ✓ Editor Bait. PASSED (editor removed bait + pushed fix commit)"
+            echo "  ✓ Editor Bait. PASSED (editor restored canary + pushed fix commit)"
+          elif [ "$BAIT_VERIFIED" = "success_after_retry" ]; then
+            echo "  ✓ Editor Bait. PASSED on retry (editor restored canary after one re-dispatch — see Phase 4b log)"
           else
-            # Soft check: editor-side failures (bait_remained,
-            # no_editor_commit, fetch_failed) do not block release —
-            # see Phase 4b's comment for the rationale.
-            echo "  ⚠ Editor Bait. WARN (${BAIT_VERIFIED:-not_run}) — editor pipeline did not exercise correctly (soft check; non-blocking — see Phase 4b log)"
+            # Hard-fail: pytest verification (Phase 4b) failed both on
+            # the first attempt AND after a one-shot review_autofix
+            # re-dispatch. This is consistent with a real production
+            # regression (Serena/MCP breakage, prompt drift, parser bug)
+            # rather than a single-shot model flake — those get absorbed
+            # by the retry budget.
+            echo "  ✗ Editor Bait. FAILED (${BAIT_VERIFIED:-not_run}) — editor pipeline did not exercise correctly even after retry"
+            PASSED=false
           fi
 
           # Check orchestrator scripts (Phase 5)

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -381,20 +381,27 @@ jobs:
             echo "::error::Canary spec template missing at ${SPEC_TEMPLATE_PATH}"
             exit 1
           fi
-          # Substitute RUN_ID and strip any trailing newline so it doesn't
-          # double-up inside the markdown fenced block below.
-          SPEC_BLOCK=$(sed "s/__RUN_ID__/${RUN_ID}/g" "${SPEC_TEMPLATE_PATH}")
+          # Substitute RUN_ID. Use the trailing-newline-preserving
+          # sentinel trick around `$(...)` because command substitution
+          # otherwise strips ALL trailing newlines, which would render
+          # the issue body's fenced code block one line shorter than
+          # the byte-for-byte spec the pytest verifier asserts. The
+          # `; echo X` appends a sentinel char so the trailing `\n`
+          # from the spec template survives, and `${var%X}` strips it
+          # back off — net result: SPEC_BLOCK ends in `\n` exactly as
+          # the template does.
+          SPEC_BLOCK=$(sed "s|__RUN_ID__|${RUN_ID}|g" "${SPEC_TEMPLATE_PATH}"; echo X)
+          SPEC_BLOCK="${SPEC_BLOCK%X}"
           # Build a single-line printf-quoted form for the example shell
           # command later in the body (newlines as literal `\n`).
           SPEC_PRINTF=$(printf '%s' "${SPEC_BLOCK}" | awk 'BEGIN{ORS="\\n"}1' | sed 's/\\n$//')
 
           BODY="## Task
 
-          The file \`tests/e2e_smoke_canary.txt\` already exists in the repository. Update its content so it is **exactly** these three lines (no more, no less):
+          The file \`tests/e2e_smoke_canary.txt\` already exists in the repository. Update its content so it is **exactly** these three lines (no more, no less, with a trailing newline after the final line per POSIX file convention):
 
           \`\`\`text
-          ${SPEC_BLOCK}
-          \`\`\`
+          ${SPEC_BLOCK}\`\`\`
 
           ## How to do it
 
@@ -1552,6 +1559,28 @@ jobs:
       # detour. Phase 3c's `pr_already_closed` path is still
       # hard-failing on its own (test-setup race, not editor
       # reliability).
+      #
+      # Status outputs (echoed into $GITHUB_OUTPUT, consumed by the
+      # aggregator below):
+      #   success                  — first attempt passed
+      #   success_after_retry      — passed after one re-dispatch
+      #   spec_mismatch            — pytest FAILED after retry (real editor bug)
+      #   harness_misconfigured    — pytest fixture/INTERNALERROR (workflow / runner / template
+      #                              issue, not editor)
+      #   no_editor_commit         — canary content correct but PR head still equals BAIT_SHA
+      #   fetch_failed             — Contents API couldn't return the canary on first attempt
+      #   fetch_failed_after_retry — same, after retry
+      #   pytest_unavailable       — pip + apt fallback both failed (infra error)
+      #   pr_head_fetch_failed     — pulls/<n> API failed; refused to fail-open commit guard
+      #   retry_dispatch_failed    — gh workflow run failed, or wait-review id non-numeric
+      #   retry_timeout            — re-dispatched run did not complete in 10 min
+      #   retry_workflow_failed    — retry run completed but conclusion != success
+      #   pr_closed_during_retry   — PR closed/merged while waiting for the retry run
+      #   pr_state_check_failed    — fetch_pr_state returned "unknown" 4 consecutive times
+      #                              (~60s of GitHub API outage); poll loop bails to avoid
+      #                              burning the full 10-min retry window
+      # Aggregator hard-fails on anything except success / success_after_retry. Phase 3c's
+      # pr_already_closed (test-setup race) is hard-failed in the aggregator separately.
       #
       # Gate on wait-review's status: if the review pipeline didn't
       # complete cleanly upstream, retrying it from here would burn

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1495,17 +1495,30 @@ jobs:
       # known-flaky (seven prior in-tree fixes targeting reasoning
       # effort and prompt content; production runs hit empty-completion
       # state non-deterministically). On first pytest failure we
-      # re-dispatch internal-review.yml against the bait commit and
-      # poll the new run for up to 10 minutes; if the second
-      # verification also fails we hard-fail this step. The retry
+      # snapshot the branch head SHA, re-dispatch internal-review.yml
+      # via `--ref "${BRANCH}"`, and poll for a new workflow_dispatch
+      # run whose head_sha matches the snapshotted SHA. We allow up
+      # to 10 minutes for the new run to complete; if the second
+      # verification also fails, we hard-fail this step. The retry
       # absorbs single-shot model flakes without re-introducing the
       # release-blocking failure mode that drove the soft-check
       # detour. Phase 3c's `pr_already_closed` path is still
       # hard-failing on its own (test-setup race, not editor
       # reliability).
+      #
+      # Gate on wait-review's status: if the review pipeline didn't
+      # complete cleanly upstream, retrying it from here would burn
+      # the 10-min retry window on a known-broken state. Skip Phase 4b
+      # in that case — the aggregator already counts the review
+      # failure, and the skipped status is treated non-blocking
+      # ("review didn't complete") instead of double-counting it as
+      # an editor failure.
       - name: "Phase 4b: Verify editor restored canary (pytest + retry)"
         id: verify-bait-removed
-        if: steps.inject-bait.outputs.status == 'injected'
+        if: |
+          steps.inject-bait.outputs.status == 'injected' &&
+          (steps.wait-review.outputs.status == 'success' ||
+           steps.wait-review.outputs.status == 'completed_with_findings')
         env:
           PR_NUMBER: ${{ steps.wait-implement.outputs.pr_number }}
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
@@ -2661,6 +2674,10 @@ jobs:
           # Check editor bait removal (Phase 4b)
           BAIT_INJECTED="${{ steps.inject-bait.outputs.status }}"
           BAIT_VERIFIED="${{ steps.verify-bait-removed.outputs.status }}"
+          REVIEW_OK=false
+          if [ "$REVIEW" = "success" ] || [ "$REVIEW" = "completed_with_findings" ]; then
+            REVIEW_OK=true
+          fi
           if [ "$BAIT_INJECTED" = "skipped" ]; then
             echo "  - Editor Bait. SKIPPED (could not inject — non-blocking)"
           elif [ "$BAIT_INJECTED" = "pr_already_closed" ]; then
@@ -2671,6 +2688,13 @@ jobs:
             # to run because the test setup itself was sabotaged.
             echo "  ✗ Editor Bait. FAILED (pr_already_closed) — PR was merged/closed before bait injection; editor never invoked. See Phase 3c log."
             PASSED=false
+          elif [ -z "$BAIT_VERIFIED" ] && [ "$REVIEW_OK" != true ]; then
+            # Phase 4b is gated on wait-review succeeding; if Review
+            # didn't complete cleanly, Phase 4b was skipped on
+            # purpose (no point retry-polling a known-broken state).
+            # The Review FAILED line above already counts that
+            # failure — don't double-count it as an editor bug.
+            echo "  - Editor Bait. SKIPPED (review didn't complete — see Review row above)"
           elif [ "$BAIT_VERIFIED" = "success" ]; then
             echo "  ✓ Editor Bait. PASSED (editor restored canary + pushed fix commit)"
           elif [ "$BAIT_VERIFIED" = "success_after_retry" ]; then

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -348,10 +348,12 @@ jobs:
           # `gh workflow run` / Actions API as a positional. If the
           # value starts with `-` (e.g. `--help`), gh would treat it
           # as a flag; if it contains `/` or other unexpected chars,
-          # the API path can break. Lock it down to a basename
-          # matching `<safe>.yml` and reject anything else early.
-          if ! printf '%s' "${REVIEW_WORKFLOW_FILE}" | grep -qE '^[A-Za-z0-9_.-]+\.yml$'; then
-            echo "::error::REVIEW_WORKFLOW_FILE='${REVIEW_WORKFLOW_FILE}' is not a safe basename matching ^[A-Za-z0-9_.-]+\\.yml\$ — refusing to proceed"
+          # the API path can break. Require a leading alphanumeric
+          # character so degenerate basenames like `.yml`, `..yml`,
+          # `-x.yml` are rejected at validation time instead of
+          # later at dispatch.
+          if ! printf '%s' "${REVIEW_WORKFLOW_FILE}" | grep -qE '^[A-Za-z0-9][A-Za-z0-9_.-]*\.yml$'; then
+            echo "::error::REVIEW_WORKFLOW_FILE='${REVIEW_WORKFLOW_FILE}' is not a safe basename matching ^[A-Za-z0-9][A-Za-z0-9_.-]*\\.yml\$ — refusing to proceed"
             exit 1
           fi
           # Verify we can access the repo
@@ -1567,7 +1569,6 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.wait-implement.outputs.pr_number }}
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
-          BAIT_MARKER: ${{ steps.inject-bait.outputs.marker }}
           BAIT_SHA: ${{ steps.inject-bait.outputs.bait_sha }}
         run: |
           set -euo pipefail
@@ -1842,6 +1843,13 @@ jobs:
           RETRY_RUN_ID=""
           RETRY_STATUS=""
           RETRY_CONCL=""
+          # Circuit breaker: if fetch_pr_state returns "unknown" (API
+          # failure / parse failure) for too many consecutive iterations
+          # we're effectively polling blind and the closed-PR guard
+          # above is inactive. Bail out instead of burning the full
+          # 10-min retry window during a GitHub outage.
+          PR_STATE_FAILURES=0
+          PR_STATE_FAILURE_LIMIT=4  # ~60s of consecutive unknowns
           while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
             sleep 15
             # Bail out if the PR closed/merged during the wait — no
@@ -1852,6 +1860,18 @@ jobs:
               echo "::error::PR #${PR_NUMBER} closed during retry wait — abandoning retry"
               echo "status=pr_closed_during_retry" >> "$GITHUB_OUTPUT"
               exit 1
+            fi
+            if [ "${PR_STATE}" = "unknown" ]; then
+              PR_STATE_FAILURES=$((PR_STATE_FAILURES + 1))
+              if [ "${PR_STATE_FAILURES}" -ge "${PR_STATE_FAILURE_LIMIT}" ]; then
+                echo "::error::PR state unresolvable after ${PR_STATE_FAILURES} consecutive attempts (likely GitHub API outage) — bailing out instead of burning the full retry window"
+                echo "status=pr_state_check_failed" >> "$GITHUB_OUTPUT"
+                exit 1
+              fi
+            else
+              # Reset on any successful resolve so we only bail on
+              # *consecutive* failures, not cumulative.
+              PR_STATE_FAILURES=0
             fi
             CANDIDATES=$(gh_api_with_retry \
               "repos/${TEST_REPO}/actions/workflows/${REVIEW_WORKFLOW_FILE}/runs?event=workflow_dispatch&per_page=10" \

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1740,7 +1740,8 @@ jobs:
           fi
           echo "✓ Retry dispatch sent on ${BRANCH} (head ${RETRY_DISPATCH_SHA:0:7}) — polling for the new review run"
 
-          # Poll for the new review run on the bait SHA. Skip the run
+          # Poll for the new review run on RETRY_DISPATCH_SHA (the
+          # branch head we snapshotted at dispatch time). Skip the run
           # we already saw via wait-review by recording its id.
           PRIOR_REVIEW_RUN="${{ steps.wait-review.outputs.review_run_id }}"
           DEADLINE=$(( $(date +%s) + 600 ))  # 10 minutes

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1520,11 +1520,24 @@ jobs:
           # same value works on both sides.
           export E2E_EXPECTED_RUN_ID="${GITHUB_RUN_ID}"
           export E2E_CANARY_FILE="${RUNNER_TEMP:-/tmp}/e2e_canary_fetched.txt"
+          # Sentinel telling the test fixture this is the production
+          # invocation: missing canary env vars must fail loudly here
+          # (a configuration bug), not skip silently.
+          export E2E_PHASE_4B_INVOKED=1
 
           python3 -m pip install --quiet pytest >/dev/null 2>&1 || {
             echo "::warning::pip install pytest failed; trying apt fallback"
             sudo apt-get install -y --no-install-recommends python3-pytest >/dev/null 2>&1 || true
           }
+          # Verify pytest is actually importable. Without this, a
+          # double-failure in pip+apt would later surface as a
+          # ModuleNotFoundError that looks like a test/spec mismatch
+          # rather than the infrastructure error it is.
+          if ! python3 -c "import pytest" 2>/dev/null; then
+            echo "::error::pytest is not importable after pip + apt install attempts; cannot verify canary"
+            echo "status=pytest_unavailable" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
 
           fetch_canary_to_tmp() {
             # NOTE: do NOT use `blob=$(gh api ... || echo "")` — on
@@ -1551,6 +1564,30 @@ jobs:
             return 0
           }
 
+          # Fetch PR head SHA with the same fail-loud discipline as
+          # fetch_canary_to_tmp. Echoes the SHA on stdout, returns rc=0
+          # on success and rc=1 on any API/parse failure — callers MUST
+          # check rc and treat empty as "infrastructure error", not as
+          # "head differs from bait" (the original `|| echo ""` form
+          # silently fail-opened the no_editor_commit guard).
+          fetch_pr_head_sha() {
+            local resp_path="${RUNNER_TEMP:-/tmp}/e2e_pr_head_resp.json"
+            : > "${resp_path}"
+            local rc=0
+            gh api "repos/${TEST_REPO}/pulls/${PR_NUMBER}" \
+              > "${resp_path}" 2>/dev/null || rc=$?
+            if [ "${rc}" -ne 0 ] || [ ! -s "${resp_path}" ]; then
+              return 1
+            fi
+            local sha
+            sha=$(jq -r '.head.sha // empty' "${resp_path}")
+            if [ -z "${sha}" ]; then
+              return 1
+            fi
+            printf '%s' "${sha}"
+            return 0
+          }
+
           run_pytest() {
             python3 -m pytest tests/test_e2e_editor_smoke_canary.py -v --no-header
           }
@@ -1565,7 +1602,11 @@ jobs:
           if run_pytest; then
             echo "✓ Canary verification passed on first attempt"
             # Confirm the editor pushed at least one commit on top of the bait.
-            PR_HEAD=$(gh api "repos/${TEST_REPO}/pulls/${PR_NUMBER}" --jq '.head.sha // ""' 2>/dev/null || echo "")
+            if ! PR_HEAD=$(fetch_pr_head_sha); then
+              echo "::error::Could not fetch PR head SHA to verify editor commit; treating as infra failure (refusing to fail-open the no_editor_commit guard)"
+              echo "status=pr_head_fetch_failed" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
             if [ "${PR_HEAD}" = "${BAIT_SHA}" ]; then
               echo "::error::PR head is still the bait commit — editor did not push a fix commit"
               echo "status=no_editor_commit" >> "$GITHUB_OUTPUT"
@@ -1594,24 +1635,42 @@ jobs:
           fi
           echo "✓ Retry dispatch sent — polling for the new review run"
 
+          # gh api wrapper with a small retry budget so a transient
+          # 429/5xx during the 10min poll window doesn't cause a
+          # spurious retry_timeout.
+          gh_api_with_retry() {
+            local out
+            local rc
+            for try in 1 2 3; do
+              out=$(gh api "$@" 2>/dev/null) && { printf '%s' "${out}"; return 0; }
+              rc=$?
+              [ "${try}" -lt 3 ] && sleep $((try * 2))
+            done
+            return "${rc}"
+          }
+
           # Poll for the new review run on the bait SHA. Skip the run
-          # we already saw via wait-review by recording its id (if
-          # available) and matching .head_sha + greater-than created_at.
+          # we already saw via wait-review by recording its id.
           PRIOR_REVIEW_RUN="${{ steps.wait-review.outputs.review_run_id }}"
           DEADLINE=$(( $(date +%s) + 600 ))  # 10 minutes
           RETRY_RUN_ID=""
+          RETRY_STATUS=""
+          RETRY_CONCL=""
           while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
             sleep 15
-            CANDIDATES=$(gh api "repos/${TEST_REPO}/actions/workflows/internal-review.yml/runs?event=workflow_dispatch&per_page=10" \
-              --jq ".workflow_runs[] | select(.head_sha == \"${BAIT_SHA}\") | select(.id != ${PRIOR_REVIEW_RUN:-0}) | \"\(.id) \(.status) \(.conclusion // \"null\")\"" 2>/dev/null || echo "")
+            CANDIDATES=$(gh_api_with_retry \
+              "repos/${TEST_REPO}/actions/workflows/internal-review.yml/runs?event=workflow_dispatch&per_page=10" \
+              --jq ".workflow_runs[] | select(.head_sha == \"${BAIT_SHA}\") | select(.id != ${PRIOR_REVIEW_RUN:-0}) | \"\(.id) \(.status) \(.conclusion // \"null\")\"") || CANDIDATES=""
             if [ -z "${CANDIDATES}" ]; then
               echo "  (no new review run yet)"
               continue
             fi
-            # Pick the latest candidate id
-            RETRY_RUN_ID=$(echo "${CANDIDATES}" | tail -n 1 | awk '{print $1}')
-            RETRY_STATUS=$(echo "${CANDIDATES}" | tail -n 1 | awk '{print $2}')
-            RETRY_CONCL=$(echo "${CANDIDATES}" | tail -n 1 | awk '{print $3}')
+            # GitHub returns runs newest-first; the matching list is in
+            # the same order so head -n 1 picks the most recent
+            # candidate (the run we just dispatched).
+            RETRY_RUN_ID=$(echo "${CANDIDATES}" | head -n 1 | awk '{print $1}')
+            RETRY_STATUS=$(echo "${CANDIDATES}" | head -n 1 | awk '{print $2}')
+            RETRY_CONCL=$(echo "${CANDIDATES}" | head -n 1 | awk '{print $3}')
             echo "  retry run #${RETRY_RUN_ID}: status=${RETRY_STATUS} conclusion=${RETRY_CONCL}"
             if [ "${RETRY_STATUS}" = "completed" ]; then
               break
@@ -1638,7 +1697,11 @@ jobs:
           fi
           echo "✓ Canary verification passed on retry"
 
-          PR_HEAD=$(gh api "repos/${TEST_REPO}/pulls/${PR_NUMBER}" --jq '.head.sha // ""' 2>/dev/null || echo "")
+          if ! PR_HEAD=$(fetch_pr_head_sha); then
+            echo "::error::Could not fetch PR head SHA after retry; treating as infra failure"
+            echo "status=pr_head_fetch_failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
           if [ "${PR_HEAD}" = "${BAIT_SHA}" ]; then
             echo "::error::PR head is still the bait commit after retry — editor did not push a fix commit"
             echo "status=no_editor_commit" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -369,14 +369,29 @@ jobs:
 
           TITLE="[E2E Smoke Test] Update smoke-test canary (run ${RUN_ID})"
 
+          # Single source of truth for the canary spec lives in
+          # tests/e2e_smoke_canary_spec.txt with `__RUN_ID__` as the
+          # placeholder. Phase 4b's pytest reads the same file and
+          # substitutes the same way, so the issue body and the
+          # downstream byte-for-byte assertion can never drift.
+          SPEC_TEMPLATE_PATH="tests/e2e_smoke_canary_spec.txt"
+          if [ ! -f "${SPEC_TEMPLATE_PATH}" ]; then
+            echo "::error::Canary spec template missing at ${SPEC_TEMPLATE_PATH}"
+            exit 1
+          fi
+          # Substitute RUN_ID and strip any trailing newline so it doesn't
+          # double-up inside the markdown fenced block below.
+          SPEC_BLOCK=$(sed "s/__RUN_ID__/${RUN_ID}/g" "${SPEC_TEMPLATE_PATH}")
+          # Build a single-line printf-quoted form for the example shell
+          # command later in the body (newlines as literal `\n`).
+          SPEC_PRINTF=$(printf '%s' "${SPEC_BLOCK}" | awk 'BEGIN{ORS="\\n"}1' | sed 's/\\n$//')
+
           BODY="## Task
 
           The file \`tests/e2e_smoke_canary.txt\` already exists in the repository. Update its content so it is **exactly** these three lines (no more, no less):
 
           \`\`\`text
-          status: ok
-          run_id: ${RUN_ID}
-          updated-by: ai-pipeline
+          ${SPEC_BLOCK}
           \`\`\`
 
           ## How to do it
@@ -384,7 +399,7 @@ jobs:
           Overwrite the entire file. For example, the equivalent shell command would be:
 
           \`\`\`bash
-          printf 'status: ok\nrun_id: ${RUN_ID}\nupdated-by: ai-pipeline\n' > tests/e2e_smoke_canary.txt
+          printf '${SPEC_PRINTF}\n' > tests/e2e_smoke_canary.txt
           \`\`\`
 
           ## Constraints
@@ -1595,15 +1610,20 @@ jobs:
           # by every gh api call in this step (fetch helpers + poll
           # loop) so any single API blip gets up to 3 attempts with
           # 2s/4s backoff before being treated as terminal. On final
-          # failure the last attempt's stderr is surfaced as a warning
-          # so triage isn't blind to the underlying API error.
+          # failure ALL attempts' stderr is surfaced (not just the
+          # last) so triage can spot patterns like "first 2 were
+          # rate-limited then 3rd was 5xx".
           gh_api_with_retry() {
             local out
             local rc=0
             local err_file
             err_file="$(mktemp)"
             for try in 1 2 3; do
-              out=$(gh api "$@" 2>"${err_file}") && {
+              # Tag each attempt's stderr so they're distinguishable
+              # in the final warning and append (>>) — overwriting
+              # would lose earlier diagnostics.
+              echo "--- attempt ${try} stderr ---" >> "${err_file}"
+              out=$(gh api "$@" 2>>"${err_file}") && {
                 rm -f "${err_file}"
                 printf '%s' "${out}"
                 return 0
@@ -1612,7 +1632,7 @@ jobs:
               [ "${try}" -lt 3 ] && sleep $((try * 2))
             done
             if [ -s "${err_file}" ]; then
-              echo "::warning::gh api failed after 3 attempts (rc=${rc}): $(tr '\n' ' ' < "${err_file}" | head -c 500)" >&2
+              echo "::warning::gh api failed after 3 attempts (rc=${rc}): $(tr '\n' ' ' < "${err_file}" | head -c 1000)" >&2
             fi
             rm -f "${err_file}"
             return "${rc}"
@@ -1716,7 +1736,14 @@ jobs:
           # UsageError, and similar infra failures that should NOT
           # blame the editor.
           classify_pytest_failure() {
-            if grep -qE "INTERNALERROR" "${PYTEST_OUTPUT}" 2>/dev/null; then
+            # Case-insensitive INTERNALERROR (-i) for forward-compat
+            # against pytest output-format tweaks. ^FAILED  stays
+            # case-sensitive — pytest's short-summary prefix is
+            # documented as uppercase and matching it case-insensitively
+            # would risk false positives on user-controlled error
+            # message bodies that happen to contain "failed " at line
+            # start.
+            if grep -qiE "INTERNALERROR" "${PYTEST_OUTPUT}" 2>/dev/null; then
               echo "harness_misconfigured"
             elif grep -qE "^FAILED " "${PYTEST_OUTPUT}" 2>/dev/null; then
               echo "spec_mismatch"

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -57,6 +57,16 @@ name: Test & Mark Stable Release
         required: false
         type: number
         default: 30
+      review_workflow_file:
+        description: >
+          Filename (under .github/workflows/ in TEST_REPO) of the
+          review-autofix wrapper that the smoke gate dispatches and
+          polls. Defaults to `internal-review.yml`, the source repo's
+          template. Override only when smoke-testing against a
+          consumer repo that renamed the wrapper.
+        required: false
+        type: string
+        default: "internal-review.yml"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -300,6 +310,12 @@ jobs:
       PHASE_TIMEOUT: ${{ inputs.phase_timeout || 30 }}
       REVIEW_TIMEOUT: ${{ inputs.review_timeout || inputs.phase_timeout || 30 }}
       POLL_INTERVAL: 10
+      # Wrapper-workflow filename used by the smoke gate to dispatch
+      # / poll review_autofix runs. Defaults to the source repo's
+      # `internal-review.yml`; override at workflow_dispatch time
+      # (input below) when smoke-testing against a TEST_REPO that
+      # uses a different wrapper filename.
+      REVIEW_WORKFLOW_FILE: ${{ inputs.review_workflow_file || 'internal-review.yml' }}
 
     steps:
       # Checkout repo at the start so `if: always()` steps (per-phase
@@ -1098,13 +1114,13 @@ jobs:
           # itself, per the early checkout at line 316) instead of the
           # repo we just pushed the bait commit to, leaving Phase 4
           # still vulnerable to no_review_triggered.
-          if gh workflow run "internal-review.yml" \
+          if gh workflow run "${REVIEW_WORKFLOW_FILE}" \
               --repo "${TEST_REPO}" \
               --ref "${BRANCH}" \
               -f pr_number="${PR_NUMBER}" >/tmp/dispatch_resp.txt 2>&1; then
-            echo "✓ Dispatched internal-review.yml on ${BRANCH} for PR #${PR_NUMBER} (Bug B fallback)"
+            echo "✓ Dispatched ${REVIEW_WORKFLOW_FILE} on ${BRANCH} for PR #${PR_NUMBER} (Bug B fallback)"
           else
-            echo "::warning::Could not dispatch internal-review.yml as Bug B fallback; relying on pull_request:synchronize event only"
+            echo "::warning::Could not dispatch ${REVIEW_WORKFLOW_FILE} as Bug B fallback; relying on pull_request:synchronize event only"
             cat /tmp/dispatch_resp.txt >&2 || true
           fi
 
@@ -1742,7 +1758,7 @@ jobs:
           fi
           echo "  resolved ${BRANCH} head for retry dispatch: ${RETRY_DISPATCH_SHA:0:7}"
 
-          if ! gh workflow run "internal-review.yml" \
+          if ! gh workflow run "${REVIEW_WORKFLOW_FILE}" \
               --repo "${TEST_REPO}" \
               --ref "${BRANCH}" \
               -f pr_number="${PR_NUMBER}" >/tmp/retry_dispatch.txt 2>&1; then
@@ -1773,7 +1789,7 @@ jobs:
               exit 1
             fi
             CANDIDATES=$(gh_api_with_retry \
-              "repos/${TEST_REPO}/actions/workflows/internal-review.yml/runs?event=workflow_dispatch&per_page=10" \
+              "repos/${TEST_REPO}/actions/workflows/${REVIEW_WORKFLOW_FILE}/runs?event=workflow_dispatch&per_page=10" \
               --jq ".workflow_runs[] | select(.head_sha == \"${RETRY_DISPATCH_SHA}\") | select(.id != ${PRIOR_REVIEW_RUN:-0}) | \"\(.id) \(.status) \(.conclusion // \"null\")\"") || CANDIDATES=""
             if [ -z "${CANDIDATES}" ]; then
               echo "  (no new review run yet, pr_state=${PR_STATE})"
@@ -1794,6 +1810,18 @@ jobs:
           if [ -z "${RETRY_RUN_ID}" ] || [ "${RETRY_STATUS:-}" != "completed" ]; then
             echo "::error::Retry review run did not complete within 10 minutes"
             echo "status=retry_timeout" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          # Validate the retry run's conclusion. If review_autofix
+          # itself errored (failure / cancelled / timed_out), running
+          # attempt-2 pytest against the resulting unchanged canary
+          # would surface as spec_mismatch and falsely blame the
+          # editor model. Report retry_workflow_failed so operators
+          # look at the retry run's logs, not the editor.
+          if [ "${RETRY_CONCL}" != "success" ]; then
+            echo "::error::Retry review run #${RETRY_RUN_ID} completed with conclusion=${RETRY_CONCL} (not 'success'); refusing to attribute the resulting canary state to the editor"
+            echo "status=retry_workflow_failed" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -352,7 +352,13 @@ jobs:
           # character so degenerate basenames like `.yml`, `..yml`,
           # `-x.yml` are rejected at validation time instead of
           # later at dispatch.
-          if ! printf '%s' "${REVIEW_WORKFLOW_FILE}" | grep -qE '^[A-Za-z0-9][A-Za-z0-9_.-]*\.yml$'; then
+          #
+          # Use bash's `[[ =~ ]]` rather than `printf | grep -qE` so
+          # the match anchors against the WHOLE variable value
+          # (including any embedded newlines), not just the first
+          # line. The hyphen sits at the end of the character class
+          # so it's literal under POSIX ERE.
+          if ! [[ "${REVIEW_WORKFLOW_FILE}" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*\.yml$ ]]; then
             echo "::error::REVIEW_WORKFLOW_FILE='${REVIEW_WORKFLOW_FILE}' is not a safe basename matching ^[A-Za-z0-9][A-Za-z0-9_.-]*\\.yml\$ — refusing to proceed"
             exit 1
           fi
@@ -1010,7 +1016,6 @@ jobs:
             PR_CLOSED_AT=$(printf '%s' "${PR_META}" | jq -r '.closed_at // ""' 2>/dev/null || echo "")
             echo "::error::PR #${PR_NUMBER} is already ${PR_STATE} (merged=${PR_MERGED}, merged_at=${PR_MERGED_AT}, closed_at=${PR_CLOSED_AT}) before bait could be injected — pushes to the head branch will not fan out a pull_request synchronize event, so no review_autofix run will be triggered. Likely cause: review_autofix.yml's deterministic-skip-merge job auto-merged the PR before the e2e gate's force-review/e2e-smoke-test labels took effect (see implement.yml steps 'Ensure E2E smoke-test labels exist on repo' / 'Backstop E2E smoke-test labels on PR after creation' and review_autofix.yml 'Enable auto-merge on PR' step's e2e-smoke-test guard)."
             echo "status=pr_already_closed" >> "$GITHUB_OUTPUT"
-            echo "marker=${BAIT_MARKER}" >> "$GITHUB_OUTPUT"
             # Fail fast. Phase 4 (wait-review), Phase 4b (verify-bait-
             # removed), Phase 5 (orchestrator-scripts), Phase 6
             # (review-blocked sim) and Phase 7 (cancel_on_pr_close)
@@ -1040,7 +1045,6 @@ jobs:
           if [ -z "${BLOB_JSON}" ] || [ "${BLOB_JSON}" = "null" ]; then
             echo "::warning::Could not fetch ${CANARY_PATH} from branch ${BRANCH} — skipping bait injection (editor exercise not enforced this run)"
             echo "status=skipped" >> "$GITHUB_OUTPUT"
-            echo "marker=${BAIT_MARKER}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -1049,7 +1053,6 @@ jobs:
           if [ -z "${BLOB_SHA}" ]; then
             echo "::warning::Canary blob has no SHA — skipping bait injection"
             echo "status=skipped" >> "$GITHUB_OUTPUT"
-            echo "marker=${BAIT_MARKER}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -1094,7 +1097,6 @@ jobs:
             echo "::warning::Bait commit failed; editor exercise will not be enforced"
             cat /tmp/bait_resp.json >&2 || true
             echo "status=skipped" >> "$GITHUB_OUTPUT"
-            echo "marker=${BAIT_MARKER}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -1102,7 +1104,6 @@ jobs:
           if [ -z "${BAIT_SHA}" ]; then
             echo "::warning::Bait commit response missing SHA"
             echo "status=skipped" >> "$GITHUB_OUTPUT"
-            echo "marker=${BAIT_MARKER}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -1119,7 +1120,6 @@ jobs:
           jq '{commit_sha: .commit.sha, commit_url: .commit.html_url, author: .commit.author.name, committer: .commit.committer.name, verification: .commit.verification.verified, content_url: .content.html_url} | with_entries(select(.value != null))' /tmp/bait_resp.json 2>/dev/null \
             || echo "  (could not parse bait_resp.json)"
           echo "status=injected" >> "$GITHUB_OUTPUT"
-          echo "marker=${BAIT_MARKER}" >> "$GITHUB_OUTPUT"
           echo "bait_sha=${BAIT_SHA}" >> "$GITHUB_OUTPUT"
 
           # Defense-in-depth for "Bug B" (PR #1811): the Contents-API PUT
@@ -1615,15 +1615,23 @@ jobs:
           export E2E_PHASE_4B_INVOKED=1
           PYTEST_OUTPUT="${RUNNER_TEMP:-/tmp}/e2e_pytest_output.txt"
 
-          python3 -m pip install --quiet pytest >/dev/null 2>&1 || {
+          # Capture pip + apt diagnostics into a tmp file so a failed
+          # install isn't silently lost. If the import probe below
+          # fails, we surface the captured log alongside the error
+          # so operators triaging pytest_unavailable can see the root
+          # cause (network error, missing package, permission, etc.)
+          # without re-running the workflow with verbose flags.
+          PYTEST_INSTALL_LOG="${RUNNER_TEMP:-/tmp}/e2e_pytest_install.log"
+          : > "${PYTEST_INSTALL_LOG}"
+          python3 -m pip install --quiet pytest >>"${PYTEST_INSTALL_LOG}" 2>&1 || {
             echo "::warning::pip install pytest failed; trying apt fallback"
             # Refresh package indexes before the apt install — without
             # this a stale index on a long-running runner image can
             # surface as a spurious pytest_unavailable. Other workflows
             # in this repo (review_autofix.yml) precede their apt-get
             # installs the same way.
-            sudo apt-get update -qq >/dev/null 2>&1 || true
-            sudo apt-get install -y --no-install-recommends python3-pytest >/dev/null 2>&1 || true
+            sudo apt-get update -qq >>"${PYTEST_INSTALL_LOG}" 2>&1 || true
+            sudo apt-get install -y --no-install-recommends python3-pytest >>"${PYTEST_INSTALL_LOG}" 2>&1 || true
           }
           # Verify pytest is actually importable. Without this, a
           # double-failure in pip+apt would later surface as a
@@ -1631,6 +1639,9 @@ jobs:
           # rather than the infrastructure error it is.
           if ! python3 -c "import pytest" 2>/dev/null; then
             echo "::error::pytest is not importable after pip + apt install attempts; cannot verify canary"
+            echo "::group::pytest install diagnostics"
+            cat "${PYTEST_INSTALL_LOG}" || true
+            echo "::endgroup::"
             echo "status=pytest_unavailable" >> "$GITHUB_OUTPUT"
             exit 1
           fi
@@ -1767,17 +1778,29 @@ jobs:
           # blame the editor.
           classify_pytest_failure() {
             # Case-insensitive INTERNALERROR (-i) for forward-compat
-            # against pytest output-format tweaks. ^FAILED  stays
-            # case-sensitive — pytest's short-summary prefix is
-            # documented as uppercase and matching it case-insensitively
+            # against pytest output-format tweaks. ^FAILED / ^ERROR
+            # stay case-sensitive — pytest's short-summary prefixes are
+            # documented as uppercase and matching them case-insensitively
             # would risk false positives on user-controlled error
-            # message bodies that happen to contain "failed " at line
-            # start.
+            # message bodies that happen to contain "failed " or "error "
+            # at line start.
+            #
+            # ERROR is matched explicitly (rather than relying on the
+            # else fallthrough) so the classification decision is
+            # readable without having to know that pytest's setup/
+            # collection failures emit "ERROR file::test ..." in the
+            # short summary.
             if grep -qiE "INTERNALERROR" "${PYTEST_OUTPUT}" 2>/dev/null; then
+              echo "harness_misconfigured"
+            elif grep -qE "^ERROR " "${PYTEST_OUTPUT}" 2>/dev/null; then
               echo "harness_misconfigured"
             elif grep -qE "^FAILED " "${PYTEST_OUTPUT}" 2>/dev/null; then
               echo "spec_mismatch"
             else
+              # Catch-all for unknown pytest output shapes (e.g. future
+              # format changes, pytest exiting with no FAILED/ERROR
+              # summary at all). Bias to harness_misconfigured rather
+              # than silently misclassifying as spec_mismatch.
               echo "harness_misconfigured"
             fi
           }

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1473,21 +1473,13 @@ jobs:
       # PR head no longer contains the bait marker AND that the editor
       # pushed at least one commit on top of the bait.
       #
-      # Soft check: emits the same diagnostic outputs (status=success /
-      # bait_remained / no_editor_commit / fetch_failed), but the step
-      # itself uses continue-on-error so a failure does not short-circuit
-      # the rest of the e2e job. The aggregator below ("Verify all phases
-      # passed") downgrades a failed editor-removed-bait check to a
-      # non-blocking warning because the autofix editor (codex CLI →
-      # OpenRouter `openai/gpt-5.3-codex`) has a known reliability gap
-      # that returns empty completions for ~100% of recent smoke runs;
-      # a 28-run failure streak (2026-04-30 → 2026-05-04, runs 25200104592+
-      # via `gh run list --workflow=test-and-mark-stable.yml`) was
-      # repeatedly mis-blocking releases despite seven prior in-tree
-      # fixes (016cbad, 358b1b9, ceb8617, edef200, 93d13e8, 2dc3646,
-      # 7fe2b80) targeting reasoning effort and prompt content. Phase 3c's
-      # `pr_already_closed` path is still hard-failing — that's a test-setup
-      # race, not editor reliability.
+      # Soft check (continue-on-error + WARN downgrade in the aggregator):
+      # the autofix editor model is flaky enough that this gate has been
+      # blocking unrelated releases. The diagnostic status (success /
+      # bait_remained / no_editor_commit / fetch_failed) is still emitted
+      # for visibility. Phase 3c's `pr_already_closed` is unaffected and
+      # remains hard-failing — that path signals a test-setup race, not
+      # editor reliability.
       - name: "Phase 4b: Verify editor removed bait line"
         id: verify-bait-removed
         if: steps.inject-bait.outputs.status == 'injected'
@@ -2385,12 +2377,8 @@ jobs:
             echo "  ✓ Editor Bait. PASSED (editor removed bait + pushed fix commit)"
           else
             # Soft check: editor-side failures (bait_remained,
-            # no_editor_commit, fetch_failed) do not block release. The
-            # autofix editor model is known-flaky on smoke runs (see
-            # Phase 4b comment for context); blocking on it caused a
-            # 28-run consecutive-failure streak that gated unrelated
-            # changes. The diagnostic is preserved in Phase 4b's log so
-            # we can still see when the editor regresses or recovers.
+            # no_editor_commit, fetch_failed) do not block release —
+            # see Phase 4b's comment for the rationale.
             echo "  ⚠ Editor Bait. WARN (${BAIT_VERIFIED:-not_run}) — editor pipeline did not exercise correctly (soft check; non-blocking — see Phase 4b log)"
           fi
 

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1594,15 +1594,27 @@ jobs:
           # 429/5xx doesn't bypass the editor-flake retry budget. Used
           # by every gh api call in this step (fetch helpers + poll
           # loop) so any single API blip gets up to 3 attempts with
-          # 2s/4s backoff before being treated as terminal.
+          # 2s/4s backoff before being treated as terminal. On final
+          # failure the last attempt's stderr is surfaced as a warning
+          # so triage isn't blind to the underlying API error.
           gh_api_with_retry() {
             local out
             local rc=0
+            local err_file
+            err_file="$(mktemp)"
             for try in 1 2 3; do
-              out=$(gh api "$@" 2>/dev/null) && { printf '%s' "${out}"; return 0; }
+              out=$(gh api "$@" 2>"${err_file}") && {
+                rm -f "${err_file}"
+                printf '%s' "${out}"
+                return 0
+              }
               rc=$?
               [ "${try}" -lt 3 ] && sleep $((try * 2))
             done
+            if [ -s "${err_file}" ]; then
+              echo "::warning::gh api failed after 3 attempts (rc=${rc}): $(tr '\n' ' ' < "${err_file}" | head -c 500)" >&2
+            fi
+            rm -f "${err_file}"
             return "${rc}"
           }
 
@@ -1785,8 +1797,20 @@ jobs:
 
           # Poll for the new review run on RETRY_DISPATCH_SHA (the
           # branch head we snapshotted at dispatch time). Skip the run
-          # we already saw via wait-review by recording its id.
+          # we already saw via wait-review by recording its id. We
+          # gate Phase 4b on wait-review having succeeded, which means
+          # review_run_id should be a non-empty numeric string here;
+          # if it's somehow empty/non-numeric, the jq exclusion filter
+          # would default to `select(.id != 0)` (no-op, since GitHub
+          # run ids are always positive) and could pick up the
+          # original review run as the "retry run". Fail fast in that
+          # case rather than silently misattribute.
           PRIOR_REVIEW_RUN="${{ steps.wait-review.outputs.review_run_id }}"
+          if ! [[ "${PRIOR_REVIEW_RUN}" =~ ^[0-9]+$ ]]; then
+            echo "::error::wait-review.outputs.review_run_id is not a positive integer ('${PRIOR_REVIEW_RUN}'); refusing to enter retry poll loop with a no-op exclusion filter"
+            echo "status=retry_dispatch_failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
           DEADLINE=$(( $(date +%s) + 600 ))  # 10 minutes
           RETRY_RUN_ID=""
           RETRY_STATUS=""

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -343,6 +343,17 @@ jobs:
           fi
           echo "Target repo: ${TEST_REPO}"
           echo "Phase timeout: ${PHASE_TIMEOUT} minutes"
+          echo "Review workflow file: ${REVIEW_WORKFLOW_FILE}"
+          # Validate REVIEW_WORKFLOW_FILE before it gets passed to
+          # `gh workflow run` / Actions API as a positional. If the
+          # value starts with `-` (e.g. `--help`), gh would treat it
+          # as a flag; if it contains `/` or other unexpected chars,
+          # the API path can break. Lock it down to a basename
+          # matching `<safe>.yml` and reject anything else early.
+          if ! printf '%s' "${REVIEW_WORKFLOW_FILE}" | grep -qE '^[A-Za-z0-9_.-]+\.yml$'; then
+            echo "::error::REVIEW_WORKFLOW_FILE='${REVIEW_WORKFLOW_FILE}' is not a safe basename matching ^[A-Za-z0-9_.-]+\\.yml\$ — refusing to proceed"
+            exit 1
+          fi
           # Verify we can access the repo
           gh api "repos/${TEST_REPO}" --jq '.full_name' \
             || { echo "::error::Cannot access ${TEST_REPO}. Check GH_PAT permissions."; exit 1; }
@@ -1511,7 +1522,7 @@ jobs:
       # known-flaky (seven prior in-tree fixes targeting reasoning
       # effort and prompt content; production runs hit empty-completion
       # state non-deterministically). On first pytest failure we
-      # snapshot the branch head SHA, re-dispatch internal-review.yml
+      # snapshot the branch head SHA, re-dispatch ${REVIEW_WORKFLOW_FILE}
       # via `--ref "${BRANCH}"`, and poll for a new workflow_dispatch
       # run whose head_sha matches the snapshotted SHA. We allow up
       # to 10 minutes for the new run to complete; if the second
@@ -2699,7 +2710,11 @@ jobs:
             PASSED=false
           fi
 
-          # Check editor bait removal (Phase 4b)
+          # Check Phase 4b — pytest verification that the editor
+          # restored the canary file byte-for-byte and pushed a fix
+          # commit past the bait. (Variable names retain the "BAIT_"
+          # prefix from the prior single-line-bait era so existing
+          # log greps and downstream tooling keep working.)
           BAIT_INJECTED="${{ steps.inject-bait.outputs.status }}"
           BAIT_VERIFIED="${{ steps.verify-bait-removed.outputs.status }}"
           REVIEW_OK=false

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1471,13 +1471,27 @@ jobs:
       # Closes the loop on Phase 3c: confirms the reviewer→editor→commit
       # pipeline actually fired by checking the canary on the post-review
       # PR head no longer contains the bait marker AND that the editor
-      # pushed at least one commit on top of the bait. Reports as a
-      # workflow-step failure (blocking) when the editor failed to act,
-      # since the whole point of injecting bait is to fail the gate when
-      # the editor is broken.
+      # pushed at least one commit on top of the bait.
+      #
+      # Soft check: emits the same diagnostic outputs (status=success /
+      # bait_remained / no_editor_commit / fetch_failed), but the step
+      # itself uses continue-on-error so a failure does not short-circuit
+      # the rest of the e2e job. The aggregator below ("Verify all phases
+      # passed") downgrades a failed editor-removed-bait check to a
+      # non-blocking warning because the autofix editor (codex CLI →
+      # OpenRouter `openai/gpt-5.3-codex`) has a known reliability gap
+      # that returns empty completions for ~100% of recent smoke runs;
+      # a 28-run failure streak (2026-04-30 → 2026-05-04, runs 25200104592+
+      # via `gh run list --workflow=test-and-mark-stable.yml`) was
+      # repeatedly mis-blocking releases despite seven prior in-tree
+      # fixes (016cbad, 358b1b9, ceb8617, edef200, 93d13e8, 2dc3646,
+      # 7fe2b80) targeting reasoning effort and prompt content. Phase 3c's
+      # `pr_already_closed` path is still hard-failing — that's a test-setup
+      # race, not editor reliability.
       - name: "Phase 4b: Verify editor removed bait line"
         id: verify-bait-removed
         if: steps.inject-bait.outputs.status == 'injected'
+        continue-on-error: true
         env:
           PR_NUMBER: ${{ steps.wait-implement.outputs.pr_number }}
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
@@ -2370,8 +2384,14 @@ jobs:
           elif [ "$BAIT_VERIFIED" = "success" ]; then
             echo "  ✓ Editor Bait. PASSED (editor removed bait + pushed fix commit)"
           else
-            echo "  ✗ Editor Bait. FAILED (${BAIT_VERIFIED:-not_run}) — editor pipeline did not exercise correctly"
-            PASSED=false
+            # Soft check: editor-side failures (bait_remained,
+            # no_editor_commit, fetch_failed) do not block release. The
+            # autofix editor model is known-flaky on smoke runs (see
+            # Phase 4b comment for context); blocking on it caused a
+            # 28-run consecutive-failure streak that gated unrelated
+            # changes. The diagnostic is preserved in Phase 4b's log so
+            # we can still see when the editor regresses or recovers.
+            echo "  ⚠ Editor Bait. WARN (${BAIT_VERIFIED:-not_run}) — editor pipeline did not exercise correctly (soft check; non-blocking — see Phase 4b log)"
           fi
 
           # Check orchestrator scripts (Phase 5)

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1482,13 +1482,14 @@ jobs:
           model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
           reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'none' }}
 
-      # ── Phase 4b: Verify the editor restored the bait commit ──
+      # ── Phase 4b: Verify editor restored the canary file ──
       # Confirms the reviewer→editor→commit pipeline actually fired by
       # running the pytest assertions in tests/test_e2e_editor_smoke_canary.py
-      # against the canary fetched from the post-review PR head. The
-      # test asserts byte-for-byte match to the issue's 3-line spec
-      # (any value mangled, any line added/removed, any bait marker
-      # surviving = test fails).
+      # against the canary file fetched from the post-review PR head,
+      # then checking the editor pushed at least one commit past the
+      # Phase 3c bait commit. The pytest test asserts byte-for-byte
+      # match to the issue's 3-line spec (any value mangled, any line
+      # added/removed, any bait marker surviving = test fails).
       #
       # Hard-fail with retry budget: the autofix editor model is
       # known-flaky (seven prior in-tree fixes targeting reasoning
@@ -1528,6 +1529,12 @@ jobs:
 
           python3 -m pip install --quiet pytest >/dev/null 2>&1 || {
             echo "::warning::pip install pytest failed; trying apt fallback"
+            # Refresh package indexes before the apt install — without
+            # this a stale index on a long-running runner image can
+            # surface as a spurious pytest_unavailable. Other workflows
+            # in this repo (review_autofix.yml) precede their apt-get
+            # installs the same way.
+            sudo apt-get update -qq >/dev/null 2>&1 || true
             sudo apt-get install -y --no-install-recommends python3-pytest >/dev/null 2>&1 || true
           }
           # Verify pytest is actually importable. Without this, a
@@ -1667,21 +1674,41 @@ jobs:
 
           echo "::warning::Phase 4b first attempt failed — re-dispatching review_autofix and retrying once"
 
-          # ── Retry: redispatch internal-review.yml on the bait commit ──
+          # ── Retry: redispatch internal-review.yml on the current branch head ──
           # Mirrors the Phase 3c fallback dispatch (lines ~1101-1109),
           # which uses internal-review.yml as the public entry-point that
           # gates into review_autofix.yml without an `[ai-autofix]` self-
           # trigger guard.
+          #
+          # Capture the branch head SHA right before dispatch — that's
+          # what the new workflow_dispatch run will carry as head_sha,
+          # and what we'll poll for. Filtering on BAIT_SHA would miss
+          # the retry run whenever the editor's first attempt already
+          # advanced the branch past the bait (e.g. the editor pushed
+          # a wrong-fix commit but pytest still failed); we'd hit
+          # retry_timeout even though the dispatch succeeded.
+          if ! RETRY_DISPATCH_SHA=$(gh_api_with_retry "repos/${TEST_REPO}/git/refs/heads/${BRANCH}" --jq '.object.sha // empty'); then
+            echo "::error::Could not resolve ${BRANCH} head SHA before retry dispatch"
+            echo "status=retry_dispatch_failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          if [ -z "${RETRY_DISPATCH_SHA}" ]; then
+            echo "::error::Branch head SHA empty before retry dispatch"
+            echo "status=retry_dispatch_failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          echo "  resolved ${BRANCH} head for retry dispatch: ${RETRY_DISPATCH_SHA:0:7}"
+
           if ! gh workflow run "internal-review.yml" \
               --repo "${TEST_REPO}" \
-              --ref "${BRANCH}" \
+              --ref "${RETRY_DISPATCH_SHA}" \
               -f pr_number="${PR_NUMBER}" >/tmp/retry_dispatch.txt 2>&1; then
             echo "::error::Retry dispatch failed; cannot recover"
             cat /tmp/retry_dispatch.txt >&2 || true
             echo "status=retry_dispatch_failed" >> "$GITHUB_OUTPUT"
             exit 1
           fi
-          echo "✓ Retry dispatch sent — polling for the new review run"
+          echo "✓ Retry dispatch sent at ${RETRY_DISPATCH_SHA:0:7} — polling for the new review run"
 
           # Poll for the new review run on the bait SHA. Skip the run
           # we already saw via wait-review by recording its id.
@@ -1703,7 +1730,7 @@ jobs:
             fi
             CANDIDATES=$(gh_api_with_retry \
               "repos/${TEST_REPO}/actions/workflows/internal-review.yml/runs?event=workflow_dispatch&per_page=10" \
-              --jq ".workflow_runs[] | select(.head_sha == \"${BAIT_SHA}\") | select(.id != ${PRIOR_REVIEW_RUN:-0}) | \"\(.id) \(.status) \(.conclusion // \"null\")\"") || CANDIDATES=""
+              --jq ".workflow_runs[] | select(.head_sha == \"${RETRY_DISPATCH_SHA}\") | select(.id != ${PRIOR_REVIEW_RUN:-0}) | \"\(.id) \(.status) \(.conclusion // \"null\")\"") || CANDIDATES=""
             if [ -z "${CANDIDATES}" ]; then
               echo "  (no new review run yet, pr_state=${PR_STATE})"
               continue

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1002,10 +1002,25 @@ jobs:
             exit 0
           fi
 
-          # Build new content: existing content + bait line. Strip any trailing
-          # newline first so the bait doesn't end up two lines down.
-          BAIT_LINE="# ${BAIT_MARKER}: this line should be removed by the editor (smoke gate)"
-          NEW_CONTENT="$(printf '%s' "${BLOB_CONTENT%$'\n'}")"$'\n'"${BAIT_LINE}"$'\n'
+          # Build new content: a multi-line corruption that violates the
+          # linked issue's spec on every line, plus extra noise lines. The
+          # editor must restore the file to the issue's exact 3-line target
+          # — a single-line removal is no longer sufficient. This stresses
+          # more of the production review pipeline (reviewer consensus on
+          # multiple findings, multi-hunk apply_patch, post-edit validation)
+          # so failures here track real production-class regressions
+          # (Serena/MCP breakage, prompt-template drift, parser bugs)
+          # rather than just "did the model strip one line."
+          #
+          # The `# E2E_EDITOR_BAIT_<run>:` marker is preserved verbatim so
+          # the smoke override in scripts/review_apply_fixes.sh still
+          # triggers (it greps for `^# E2E_EDITOR_BAIT_[0-9]+:`).
+          NEW_CONTENT="status: BROKEN_BY_E2E_BAIT_${GITHUB_RUN_ID}"$'\n'
+          NEW_CONTENT+="run_id: WRONG_VALUE_SHOULD_BE_${GITHUB_RUN_ID}"$'\n'
+          NEW_CONTENT+="updated-by: e2e-bait-injector"$'\n'
+          NEW_CONTENT+="extra: this line violates the issue spec"$'\n'
+          NEW_CONTENT+="also: another line that must be removed"$'\n'
+          NEW_CONTENT+="# ${BAIT_MARKER}: canary corrupted; restore to linked issue spec (smoke gate)"$'\n'
           NEW_B64=$(printf '%s' "${NEW_CONTENT}" | base64 -w0)
 
           echo "Pushing bait commit to ${BRANCH}..."
@@ -1493,6 +1508,12 @@ jobs:
           set -euo pipefail
           BRANCH="ai/issue-${ISSUE_NUMBER}"
           CANARY_PATH="tests/e2e_smoke_canary.txt"
+          # Reconstruct the issue's exact 3-line target. Phase 3c
+          # corrupts every line of the canary plus adds extras; the
+          # editor must restore EXACTLY this content. The issue body
+          # at line ~347 hardcodes `run_id: ${RUN_ID}` where RUN_ID =
+          # GITHUB_RUN_ID, so the same value works on both sides.
+          EXPECTED=$(printf 'status: ok\nrun_id: %s\nupdated-by: ai-pipeline\n' "${GITHUB_RUN_ID}")
 
           # Re-fetch canary on the (post-review) PR head.
           BLOB=$(gh api "repos/${TEST_REPO}/contents/${CANARY_PATH}?ref=${BRANCH}" 2>/dev/null || echo "")
@@ -1503,12 +1524,21 @@ jobs:
           fi
           DECODED=$(echo "${BLOB}" | jq -r '.content // empty' | tr -d '\n' | base64 -d 2>/dev/null || echo "")
           if echo "${DECODED}" | grep -qF "${BAIT_MARKER}"; then
-            echo "::error::Editor failed to remove bait line ${BAIT_MARKER}. Canary contents:"
+            echo "::error::Editor failed to remove bait marker ${BAIT_MARKER}. Canary contents:"
             printf '%s\n' "${DECODED}"
             echo "status=bait_remained" >> "$GITHUB_OUTPUT"
             exit 1
           fi
-          echo "✓ Bait line removed from canary"
+          if [ "${DECODED}" != "${EXPECTED}" ]; then
+            echo "::error::Canary content does not match the issue's required 3-line spec."
+            echo "Expected:"
+            printf '%s' "${EXPECTED}" | sed 's/^/  /'
+            echo "Actual:"
+            printf '%s' "${DECODED}" | sed 's/^/  /'
+            echo "status=spec_mismatch" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          echo "✓ Canary restored to the issue's exact 3-line spec"
 
           # Confirm the editor pushed at least one commit on top of the bait.
           COMMITS_AFTER=$(gh api "repos/${TEST_REPO}/commits?sha=${BRANCH}&per_page=20" \

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1629,8 +1629,17 @@ jobs:
 
           run_pytest() {
             : > "${PYTEST_OUTPUT}"
+            # Locally disable -e so a non-zero pytest exit doesn't
+            # propagate up before we can capture it. `set -e` semantics
+            # for a function called from `if !` should already exempt
+            # the body, but pipefail + the `tee` pipeline make the
+            # interaction subtle enough to be worth pinning down
+            # explicitly.
+            set +e
             python3 -m pytest tests/test_e2e_editor_smoke_canary.py -v --no-header 2>&1 | tee "${PYTEST_OUTPUT}"
-            return "${PIPESTATUS[0]}"
+            local rc="${PIPESTATUS[0]}"
+            set -e
+            return "${rc}"
           }
 
           # When pytest fails, distinguish a true editor regression
@@ -1701,6 +1710,13 @@ jobs:
           # advanced the branch past the bait (e.g. the editor pushed
           # a wrong-fix commit but pytest still failed); we'd hit
           # retry_timeout even though the dispatch succeeded.
+          #
+          # `gh workflow run` is dispatched with --ref "${BRANCH}"
+          # (its documented contract is branch/tag, not raw SHA);
+          # RETRY_DISPATCH_SHA is used only as the poll filter. Tiny
+          # race window if the branch advances between snapshot and
+          # dispatch — acceptable, and the retry_timeout path catches
+          # it cleanly.
           if ! RETRY_DISPATCH_SHA=$(gh_api_with_retry "repos/${TEST_REPO}/git/refs/heads/${BRANCH}" --jq '.object.sha // empty'); then
             echo "::error::Could not resolve ${BRANCH} head SHA before retry dispatch"
             echo "status=retry_dispatch_failed" >> "$GITHUB_OUTPUT"
@@ -1715,14 +1731,14 @@ jobs:
 
           if ! gh workflow run "internal-review.yml" \
               --repo "${TEST_REPO}" \
-              --ref "${RETRY_DISPATCH_SHA}" \
+              --ref "${BRANCH}" \
               -f pr_number="${PR_NUMBER}" >/tmp/retry_dispatch.txt 2>&1; then
             echo "::error::Retry dispatch failed; cannot recover"
             cat /tmp/retry_dispatch.txt >&2 || true
             echo "status=retry_dispatch_failed" >> "$GITHUB_OUTPUT"
             exit 1
           fi
-          echo "✓ Retry dispatch sent at ${RETRY_DISPATCH_SHA:0:7} — polling for the new review run"
+          echo "✓ Retry dispatch sent on ${BRANCH} (head ${RETRY_DISPATCH_SHA:0:7}) — polling for the new review run"
 
           # Poll for the new review run on the bait SHA. Skip the run
           # we already saw via wait-review by recording its id.

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1634,16 +1634,30 @@ jobs:
           }
 
           # When pytest fails, distinguish a true editor regression
-          # (assertion failure on canary content) from a harness/infra
-          # error (fixture RuntimeError on missing config, internal
-          # pytest error, etc.). Operators investigating spec_mismatch
-          # look at the editor; harness_misconfigured points them at
-          # the workflow YAML / runner setup instead.
+          # (test assertion failed on canary content) from a harness/
+          # infra error (fixture exception, pytest internal error,
+          # missing dependency, runner I/O failure). pytest's own
+          # FAILED-vs-ERROR distinction is the cleanest signal:
+          #
+          #   FAILED  → the test function ran and an assertion failed
+          #             → real editor/spec bug → spec_mismatch
+          #   ERROR   → fixture / collection / setup raised before the
+          #             test body could run → harness issue
+          #   INTERNALERROR → pytest itself crashed → harness issue
+          #
+          # Anything that's neither FAILED nor a clean pass falls into
+          # the harness bucket — that catches RuntimeError from the
+          # canary_invocation fixture, ImportError on a broken Python
+          # env, OSError/PermissionError on runner I/O, pytest
+          # UsageError, and similar infra failures that should NOT
+          # blame the editor.
           classify_pytest_failure() {
-            if grep -qE "RuntimeError|INTERNALERROR" "${PYTEST_OUTPUT}" 2>/dev/null; then
+            if grep -qE "INTERNALERROR" "${PYTEST_OUTPUT}" 2>/dev/null; then
               echo "harness_misconfigured"
-            else
+            elif grep -qE "^FAILED " "${PYTEST_OUTPUT}" 2>/dev/null; then
               echo "spec_mismatch"
+            else
+              echo "harness_misconfigured"
             fi
           }
 
@@ -1785,6 +1799,10 @@ jobs:
           fi
           echo "✓ Editor produced commit(s) past the bait on retry (PR head: ${PR_HEAD:0:7}, bait: ${BAIT_SHA:0:7})"
           echo "status=success_after_retry" >> "$GITHUB_OUTPUT"
+          # Explicit exit 0 — symmetric with the first-attempt success
+          # path above, and a guard against future code being added
+          # past this echo without realising the step was already done.
+          exit 0
 
       # ── Phase 5: Orchestrator script integration test ──────────
       - name: Checkout repository for integration tests

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1101,18 +1101,21 @@ jobs:
           # Defense-in-depth for "Bug B" (PR #1811): the Contents-API PUT
           # above sometimes succeeds (commit + PR head pointer updated)
           # without GitHub fanning out a `pull_request: synchronize`
-          # event, so internal-review.yml is never auto-triggered and
+          # event, so the wrapper workflow (${REVIEW_WORKFLOW_FILE},
+          # default internal-review.yml) is never auto-triggered and
           # wait-review (Phase 4) ages out at REVIEW_TIMEOUT minutes.
           # Run 25204168842 was the most recent confirmed occurrence.
-          # Explicitly dispatch internal-review.yml against the PR
+          # Explicitly dispatch ${REVIEW_WORKFLOW_FILE} against the PR
           # branch so a review run with head_sha=BAIT_SHA always exists
           # — workflow_dispatch resolves the ref's tip SHA at dispatch
           # time, and we just pushed the bait commit there, so the
           # dispatched run carries head_sha=BAIT_SHA and is matched by
           # wait-review's pinned filter without any extra logic.
-          # The dispatch is keyed on a separate concurrency group (see
-          # internal-review.yml:48-50, `internal-review-dispatch-pr-N`),
-          # so if the synchronize event ever DID fire, both runs are
+          # The dispatch is keyed on a separate concurrency group (in
+          # the source repo's internal-review.yml at lines 48-50,
+          # group `internal-review-dispatch-pr-N`; consumer repos with
+          # a renamed wrapper own the equivalent guard there), so if
+          # the synchronize event ever DID fire, both runs are
           # serialised downstream by review_autofix.yml's `pr-autofix-N`
           # group rather than racing — only one autofix proceeds.
           # Fail-soft: if dispatch fails, the synchronize event (when
@@ -1219,7 +1222,7 @@ jobs:
             # (status=skipped path).
             #
             # The URL no longer pins event=pull_request: Phase 3c also
-            # dispatches internal-review.yml as a Bug B fallback, and
+            # dispatches ${REVIEW_WORKFLOW_FILE} as a Bug B fallback, and
             # those runs carry event=workflow_dispatch. Dropping the
             # event filter from the URL lets head_sha=BAIT_SHA match
             # both paths uniformly. (We still rely on the jq name match
@@ -1737,11 +1740,11 @@ jobs:
 
           echo "::warning::Phase 4b first attempt failed — re-dispatching review_autofix and retrying once"
 
-          # ── Retry: redispatch internal-review.yml on the current branch head ──
+          # ── Retry: redispatch ${REVIEW_WORKFLOW_FILE} on the current branch head ──
           # Mirrors the Phase 3c fallback dispatch (lines ~1101-1109),
-          # which uses internal-review.yml as the public entry-point that
-          # gates into review_autofix.yml without an `[ai-autofix]` self-
-          # trigger guard.
+          # which uses ${REVIEW_WORKFLOW_FILE} as the public entry-point
+          # that gates into review_autofix.yml without an `[ai-autofix]`
+          # self-trigger guard.
           #
           # Capture the branch head SHA right before dispatch — that's
           # what the new workflow_dispatch run will carry as head_sha,

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1524,6 +1524,7 @@ jobs:
           # invocation: missing canary env vars must fail loudly here
           # (a configuration bug), not skip silently.
           export E2E_PHASE_4B_INVOKED=1
+          PYTEST_OUTPUT="${RUNNER_TEMP:-/tmp}/e2e_pytest_output.txt"
 
           python3 -m pip install --quiet pytest >/dev/null 2>&1 || {
             echo "::warning::pip install pytest failed; trying apt fallback"
@@ -1539,22 +1540,39 @@ jobs:
             exit 1
           fi
 
+          # gh api wrapper with a small retry budget so a transient
+          # 429/5xx doesn't bypass the editor-flake retry budget. Used
+          # by every gh api call in this step (fetch helpers + poll
+          # loop) so any single API blip gets up to 3 attempts with
+          # 2s/4s backoff before being treated as terminal.
+          gh_api_with_retry() {
+            local out
+            local rc=0
+            for try in 1 2 3; do
+              out=$(gh api "$@" 2>/dev/null) && { printf '%s' "${out}"; return 0; }
+              rc=$?
+              [ "${try}" -lt 3 ] && sleep $((try * 2))
+            done
+            return "${rc}"
+          }
+
           fetch_canary_to_tmp() {
             # NOTE: do NOT use `blob=$(gh api ... || echo "")` — on
             # non-zero exit, `gh api` writes the error JSON body
             # (e.g. `{"message":"Not Found",...}`) to stdout, which
             # would land in $blob as a valid-looking but bogus
-            # response. Capture exit status separately and require
-            # the .content field to be present before returning OK.
+            # response. gh_api_with_retry returns rc!=0 on hard
+            # failure and we further validate the .content field
+            # before trusting the response.
             local blob_path="${RUNNER_TEMP:-/tmp}/e2e_canary_blob.json"
             : > "${blob_path}"
-            local rc=0
-            gh api "repos/${TEST_REPO}/contents/${CANARY_PATH}?ref=${BRANCH}" \
-              > "${blob_path}" 2>/dev/null || rc=$?
-            if [ "${rc}" -ne 0 ] || [ ! -s "${blob_path}" ]; then
+            if ! gh_api_with_retry "repos/${TEST_REPO}/contents/${CANARY_PATH}?ref=${BRANCH}" \
+                > "${blob_path}"; then
               return 1
             fi
-            # Validate response schema before trusting it.
+            if [ ! -s "${blob_path}" ]; then
+              return 1
+            fi
             local content_b64
             content_b64=$(jq -r '.content // empty' "${blob_path}")
             if [ -z "${content_b64}" ]; then
@@ -1573,10 +1591,11 @@ jobs:
           fetch_pr_head_sha() {
             local resp_path="${RUNNER_TEMP:-/tmp}/e2e_pr_head_resp.json"
             : > "${resp_path}"
-            local rc=0
-            gh api "repos/${TEST_REPO}/pulls/${PR_NUMBER}" \
-              > "${resp_path}" 2>/dev/null || rc=$?
-            if [ "${rc}" -ne 0 ] || [ ! -s "${resp_path}" ]; then
+            if ! gh_api_with_retry "repos/${TEST_REPO}/pulls/${PR_NUMBER}" \
+                > "${resp_path}"; then
+              return 1
+            fi
+            if [ ! -s "${resp_path}" ]; then
               return 1
             fi
             local sha
@@ -1588,8 +1607,37 @@ jobs:
             return 0
           }
 
+          # Returns the PR's state ("open" / "closed") or "unknown" on
+          # API failure. Used by the retry poll loop to bail out if
+          # the PR is closed/merged mid-wait — no point polling for a
+          # review run that won't fire on a closed PR.
+          fetch_pr_state() {
+            local state
+            state=$(gh_api_with_retry "repos/${TEST_REPO}/pulls/${PR_NUMBER}" --jq '.state // "unknown"') || {
+              echo "unknown"
+              return 0
+            }
+            echo "${state:-unknown}"
+          }
+
           run_pytest() {
-            python3 -m pytest tests/test_e2e_editor_smoke_canary.py -v --no-header
+            : > "${PYTEST_OUTPUT}"
+            python3 -m pytest tests/test_e2e_editor_smoke_canary.py -v --no-header 2>&1 | tee "${PYTEST_OUTPUT}"
+            return "${PIPESTATUS[0]}"
+          }
+
+          # When pytest fails, distinguish a true editor regression
+          # (assertion failure on canary content) from a harness/infra
+          # error (fixture RuntimeError on missing config, internal
+          # pytest error, etc.). Operators investigating spec_mismatch
+          # look at the editor; harness_misconfigured points them at
+          # the workflow YAML / runner setup instead.
+          classify_pytest_failure() {
+            if grep -qE "RuntimeError|INTERNALERROR" "${PYTEST_OUTPUT}" 2>/dev/null; then
+              echo "harness_misconfigured"
+            else
+              echo "spec_mismatch"
+            fi
           }
 
           # ── Attempt 1 ──────────────────────────────────────────────
@@ -1635,20 +1683,6 @@ jobs:
           fi
           echo "✓ Retry dispatch sent — polling for the new review run"
 
-          # gh api wrapper with a small retry budget so a transient
-          # 429/5xx during the 10min poll window doesn't cause a
-          # spurious retry_timeout.
-          gh_api_with_retry() {
-            local out
-            local rc
-            for try in 1 2 3; do
-              out=$(gh api "$@" 2>/dev/null) && { printf '%s' "${out}"; return 0; }
-              rc=$?
-              [ "${try}" -lt 3 ] && sleep $((try * 2))
-            done
-            return "${rc}"
-          }
-
           # Poll for the new review run on the bait SHA. Skip the run
           # we already saw via wait-review by recording its id.
           PRIOR_REVIEW_RUN="${{ steps.wait-review.outputs.review_run_id }}"
@@ -1658,11 +1692,20 @@ jobs:
           RETRY_CONCL=""
           while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
             sleep 15
+            # Bail out if the PR closed/merged during the wait — no
+            # point polling for a review run that won't fire on a
+            # closed PR.
+            PR_STATE=$(fetch_pr_state)
+            if [ "${PR_STATE}" = "closed" ]; then
+              echo "::error::PR #${PR_NUMBER} closed during retry wait — abandoning retry"
+              echo "status=pr_closed_during_retry" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
             CANDIDATES=$(gh_api_with_retry \
               "repos/${TEST_REPO}/actions/workflows/internal-review.yml/runs?event=workflow_dispatch&per_page=10" \
               --jq ".workflow_runs[] | select(.head_sha == \"${BAIT_SHA}\") | select(.id != ${PRIOR_REVIEW_RUN:-0}) | \"\(.id) \(.status) \(.conclusion // \"null\")\"") || CANDIDATES=""
             if [ -z "${CANDIDATES}" ]; then
-              echo "  (no new review run yet)"
+              echo "  (no new review run yet, pr_state=${PR_STATE})"
               continue
             fi
             # GitHub returns runs newest-first; the matching list is in
@@ -1691,8 +1734,14 @@ jobs:
             exit 1
           fi
           if ! run_pytest; then
-            echo "::error::Canary verification still failed after retry — editor is broken or model fully unavailable"
-            echo "status=spec_mismatch" >> "$GITHUB_OUTPUT"
+            FAILURE_KIND=$(classify_pytest_failure)
+            if [ "${FAILURE_KIND}" = "harness_misconfigured" ]; then
+              echo "::error::Phase 4b pytest fixture raised RuntimeError or pytest had INTERNALERROR — harness misconfigured (env var / file path / pytest setup), not an editor regression"
+              echo "status=harness_misconfigured" >> "$GITHUB_OUTPUT"
+            else
+              echo "::error::Canary verification still failed after retry — editor is broken or model fully unavailable"
+              echo "status=spec_mismatch" >> "$GITHUB_OUTPUT"
+            fi
             exit 1
           fi
           echo "✓ Canary verification passed on retry"

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -150,20 +150,21 @@ echo "Artifacts: floor_tags=$(wc -c < "${FLOOR_TAGS_FILE}" 2>/dev/null || echo 0
 # The smoke override prepends a "you MUST call apply_patch on
 # tests/e2e_smoke_canary.txt" directive to the editor prompt, but
 # only when (a) the workflow flagged this as a smoke run AND (b) the
-# canary file actually contains an injected bait line.
+# canary file actually contains an injected bait marker.
 #
 # (b) matters because review_autofix triggers on pull_request:opened
 # (internal-review.yml:4-5), which fires the FIRST review_autofix run
 # the moment the smoke PR is created — BEFORE
-# test-and-mark-stable.yml's Phase 3c appends the bait commit
-# (test-and-mark-stable.yml:904-1009). On that first round the canary
-# is still the legitimate 3-line file from the implement step; telling
-# the editor it "currently contains 4 lines" would force a
-# guaranteed-false apply_patch (Copilot review on PR #2086).
+# test-and-mark-stable.yml's Phase 3c rewrites the canary with the
+# multi-line corruption. On that first round the canary is still the
+# legitimate 3-line file from the implement step; telling the editor
+# it "is corrupted and must be restored" would force a guaranteed-
+# false apply_patch (Copilot review on PR #2086).
 #
-# The bait line shape is fixed by Phase 3c at line ~1007:
-#   "# E2E_EDITOR_BAIT_${GITHUB_RUN_ID}: this line should be removed
-#    by the editor (smoke gate)"
+# Phase 3c rewrites the canary with mangled values, extra noise lines,
+# and a marker line of the form:
+#   "# E2E_EDITOR_BAIT_${GITHUB_RUN_ID}: canary corrupted; restore to
+#    linked issue spec (smoke gate)"
 # Match on the leading comment + marker prefix only — the run ID
 # changes per smoke run and we don't want to plumb it through here.
 EDITOR_BODY_RENDER_SMOKE=false

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -191,36 +191,38 @@ fi
 
 This run is the repository's end-to-end smoke fixture. The PR title /
 linked issue carry the marker "[E2E Smoke Test]". The smoke gate has
-deliberately appended a single bait line of the form
-"# E2E_EDITOR_BAIT_<run_id>: ..." to the file
-tests/e2e_smoke_canary.txt; the file currently contains 4 lines and
-must end up as exactly these 3 lines (no comments, no headers, no
-trailing content beyond the final newline):
+deliberately corrupted tests/e2e_smoke_canary.txt: every required
+value has been mangled (status / run_id / updated-by are all wrong),
+extra noise lines have been appended, and the file ends with a marker
+line of the form "# E2E_EDITOR_BAIT_<run_id>: ...".
 
-  status: ok
-  run_id: <whatever value already appears on line 2 of the file>
-  updated-by: ai-pipeline
+The file MUST be restored to EXACTLY the 3-line target specified in
+the linked issue body — no comments, no headers, no extra lines, no
+trailing content beyond the final newline. The issue body lists the
+exact required content (status / run_id / updated-by); use those
+literal values, not the corrupted ones currently in the file.
 
 MANDATORY ACTIONS for this run:
 1. You MUST invoke the apply_patch tool on tests/e2e_smoke_canary.txt
-   in this turn. Removing the bait line is a one-line patch — do not
+   in this turn. Restoring the file is a deterministic edit — do not
    wait for additional context, do not ask for clarification, do not
    defer to a future iteration.
 2. Do NOT exit without calling apply_patch. Returning an empty
    completion / a final assistant message that only describes the fix
    ("I will apply_patch ..." / "the change is straightforward") is a
-   smoke-test FAILURE — the gate downstream greps the file via the
-   GitHub contents API after this run and fails the e2e job if the
-   bait line is still present.
+   smoke-test FAILURE — the gate downstream re-fetches the file via
+   the GitHub contents API and fails the e2e job if the contents do
+   not match the issue spec byte-for-byte.
 3. Do not modify any file other than tests/e2e_smoke_canary.txt.
 4. After the apply_patch succeeds, emit the standard editor summary
-   schema below as usual; under "Changes made:" list the single bullet
-   "modified tests/e2e_smoke_canary.txt: removed E2E_EDITOR_BAIT
-   line", and under "Change status:" emit "- edited".
+   schema below as usual; under "Changes made:" list the bullet
+   "modified tests/e2e_smoke_canary.txt: restored canary to issue
+   spec (removed bait corruption)", and under "Change status:" emit
+   "- edited".
 
 The remaining sections of this prompt (reviewer inputs, consolidator,
 hardening tasks, etc.) still apply, but for this fixture the only
-WILL_FIX item is the bait removal above. Proceed directly to
+WILL_FIX item is the canary restoration above. Proceed directly to
 apply_patch.
 
 === END E2E SMOKE TEST OVERRIDE ===

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -217,9 +217,8 @@ MANDATORY ACTIONS for this run:
 3. Do not modify any file other than tests/e2e_smoke_canary.txt.
 4. After the apply_patch succeeds, emit the standard editor summary
    schema below as usual; under "Changes made:" list the bullet
-   "modified tests/e2e_smoke_canary.txt: restored canary to issue
-   spec (removed bait corruption)", and under "Change status:" emit
-   "- edited".
+   "modified tests/e2e_smoke_canary.txt: restored canary to issue spec (removed bait corruption)",
+   and under "Change status:" emit "- edited".
 
 The remaining sections of this prompt (reviewer inputs, consolidator,
 hardening tasks, etc.) still apply, but for this fixture the only

--- a/tests/e2e_smoke_canary_spec.txt
+++ b/tests/e2e_smoke_canary_spec.txt
@@ -1,0 +1,3 @@
+status: ok
+run_id: __RUN_ID__
+updated-by: ai-pipeline

--- a/tests/test_e2e_editor_smoke_canary.py
+++ b/tests/test_e2e_editor_smoke_canary.py
@@ -1,0 +1,73 @@
+"""E2E smoke-test canary verification (run from test-and-mark-stable.yml Phase 4b).
+
+Asserts that the canary file produced by the autofix editor on the
+post-review PR head matches the issue body's exact 3-line target. Phase 4b
+fetches the canary from the PR branch via the GitHub Contents API, writes
+it to a tmp path, and runs this test with two env vars:
+
+- E2E_CANARY_FILE       absolute path to the fetched canary content
+- E2E_EXPECTED_RUN_ID   the GITHUB_RUN_ID of the test-and-mark-stable run
+                        (same value the issue body templated into the spec)
+
+Both vars are required when invoked from Phase 4b. When neither is set,
+the tests skip so the file stays runnable from a normal `pytest` sweep
+of the tests/ directory without polluting CI signal.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def _expected_content(run_id: str) -> str:
+    return f"status: ok\nrun_id: {run_id}\nupdated-by: ai-pipeline\n"
+
+
+@pytest.fixture(scope="module")
+def canary_invocation() -> tuple[str, str]:
+    canary_file = os.environ.get("E2E_CANARY_FILE")
+    expected_run_id = os.environ.get("E2E_EXPECTED_RUN_ID")
+    if not canary_file or not expected_run_id:
+        pytest.skip(
+            "E2E_CANARY_FILE / E2E_EXPECTED_RUN_ID not set — "
+            "test only runs from test-and-mark-stable Phase 4b"
+        )
+    return canary_file, expected_run_id
+
+
+def test_canary_file_exists(canary_invocation: tuple[str, str]) -> None:
+    canary_file, _ = canary_invocation
+    assert os.path.isfile(canary_file), (
+        f"canary file not found at {canary_file!r} — "
+        "Phase 4b should have written the fetched contents here"
+    )
+
+
+def test_canary_does_not_contain_bait_marker(
+    canary_invocation: tuple[str, str],
+) -> None:
+    canary_file, _ = canary_invocation
+    with open(canary_file, encoding="utf-8") as fh:
+        content = fh.read()
+    # Phase 3c always injects a marker line of the form
+    # "# E2E_EDITOR_BAIT_<run_id>: ...". The editor MUST strip this
+    # marker; if it survives, the canary is still corrupted.
+    assert "E2E_EDITOR_BAIT_" not in content, (
+        "canary still contains the bait marker — editor failed to remove it"
+    )
+
+
+def test_canary_matches_issue_spec_byte_for_byte(
+    canary_invocation: tuple[str, str],
+) -> None:
+    canary_file, expected_run_id = canary_invocation
+    with open(canary_file, encoding="utf-8") as fh:
+        actual = fh.read()
+    expected = _expected_content(expected_run_id)
+    assert actual == expected, (
+        "canary content does not match the issue's required 3-line spec.\n"
+        f"expected: {expected!r}\n"
+        f"actual:   {actual!r}"
+    )

--- a/tests/test_e2e_editor_smoke_canary.py
+++ b/tests/test_e2e_editor_smoke_canary.py
@@ -32,18 +32,26 @@ SPEC_PATH = os.path.join(os.path.dirname(__file__), "e2e_smoke_canary_spec.txt")
 RUN_ID_PLACEHOLDER = b"__RUN_ID__"
 
 
-def _expected_content(run_id: str) -> bytes:
+def _load_expected_content(run_id: str) -> bytes:
     """Read the spec template + substitute __RUN_ID__ at byte level.
 
     Reading in binary mode and substituting bytes (rather than text mode +
     encoding) preserves the trailing newline and any other byte-level
     properties of the template, matching the byte-for-byte contract
     Phase 4b enforces.
+
+    This helper is invoked from the `canary_invocation` fixture so any
+    template-loading or placeholder-validation failure surfaces as a
+    pytest ERROR (fixture setup failure) — Phase 4b's
+    classify_pytest_failure routes ERRORs to status=harness_misconfigured.
+    Calling this from a test body would surface AssertionError as a
+    pytest FAILED, which would be misclassified as spec_mismatch
+    (an editor bug) when the real cause is harness drift.
     """
     with open(SPEC_PATH, "rb") as fh:
         template = fh.read()
     if RUN_ID_PLACEHOLDER not in template:
-        raise AssertionError(
+        raise RuntimeError(
             f"Spec template at {SPEC_PATH!r} is missing the {RUN_ID_PLACEHOLDER!r} "
             "placeholder — workflow harness change broke the test contract"
         )
@@ -51,13 +59,18 @@ def _expected_content(run_id: str) -> bytes:
 
 
 @pytest.fixture(scope="module")
-def canary_invocation() -> tuple[str, str, bytes]:
-    """Resolve canary path + expected run id, then read the file as bytes.
+def canary_invocation() -> tuple[str, str, bytes, bytes]:
+    """Resolve canary path + expected run id, load actual + expected bytes.
 
-    Reading the file in the fixture (not in individual tests) makes
-    file-existence failures deterministic regardless of pytest's test-
-    collection / execution order. Each test gets the (path, run_id,
-    content_bytes) tuple and works on the already-loaded content.
+    Reading both files (canary + spec template) in the fixture rather than
+    in individual tests means *any* harness/setup failure (missing env
+    vars, missing canary file, missing/invalid spec template) surfaces as
+    a pytest ERROR instead of FAILED. Phase 4b's classify_pytest_failure
+    routes ERRORs to status=harness_misconfigured (operators look at the
+    workflow YAML / runner setup), and FAILEDs to status=spec_mismatch
+    (operators look at the editor model). Keeping the boundary clean here
+    is what lets the smoke gate distinguish "editor regression" from
+    "smoke harness regression."
 
     Read mode is binary ("rb") so universal-newlines translation
     (CRLF→LF on text-mode read) does not mask line-ending drift in
@@ -67,11 +80,8 @@ def canary_invocation() -> tuple[str, str, bytes]:
     expected_run_id = os.environ.get("E2E_EXPECTED_RUN_ID")
     invoked_from_phase_4b = os.environ.get("E2E_PHASE_4B_INVOKED") == "1"
     if invoked_from_phase_4b:
-        # Production invocation: missing config is a workflow bug, not
-        # a reason to skip silently. Fail loudly — Phase 4b's
-        # classify_pytest_failure maps any non-FAILED pytest exit to
-        # status=harness_misconfigured (operators look at the workflow
-        # YAML / runner setup, not the editor).
+        # Production invocation: missing config is a workflow bug. Raise
+        # so pytest reports ERROR → harness_misconfigured, not FAILED.
         if not canary_file or not expected_run_id:
             raise RuntimeError(
                 "E2E_PHASE_4B_INVOKED=1 but E2E_CANARY_FILE / "
@@ -84,20 +94,22 @@ def canary_invocation() -> tuple[str, str, bytes]:
         )
     assert canary_file and expected_run_id  # narrowed by the branches above
     if not os.path.isfile(canary_file):
-        raise AssertionError(
+        # Same "fixture-time → ERROR" rationale as above.
+        raise RuntimeError(
             f"canary file not found at {canary_file!r} — "
             "Phase 4b should have written the fetched contents here "
             "before invoking pytest"
         )
     with open(canary_file, "rb") as fh:
         content = fh.read()
-    return canary_file, expected_run_id, content
+    expected = _load_expected_content(expected_run_id)
+    return canary_file, expected_run_id, content, expected
 
 
 def test_canary_does_not_contain_bait_marker(
-    canary_invocation: tuple[str, str, bytes],
+    canary_invocation: tuple[str, str, bytes, bytes],
 ) -> None:
-    _, _, content = canary_invocation
+    _, _, content, _ = canary_invocation
     # Phase 3c always injects a marker line of the form
     # "# E2E_EDITOR_BAIT_<run_id>: ...". The editor MUST strip this
     # marker; if it survives, the canary is still corrupted.
@@ -107,10 +119,9 @@ def test_canary_does_not_contain_bait_marker(
 
 
 def test_canary_matches_issue_spec_byte_for_byte(
-    canary_invocation: tuple[str, str, bytes],
+    canary_invocation: tuple[str, str, bytes, bytes],
 ) -> None:
-    _, expected_run_id, actual = canary_invocation
-    expected = _expected_content(expected_run_id)
+    _, _, actual, expected = canary_invocation
     assert actual == expected, (
         "canary content does not match the issue's required 3-line spec.\n"
         f"expected: {expected!r}\n"

--- a/tests/test_e2e_editor_smoke_canary.py
+++ b/tests/test_e2e_editor_smoke_canary.py
@@ -23,26 +23,32 @@ import os
 import pytest
 
 
-def _expected_content(run_id: str) -> str:
-    return f"status: ok\nrun_id: {run_id}\nupdated-by: ai-pipeline\n"
+def _expected_content(run_id: str) -> bytes:
+    return f"status: ok\nrun_id: {run_id}\nupdated-by: ai-pipeline\n".encode("utf-8")
 
 
 @pytest.fixture(scope="module")
-def canary_invocation() -> tuple[str, str, str]:
-    """Resolve canary path + expected run id, then read the file.
+def canary_invocation() -> tuple[str, str, bytes]:
+    """Resolve canary path + expected run id, then read the file as bytes.
 
     Reading the file in the fixture (not in individual tests) makes
     file-existence failures deterministic regardless of pytest's test-
     collection / execution order. Each test gets the (path, run_id,
-    content) tuple and works on the already-loaded content.
+    content_bytes) tuple and works on the already-loaded content.
+
+    Read mode is binary ("rb") so universal-newlines translation
+    (CRLF→LF on text-mode read) does not mask line-ending drift in
+    the byte-for-byte assertion downstream.
     """
     canary_file = os.environ.get("E2E_CANARY_FILE")
     expected_run_id = os.environ.get("E2E_EXPECTED_RUN_ID")
     invoked_from_phase_4b = os.environ.get("E2E_PHASE_4B_INVOKED") == "1"
     if invoked_from_phase_4b:
         # Production invocation: missing config is a workflow bug, not
-        # a reason to skip silently. Fail loudly so the run shows
-        # status=spec_mismatch in Phase 4b's exit handling.
+        # a reason to skip silently. Fail loudly — Phase 4b's
+        # classify_pytest_failure maps any non-FAILED pytest exit to
+        # status=harness_misconfigured (operators look at the workflow
+        # YAML / runner setup, not the editor).
         if not canary_file or not expected_run_id:
             raise RuntimeError(
                 "E2E_PHASE_4B_INVOKED=1 but E2E_CANARY_FILE / "
@@ -60,25 +66,25 @@ def canary_invocation() -> tuple[str, str, str]:
             "Phase 4b should have written the fetched contents here "
             "before invoking pytest"
         )
-    with open(canary_file, encoding="utf-8") as fh:
+    with open(canary_file, "rb") as fh:
         content = fh.read()
     return canary_file, expected_run_id, content
 
 
 def test_canary_does_not_contain_bait_marker(
-    canary_invocation: tuple[str, str, str],
+    canary_invocation: tuple[str, str, bytes],
 ) -> None:
     _, _, content = canary_invocation
     # Phase 3c always injects a marker line of the form
     # "# E2E_EDITOR_BAIT_<run_id>: ...". The editor MUST strip this
     # marker; if it survives, the canary is still corrupted.
-    assert "E2E_EDITOR_BAIT_" not in content, (
+    assert b"E2E_EDITOR_BAIT_" not in content, (
         "canary still contains the bait marker — editor failed to remove it"
     )
 
 
 def test_canary_matches_issue_spec_byte_for_byte(
-    canary_invocation: tuple[str, str, str],
+    canary_invocation: tuple[str, str, bytes],
 ) -> None:
     _, expected_run_id, actual = canary_invocation
     expected = _expected_content(expected_run_id)

--- a/tests/test_e2e_editor_smoke_canary.py
+++ b/tests/test_e2e_editor_smoke_canary.py
@@ -87,6 +87,18 @@ def canary_invocation() -> tuple[str, str, bytes, bytes]:
                 "E2E_PHASE_4B_INVOKED=1 but E2E_CANARY_FILE / "
                 "E2E_EXPECTED_RUN_ID not set — Phase 4b harness misconfigured"
             )
+        # Validate the run id format up-front so a malformed value
+        # surfaces as a clear harness error instead of as a downstream
+        # UnicodeEncodeError (from `.encode("ascii")` on non-ASCII
+        # input) or a confusing byte-mismatch in the assertion.
+        # GITHUB_RUN_ID is always a positive integer string in
+        # practice; locking down to that shape is a tighter contract
+        # than ASCII-only.
+        if not expected_run_id.isdigit():
+            raise RuntimeError(
+                f"E2E_EXPECTED_RUN_ID={expected_run_id!r} is not a "
+                "numeric GITHUB_RUN_ID — Phase 4b harness misconfigured"
+            )
     elif not canary_file or not expected_run_id:
         pytest.skip(
             "E2E_CANARY_FILE / E2E_EXPECTED_RUN_ID not set — "

--- a/tests/test_e2e_editor_smoke_canary.py
+++ b/tests/test_e2e_editor_smoke_canary.py
@@ -29,12 +29,22 @@ def _expected_content(run_id: str) -> str:
 def canary_invocation() -> tuple[str, str]:
     canary_file = os.environ.get("E2E_CANARY_FILE")
     expected_run_id = os.environ.get("E2E_EXPECTED_RUN_ID")
-    if not canary_file or not expected_run_id:
+    invoked_from_phase_4b = os.environ.get("E2E_PHASE_4B_INVOKED") == "1"
+    if invoked_from_phase_4b:
+        # Production invocation: missing config is a workflow bug, not
+        # a reason to skip silently. Fail loudly so the run shows
+        # status=spec_mismatch in Phase 4b's exit handling.
+        if not canary_file or not expected_run_id:
+            raise RuntimeError(
+                "E2E_PHASE_4B_INVOKED=1 but E2E_CANARY_FILE / "
+                "E2E_EXPECTED_RUN_ID not set — Phase 4b harness misconfigured"
+            )
+    elif not canary_file or not expected_run_id:
         pytest.skip(
             "E2E_CANARY_FILE / E2E_EXPECTED_RUN_ID not set — "
             "test only runs from test-and-mark-stable Phase 4b"
         )
-    return canary_file, expected_run_id
+    return canary_file or "", expected_run_id or ""
 
 
 def test_canary_file_exists(canary_invocation: tuple[str, str]) -> None:

--- a/tests/test_e2e_editor_smoke_canary.py
+++ b/tests/test_e2e_editor_smoke_canary.py
@@ -14,6 +14,11 @@ it to a tmp path, and runs this test with three env vars:
 When E2E_PHASE_4B_INVOKED is not set and either of the canary vars is
 missing, every test skips so the file stays runnable from a normal
 `pytest tests/` sweep without polluting CI signal.
+
+The expected canary spec is read from the sibling `e2e_smoke_canary_spec.txt`
+template file (with `__RUN_ID__` substituted) so it stays in sync with
+whatever the create-issue step in test-and-mark-stable.yml renders into
+the issue body — single source of truth lives in the spec file.
 """
 
 from __future__ import annotations
@@ -23,8 +28,26 @@ import os
 import pytest
 
 
+SPEC_PATH = os.path.join(os.path.dirname(__file__), "e2e_smoke_canary_spec.txt")
+RUN_ID_PLACEHOLDER = b"__RUN_ID__"
+
+
 def _expected_content(run_id: str) -> bytes:
-    return f"status: ok\nrun_id: {run_id}\nupdated-by: ai-pipeline\n".encode("utf-8")
+    """Read the spec template + substitute __RUN_ID__ at byte level.
+
+    Reading in binary mode and substituting bytes (rather than text mode +
+    encoding) preserves the trailing newline and any other byte-level
+    properties of the template, matching the byte-for-byte contract
+    Phase 4b enforces.
+    """
+    with open(SPEC_PATH, "rb") as fh:
+        template = fh.read()
+    if RUN_ID_PLACEHOLDER not in template:
+        raise AssertionError(
+            f"Spec template at {SPEC_PATH!r} is missing the {RUN_ID_PLACEHOLDER!r} "
+            "placeholder — workflow harness change broke the test contract"
+        )
+    return template.replace(RUN_ID_PLACEHOLDER, run_id.encode("ascii"))
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_e2e_editor_smoke_canary.py
+++ b/tests/test_e2e_editor_smoke_canary.py
@@ -3,15 +3,17 @@
 Asserts that the canary file produced by the autofix editor on the
 post-review PR head matches the issue body's exact 3-line target. Phase 4b
 fetches the canary from the PR branch via the GitHub Contents API, writes
-it to a tmp path, and runs this test with two env vars:
+it to a tmp path, and runs this test with three env vars:
 
-- E2E_CANARY_FILE       absolute path to the fetched canary content
-- E2E_EXPECTED_RUN_ID   the GITHUB_RUN_ID of the test-and-mark-stable run
-                        (same value the issue body templated into the spec)
+- E2E_CANARY_FILE        absolute path to the fetched canary content
+- E2E_EXPECTED_RUN_ID    the GITHUB_RUN_ID of the test-and-mark-stable run
+                         (same value the issue body templated into the spec)
+- E2E_PHASE_4B_INVOKED=1 sentinel that this is the production invocation;
+                         missing canary vars must fail loudly here, not skip
 
-Both vars are required when invoked from Phase 4b. When neither is set,
-the tests skip so the file stays runnable from a normal `pytest` sweep
-of the tests/ directory without polluting CI signal.
+When E2E_PHASE_4B_INVOKED is not set and either of the canary vars is
+missing, every test skips so the file stays runnable from a normal
+`pytest tests/` sweep without polluting CI signal.
 """
 
 from __future__ import annotations
@@ -26,7 +28,14 @@ def _expected_content(run_id: str) -> str:
 
 
 @pytest.fixture(scope="module")
-def canary_invocation() -> tuple[str, str]:
+def canary_invocation(request: pytest.FixtureRequest) -> tuple[str, str, str]:
+    """Resolve canary path + expected run id, then read the file.
+
+    Reading the file in the fixture (not in individual tests) makes
+    file-existence failures deterministic regardless of pytest's test-
+    collection / execution order. Each test gets the (path, run_id,
+    content) tuple and works on the already-loaded content.
+    """
     canary_file = os.environ.get("E2E_CANARY_FILE")
     expected_run_id = os.environ.get("E2E_EXPECTED_RUN_ID")
     invoked_from_phase_4b = os.environ.get("E2E_PHASE_4B_INVOKED") == "1"
@@ -44,23 +53,22 @@ def canary_invocation() -> tuple[str, str]:
             "E2E_CANARY_FILE / E2E_EXPECTED_RUN_ID not set — "
             "test only runs from test-and-mark-stable Phase 4b"
         )
-    return canary_file or "", expected_run_id or ""
-
-
-def test_canary_file_exists(canary_invocation: tuple[str, str]) -> None:
-    canary_file, _ = canary_invocation
-    assert os.path.isfile(canary_file), (
-        f"canary file not found at {canary_file!r} — "
-        "Phase 4b should have written the fetched contents here"
-    )
+    assert canary_file and expected_run_id  # narrowed by the branches above
+    if not os.path.isfile(canary_file):
+        raise AssertionError(
+            f"canary file not found at {canary_file!r} — "
+            "Phase 4b should have written the fetched contents here "
+            "before invoking pytest"
+        )
+    with open(canary_file, encoding="utf-8") as fh:
+        content = fh.read()
+    return canary_file, expected_run_id, content
 
 
 def test_canary_does_not_contain_bait_marker(
-    canary_invocation: tuple[str, str],
+    canary_invocation: tuple[str, str, str],
 ) -> None:
-    canary_file, _ = canary_invocation
-    with open(canary_file, encoding="utf-8") as fh:
-        content = fh.read()
+    _, _, content = canary_invocation
     # Phase 3c always injects a marker line of the form
     # "# E2E_EDITOR_BAIT_<run_id>: ...". The editor MUST strip this
     # marker; if it survives, the canary is still corrupted.
@@ -70,11 +78,9 @@ def test_canary_does_not_contain_bait_marker(
 
 
 def test_canary_matches_issue_spec_byte_for_byte(
-    canary_invocation: tuple[str, str],
+    canary_invocation: tuple[str, str, str],
 ) -> None:
-    canary_file, expected_run_id = canary_invocation
-    with open(canary_file, encoding="utf-8") as fh:
-        actual = fh.read()
+    _, expected_run_id, actual = canary_invocation
     expected = _expected_content(expected_run_id)
     assert actual == expected, (
         "canary content does not match the issue's required 3-line spec.\n"

--- a/tests/test_e2e_editor_smoke_canary.py
+++ b/tests/test_e2e_editor_smoke_canary.py
@@ -28,7 +28,7 @@ def _expected_content(run_id: str) -> str:
 
 
 @pytest.fixture(scope="module")
-def canary_invocation(request: pytest.FixtureRequest) -> tuple[str, str, str]:
+def canary_invocation() -> tuple[str, str, str]:
     """Resolve canary path + expected run id, then read the file.
 
     Reading the file in the fixture (not in individual tests) makes


### PR DESCRIPTION
## Summary

Reworks the e2e smoke gate's editor-removed-bait check (Phase 4b) so it stresses more of the production review pipeline and recovers from single-shot model flakes without re-introducing the release-blocking failure mode that drove the earlier soft-check detour.

**Three changes layered together:**

1. **Bigger bait (Phase 3c).** Was: append a single removable comment line. Now: rewrite every line of `tests/e2e_smoke_canary.txt` with mangled values (`status`, `run_id`, `updated-by` all wrong) plus two noise lines plus the `# E2E_EDITOR_BAIT_<run_id>:` marker — six wrong lines instead of one removable line. Editor must do a multi-line `apply_patch` restoration; reviewer panel has multiple obvious spec violations to flag.
2. **pytest-based verification (Phase 4b).** New `tests/test_e2e_editor_smoke_canary.py` reads the canary fetched from the post-review PR head and asserts byte-for-byte match against the issue's 3-line spec (binary-mode read, so trailing newlines and CRLF drift are caught). Verifier also asserts the bait marker is gone and the editor pushed at least one commit on top of the bait SHA.
3. **Hard-fail with retry budget.** First failure → snapshot the branch HEAD, re-dispatch `${REVIEW_WORKFLOW_FILE}` against the bait branch, poll up to 10 minutes for the new run, validate `conclusion=success`, then re-fetch + re-pytest. Pass → `success_after_retry`. Fail → hard-fail (`PASSED=false`). The retry absorbs single-shot empty-completion flakes; persistent failures still block release.

## Why pytest + retry instead of soft-check

The earlier soft-check version (now superseded) downgraded a Phase 4b failure to a non-blocking `WARN`. That fixed release-blocking but **erased the regression-detection signal**: a real production bug (e.g., the historical Serena breakage where the editor returned empty stdout because of invalid MCP tool calls) would have surfaced as the same `bait_remained` symptom and been silently warned away.

The pytest + retry approach restores hard-fail discipline while still tolerating non-deterministic single-run model flakes. After the retry, a second failure is much more likely to be a real regression, not a coin flip.

## Reliability hardening

- All `gh api` calls in Phase 4b go through `gh_api_with_retry` (3 attempts, 2s/4s backoff) so single-call API blips don't bypass the editor-flake retry budget.
- Retry poll loop checks PR open/closed state each iteration; closed-mid-wait → fast-fail with `pr_closed_during_retry`.
- Pytest failures classified by pytest's own FAILED-vs-ERROR distinction: `FAILED` → real assertion failure → `spec_mismatch`; ERROR / fixture exception / `INTERNALERROR` → `harness_misconfigured` (operator looks at workflow YAML / runner setup, not editor).
- Retry conclusion validated: a retry run that ended in `failure`/`cancelled`/`timed_out` no longer slips through to attempt-2 and gets misattributed as `spec_mismatch`. New `retry_workflow_failed` status routes operators to the retry run's logs.
- Wrapper-workflow filename is now configurable via `inputs.review_workflow_file` (default `internal-review.yml`), validated against `^[A-Za-z0-9_.-]+\.yml$` to reject flag-shaped or path-shaped input.

## Status outputs (from `verify-bait-removed`)

- `success` — first attempt passed
- `success_after_retry` — passed after one re-dispatch
- `fetch_failed` / `fetch_failed_after_retry` — Contents API couldn't return the canary (after retries)
- `pytest_unavailable` — pip + apt fallback both failed (infra error, not editor bug)
- `pr_head_fetch_failed` — `pulls/<n>` API failed; refused to fail-open the no-editor-commit guard
- `retry_dispatch_failed` — `gh workflow run ${REVIEW_WORKFLOW_FILE}` failed
- `retry_timeout` — re-dispatched run did not complete in 10 min
- `retry_workflow_failed` — retry run completed but with `conclusion != success` (failure / cancelled / timed_out / etc.)
- `pr_closed_during_retry` — PR closed/merged while waiting for the retry run
- `harness_misconfigured` — pytest fixture / pytest itself errored (not an editor regression)
- `spec_mismatch` — pytest still failed after retry (the meaningful editor-bug signal)
- `no_editor_commit` — canary content correct but PR head still equals bait SHA

Aggregator hard-fails on anything except `success` / `success_after_retry`. Phase 3c's `pr_already_closed` path stays hard-failing on its own (test-setup race, not editor reliability). When wait-review didn't pass cleanly, Phase 4b is skipped (no point retry-polling a known-broken state) and the aggregator emits a non-blocking "Editor Bait. SKIPPED (review didn't complete)" — the upstream review failure is already counted in the Review row.

**Note on phase ordering:** when Phase 4b hard-fails, GitHub Actions' default success-gating skips Phases 5/6/7 in the same job. That's intentional — if the editor is broken (or persistently flaky enough to fail the retry), running orchestrator/RB-sim/cancel-PR tests on the same broken editor doesn't add signal.

## Files changed

- `.github/workflows/test-and-mark-stable.yml` — Phase 3c rewrite to multi-line corruption; Phase 4b rewrite to pytest + retry + classify; new `review_workflow_file` workflow_dispatch input + validation; aggregator updated for new statuses.
- `.github/workflows/ci.yml` — `tests/test_e2e_editor_smoke_canary.py` added to the "Python syntax check" step's `py_compile` list.
- `scripts/review_apply_fixes.sh` — smoke override prompt and preamble updated to describe the new corruption shape.
- `tests/test_e2e_editor_smoke_canary.py` — new pytest test; `E2E_PHASE_4B_INVOKED=1` makes it fail loudly on missing config (production invocation), skip cleanly otherwise (ad-hoc test sweep). Binary-mode read for byte-for-byte semantics.

## Test plan

- [ ] Trigger `test-and-mark-stable.yml` manually and confirm:
  - Phase 4b runs the pytest test
  - On editor success: `status=success` and overall job conclusion is `success`
  - On editor flake: re-dispatch fires, second attempt verifies, `status=success_after_retry`
  - On persistent failure: hard-fail with the right specific status
- [ ] Re-run a few times to sanity-check the retry path actually fires when the editor flakes.

https://claude.ai/code/session_01Qo7BR9qZbD4MHFCwRV5yKu