### PR TITLE
fix(e2e-smoke): Phase 7 handle already-closed PR (cancel-on-close)

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -2688,6 +2688,56 @@ jobs:
         run: |
           set -euo pipefail
           BRANCH="ai/issue-${ISSUE_NUMBER}"
+
+          # The PR may already be closed/merged by the time Phase 7 runs —
+          # earlier phases (orchestrator auto-merge after review approval)
+          # can close it asynchronously. PATCH-ing state=closed on an
+          # already-closed PR is a no-op and fires no `pull_request.closed`
+          # webhook, so the poll below would time out even though
+          # cancel_on_pr_close already ran successfully on the original
+          # close. Detect that case and verify the cancel run that fired
+          # for the prior close instead.
+          PR_INFO=$(gh api "repos/${TEST_REPO}/pulls/${PR_NUMBER}" \
+            --jq '{state, head_sha: .head.sha}' 2>/dev/null || echo "")
+          PR_STATE=$(echo "${PR_INFO}" | jq -r '.state // ""')
+          PR_HEAD_SHA=$(echo "${PR_INFO}" | jq -r '.head_sha // ""')
+          if [ "${PR_STATE}" = "closed" ]; then
+            echo "PR #${PR_NUMBER} is already closed (head_sha=${PR_HEAD_SHA}); looking up the cancel-on-close run that fired for that closure."
+            EXISTING=$(gh api \
+              "repos/${TEST_REPO}/actions/workflows/internal-cancel-on-pr-close.yml/runs?per_page=20&head_sha=${PR_HEAD_SHA}" \
+              --jq '[.workflow_runs[] | select(.event == "pull_request")] | sort_by(.created_at) | last' 2>/dev/null || echo "")
+            if [ -z "${EXISTING}" ] || [ "${EXISTING}" = "null" ]; then
+              echo "::error::PR #${PR_NUMBER} already closed but no internal-cancel-on-pr-close run found for head_sha=${PR_HEAD_SHA}"
+              echo "status=no_run" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
+            EXISTING_RUN_ID=$(echo "${EXISTING}" | jq -r '.id // ""')
+            EXISTING_STATUS=$(echo "${EXISTING}" | jq -r '.status // ""')
+            EXISTING_CONCLUSION=$(echo "${EXISTING}" | jq -r '.conclusion // ""')
+            echo "  found pre-existing cancel-on-close run #${EXISTING_RUN_ID}: status=${EXISTING_STATUS}, conclusion=${EXISTING_CONCLUSION}"
+            # If still in flight, wait briefly for it to settle.
+            WAIT_DEADLINE=$(( $(date +%s) + 120 ))
+            while [ "${EXISTING_STATUS}" != "completed" ] && [ "$(date +%s)" -lt "${WAIT_DEADLINE}" ]; do
+              sleep 5
+              REFRESH=$(gh api "repos/${TEST_REPO}/actions/runs/${EXISTING_RUN_ID}" \
+                --jq '{status, conclusion}' 2>/dev/null || echo "")
+              EXISTING_STATUS=$(echo "${REFRESH}" | jq -r '.status // ""')
+              EXISTING_CONCLUSION=$(echo "${REFRESH}" | jq -r '.conclusion // ""')
+              echo "  cancel-on-close run #${EXISTING_RUN_ID}: status=${EXISTING_STATUS}, conclusion=${EXISTING_CONCLUSION}"
+            done
+            if [ "${EXISTING_CONCLUSION}" != "success" ]; then
+              echo "::error::cancel-on-close run #${EXISTING_RUN_ID} concluded ${EXISTING_CONCLUSION}"
+              echo "status=${EXISTING_CONCLUSION:-no_run}" >> "$GITHUB_OUTPUT"
+              echo "cancel_run_id=${EXISTING_RUN_ID}" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
+            echo "✓ cancel-on-close run #${EXISTING_RUN_ID} succeeded (fired on prior PR close)"
+            echo "status=success" >> "$GITHUB_OUTPUT"
+            echo "cancel_run_id=${EXISTING_RUN_ID}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # PR is still open — exercise the close path end to end.
           # Snapshot the most recent cancel-on-close run BEFORE we close the
           # PR so we can detect a fresh run by monotonic ID after the close.
           PRE_RUN_ID=$(gh api \

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -2697,10 +2697,17 @@ jobs:
           # cancel_on_pr_close already ran successfully on the original
           # close. Detect that case and verify the cancel run that fired
           # for the prior close instead.
+          # Default to '{}' on gh failure so subsequent jq parses don't
+          # blow up under `set -euo pipefail`.
           PR_INFO=$(gh api "repos/${TEST_REPO}/pulls/${PR_NUMBER}" \
-            --jq '{state, head_sha: .head.sha}' 2>/dev/null || echo "")
+            --jq '{state, head_sha: .head.sha}' 2>/dev/null || echo "{}")
           PR_STATE=$(echo "${PR_INFO}" | jq -r '.state // ""')
           PR_HEAD_SHA=$(echo "${PR_INFO}" | jq -r '.head_sha // ""')
+          if [ -z "${PR_STATE}" ]; then
+            echo "::error::Could not read state of PR #${PR_NUMBER} (gh api returned empty)"
+            echo "status=lookup_failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
           if [ "${PR_STATE}" = "closed" ]; then
             echo "PR #${PR_NUMBER} is already closed (head_sha=${PR_HEAD_SHA}); looking up the cancel-on-close run that fired for that closure."
             EXISTING=$(gh api \
@@ -2715,18 +2722,29 @@ jobs:
             EXISTING_STATUS=$(echo "${EXISTING}" | jq -r '.status // ""')
             EXISTING_CONCLUSION=$(echo "${EXISTING}" | jq -r '.conclusion // ""')
             echo "  found pre-existing cancel-on-close run #${EXISTING_RUN_ID}: status=${EXISTING_STATUS}, conclusion=${EXISTING_CONCLUSION}"
-            # If still in flight, wait briefly for it to settle.
-            WAIT_DEADLINE=$(( $(date +%s) + 120 ))
+            # Match the open-PR poll budget (600s) so a slow/queued run
+            # doesn't flake the smoke test if it would have eventually
+            # succeeded.
+            WAIT_DEADLINE=$(( $(date +%s) + 600 ))
             while [ "${EXISTING_STATUS}" != "completed" ] && [ "$(date +%s)" -lt "${WAIT_DEADLINE}" ]; do
               sleep 5
-              REFRESH=$(gh api "repos/${TEST_REPO}/actions/runs/${EXISTING_RUN_ID}" \
-                --jq '{status, conclusion}' 2>/dev/null || echo "")
-              EXISTING_STATUS=$(echo "${REFRESH}" | jq -r '.status // ""')
-              EXISTING_CONCLUSION=$(echo "${REFRESH}" | jq -r '.conclusion // ""')
-              echo "  cancel-on-close run #${EXISTING_RUN_ID}: status=${EXISTING_STATUS}, conclusion=${EXISTING_CONCLUSION}"
+              # `gh api --jq` consumes the JSON inside gh, so a transient
+              # failure produces an empty string rather than malformed
+              # JSON for the next iteration to parse.
+              EXISTING_STATUS=$(gh api "repos/${TEST_REPO}/actions/runs/${EXISTING_RUN_ID}" \
+                --jq '.status // ""' 2>/dev/null || echo "")
+              EXISTING_CONCLUSION=$(gh api "repos/${TEST_REPO}/actions/runs/${EXISTING_RUN_ID}" \
+                --jq '.conclusion // ""' 2>/dev/null || echo "")
+              echo "  cancel-on-close run #${EXISTING_RUN_ID}: status=${EXISTING_STATUS:-?}, conclusion=${EXISTING_CONCLUSION:-?}"
             done
+            if [ "${EXISTING_STATUS}" != "completed" ]; then
+              echo "::error::cancel-on-close run #${EXISTING_RUN_ID} did not complete within 600s (status=${EXISTING_STATUS:-?})"
+              echo "status=timeout" >> "$GITHUB_OUTPUT"
+              echo "cancel_run_id=${EXISTING_RUN_ID}" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
             if [ "${EXISTING_CONCLUSION}" != "success" ]; then
-              echo "::error::cancel-on-close run #${EXISTING_RUN_ID} concluded ${EXISTING_CONCLUSION}"
+              echo "::error::cancel-on-close run #${EXISTING_RUN_ID} concluded ${EXISTING_CONCLUSION:-no_run}"
               echo "status=${EXISTING_CONCLUSION:-no_run}" >> "$GITHUB_OUTPUT"
               echo "cancel_run_id=${EXISTING_RUN_ID}" >> "$GITHUB_OUTPUT"
               exit 1


### PR DESCRIPTION
## Summary
- Phase 7 of `test-and-mark-stable.yml` (`Phase 7: Close PR and verify cancel_on_pr_close fires`) hard-failed run [25375729485 / job 51ca5378](https://github.com/shubhodeep1/coding-workflows/actions/runs/25375729485) with `internal-cancel-on-pr-close did not register a new run within timeout` even though the workflow under test ran successfully.
- Root cause: PR #2121 (`ai/issue-2114`) was merged at `2026-05-05T12:53:40Z` by the orchestrator's auto-merge — that merge **already** fired `internal-cancel-on-pr-close` run [25377544960](https://github.com/shubhodeep1/coding-workflows/actions/runs/25377544960) at `12:53:43Z` (3s later, success). When Phase 7 ran at `12:54:32Z` it `PATCH`-ed `state=closed` on the already-closed PR — a no-op, no `pull_request.closed` webhook fired, the 600s poll never saw a new run, and the smoke test failed.
- Fix: at the start of Phase 7, check the PR state. If it's already closed, look up the `internal-cancel-on-pr-close` run that fired for that closure (matched by `head_sha` + `event=pull_request`) and verify it instead. Fall through to the existing close-then-poll flow when the PR is still open.

## Test plan
- [ ] Re-run `test-and-mark-stable.yml` smoke; confirm Phase 7 now passes when the orchestrator auto-merges the smoke PR before Phase 7 runs.
- [ ] Confirm Phase 7 still works end-to-end on a run where the PR is open at Phase 7 entry (the close-then-poll path is unchanged).
- [ ] Confirm Phase 7 fails (rather than passing silently) when the PR is closed but no cancel-on-close run can be found for `head_sha`, or the found run concluded non-`success`.

https://claude.ai/code/session_01FbPvE7CzExUJrpNUWBXWot

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbPvE7CzExUJrpNUWBXWot)_