### PR TITLE
implement: targeted file context, unattended override, parser test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,11 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_implement_post_codex_recovery.py
 
+      - name: Implement targeted-file-context parser contract test
+        run: |
+          set -euo pipefail
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_implement_targeted_file_context_parser.py
+
       - name: Review autofix failure-log upload contract test
         run: |
           set -euo pipefail

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -846,6 +846,8 @@ jobs:
           TOOL_CALL_BUDGET: ${{ vars.TOOL_CALL_BUDGET_IMPLEMENT || '50' }}
           EDITOR_IDLE_TIMEOUT: ${{ vars.EDITOR_IDLE_TIMEOUT || '1200' }}
           EDITOR_MAX_WALL: ${{ vars.EDITOR_MAX_WALL || '7800' }}
+          TARGETED_FILE_CONTEXT_MAX_FILES: ${{ vars.TARGETED_FILE_CONTEXT_MAX_FILES || '10' }}
+          TARGETED_FILE_CONTEXT_MAX_BYTES: ${{ vars.TARGETED_FILE_CONTEXT_MAX_BYTES || '102400' }}
           # Required by the Fix #5 diagnostics-posting branch. Without
           # this, `[ -n "${GH_TOKEN:-}" ]` at the gh-issue-comment guard
           # is always false and the per-attempt failure diagnostics
@@ -956,27 +958,81 @@ jobs:
           TARGETED_MAX_FILES="${TARGETED_FILE_CONTEXT_MAX_FILES:-10}"
           TARGETED_MAX_BYTES="${TARGETED_FILE_CONTEXT_MAX_BYTES:-102400}"
 
-          # Extract `backticked` paths under the "Files likely to change"
-          # markdown header. Section ends at the next bold header
-          # (`**...**` on its own line) or EOF. Reject absolute paths and
-          # parent-traversal tokens so a malformed plan can't escape the
-          # workspace.
+          # Extract paths from the plan's "Files likely to change" section.
+          # Accepts every section-start form the rest of the workflow already
+          # produces or accepts: bold (`**Files likely to change**`), ATX
+          # heading (`## Files likely to change`), numbered list
+          # (`1. Files likely to change` — the canonical mode-plan.txt form),
+          # plain heading (`Files to change`), and the `1)` numbered variant.
+          # The end of the section is the next peer header at the same depth.
+          # Inside the section, both backticked paths and bare path-like
+          # tokens on list-item lines are extracted; lexical filters reject
+          # absolute paths and parent-traversal tokens. (The follow-up
+          # symlink check below is what actually keeps a malformed plan
+          # from inlining files outside the workspace — the lexical filter
+          # alone is not sufficient.) mawk-compatible: each `if` test is
+          # one statement because mawk does not parse multi-line `if` heads.
           targeted_paths_raw="$(
             awk '
-              BEGIN { in_section = 0 }
-              /^\*\*Files likely to change\*\*[[:space:]]*$/ { in_section = 1; next }
-              in_section && /^\*\*[^*]+\*\*[[:space:]]*$/ { in_section = 0 }
+              {
+                orig_line = $0
+                lc = tolower(orig_line)
+                start_match = 0
+                if (lc ~ /^[[:space:]]{0,3}files[[:space:]]+[^\n]*change/) start_match = 1
+                if (lc ~ /^[[:space:]]{0,3}#+[[:space:]]+files[[:space:]]+[^\n]*change/) start_match = 1
+                if (lc ~ /^[[:space:]]{0,3}\*\*files[[:space:]]+[^\n]*change/) start_match = 1
+                if (lc ~ /^[[:space:]]{0,3}[0-9]+[.][[:space:]]+files[[:space:]]+[^\n]*change/) start_match = 1
+                if (lc ~ /^[[:space:]]{0,3}[0-9]+[)][[:space:]]+files[[:space:]]+[^\n]*change/) start_match = 1
+                if (start_match && !in_section) {
+                  in_section = 1
+                  next
+                }
+              }
+              {
+                end_match = 0
+                if (in_section && orig_line ~ /^[[:space:]]*\*\*[^*]+\*\*[[:space:]]*$/) end_match = 1
+                if (in_section && orig_line ~ /^[[:space:]]{0,3}#+[[:space:]]+[^[:space:]]/) end_match = 1
+                if (in_section && orig_line ~ /^[[:space:]]{0,3}[0-9]+[.][[:space:]]+[^[:space:]]/) end_match = 1
+                if (in_section && orig_line ~ /^[[:space:]]{0,3}[0-9]+[)][[:space:]]+[^[:space:]]/) end_match = 1
+                if (end_match) in_section = 0
+              }
               in_section {
-                while (match($0, /`[^`]+`/)) {
-                  token = substr($0, RSTART + 1, RLENGTH - 2)
-                  $0 = substr($0, RSTART + RLENGTH)
-                  if (token ~ /^[A-Za-z0-9._\/-]+$/ && token !~ /^\// && token !~ /\.\./) {
+                tmp = orig_line
+                while (match(tmp, /`[^`]+`/)) {
+                  token = substr(tmp, RSTART + 1, RLENGTH - 2)
+                  tmp = substr(tmp, RSTART + RLENGTH)
+                  if (token ~ /^[A-Za-z0-9._/-]+$/ && token !~ /^\// && token !~ /\.\./) {
                     print token
+                  }
+                }
+                is_list_item = 0
+                if (orig_line ~ /^[[:space:]]*[-*+][[:space:]]+/) is_list_item = 1
+                if (orig_line ~ /^[[:space:]]*[0-9]+[.][[:space:]]+/) is_list_item = 1
+                if (orig_line ~ /^[[:space:]]*[0-9]+[)][[:space:]]+/) is_list_item = 1
+                if (is_list_item) {
+                  body = orig_line
+                  sub(/^[[:space:]]*[-*+][[:space:]]+/, "", body)
+                  sub(/^[[:space:]]*[0-9]+[.][[:space:]]+/, "", body)
+                  sub(/^[[:space:]]*[0-9]+[)][[:space:]]+/, "", body)
+                  n = split(body, words, /[[:space:]]+/)
+                  for (i = 1; i <= n; i++) {
+                    w = words[i]
+                    gsub(/^[`(\[<{"]+/, "", w)
+                    gsub(/[`)\],.;:!?>}"]+$/, "", w)
+                    if (w ~ /^[A-Za-z0-9._/-]+$/ && w ~ /\// && w !~ /^\// && w !~ /\.\./) {
+                      print w
+                    }
                   }
                 }
               }
             ' "${PLAN_FILE}" 2>/dev/null | awk '!seen[$0]++' || true
           )"
+
+          # Workspace-root anchor for the symlink safety check below.
+          # GITHUB_WORKSPACE is set by the runner; fall back to PWD locally.
+          # Resolve once so per-path realpath comparisons are fast and stable.
+          ws_root="${GITHUB_WORKSPACE:-${PWD}}"
+          ws_resolved="$(realpath -e -- "${ws_root}" 2>/dev/null || printf '%s' "${ws_root}")"
 
           inlined_count=0
           inlined_bytes=0
@@ -987,18 +1043,45 @@ jobs:
                 echo "::notice::Targeted file context: ${TARGETED_MAX_FILES}-file cap reached; skipping remaining plan files."
                 break
               fi
-              if [ ! -f "${path}" ]; then
+              if [ ! -e "${path}" ]; then
                 echo "::notice::Targeted file context: skipping plan file '${path}' (not present in worktree; codex will explore if needed)."
                 continue
               fi
-              fsize="$(wc -c < "${path}" 2>/dev/null || echo 0)"
+              # Symlink safety: resolve the path and confirm it stays under
+              # the workspace root. The lexical filters above only screen
+              # the plan-supplied STRING; a checked-in symlink whose name
+              # passes the filter could still point at /proc/self/environ
+              # or any other runner-local file, exfiltrating it into the
+              # prompt sent to OpenRouter. Reject anything that resolves
+              # outside ${ws_resolved}.
+              resolved_path="$(realpath -e -- "${path}" 2>/dev/null || true)"
+              if [ -z "${resolved_path}" ]; then
+                echo "::notice::Targeted file context: skipping plan file '${path}' (realpath failed; possible broken symlink)."
+                continue
+              fi
+              case "${resolved_path}/" in
+                "${ws_resolved}/"*) ;;
+                *)
+                  echo "::warning::Targeted file context: refusing plan file '${path}' — resolves to '${resolved_path}' outside workspace '${ws_resolved}'. Possible symlink escape attempt."
+                  continue
+                  ;;
+              esac
+              if [ ! -f "${resolved_path}" ]; then
+                echo "::notice::Targeted file context: skipping plan file '${path}' — resolves to non-regular file '${resolved_path}'."
+                continue
+              fi
+              fsize="$(wc -c < "${resolved_path}" 2>/dev/null || echo 0)"
               if [ "$((inlined_bytes + fsize))" -gt "${TARGETED_MAX_BYTES}" ]; then
                 echo "::notice::Targeted file context: ${TARGETED_MAX_BYTES}-byte cap would be exceeded by '${path}' (${fsize}B); skipping (already inlined ${inlined_bytes}B)."
                 continue
               fi
+              # Label with the plan-supplied path (what the model should
+              # apply_patch against) but read bytes from the resolved path
+              # so the symlink check above is the source of truth on what
+              # ends up in the prompt.
               {
                 printf -- '----- FILE: %s -----\n' "${path}"
-                cat "${path}"
+                cat "${resolved_path}"
                 printf '\n'
               } >> "${TARGETED_FILES_FILE}"
               inlined_count=$((inlined_count + 1))

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -886,12 +886,19 @@ jobs:
           - The files named in the approved plan's "Files likely to change" set
             are already inlined verbatim under "=== TARGETED FILE CONTEXT ===" below.
             Do NOT issue shell reads (`sed`, `cat`, `rg`, `head`, `awk`, ...) to
-            re-fetch them — jump straight to apply_patch using the inlined contents
-            as ground truth.
-          - For ANY other file you genuinely need to read, request only the specific
-            line range you need. Do NOT read entire files speculatively, and do NOT
-            run repeated `rg`/`grep` sweeps to discover structure the plan already
-            described.
+            re-fetch THOSE files — jump straight to apply_patch using the inlined
+            contents as ground truth.
+          - When the plan does NOT contain a "Files likely to change" section, or
+            when no TARGETED FILE CONTEXT block appears below, targeted shell
+            discovery (`rg <symbol>`, `grep -n <pattern>`, `sed -n '<n>,<m>p'`) is
+            the right tool — use it, but request specific patterns / line ranges
+            rather than full-file sweeps. The restriction above is about avoiding
+            duplicate reads of files already inlined, not about banning shell
+            discovery in general.
+          - For ANY file not present in TARGETED FILE CONTEXT, request only the
+            specific line range you need. Do NOT read entire files speculatively,
+            and do NOT run repeated `rg`/`grep` sweeps to re-discover structure
+            the plan or a previous read already described.
           - Never read the same file region twice. Plan your reads upfront.
           - Aim to keep total tool calls (MCP + shell exec combined) under TOOL_CALL_BUDGET.
             For large refactors that touch many files, exceeding the budget is acceptable —
@@ -1008,24 +1015,52 @@ jobs:
                 if (lc ~ /^[[:space:]]{0,3}[0-9]+[)][[:space:]]+files[[:space:]]+[^\n]*change/) start_match = 1
                 if (start_match && !in_section) {
                   in_section = 1
+                  # Track ATX heading depth at section start so the
+                  # end-rule below can distinguish a peer-or-shallower
+                  # heading (which terminates the section) from a nested
+                  # subheading like "### Backend files" inside the
+                  # section (which must NOT terminate). For non-ATX
+                  # starts (bold, numbered, plain) leave depth=0 to
+                  # preserve the prior behaviour where any ATX heading
+                  # closes the section.
+                  section_start_depth = 0
+                  if (orig_line ~ /^[[:space:]]{0,3}#+[[:space:]]+/) {
+                    match(orig_line, /#+/)
+                    section_start_depth = RLENGTH
+                  }
                   next
                 }
               }
               {
                 # Section end: peer header at same depth.
-                # Numbered-item end is gated: the body after the "1." prefix
-                # MUST look like a section TITLE, not a path entry. Plans
-                # written as "1. Files likely to change / 1. `src/foo.ts` /
-                # 2. `src/bar.ts`" must keep the section open through the
-                # numbered children — only "2. Functions/modules to
-                # implement" (a multi-word natural-language phrase) should
-                # close it. Heuristic: a numbered line is a section
-                # terminator if its body does NOT begin with a backtick AND
-                # its first whitespace-delimited token is not lower-case
-                # path-like (slash present, lower-case start).
+                # ATX end is gated by section-start depth (tracked in
+                # section_start_depth at the section-start branch above):
+                # an ATX section like "## Files likely to change" closes
+                # only on a peer-or-shallower ATX heading ("## Functions",
+                # "# Anything"), NOT on a nested deeper heading like
+                # "### Backend files" inside the section. Non-ATX section
+                # starts (bold/numbered/plain) leave section_start_depth=0
+                # and any ATX heading still terminates them (current
+                # behaviour preserved).
+                # Numbered-item end is gated: the body after the "1."
+                # prefix MUST look like a section TITLE, not a path entry.
+                # Plans written as "1. Files likely to change /
+                # 1. `src/foo.ts` / 2. `src/bar.ts`" must keep the section
+                # open through the numbered children — only the next
+                # numbered title (multi-word natural-language phrase, like
+                # "2. Functions/modules to implement") should close it.
+                # is_path_entry rule: a numbered line is a path entry
+                # (= keep section open) if its body begins with a backtick
+                # OR its first whitespace-token contains "/" AND ends with
+                # a file-extension dot-suffix. Case-agnostic — handles
+                # both "1. src/foo.ts" and "1. API/Button.tsx".
                 end_match = 0
                 if (in_section && orig_line ~ /^[[:space:]]*\*\*[^*]+\*\*[[:space:]]*$/) end_match = 1
-                if (in_section && orig_line ~ /^[[:space:]]{0,3}#+[[:space:]]+[^[:space:]]/) end_match = 1
+                if (in_section && orig_line ~ /^[[:space:]]{0,3}#+[[:space:]]+[^[:space:]]/) {
+                  match(orig_line, /#+/)
+                  this_atx_depth = RLENGTH
+                  if (section_start_depth == 0 || this_atx_depth <= section_start_depth) end_match = 1
+                }
                 numbered_peer = 0
                 if (in_section && orig_line ~ /^[[:space:]]{0,3}[0-9]+[.][[:space:]]+[^[:space:]]/) numbered_peer = 1
                 if (in_section && orig_line ~ /^[[:space:]]{0,3}[0-9]+[)][[:space:]]+[^[:space:]]/) numbered_peer = 1
@@ -1121,6 +1156,7 @@ jobs:
               denied_path=0
               case "${path}" in
                 .git|.git/*|*/.git|*/.git/*) denied_path=1 ;;
+                .gitmodules|*/.gitmodules) denied_path=1 ;;
                 .env|.env.*|*/.env|*/.env.*) denied_path=1 ;;
                 .npmrc|*/.npmrc|.pypirc|*/.pypirc|.netrc|*/.netrc) denied_path=1 ;;
                 .ssh|.ssh/*|*/.ssh|*/.ssh/*) denied_path=1 ;;
@@ -1162,6 +1198,7 @@ jobs:
                 "${ws_resolved}/.ssh/"*) denied_resolved=1 ;;
               esac
               case "${resolved_path}" in
+                "${ws_resolved}/.gitmodules") denied_resolved=1 ;;
                 "${ws_resolved}/.env"|"${ws_resolved}/.env."*) denied_resolved=1 ;;
                 "${ws_resolved}/.npmrc"|"${ws_resolved}/.pypirc"|"${ws_resolved}/.netrc") denied_resolved=1 ;;
               esac

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -985,8 +985,23 @@ jobs:
           # don't bloat the prompt past provider limits.
           TARGETED_FILES_FILE="${RUNTIME_DIR}/targeted_files_context.txt"
           : > "${TARGETED_FILES_FILE}"
+          # Validate the repo-var-sourced caps before they reach numeric
+          # comparisons / arithmetic. Under `set -euo pipefail` a
+          # non-numeric value (typo, trailing whitespace, accidental
+          # quote) would make `[ -ge ]` or `$((...))` error out and
+          # abort the whole implement step — turning a config typo into
+          # a hard CI failure. Fall back to defaults with a `::warning::`
+          # so operators see the misconfig but the run still completes.
           TARGETED_MAX_FILES="${TARGETED_FILE_CONTEXT_MAX_FILES:-10}"
+          if ! [[ "${TARGETED_MAX_FILES}" =~ ^[0-9]+$ ]]; then
+            echo "::warning::Targeted file context: TARGETED_FILE_CONTEXT_MAX_FILES='${TARGETED_MAX_FILES}' is not a non-negative integer; falling back to default 10. Set vars.TARGETED_FILE_CONTEXT_MAX_FILES to a digits-only value (e.g. 10) to silence this warning."
+            TARGETED_MAX_FILES=10
+          fi
           TARGETED_MAX_BYTES="${TARGETED_FILE_CONTEXT_MAX_BYTES:-102400}"
+          if ! [[ "${TARGETED_MAX_BYTES}" =~ ^[0-9]+$ ]]; then
+            echo "::warning::Targeted file context: TARGETED_FILE_CONTEXT_MAX_BYTES='${TARGETED_MAX_BYTES}' is not a non-negative integer; falling back to default 102400 (100KB). Set vars.TARGETED_FILE_CONTEXT_MAX_BYTES to a digits-only value (e.g. 102400) to silence this warning."
+            TARGETED_MAX_BYTES=102400
+          fi
 
           # Extract paths from the plan's "Files likely to change" section.
           # Accepts every section-start form the rest of the workflow already

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -946,9 +946,13 @@ jobs:
             the UNATTENDED EXECUTION OVERRIDE block in your context — see its
             §3 ("If a file is missing: continue with available context, note
             the limitation. Never fabricate contents.") and §4 (Unattended
-            Decision Policy). Continue with the available context, record any
-            assumptions inline in your output, and never STOP/ASK on missing
-            context files.
+            Decision Policy). Continue with the available context and never
+            STOP/ASK on missing context files. If a non-obvious assumption is
+            required, encode it as a code comment in the file you're editing
+            (the assumption is then itself a repository change, consistent
+            with "Output ONLY repository changes" / "Your output should be
+            repository changes only" elsewhere in this prompt) — do not emit
+            assumptions as narrative output.
           {{WORKFLOW_EDIT_RESTRICTION}}
           - Do not modify ai_pipeline.md or codex_system_instructions.md.
 
@@ -1000,11 +1004,34 @@ jobs:
                 }
               }
               {
+                # Section end: peer header at same depth.
+                # Numbered-item end is gated: the body after the "1." prefix
+                # MUST look like a section TITLE, not a path entry. Plans
+                # written as "1. Files likely to change / 1. `src/foo.ts` /
+                # 2. `src/bar.ts`" must keep the section open through the
+                # numbered children — only "2. Functions/modules to
+                # implement" (a multi-word natural-language phrase) should
+                # close it. Heuristic: a numbered line is a section
+                # terminator if its body does NOT begin with a backtick AND
+                # its first whitespace-delimited token is not lower-case
+                # path-like (slash present, lower-case start).
                 end_match = 0
                 if (in_section && orig_line ~ /^[[:space:]]*\*\*[^*]+\*\*[[:space:]]*$/) end_match = 1
                 if (in_section && orig_line ~ /^[[:space:]]{0,3}#+[[:space:]]+[^[:space:]]/) end_match = 1
-                if (in_section && orig_line ~ /^[[:space:]]{0,3}[0-9]+[.][[:space:]]+[^[:space:]]/) end_match = 1
-                if (in_section && orig_line ~ /^[[:space:]]{0,3}[0-9]+[)][[:space:]]+[^[:space:]]/) end_match = 1
+                numbered_peer = 0
+                if (in_section && orig_line ~ /^[[:space:]]{0,3}[0-9]+[.][[:space:]]+[^[:space:]]/) numbered_peer = 1
+                if (in_section && orig_line ~ /^[[:space:]]{0,3}[0-9]+[)][[:space:]]+[^[:space:]]/) numbered_peer = 1
+                if (numbered_peer) {
+                  numbered_body = orig_line
+                  sub(/^[[:space:]]{0,3}[0-9]+[.][[:space:]]+/, "", numbered_body)
+                  sub(/^[[:space:]]{0,3}[0-9]+[)][[:space:]]+/, "", numbered_body)
+                  numbered_first = numbered_body
+                  sub(/[[:space:]].*/, "", numbered_first)
+                  is_path_entry = 0
+                  if (numbered_body ~ /^`/) is_path_entry = 1
+                  if (numbered_first ~ /^[a-z][A-Za-z0-9._/-]*\// && numbered_first ~ /\./) is_path_entry = 1
+                  if (!is_path_entry) end_match = 1
+                }
                 if (end_match) in_section = 0
               }
               in_section {

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1094,10 +1094,40 @@ jobs:
           inlined_bytes=0
           if [ -n "${targeted_paths_raw}" ]; then
             while IFS= read -r path; do
+              # Defensive whitespace trim. The here-string below feeds
+              # `${targeted_paths_raw}` flush-left, but a future caller
+              # that builds the variable from a different source could
+              # leak indentation; trimming makes the loop tolerant of
+              # either input shape.
+              path="${path#"${path%%[![:space:]]*}"}"
+              path="${path%"${path##*[![:space:]]}"}"
               [ -z "${path}" ] && continue
               if [ "${inlined_count}" -ge "${TARGETED_MAX_FILES}" ]; then
                 echo "::notice::Targeted file context: ${TARGETED_MAX_FILES}-file cap reached; skipping remaining plan files."
                 break
+              fi
+              # Credential-bearing path denylist (defense in depth — the
+              # plan is LLM-produced and not fully trusted). Earlier in
+              # this workflow `git remote set-url origin
+              # "https://x-access-token:${GH_TOKEN}@..."` writes GH_PAT
+              # in plaintext into .git/config, and other dotfiles
+              # commonly hold secrets (.env, .npmrc, .pypirc,
+              # .netrc, etc.). Reject any plan-named path that
+              # resolves into one of these so a malformed or malicious
+              # plan cannot exfiltrate credentials into the prompt sent
+              # to OpenRouter. The check runs against both the
+              # plan-supplied STRING and (after realpath below) the
+              # resolved location — symlink-into-.git is also blocked.
+              denied_path=0
+              case "${path}" in
+                .git|.git/*|*/.git|*/.git/*) denied_path=1 ;;
+                .env|.env.*|*/.env|*/.env.*) denied_path=1 ;;
+                .npmrc|*/.npmrc|.pypirc|*/.pypirc|.netrc|*/.netrc) denied_path=1 ;;
+                .ssh|.ssh/*|*/.ssh|*/.ssh/*) denied_path=1 ;;
+              esac
+              if [ "${denied_path}" -eq 1 ]; then
+                echo "::warning::Targeted file context: refusing plan file '${path}' (denylist: .git/*, .env*, .npmrc, .pypirc, .netrc, .ssh/* commonly contain credentials and must not enter the LLM prompt)."
+                continue
               fi
               if [ ! -e "${path}" ]; then
                 echo "::notice::Targeted file context: skipping plan file '${path}' (not present in worktree; codex will explore if needed)."
@@ -1122,6 +1152,23 @@ jobs:
                   continue
                   ;;
               esac
+              # Resolved-path denylist (catches symlink-into-.git etc.).
+              # Mirrors the plan-string denylist above, run after symlink
+              # resolution so a checked-in symlink at, say, `notes.md ->
+              # .git/config` is also rejected.
+              denied_resolved=0
+              case "${resolved_path}/" in
+                "${ws_resolved}/.git/"*) denied_resolved=1 ;;
+                "${ws_resolved}/.ssh/"*) denied_resolved=1 ;;
+              esac
+              case "${resolved_path}" in
+                "${ws_resolved}/.env"|"${ws_resolved}/.env."*) denied_resolved=1 ;;
+                "${ws_resolved}/.npmrc"|"${ws_resolved}/.pypirc"|"${ws_resolved}/.netrc") denied_resolved=1 ;;
+              esac
+              if [ "${denied_resolved}" -eq 1 ]; then
+                echo "::warning::Targeted file context: refusing plan file '${path}' — resolves to credential-bearing path '${resolved_path}'. Possible symlink-into-secret attempt."
+                continue
+              fi
               if [ ! -f "${resolved_path}" ]; then
                 echo "::notice::Targeted file context: skipping plan file '${path}' — resolves to non-regular file '${resolved_path}'."
                 continue
@@ -1142,9 +1189,7 @@ jobs:
               } >> "${TARGETED_FILES_FILE}"
               inlined_count=$((inlined_count + 1))
               inlined_bytes=$((inlined_bytes + fsize))
-            done <<EOF_TARGETED_PATHS
-          ${targeted_paths_raw}
-          EOF_TARGETED_PATHS
+            done <<< "${targeted_paths_raw}"
           fi
 
           if [ "${inlined_count}" -gt 0 ]; then

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -873,9 +873,15 @@ jobs:
           Implement the approved implementation plan. Modify only the files the plan requires; keep changes minimal and safe.
 
           EFFICIENCY RULES (MANDATORY — reduces token waste):
-          - Read ONLY the specific lines/symbols you need. Do NOT read entire files or
-            request large ranges speculatively. Use targeted line
-            ranges (e.g. sed -n '10,30p') instead of full-file reads.
+          - The files named in the approved plan's "Files likely to change" set
+            are already inlined verbatim under "=== TARGETED FILE CONTEXT ===" below.
+            Do NOT issue shell reads (`sed`, `cat`, `rg`, `head`, `awk`, ...) to
+            re-fetch them — jump straight to apply_patch using the inlined contents
+            as ground truth.
+          - For ANY other file you genuinely need to read, request only the specific
+            line range you need. Do NOT read entire files speculatively, and do NOT
+            run repeated `rg`/`grep` sweeps to discover structure the plan already
+            described.
           - Never read the same file region twice. Plan your reads upfront.
           - Aim to keep total tool calls (MCP + shell exec combined) under TOOL_CALL_BUDGET.
             For large refactors that touch many files, exceeding the budget is acceptable —
@@ -936,10 +942,87 @@ jobs:
           Your output should be repository changes only.
           EOF
 
-          # Build prompt: static context + instructions + dynamic implementation context,
-          # all inlined so the model doesn't waste tool calls reading files.
-          # The static prefix (pre_assembled_static.txt) is identical across all
-          # runs, enabling LLM provider prompt-prefix caching.
+          # Targeted file context: parse the approved plan's "Files likely to
+          # change" section, inline each named file's contents into the prompt
+          # so Codex can apply_patch without first issuing shell reads to
+          # discover their structure. This addresses the gpt-5.3-codex
+          # "announce-without-emit" failure mode (openai/codex#11151) where
+          # the agent burns its budget on rg/sed exploration of files the
+          # plan already named, then bails before invoking apply_patch.
+          # Bounded by file count + total bytes so large-refactor plans
+          # don't bloat the prompt past provider limits.
+          TARGETED_FILES_FILE="${RUNTIME_DIR}/targeted_files_context.txt"
+          : > "${TARGETED_FILES_FILE}"
+          TARGETED_MAX_FILES="${TARGETED_FILE_CONTEXT_MAX_FILES:-10}"
+          TARGETED_MAX_BYTES="${TARGETED_FILE_CONTEXT_MAX_BYTES:-102400}"
+
+          # Extract `backticked` paths under the "Files likely to change"
+          # markdown header. Section ends at the next bold header
+          # (`**...**` on its own line) or EOF. Reject absolute paths and
+          # parent-traversal tokens so a malformed plan can't escape the
+          # workspace.
+          targeted_paths_raw="$(
+            awk '
+              BEGIN { in_section = 0 }
+              /^\*\*Files likely to change\*\*[[:space:]]*$/ { in_section = 1; next }
+              in_section && /^\*\*[^*]+\*\*[[:space:]]*$/ { in_section = 0 }
+              in_section {
+                while (match($0, /`[^`]+`/)) {
+                  token = substr($0, RSTART + 1, RLENGTH - 2)
+                  $0 = substr($0, RSTART + RLENGTH)
+                  if (token ~ /^[A-Za-z0-9._\/-]+$/ && token !~ /^\// && token !~ /\.\./) {
+                    print token
+                  }
+                }
+              }
+            ' "${PLAN_FILE}" 2>/dev/null | awk '!seen[$0]++' || true
+          )"
+
+          inlined_count=0
+          inlined_bytes=0
+          if [ -n "${targeted_paths_raw}" ]; then
+            while IFS= read -r path; do
+              [ -z "${path}" ] && continue
+              if [ "${inlined_count}" -ge "${TARGETED_MAX_FILES}" ]; then
+                echo "::notice::Targeted file context: ${TARGETED_MAX_FILES}-file cap reached; skipping remaining plan files."
+                break
+              fi
+              if [ ! -f "${path}" ]; then
+                echo "::notice::Targeted file context: skipping plan file '${path}' (not present in worktree; codex will explore if needed)."
+                continue
+              fi
+              fsize="$(wc -c < "${path}" 2>/dev/null || echo 0)"
+              if [ "$((inlined_bytes + fsize))" -gt "${TARGETED_MAX_BYTES}" ]; then
+                echo "::notice::Targeted file context: ${TARGETED_MAX_BYTES}-byte cap would be exceeded by '${path}' (${fsize}B); skipping (already inlined ${inlined_bytes}B)."
+                continue
+              fi
+              {
+                printf -- '----- FILE: %s -----\n' "${path}"
+                cat "${path}"
+                printf '\n'
+              } >> "${TARGETED_FILES_FILE}"
+              inlined_count=$((inlined_count + 1))
+              inlined_bytes=$((inlined_bytes + fsize))
+            done <<EOF_TARGETED_PATHS
+          ${targeted_paths_raw}
+          EOF_TARGETED_PATHS
+          fi
+
+          if [ "${inlined_count}" -gt 0 ]; then
+            echo "Targeted file context: inlined ${inlined_count} file(s), ${inlined_bytes} bytes from approved plan."
+          else
+            echo "Targeted file context: no plan files matched (plan may lack a 'Files likely to change' section, or all named paths were missing/over-cap)."
+          fi
+
+          # Build prompt: static context + instructions + targeted file
+          # contents + dynamic implementation context, all inlined so the
+          # model doesn't waste tool calls reading files.
+          # The static prefix (pre_assembled_static.txt) is identical across
+          # all runs, enabling LLM provider prompt-prefix caching. The
+          # targeted file block is appended AFTER the cacheable prefix and
+          # the rendered template so the cache hit on the prefix is preserved
+          # — the targeted block varies per plan and is never expected to be
+          # cache-hit material.
           {
             cat ./pre_assembled_static.txt
             echo
@@ -948,6 +1031,19 @@ jobs:
             echo
             bash scripts/render_prompt.sh "${PROMPT_TEMPLATE_FILE}"
             echo
+            if [ -s "${TARGETED_FILES_FILE}" ]; then
+              echo "=== TARGETED FILE CONTEXT ==="
+              echo "The files below are named in the approved plan's \"Files"
+              echo "likely to change\" section. Their full contents are inlined"
+              echo "here as ground truth. Use them directly with apply_patch —"
+              echo "do NOT issue shell reads to re-fetch them. If the plan also"
+              echo "names files that are absent here, they were missing from the"
+              echo "worktree or exceeded the inlining cap; only those may be read"
+              echo "via shell, and only with targeted line ranges."
+              echo
+              cat "${TARGETED_FILES_FILE}"
+              echo
+            fi
             echo "=== AI MEMORY CONTEXT ==="
             cat "${MEMORY_CONTEXT_FILE}"
             echo

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -938,6 +938,17 @@ jobs:
           Restrictions:
 
           - Do not ask clarification questions.
+          - Missing repo-level context files (`agents.md`, `db/contracts/*.yml`,
+            `README.md`, app-level `AGENTS.md`) are NOT blockers. The
+            "PRE-TASK MANDATORY CONTEXT LOADING" preamble in the system
+            instructions ("STOP and ask using mandatory Q/A format" when any
+            of those are missing) is OVERRIDDEN for this unattended run by
+            the UNATTENDED EXECUTION OVERRIDE block in your context — see its
+            §3 ("If a file is missing: continue with available context, note
+            the limitation. Never fabricate contents.") and §4 (Unattended
+            Decision Policy). Continue with the available context, record any
+            assumptions inline in your output, and never STOP/ASK on missing
+            context files.
           {{WORKFLOW_EDIT_RESTRICTION}}
           - Do not modify ai_pipeline.md or codex_system_instructions.md.
 

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -443,7 +443,15 @@ jobs:
             fi
           done
 
-          for f in codex_system_instructions.md ai_pipeline.md; do
+          # unattended_llm_system_instructions.md staging note: the file
+          # is required by build_static_context.sh's implement branch to
+          # emit the UNATTENDED EXECUTION OVERRIDE block. Without it, the
+          # model sees only the STOP-and-ASK rules from
+          # codex_system_instructions.md / agents.md and no override
+          # context, which can drive the gpt-5.3-codex
+          # announce-without-emit failure mode. Stage it alongside the
+          # other system-instruction files.
+          for f in codex_system_instructions.md unattended_llm_system_instructions.md ai_pipeline.md; do
             if [ ! -f "${f}" ]; then
               src=".codex-workflow-src/${f}"
               if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/${f}" ]; then
@@ -1027,9 +1035,19 @@ jobs:
                   sub(/^[[:space:]]{0,3}[0-9]+[)][[:space:]]+/, "", numbered_body)
                   numbered_first = numbered_body
                   sub(/[[:space:]].*/, "", numbered_first)
+                  # is_path_entry test: a numbered child whose body looks
+                  # like a file path, not a section title.
+                  #   1) Body starts with a backtick — backticked path.
+                  #   2) First whitespace-token contains "/" AND ends with
+                  #      a file-extension dot-suffix (".ts", ".sol", etc.).
+                  # The extension-dot rule is case-agnostic, so plans that
+                  # use uppercase-starting paths like "1. API/foo.ts" are
+                  # recognised correctly. Section titles like
+                  # "2. Functions/modules to implement" do not end with a
+                  # dot-extension, so they still close the section.
                   is_path_entry = 0
                   if (numbered_body ~ /^`/) is_path_entry = 1
-                  if (numbered_first ~ /^[a-z][A-Za-z0-9._/-]*\// && numbered_first ~ /\./) is_path_entry = 1
+                  if (numbered_first ~ /\// && numbered_first ~ /\.[A-Za-z0-9]{1,8}$/) is_path_entry = 1
                   if (!is_path_entry) end_match = 1
                 }
                 if (end_match) in_section = 0

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1211,7 +1211,24 @@ jobs:
               echo
             fi
             if [ -f "${SUPPORT_AGENTS_FILE}" ]; then
+              # agents.md is a verbatim copy of codex_system_instructions.md
+              # (same PRE-TASK MANDATORY CONTEXT LOADING preamble, same §0
+              # Prime Directive "STOP. ASK. DO NOT PROCEED", same §2
+              # Always-On Ask-First Mode, same FINAL REMINDER). For
+              # unattended runs those rules conflict with the
+              # UNATTENDED SYSTEM INSTRUCTIONS block above. Emit an
+              # explicit displacement note so the model treats the
+              # agents.md system-rules sections as overridden — without
+              # this the model can pattern-match the concrete "STOP and
+              # ASK" rules over the override and enter the
+              # narrate-without-edit stuck state that EDITOR_NOOP_SUSPICIOUS
+              # detects (see the same fix applied to implement.yml in
+              # this commit; analogous failure mechanism). agents.md's
+              # repo-specific guidance (Q-format, naming, contract paths,
+              # MongoDB rules, etc.) still applies.
               echo "=== AGENTS.MD ==="
+              echo "NOTE: agents.md reproduces codex_system_instructions.md's PRE-TASK MANDATORY CONTEXT LOADING preamble, §0 Prime Directive, §2 Always-On Ask-First Mode, and FINAL REMINDER verbatim. Those four sections are OVERRIDDEN for this unattended run by the UNATTENDED SYSTEM INSTRUCTIONS block at the top of this prompt — see its §0 (Execution Mode) and §3 (Mandatory Context Loading: 'If a file is missing: continue with available context'). agents.md's repo-specific guidance (custom Q-formats, naming conventions, contract paths, MongoDB rules, code-style §9, etc.) still applies; only its STOP-and-ASK directives are displaced."
+              echo
               cat "${SUPPORT_AGENTS_FILE}"
               echo
             fi

--- a/scripts/build_static_context.sh
+++ b/scripts/build_static_context.sh
@@ -171,6 +171,15 @@ case "${phase}" in
 				echo
 				cat unattended_llm_system_instructions.md
 				echo
+			else
+				# Loud signal: silent omission would leave the model with the
+				# original SYSTEM INSTRUCTIONS' STOP-and-ASK rules and no
+				# override context, reintroducing exactly the conflict this
+				# block is meant to resolve. Operators who see this warning
+				# should add unattended_llm_system_instructions.md to their
+				# consumer-repo wrapper-workflow staging step (the same step
+				# that already stages codex_system_instructions.md).
+				echo "::warning::build_static_context.sh: unattended_llm_system_instructions.md is missing from the working tree — the implement-phase static context will OMIT the UNATTENDED EXECUTION OVERRIDE block. This leaves the model with the original SYSTEM INSTRUCTIONS' STOP-and-ASK rules and no override context, which can drive the gpt-5.3-codex announce-without-emit failure mode. Stage the file alongside codex_system_instructions.md in your wrapper-workflow bootstrap." >&2
 			fi
 
 			echo "=== AI PIPELINE (implementation-trimmed) ==="
@@ -190,8 +199,23 @@ case "${phase}" in
 			# a bare "${RUNTIME_DIR:-}/agents_canonical.md" would test
 			# "/agents_canonical.md" at filesystem root when unset, and the
 			# subsequent cat would trip set -u without a default.
+			#
+			# Both files are verbatim (or near-verbatim) copies of
+			# codex_system_instructions.md's PRE-TASK MANDATORY CONTEXT
+			# LOADING preamble, §0 Prime Directive, §2 Always-On Ask-First
+			# Mode, and FINAL REMINDER. For an unattended run those four
+			# sections conflict with the UNATTENDED EXECUTION OVERRIDE
+			# block above. Without an explicit displacement note the model
+			# can pattern-match the later concrete "STOP and ASK" rules
+			# over the override and re-enter the narrate-without-emit
+			# stuck state — same conflict structure that affected
+			# review_autofix.yml's editor static context. The displacement
+			# note is emitted ONCE before the agents.md cats and names
+			# the four overridden sections by title.
 			if { [ -n "${RUNTIME_DIR:-}" ] && [ -f "${RUNTIME_DIR}/agents_canonical.md" ]; } || [ -f agents.md ]; then
 				echo "=== AGENTS.MD ==="
+				echo "NOTE: agents.md (and agents_canonical.md if present) reproduces codex_system_instructions.md's PRE-TASK MANDATORY CONTEXT LOADING preamble, §0 Prime Directive, §2 Always-On Ask-First Mode, and FINAL REMINDER. Those four sections are OVERRIDDEN for this unattended run by the UNATTENDED EXECUTION OVERRIDE block above — see its §0 (Execution Mode: 'Never ask for clarifications or stop due to ambiguity') and §3 (Mandatory Context Loading: 'If a file is missing: continue with available context'). agents.md's repo-specific guidance (custom Q-formats, naming conventions, contract paths, MongoDB rules, code-style conventions, etc.) still applies; only its STOP-and-ASK directives are displaced."
+				echo
 				if [ -n "${RUNTIME_DIR:-}" ] && [ -f "${RUNTIME_DIR}/agents_canonical.md" ]; then
 					cat "${RUNTIME_DIR}/agents_canonical.md"
 					echo

--- a/scripts/build_static_context.sh
+++ b/scripts/build_static_context.sh
@@ -25,6 +25,10 @@
 #               ai_pipeline.md trimmed before Phase 3;
 #               README.md trimmed before "### 2. Create wrapper workflows".
 #   implement — codex sections 0-6 + section 9 (Code Style) + FINAL REMINDER;
+#               unattended_llm_system_instructions.md (full) — inlined as
+#               an EXPLICIT override of codex's STOP-and-ASK rules so the
+#               unattended-execution policy is concretely present, not
+#               only referenced by name from codex §2;
 #               ai_pipeline.md Shared Runtime + Phase 3 only;
 #               agents.md canonical + repo-local; README.md NOT included.
 #
@@ -140,6 +144,34 @@ case "${phase}" in
 			echo
 			awk '/^## FINAL REMINDER$/,0{print}' codex_system_instructions.md
 			echo
+
+			# Inline the unattended-execution override. The implement phase
+			# runs non-interactively on a GitHub Actions runner; the model
+			# cannot ask the user a question. The static prefix above
+			# contains the PRE-TASK MANDATORY CONTEXT LOADING preamble
+			# ("STOP and ask using mandatory Q/A format" if agents.md /
+			# db/contracts/ are missing), §0 Prime Directive ("STOP. ASK.
+			# DO NOT PROCEED" on uncertainty), and FINAL REMINDER ("If
+			# uncertainty exists: ASK"). Without the override file inlined,
+			# the model sees only a NAME-reference at §2 to
+			# unattended_llm_system_instructions.md and must trust that
+			# pointer against three concrete "ASK" rules — empirically it
+			# does not, and on consumer repos that lack agents.md / a
+			# db/contracts/ tree (e.g. fun-token-multi-chain, run
+			# 25406869763 issue #195) the model enters an
+			# "I should ask but I am forbidden to ask" stuck state that
+			# manifests as narration-without-apply_patch, tripping the
+			# implement.yml empty_streak watchdog after 2 attempts.
+			# Inlining §0–§6 of the override here makes the
+			# "never ask, continue on missing files" policy CONCRETELY
+			# present in the same context window as the rules it overrides.
+			if [ -f unattended_llm_system_instructions.md ]; then
+				echo "=== UNATTENDED EXECUTION OVERRIDE (governs this run) ==="
+				echo "This run is non-interactive. The rules below OVERRIDE the corresponding sections of SYSTEM INSTRUCTIONS above for the duration of this run — specifically the PRE-TASK MANDATORY CONTEXT LOADING 'STOP and ask if missing' rule, §0 Prime Directive's 'STOP. ASK. DO NOT PROCEED', §2 Always-On Ask-First Mode, and the FINAL REMINDER's 'If uncertainty exists: ASK'."
+				echo
+				cat unattended_llm_system_instructions.md
+				echo
+			fi
 
 			echo "=== AI PIPELINE (implementation-trimmed) ==="
 			# Keep shared runtime behavior and implementation phase details only.

--- a/tests/test_implement_targeted_file_context_parser.py
+++ b/tests/test_implement_targeted_file_context_parser.py
@@ -307,6 +307,63 @@ def test_atx_section_with_paren_numbered_children(tmp_path: Path) -> None:
 	assert _run_parser(plan, tmp_path) == ["core/util.py", "core/parse.py"]
 
 
+def test_nested_atx_subheading_keeps_section_open(tmp_path: Path) -> None:
+	"""A `### Backend files` subheading inside a `## Files likely to change`
+	section must NOT terminate the section — only a peer-or-shallower
+	heading does.
+
+	Regression case for PR #2150 multi-reviewer finding (moonshotai +
+	qwen): the previous end-rule treated any `#+` heading as a section
+	terminator regardless of depth, so plan authors who grouped paths
+	under sub-headings would silently lose every entry that followed
+	the first sub-heading. Fixed by tracking section-start ATX depth
+	and only closing on depth ≤ start_depth."""
+	plan = (
+		"## Files likely to change\n"
+		"\n"
+		"### Backend files\n"
+		"- `src/backend/api.go`\n"
+		"- `src/backend/db.go`\n"
+		"\n"
+		"### Frontend files\n"
+		"- `src/frontend/App.tsx`\n"
+		"\n"
+		"## Functions/modules to implement\n"
+		"- not_a_path/should_not_appear.ts\n"
+	)
+	assert _run_parser(plan, tmp_path) == [
+		"src/backend/api.go",
+		"src/backend/db.go",
+		"src/frontend/App.tsx",
+	]
+
+
+def test_atx_section_closes_on_peer_heading(tmp_path: Path) -> None:
+	"""A peer-depth ATX heading (## inside ## section) MUST still
+	close the section — the depth gate only protects deeper nested
+	headings, not shallower / equal ones."""
+	plan = (
+		"## Files likely to change\n"
+		"- `src/keep.ts`\n"
+		"## Risks\n"
+		"- `src/should_not_appear.ts`\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["src/keep.ts"]
+
+
+def test_atx_section_closes_on_shallower_heading(tmp_path: Path) -> None:
+	"""A shallower ATX heading (# inside ## section) closes the
+	section — operator-level demarcation is at least as authoritative
+	as the section header itself."""
+	plan = (
+		"## Files likely to change\n"
+		"- `src/keep.ts`\n"
+		"# Top-level Section\n"
+		"- `src/should_not_appear.ts`\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["src/keep.ts"]
+
+
 def test_peer_section_title_still_ends_section(tmp_path: Path) -> None:
 	"""Confirms the carve-out doesn't break the normal end-rule: a peer
 	section title (multi-word natural-language phrase, no leading

--- a/tests/test_implement_targeted_file_context_parser.py
+++ b/tests/test_implement_targeted_file_context_parser.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Regression tests for the implement-phase TARGETED FILE CONTEXT parser.
+
+The parser lives inline in `.github/workflows/implement.yml` (the
+`Run Codex implementation` step) as an awk pipeline that extracts
+file paths from the approved plan's "Files likely to change" section.
+It is the load-bearing piece of the gpt-5.3-codex
+"announce-without-emit" mitigation (openai/codex#11151) — when it
+silently fails to match a plan format, every plan-named file
+disappears from the prompt and the model falls back to shell
+exploration, tripping the empty_streak watchdog.
+
+These tests pin:
+  - Section-start forms accepted (bold, ATX, numbered `1.`, numbered
+    `1)`, plain heading variant).
+  - Section terminator behaviour, including the carve-out for
+    numbered children whose body is a path entry (otherwise a plan
+    written as `1. Files likely to change / 1. ` + backticked path
+    silently terminates at the first child).
+  - Lexical safety filters (absolute paths, parent-traversal,
+    non-path tokens rejected).
+  - Backticked-path extraction AND bare-path extraction on list-item
+    lines.
+  - Deduplication of repeated entries.
+  - Real plan body excerpted from fun-token-multi-chain run
+    25406869763 issue #195 (regression case for the original PR).
+
+The test extracts the awk source verbatim from the workflow YAML so a
+regex tweak in production cannot diverge from the contract here. If
+the inline parser is later moved into a shared script, update
+`_extract_parser_awk_source` to read from that script instead.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+IMPLEMENT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "implement.yml"
+
+
+def _extract_parser_awk_source() -> str:
+	"""Pull the awk parser body out of the workflow YAML.
+
+	The parser is enclosed between
+	`targeted_paths_raw="$(` and `' "${PLAN_FILE}" 2>/dev/null | awk '!seen[$0]++' || true`
+	in the inline run block. We extract the awk script body so the
+	test runs the exact bytes the workflow runs.
+	"""
+	text = IMPLEMENT_WORKFLOW.read_text(encoding="utf-8")
+	# The awk source is bracketed by `awk '` and `' "${PLAN_FILE}"`.
+	# Use a non-greedy capture across newlines.
+	match = re.search(
+		r"targeted_paths_raw=\"\$\(\s*\n\s*awk '\n(?P<body>.*?)\n\s*' \"\$\{PLAN_FILE\}\"",
+		text,
+		flags=re.DOTALL,
+	)
+	if not match:
+		raise RuntimeError(
+			"Could not locate targeted-file-context awk parser in implement.yml. "
+			"Has the parser been moved or refactored? Update "
+			"_extract_parser_awk_source accordingly."
+		)
+	# Strip the YAML block-scalar indentation (10 leading spaces).
+	body = textwrap.dedent(match.group("body"))
+	return body
+
+
+def _run_parser(plan_text: str, tmp_path: Path) -> list[str]:
+	"""Run the extracted awk parser against `plan_text`.
+
+	Mirrors the production pipeline:
+	  awk '<extracted>' <plan_file> | awk '!seen[$0]++'
+	Returns the de-duplicated, ordered list of extracted path tokens.
+	"""
+	awk = shutil.which("awk")
+	assert awk, "awk binary not found on PATH"
+	plan_file = tmp_path / "plan.txt"
+	plan_file.write_text(plan_text, encoding="utf-8")
+	awk_source = _extract_parser_awk_source()
+
+	first = subprocess.run(
+		[awk, awk_source, str(plan_file)],
+		capture_output=True,
+		text=True,
+		check=False,
+	)
+	if first.returncode != 0:
+		pytest.fail(
+			f"awk parser exited {first.returncode}; stderr:\n{first.stderr}\n"
+			f"stdout:\n{first.stdout}"
+		)
+	dedup = subprocess.run(
+		[awk, "!seen[$0]++"],
+		input=first.stdout,
+		capture_output=True,
+		text=True,
+		check=True,
+	)
+	return [line for line in dedup.stdout.splitlines() if line]
+
+
+# --- Section-start forms ---------------------------------------------------
+
+def test_bold_marker_section(tmp_path: Path) -> None:
+	plan = (
+		"**Files likely to change**\n"
+		"- `contracts/FunOFT.sol`\n"
+		"\n"
+		"**Functions or modules to implement**\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["contracts/FunOFT.sol"]
+
+
+def test_atx_heading_section(tmp_path: Path) -> None:
+	plan = (
+		"## Files likely to change\n"
+		"- `src/foo.ts`\n"
+		"- `tests/foo.test.ts`\n"
+		"## Functions/modules to implement\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["src/foo.ts", "tests/foo.test.ts"]
+
+
+def test_numbered_section_with_dash_children(tmp_path: Path) -> None:
+	plan = (
+		"1. Files likely to change\n"
+		"   - `src/foo.ts`\n"
+		"   - `src/bar.ts`\n"
+		"2. Functions/modules to implement\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["src/foo.ts", "src/bar.ts"]
+
+
+def test_files_to_change_variant(tmp_path: Path) -> None:
+	plan = (
+		"## Files to change\n"
+		"- `src/x.py`\n"
+		"## Risks\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["src/x.py"]
+
+
+# --- Section-terminator carve-out (C5 regression) -------------------------
+
+def test_numbered_section_with_numbered_backticked_children(tmp_path: Path) -> None:
+	"""Plans written as `1. Files... / 1. <path> / 2. <path> / 2. <next section>`
+	must keep the section open through the numbered children. Without the
+	is_path_entry carve-out the section terminator fires on the first child
+	and the parser silently returns []. Regression case for the parser
+	end-rule bug surfaced in PR #2150 review."""
+	plan = (
+		"1. Files likely to change\n"
+		"1. `src/foo.ts`\n"
+		"2. `src/bar.ts`\n"
+		"2. Functions/modules to implement\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["src/foo.ts", "src/bar.ts"]
+
+
+def test_bold_section_with_numbered_backticked_children(tmp_path: Path) -> None:
+	plan = (
+		"**Files likely to change**\n"
+		"1. `pkg/a.go`\n"
+		"2. `pkg/b.go`\n"
+		"3. `pkg/c.go`\n"
+		"**Functions/modules**\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["pkg/a.go", "pkg/b.go", "pkg/c.go"]
+
+
+def test_numbered_section_with_numbered_bare_children(tmp_path: Path) -> None:
+	"""Lower-case path-with-extension token after the numbered prefix is
+	recognised as a path entry, not a section title — keeps section open."""
+	plan = (
+		"1. Files likely to change\n"
+		"1. src/bare/foo.ts\n"
+		"2. src/bare/bar.ts\n"
+		"2. Functions/modules to implement\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["src/bare/foo.ts", "src/bare/bar.ts"]
+
+
+def test_atx_section_with_paren_numbered_children(tmp_path: Path) -> None:
+	plan = (
+		"## Files to change\n"
+		"1) `core/util.py`\n"
+		"2) `core/parse.py`\n"
+		"## Risks\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["core/util.py", "core/parse.py"]
+
+
+def test_peer_section_title_still_ends_section(tmp_path: Path) -> None:
+	"""Confirms the carve-out doesn't break the normal end-rule: a peer
+	section title (multi-word natural-language phrase, no leading
+	backtick, first word is not lower-case path-like) MUST still close
+	the section."""
+	plan = (
+		"1. Files likely to change\n"
+		"- `keep/me.ts`\n"
+		"2. Functions/modules to implement\n"
+		"- `do_not/include.ts`\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["keep/me.ts"]
+
+
+# --- Lexical safety filters ------------------------------------------------
+
+def test_absolute_path_rejected(tmp_path: Path) -> None:
+	plan = (
+		"**Files likely to change**\n"
+		"- /etc/passwd\n"
+		"- `/var/log/syslog`\n"
+		"- `src/ok.ts`\n"
+		"**Other**\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["src/ok.ts"]
+
+
+def test_parent_traversal_rejected(tmp_path: Path) -> None:
+	plan = (
+		"**Files likely to change**\n"
+		"- ../escape.sh\n"
+		"- `../../escape.sh`\n"
+		"- `src/ok.ts`\n"
+		"**Other**\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["src/ok.ts"]
+
+
+def test_non_path_tokens_in_list_items_dropped(tmp_path: Path) -> None:
+	plan = (
+		"**Files likely to change**\n"
+		"- not_a_path\n"
+		"- alsoNotAPath\n"
+		"- `src/ok.ts`\n"
+		"**Other**\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["src/ok.ts"]
+
+
+# --- Extraction modes ------------------------------------------------------
+
+def test_backticked_paths_extracted(tmp_path: Path) -> None:
+	plan = (
+		"**Files likely to change**\n"
+		"- `a/b.ts` and `c/d.ts`\n"
+		"**Other**\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["a/b.ts", "c/d.ts"]
+
+
+def test_bare_paths_on_list_items(tmp_path: Path) -> None:
+	plan = (
+		"**Files likely to change**\n"
+		"- src/foo.ts\n"
+		"- src/bar.ts (helper)\n"
+		"**Other**\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["src/foo.ts", "src/bar.ts"]
+
+
+def test_prose_outside_section_ignored(tmp_path: Path) -> None:
+	plan = (
+		"Notes: in `unrelated/foo.ts` we will not edit anything.\n"
+		"\n"
+		"**Files likely to change**\n"
+		"- `src/real.ts`\n"
+		"\n"
+		"**Functions or modules to implement**\n"
+		"- in `unrelated/bar.ts` something happens but this is not the files section\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["src/real.ts"]
+
+
+def test_deduplication(tmp_path: Path) -> None:
+	plan = (
+		"**Files likely to change**\n"
+		"- `a/b.ts`\n"
+		"- `a/b.ts` again\n"
+		"- `a/c.ts`\n"
+		"**Other**\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["a/b.ts", "a/c.ts"]
+
+
+# --- Empty / missing section ----------------------------------------------
+
+def test_no_files_section_returns_empty(tmp_path: Path) -> None:
+	plan = (
+		"Plan summary: refactor everything.\n"
+		"\n"
+		"## Risks\n"
+		"- it might break\n"
+	)
+	assert _run_parser(plan, tmp_path) == []
+
+
+# --- Real-world fixture ----------------------------------------------------
+
+def test_real_plan_from_funtoken_run_25406869763(tmp_path: Path) -> None:
+	"""Plan body excerpted from fun-token-multi-chain run 25406869763
+	issue #195. This is the regression case the inlining feature was
+	originally written for."""
+	plan = (
+		"Implementation Plan\n"
+		"\n"
+		"Planning ref: 81a50d370c on orchestrator/project-193.\n"
+		"\n"
+		"**Files likely to change**\n"
+		"- `contracts/FunOFT.sol`\n"
+		"\n"
+		"No other file currently needs modification for the scoped cleanup.\n"
+		"\n"
+		"**Functions or modules to implement**\n"
+		"- Remove `FunOFT._debitView(uint256,uint256,uint32)` from "
+		"`contracts/FunOFT.sol`.\n"
+	)
+	assert _run_parser(plan, tmp_path) == ["contracts/FunOFT.sol"]

--- a/tests/test_implement_targeted_file_context_parser.py
+++ b/tests/test_implement_targeted_file_context_parser.py
@@ -40,36 +40,108 @@ import textwrap
 from pathlib import Path
 
 import pytest
+import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 IMPLEMENT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "implement.yml"
 
+_PARSER_ANCHOR_BEGIN = "targeted_paths_raw="
+_PARSER_AWK_BEGIN = "awk '"
+_PARSER_AWK_END = "\"${PLAN_FILE}\""
+
+
+def _extract_run_block(step_name: str) -> str:
+	"""Return the resolved bash body of a workflow step by name.
+
+	Parses YAML rather than scraping the text so the extraction is
+	robust against block-scalar reindentation, trailing-whitespace
+	tweaks, and other formatting changes that don't alter the shell
+	the runner executes.
+	"""
+	doc = yaml.safe_load(IMPLEMENT_WORKFLOW.read_text(encoding="utf-8"))
+	for job in doc["jobs"].values():
+		for step in job.get("steps", []):
+			if step.get("name") == step_name:
+				run = step.get("run", "")
+				if not run:
+					raise RuntimeError(
+						f"Step {step_name!r} has no 'run' body in implement.yml."
+					)
+				return run
+	raise RuntimeError(
+		f"Step {step_name!r} not found in implement.yml. Has it been "
+		"renamed? Update _extract_run_block accordingly."
+	)
+
 
 def _extract_parser_awk_source() -> str:
-	"""Pull the awk parser body out of the workflow YAML.
+	"""Pull the awk parser body out of the run block.
 
-	The parser is enclosed between
-	`targeted_paths_raw="$(` and `' "${PLAN_FILE}" 2>/dev/null | awk '!seen[$0]++' || true`
-	in the inline run block. We extract the awk script body so the
-	test runs the exact bytes the workflow runs.
+	The parser is the first awk invocation inside the
+	`targeted_paths_raw="$(` command substitution in the
+	"Run Codex implementation" step. We locate it by anchor-string
+	search rather than full regex so the extraction tolerates
+	whitespace, comment, and reformatting changes.
 	"""
-	text = IMPLEMENT_WORKFLOW.read_text(encoding="utf-8")
-	# The awk source is bracketed by `awk '` and `' "${PLAN_FILE}"`.
-	# Use a non-greedy capture across newlines.
-	match = re.search(
-		r"targeted_paths_raw=\"\$\(\s*\n\s*awk '\n(?P<body>.*?)\n\s*' \"\$\{PLAN_FILE\}\"",
-		text,
-		flags=re.DOTALL,
-	)
-	if not match:
+	run = _extract_run_block("Run Codex implementation")
+
+	anchor_idx = run.find(_PARSER_ANCHOR_BEGIN)
+	if anchor_idx < 0:
 		raise RuntimeError(
-			"Could not locate targeted-file-context awk parser in implement.yml. "
-			"Has the parser been moved or refactored? Update "
+			f"Could not find {_PARSER_ANCHOR_BEGIN!r} in the "
+			"'Run Codex implementation' step. Has the targeted-file-context "
+			"block been removed or refactored? Update "
 			"_extract_parser_awk_source accordingly."
 		)
-	# Strip the YAML block-scalar indentation (10 leading spaces).
-	body = textwrap.dedent(match.group("body"))
+
+	awk_idx = run.find(_PARSER_AWK_BEGIN, anchor_idx)
+	if awk_idx < 0:
+		raise RuntimeError(
+			f"Could not find {_PARSER_AWK_BEGIN!r} after {_PARSER_ANCHOR_BEGIN!r} "
+			"in the 'Run Codex implementation' step. Has the awk parser "
+			"been moved out of inline shell? Update _extract_parser_awk_source."
+		)
+
+	# Body starts just after `awk '` (typically `awk '\n`).
+	body_start = awk_idx + len(_PARSER_AWK_BEGIN)
+
+	end_idx = run.find(_PARSER_AWK_END, body_start)
+	if end_idx < 0:
+		raise RuntimeError(
+			f"Could not find {_PARSER_AWK_END!r} closing the awk parser. "
+			"Update _extract_parser_awk_source."
+		)
+
+	# Trim back from end_idx to the closing `'` of the awk single-quoted
+	# string. The shell text between body_start and end_idx looks like:
+	#     <awk body>\n         '
+	# (the `'` closes the awk script, `${PLAN_FILE}` follows). Find the
+	# last `'` before end_idx.
+	close_quote_idx = run.rfind("'", body_start, end_idx)
+	if close_quote_idx < 0:
+		raise RuntimeError(
+			"Could not locate closing single-quote of the awk parser. "
+			"Update _extract_parser_awk_source."
+		)
+
+	body = run[body_start:close_quote_idx]
+	# Strip a leading newline if present (shell `awk '\n...\n'` form).
+	if body.startswith("\n"):
+		body = body[1:]
+	# Trim trailing whitespace before the closing quote.
+	body = body.rstrip()
+
+	# Sanity: the body MUST contain the section-start guard. If it does
+	# not, the extraction is wrong even if it returned non-empty.
+	if "files[[:space:]]+[^\\n]*change" not in body:
+		raise RuntimeError(
+			"Extracted awk body does not contain the expected section-start "
+			"regex anchor (`files...change`). Extraction is misaligned — "
+			"likely picked up a different awk invocation. Update the "
+			"extraction logic."
+		)
+
 	return body
 
 
@@ -186,6 +258,47 @@ def test_numbered_section_with_numbered_bare_children(tmp_path: Path) -> None:
 		"2. Functions/modules to implement\n"
 	)
 	assert _run_parser(plan, tmp_path) == ["src/bare/foo.ts", "src/bare/bar.ts"]
+
+
+def test_numbered_section_with_uppercase_bare_children(tmp_path: Path) -> None:
+	"""Plans that name uppercase-starting paths on numbered list items
+	(e.g. `1. API/util.ts`, `2. UI/Button.tsx`) must still be recognised
+	as path entries — the file-extension dot-suffix anchors the
+	disambiguation, so case-insensitive matching is correct.
+
+	Regression case for PR #2150 multi-reviewer consensus finding
+	(deepseek + minimax + moonshotai + x-ai + z-ai): the previous
+	`^[a-z]` heuristic rejected uppercase-starting bare paths and
+	silently terminated the section."""
+	plan = (
+		"1. Files likely to change\n"
+		"1. API/util.ts\n"
+		"2. UI/Button.tsx\n"
+		"3. Backend/handler.go\n"
+		"2. Functions/modules to implement\n"
+	)
+	assert _run_parser(plan, tmp_path) == [
+		"API/util.ts",
+		"UI/Button.tsx",
+		"Backend/handler.go",
+	]
+
+
+def test_numbered_section_with_mixed_case_backticked_children(tmp_path: Path) -> None:
+	"""Backtick-wrapped paths work regardless of starting case (the
+	body-starts-with-backtick rule fires before the extension rule)."""
+	plan = (
+		"**Files likely to change**\n"
+		"1. `API/util.ts`\n"
+		"2. `core/util.py`\n"
+		"3. `Backend/Handler.go`\n"
+		"**Functions**\n"
+	)
+	assert _run_parser(plan, tmp_path) == [
+		"API/util.ts",
+		"core/util.py",
+		"Backend/Handler.go",
+	]
 
 
 def test_atx_section_with_paren_numbered_children(tmp_path: Path) -> None:

--- a/tests/test_implement_targeted_file_context_parser.py
+++ b/tests/test_implement_targeted_file_context_parser.py
@@ -23,23 +23,28 @@ These tests pin:
     lines.
   - Deduplication of repeated entries.
   - Real plan body excerpted from fun-token-multi-chain run
-    25406869763 issue #195 (regression case for the original PR).
+    25406869763 issue #195.
 
 The test extracts the awk source verbatim from the workflow YAML so a
 regex tweak in production cannot diverge from the contract here. If
 the inline parser is later moved into a shared script, update
 `_extract_parser_awk_source` to read from that script instead.
+
+Runner convention: matches the rest of `tests/test_*.py` in this
+repo (`PYTHONDONTWRITEBYTECODE=1 python3 tests/test_*.py`). Does not
+depend on pytest. Each test takes a Path argument; the `main()`
+runner provides a fresh tempdir per test. Pytest can also run the
+file (the `tmp_path: Path` parameter name matches pytest's
+auto-fixture), but pytest is not required.
 """
 
 from __future__ import annotations
 
-import re
 import shutil
 import subprocess
-import textwrap
+import tempfile
 from pathlib import Path
 
-import pytest
 import yaml
 
 
@@ -80,9 +85,9 @@ def _extract_parser_awk_source() -> str:
 
 	The parser is the first awk invocation inside the
 	`targeted_paths_raw="$(` command substitution in the
-	"Run Codex implementation" step. We locate it by anchor-string
-	search rather than full regex so the extraction tolerates
-	whitespace, comment, and reformatting changes.
+	"Run Codex implementation" step. Located by anchor-string search
+	rather than full regex so the extraction tolerates whitespace,
+	comment, and reformatting changes.
 	"""
 	run = _extract_run_block("Run Codex implementation")
 
@@ -103,7 +108,6 @@ def _extract_parser_awk_source() -> str:
 			"been moved out of inline shell? Update _extract_parser_awk_source."
 		)
 
-	# Body starts just after `awk '` (typically `awk '\n`).
 	body_start = awk_idx + len(_PARSER_AWK_BEGIN)
 
 	end_idx = run.find(_PARSER_AWK_END, body_start)
@@ -113,11 +117,6 @@ def _extract_parser_awk_source() -> str:
 			"Update _extract_parser_awk_source."
 		)
 
-	# Trim back from end_idx to the closing `'` of the awk single-quoted
-	# string. The shell text between body_start and end_idx looks like:
-	#     <awk body>\n         '
-	# (the `'` closes the awk script, `${PLAN_FILE}` follows). Find the
-	# last `'` before end_idx.
 	close_quote_idx = run.rfind("'", body_start, end_idx)
 	if close_quote_idx < 0:
 		raise RuntimeError(
@@ -126,14 +125,10 @@ def _extract_parser_awk_source() -> str:
 		)
 
 	body = run[body_start:close_quote_idx]
-	# Strip a leading newline if present (shell `awk '\n...\n'` form).
 	if body.startswith("\n"):
 		body = body[1:]
-	# Trim trailing whitespace before the closing quote.
 	body = body.rstrip()
 
-	# Sanity: the body MUST contain the section-start guard. If it does
-	# not, the extraction is wrong even if it returned non-empty.
 	if "files[[:space:]]+[^\\n]*change" not in body:
 		raise RuntimeError(
 			"Extracted awk body does not contain the expected section-start "
@@ -153,7 +148,8 @@ def _run_parser(plan_text: str, tmp_path: Path) -> list[str]:
 	Returns the de-duplicated, ordered list of extracted path tokens.
 	"""
 	awk = shutil.which("awk")
-	assert awk, "awk binary not found on PATH"
+	if not awk:
+		raise AssertionError("awk binary not found on PATH")
 	plan_file = tmp_path / "plan.txt"
 	plan_file.write_text(plan_text, encoding="utf-8")
 	awk_source = _extract_parser_awk_source()
@@ -165,7 +161,7 @@ def _run_parser(plan_text: str, tmp_path: Path) -> list[str]:
 		check=False,
 	)
 	if first.returncode != 0:
-		pytest.fail(
+		raise AssertionError(
 			f"awk parser exited {first.returncode}; stderr:\n{first.stderr}\n"
 			f"stdout:\n{first.stdout}"
 		)
@@ -438,3 +434,34 @@ def test_real_plan_from_funtoken_run_25406869763(tmp_path: Path) -> None:
 		"`contracts/FunOFT.sol`.\n"
 	)
 	assert _run_parser(plan, tmp_path) == ["contracts/FunOFT.sol"]
+
+
+# --- Standalone runner (matches `python3 tests/test_*.py` repo convention) -
+
+def main() -> int:
+	"""Discover and run every `test_*` function in this module.
+
+	Mirrors the runner pattern in tests/test_implement_post_codex_recovery.py
+	and friends: enumerate `test_*` globals, give each a fresh tempdir,
+	report PASS/FAIL with a final tally. Returns 1 on any failure so
+	`set -e` in the CI step propagates.
+	"""
+	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+	passed = 0
+	failed = 0
+	for func in test_funcs:
+		name = func.__name__
+		with tempfile.TemporaryDirectory() as td:
+			try:
+				func(Path(td))
+				print(f"  PASS  {name}")
+				passed += 1
+			except Exception as e:
+				print(f"  FAIL  {name}: {e}")
+				failed += 1
+	print(f"\n{passed} passed, {failed} failed, {passed + failed} total")
+	return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())


### PR DESCRIPTION
## Summary

Targets the `gpt-5.3-codex` "announce-without-emit" failure mode (openai/codex#11151) that was tripping the implement workflow's empty_streak watchdog (`Codex bailed: 2 consecutive attempts with no actionable output (empty-output and/or announced-edit-without-changes — agent loop stuck in exploration)`) and review_autofix's `EDITOR_NOOP_SUSPICIOUS` path on consumer repos.

Diagnosed from `shubhodeep1/fun-token-multi-chain` run [25406869763](https://github.com/shubhodeep1/fun-token-multi-chain/actions/runs/25406869763) (issue #195): single-file-delete plan, plan correctly named `contracts/FunOFT.sol`, Codex spent ~30K tokens on `rg`/`sed` shell exploration of files the plan already named, then bailed without invoking `apply_patch`. Two independent contributing causes were addressed:

1. **The prompt named the file but never inlined its contents.** Codex had to discover them via shell, and the EFFICIENCY RULES section's only concrete example (`sed -n '10,30p'`) primed shell-based reads as the natural first step.
2. **A system-context conflict.** `codex_system_instructions.md` (inlined into the implement static context via `build_static_context.sh`) contains three concrete "STOP and ASK" rules — PRE-TASK MANDATORY CONTEXT LOADING preamble (`L7-15`: "If [agents.md / db/contracts/] are missing or unclear: STOP and ask"), §0 Prime Directive ("STOP. ASK. DO NOT PROCEED"), FINAL REMINDER. §2 carries a name-only pointer to `unattended_llm_system_instructions.md` saying that file overrides §2 in unattended runs, but the override file was **never inlined into any phase's static context** — only its filename appeared in the prompt. On consumer repos that lack `agents.md` (e.g. fun-token-multi-chain), the model encountered three concrete ASK rules plus the inline template's "Do not ask clarification questions", failed to reconcile via the soft name-pointer, and entered the narrate-without-emit stuck state.

## Scope (files touched)

- `.github/workflows/implement.yml` — main implement editor: F1+F2 prompt mitigations, unattended-override directive in inline Restrictions, parser end-rule carve-out for numbered-item paths.
- `.github/workflows/review_autofix.yml` — editor static context: explicit `agents.md` displacement note (agents.md is a verbatim copy of codex's STOP-and-ASK rules; same conflict structure as implement.yml had).
- `scripts/build_static_context.sh` — implement branch now inlines the full `unattended_llm_system_instructions.md` under a new `=== UNATTENDED EXECUTION OVERRIDE (governs this run) ===` header, after FINAL REMINDER. Plan and clarify branches intentionally untouched (clarify is *meant* to ask; plan can legitimately post clarifications). `codex_system_instructions.md` continues to serve as the interactive default for Claude Code sessions per `CLAUDE.md`.
- `tests/test_implement_targeted_file_context_parser.py` — new pytest suite (18 cases) pinning the targeted-file-context parser contract by extracting the awk source verbatim from `implement.yml` and running it against canned plan fixtures.

## Commits on this branch

1. **F1+F2 — drop the priming `sed` example, inline plan-named files** (initial PR commit). The "Files likely to change" section is parsed from the approved plan, each named file's contents are inlined under a new `=== TARGETED FILE CONTEXT ===` block in the prompt. Bounded by file count (default 10) and total bytes (default 100KB), tunable via `vars.TARGETED_FILE_CONTEXT_MAX_FILES` / `vars.TARGETED_FILE_CONTEXT_MAX_BYTES`. Path-safety filters reject absolute paths, `..` traversal, and (after symlink resolution) anything outside `$GITHUB_WORKSPACE`. Block is appended **after** the cacheable static prefix so prompt-prefix caching is preserved.
2. **Earlier review fixes** — broaden parser to all five plan-section forms (bold, ATX, numbered `1.`, numbered `1)`, plain heading); `realpath`-based symlink escape rejection; wire `vars.TARGETED_FILE_CONTEXT_MAX_*` to the step's `env:` block.
3. **Unattended-override commit** (`8bf1f4f`) — inline `unattended_llm_system_instructions.md` into the implement-phase static context so the override is concretely present rather than only referenced by name; explicit "missing context not blocker" bullet in the inline Restrictions block pointing at unattended §3 / §4.
4. **Latest review-feedback commit** — repair the "record assumptions inline" / "Output ONLY repository changes" contradiction (assumptions now go in code comments, not narrative output); fix parser end-rule that broke on numbered-item path entries (`1. \`src/foo.ts\``); add the 18-case pytest suite; sweep the repo for analogous codex-edit sites and apply the displacement fix to `review_autofix.yml`'s editor static context (only other site with the same conflict pattern).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/implement.yml')); yaml.safe_load(open('.github/workflows/review_autofix.yml'))"` parses cleanly.
- [x] `bash -n` on the YAML-resolved bash bodies for both workflows.
- [x] `bash -n` on `scripts/build_static_context.sh`.
- [x] `python3 -m pytest tests/test_implement_targeted_file_context_parser.py` — 18/18 pass (bold, ATX, numbered+dash, numbered+numbered-backticked, numbered+numbered-bare, ATX+`1)`+backticked, peer-section-still-terminates, real plan from run 25406869763, prose-outside-section ignored, lexical safety filters, deduplication, empty section).
- [x] End-to-end `build_static_context.sh implement <out>` — output now contains `=== SYSTEM INSTRUCTIONS ===`, `=== UNATTENDED EXECUTION OVERRIDE ===`, `=== AI PIPELINE ===` headers; full `unattended_llm_system_instructions.md` body inlined verbatim under the override header.
- [x] End-to-end symlink test — in-workspace symlink to `/tmp/outside/secret.env` is rejected with `::warning::` and never enters the prompt; in-workspace symlink to in-workspace target is inlined under the plan-supplied label.
- [ ] **Open** — verify on a real implement run in `fun-token-multi-chain` (or another consumer repo lacking `agents.md`) by re-running issue #195 or any single-file plan and confirming Codex hits `apply_patch` on attempt 1 instead of bailing.

## Notes for follow-up

- **F3** (bump `THINKING_LEVEL_IMPLEMENT=high` repo var) and **F4** (swap `WORKFLOW_EDITOR_MODEL` away from `openai/gpt-5.3-codex`) remain as repo-variable changes available without code edits if codex#11151 hit rate persists after this PR.
- **F5** (the unreferenced `prompts/mode-implement.txt` is dead code; only the heredoc-derived `mode-implement-inline.txt` is used) was deferred to a separate cleanup PR.
- The `clarify` and `plan` branches of `build_static_context.sh` are intentionally untouched — clarify is *designed* to ask the user questions, plan can legitimately post clarifications. If the same context conflict surfaces in plan runs, the same fix shape (append the unattended override under a header that names the displaced rules) is the lowest-risk extension.