### PR TITLE
implement: reject whitespace-only salvage in Codex retry loop

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -877,7 +877,9 @@ jobs:
           The system context (`unattended_system_instructions.md`) above already
           defines the persistence rule, edit-tool discipline (apply_patch first,
           fallbacks, the gpt-5.3-codex#11151 carve-out), no-revert /
-          no-destructive-git rules, and parallel-reads guidance. Apply them.
+          no-destructive-git rules, and parallel-reads guidance. Apply them —
+          and re-read the IMPORTANT section near the end of this prompt
+          before you start writing.
 
           Efficiency:
           - Aim to keep total tool calls (MCP + shell exec combined) under
@@ -907,6 +909,42 @@ jobs:
           - Do not ask clarification questions (unattended runtime).
           {{WORKFLOW_EDIT_RESTRICTION}}
           - Do not modify ai_pipeline.md, unattended_system_instructions.md, or CLAUDE.md.
+
+          === IMPORTANT — MUST READ BEFORE WRITING ===
+
+          (This restates `unattended_system_instructions.md` §4 Edit-Tool
+          Discipline. The duplication is intentional — recency reinforcement
+          for gpt-5.3-codex's announce-without-emit regression
+          (openai/codex#11151). Do NOT skip this section, even though §4
+          already covered it earlier in the prompt.)
+
+          - `apply_patch` is the preferred write tool for surgical edits to
+            existing source files (`.sol`, `.ts`, `.py`, `.js`, `.go`, `.rs`,
+            `.java`, `.json`, …). It produces the cleanest diff and the
+            smallest blast radius.
+          - Do not use `apply_patch` for auto-generated artefacts (lockfiles,
+            formatter output, code generators). Run the generator instead.
+          - If `apply_patch` does not land on a particular hunk, fall back: a
+            different `apply_patch` shape, then `printf`/heredoc redirection
+            for fully-specified plain-text targets (`.txt`, `.csv`, small data
+            fixtures), then any other write tool. Pick whatever gets the bytes
+            onto disk this turn.
+          - After ANY shell write, verify with `git diff --stat` scoped to the
+            edited file. If zero lines changed, switch tools instead of
+            retrying the same regex shape.
+          - Avoid `sed -i`/`perl -i`/`awk` regex substitutions on multi-line
+            source — they exit 0 even when the regex misses, leaving the file
+            unchanged.
+          - Returning an empty completion or a final assistant message that
+            only describes the fix ("I will apply_patch …", "applying the
+            requested edit now", "the resolution is straightforward") is a
+            FAILURE — the workflow's stuck-detection counts this as
+            no-actionable-output. You MUST invoke a write tool — the file is
+            unchanged until the tool call executes.
+          - Known model bug: `gpt-5.3-codex` reliably narrates an `apply_patch`
+            invocation without emitting the tool call on some inputs
+            (openai/codex#11151). The fallback paths above exist for that
+            case.
 
           Output: repository changes only.
           EOF

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1028,11 +1028,15 @@ jobs:
           # salvage branch broke the loop at 2/5. The workflow then
           # committed the lone-newline diff and shipped PR #202 with zero
           # implementation of the issue's required guards or regression
-          # tests. `-w --ignore-blank-lines` together suppress in-line
-          # whitespace AND blank-line-only changes — `-w` alone still
-          # surfaces a `+` blank-line append. Fail-open (treat untracked
-          # files we can't stat as substantive) so a malformed porcelain
-          # line never silently discards real work.
+          # tests. `--ignore-space-at-eol --ignore-blank-lines` together
+          # suppress trailing-whitespace AND blank-line-only changes
+          # while keeping leading-whitespace (indentation) changes
+          # visible — `-w` would also drop indentation diffs, which are
+          # semantic in Python/YAML/Makefiles and would cause a real
+          # indentation-only fix to be misclassified as trivial. Fail-
+          # open (treat untracked files we can't stat as substantive)
+          # so a malformed porcelain line never silently discards real
+          # work.
           delta_is_substantive() {
             local delta="$1"
             [ -n "${delta}" ] || return 1
@@ -1067,8 +1071,8 @@ jobs:
                   case "${status}" in
                     R*|C*) path="${path##* -> }" ;;
                   esac
-                  if ! git diff --quiet -w --ignore-blank-lines -- "${path}" 2>/dev/null \
-                     || ! git diff --quiet -w --ignore-blank-lines --cached -- "${path}" 2>/dev/null; then
+                  if ! git diff --quiet --ignore-space-at-eol --ignore-blank-lines -- "${path}" 2>/dev/null \
+                     || ! git diff --quiet --ignore-space-at-eol --ignore-blank-lines --cached -- "${path}" 2>/dev/null; then
                     return 0
                   fi
                   ;;

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1036,21 +1036,37 @@ jobs:
           delta_is_substantive() {
             local delta="$1"
             [ -n "${delta}" ] || return 1
-            local line status path
+            local line status path grep_rc
             while IFS= read -r line; do
               [ -z "${line}" ] && continue
               status="${line:0:2}"
               path="${line:3}"
-              case "${path}" in
-                *' -> '*) path="${path##* -> }" ;;
-              esac
               case "${status}" in
                 "??")
-                  if [ ! -f "${path}" ] || grep -q '[^[:space:]]' "${path}" 2>/dev/null; then
+                  # Untracked: porcelain prints the raw filename (never the
+                  # `old -> new` rename form), so don't strip on ` -> `;
+                  # truncating would misclassify any untracked filename
+                  # that legitimately contains the substring. Fail-open on
+                  # any grep exit other than 1 (no match): unreadable file,
+                  # I/O error, or other read failure must NOT silently
+                  # discard real work.
+                  if [ ! -f "${path}" ]; then
+                    return 0
+                  fi
+                  grep_rc=0
+                  grep -q '[^[:space:]]' "${path}" 2>/dev/null || grep_rc=$?
+                  if [ "${grep_rc}" != 1 ]; then
                     return 0
                   fi
                   ;;
                 *)
+                  # Tracked: only rename (`R*`) and copy (`C*`) lines carry
+                  # the `old -> new` form; resolve to the new name so the
+                  # `git diff` calls below operate on what's actually in
+                  # the worktree / index.
+                  case "${status}" in
+                    R*|C*) path="${path##* -> }" ;;
+                  esac
                   if ! git diff --quiet -w --ignore-blank-lines -- "${path}" 2>/dev/null \
                      || ! git diff --quiet -w --ignore-blank-lines --cached -- "${path}" 2>/dev/null; then
                     return 0

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1015,6 +1015,52 @@ jobs:
           # recall on a path that's already a confirmed no-op.
           ANNOUNCE_EDIT_REGEX='(apply_patch|applying (a |an |the |this |requested |first |minimal |approved |implementation |new |my |our |proposed )*(patch|edit|implementation|change|fix|plan|update|modification|overwrite|rewrite|replacement)|(patching|editing|overwriting|rewriting|replacing|writing) `?[A-Za-z0-9_./-]+|i.?ll (now |first |then |next |only |just |go ahead and |proceed to )*(apply|patch|edit|update|modify|write|create|add|change|implement|fix|overwrite|rewrite|replace)|will (now |first |then |next |only |just |go ahead and |proceed to )*(apply|patch|edit|update|modify|write|create|add|change|implement|fix|overwrite|rewrite|replace))'
 
+          # Salvage gate. Returns 0 iff at least one path in the porcelain
+          # delta passed in carries a non-whitespace change vs HEAD/index
+          # (or, for an untracked file, contains any non-whitespace bytes).
+          # Used by the empty-stdout and watchdog-kill salvage branches
+          # below so a trivial trailing-newline / whitespace-only edit can't
+          # masquerade as partial implementation work and short-circuit the
+          # retry loop. Run b3f07ad7-4d9f-56b2-923f-aa222a1ab049 issue 200:
+          # gpt-5.3-codex announced an apply_patch in attempt 1, then on
+          # attempt 2 ran `printf '\n' >> contracts/FunOFTAdapter.sol`,
+          # exited with empty stdout, and the cmd_rc==0 + empty-stdout
+          # salvage branch broke the loop at 2/5. The workflow then
+          # committed the lone-newline diff and shipped PR #202 with zero
+          # implementation of the issue's required guards or regression
+          # tests. `-w --ignore-blank-lines` together suppress in-line
+          # whitespace AND blank-line-only changes — `-w` alone still
+          # surfaces a `+` blank-line append. Fail-open (treat untracked
+          # files we can't stat as substantive) so a malformed porcelain
+          # line never silently discards real work.
+          delta_is_substantive() {
+            local delta="$1"
+            [ -n "${delta}" ] || return 1
+            local line status path
+            while IFS= read -r line; do
+              [ -z "${line}" ] && continue
+              status="${line:0:2}"
+              path="${line:3}"
+              case "${path}" in
+                *' -> '*) path="${path##* -> }" ;;
+              esac
+              case "${status}" in
+                "??")
+                  if [ ! -f "${path}" ] || grep -q '[^[:space:]]' "${path}" 2>/dev/null; then
+                    return 0
+                  fi
+                  ;;
+                *)
+                  if ! git diff --quiet -w --ignore-blank-lines -- "${path}" 2>/dev/null \
+                     || ! git diff --quiet -w --ignore-blank-lines --cached -- "${path}" 2>/dev/null; then
+                    return 0
+                  fi
+                  ;;
+              esac
+            done <<< "${delta}"
+            return 1
+          }
+
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "Codex implement attempt ${attempt}/${max_attempts}..."
 
@@ -1269,10 +1315,12 @@ jobs:
                 # discarded full sets of streamed apply_patch diffs.
                 # Salvage any file changes already on disk here too.
                 codex_delta="$(git status --porcelain -uall | grep -vxFf "${CODEX_PRE_BASELINE}" || true)"
-                if [ -n "${codex_delta}" ]; then
+                if delta_is_substantive "${codex_delta}"; then
                   echo "::warning::Codex returned empty output on attempt ${attempt} but produced file changes; salvaging partial work."
                   implement_succeeded=true
                   break
+                elif [ -n "${codex_delta}" ]; then
+                  echo "::warning::Codex returned empty output on attempt ${attempt} and only made whitespace-only worktree changes — refusing to salvage; treating as empty."
                 fi
                 # Stuck-intent on stderr: when stdout is empty but the
                 # per-attempt stderr log carries an announce-edit
@@ -1303,10 +1351,12 @@ jobs:
               # discarded and the loop wastes its remaining budget restarting
               # from scratch (see analyze-log run 24989488561).
               codex_delta="$(git status --porcelain -uall | grep -vxFf "${CODEX_PRE_BASELINE}" || true)"
-              if [ -n "${codex_delta}" ]; then
+              if delta_is_substantive "${codex_delta}"; then
                 echo "::warning::Codex exited with code $cmd_rc on attempt ${attempt} but produced file changes; salvaging partial work."
                 implement_succeeded=true
                 break
+              elif [ -n "${codex_delta}" ]; then
+                echo "::warning::Codex exited with code $cmd_rc on attempt ${attempt} and only made whitespace-only worktree changes — refusing to salvage; treating as empty."
               fi
               # Watchdog-kill / non-zero-exit + empty stdout is the same
               # stuck/no-output failure mode as the cmd_rc==0 + empty

--- a/prompts/mode-implement.txt
+++ b/prompts/mode-implement.txt
@@ -3,7 +3,8 @@ Role: implementation-phase coder. Goal: implement the approved plan; modify only
 The system context (`unattended_system_instructions.md`) already defines the
 persistence rule, edit-tool discipline (apply_patch first, fallbacks, the
 gpt-5.3-codex#11151 carve-out), no-revert / no-destructive-git rules, and
-parallel-reads guidance. Don't restate those — apply them.
+parallel-reads guidance. Apply them — and re-read the IMPORTANT section
+near the end of this prompt before you start writing.
 
 Conflict detection: if the plan's facts conflict with the actual codebase
 (function name mismatch, file path absent, API signature differs), proceed
@@ -58,5 +59,35 @@ beginning with `@username` mentions, or a `*` glob pattern.
 If clarification context is incomplete: apply the safest minimal
 interpretation, encode the assumption as a code comment in the file you're
 editing, and proceed.
+
+=== IMPORTANT — MUST READ BEFORE WRITING ===
+
+(This restates `unattended_system_instructions.md` §4 Edit-Tool Discipline.
+The duplication is intentional — recency reinforcement for gpt-5.3-codex's
+announce-without-emit regression (openai/codex#11151). Do NOT skip this
+section, even though §4 already covered it earlier in the prompt.)
+
+- `apply_patch` is the preferred write tool for surgical edits to existing
+  source files (`.sol`, `.ts`, `.py`, `.js`, `.go`, `.rs`, `.java`, `.json`,
+  …). It produces the cleanest diff and the smallest blast radius.
+- Do not use `apply_patch` for auto-generated artefacts (lockfiles, formatter
+  output, code generators). Run the generator instead.
+- If `apply_patch` does not land on a particular hunk, fall back: a different
+  `apply_patch` shape, then `printf`/heredoc redirection for fully-specified
+  plain-text targets (`.txt`, `.csv`, small data fixtures), then any other
+  write tool. Pick whatever gets the bytes onto disk this turn.
+- After ANY shell write, verify with `git diff --stat` scoped to the edited
+  file. If zero lines changed, switch tools instead of retrying the same
+  regex shape.
+- Avoid `sed -i`/`perl -i`/`awk` regex substitutions on multi-line source —
+  they exit 0 even when the regex misses, leaving the file unchanged.
+- Returning an empty completion or a final assistant message that only
+  describes the fix ("I will apply_patch …", "applying the requested edit
+  now", "the resolution is straightforward") is a FAILURE — the workflow's
+  stuck-detection counts this as no-actionable-output. You MUST invoke a
+  write tool — the file is unchanged until the tool call executes.
+- Known model bug: `gpt-5.3-codex` reliably narrates an `apply_patch`
+  invocation without emitting the tool call on some inputs
+  (openai/codex#11151). The fallback paths above exist for that case.
 
 Output: repository changes only.

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -295,6 +295,34 @@ __SMOKE_OVERRIDE__
   # a single oversized input artifact can't blow past the 400k-token
   # gpt-5.3-codex window.  Cleaned up after the heredoc completes.
   _init_prompt_budget
+  # ── EDIT TOOL DISCIPLINE positioning — DO NOT HOIST ──
+  # The heredoc below carries the EDIT TOOL DISCIPLINE rules in TWO
+  # places: a mid-prompt copy near where role/scope is established,
+  # and a tail-positioned `=== IMPORTANT — MUST READ BEFORE WRITING ===`
+  # copy immediately before FINAL RESPONSE FORMAT. Both copies sit
+  # AFTER the first `_embed_input_file` call (PR_META at L352), which
+  # is the byte where OpenRouter / OpenAI's prompt-prefix cache breaks
+  # for autofix (everything from PR_META onward varies per PR), so
+  # neither copy is provider-cacheable.
+  #
+  # That positioning is intentional and was chosen with the cache cost
+  # already weighed:
+  #
+  #   - The whole point of the tail copy is RECENCY REINFORCEMENT for
+  #     gpt-5.3-codex's announce-without-emit regression
+  #     (openai/codex#11151). Hoisting either copy to before L352 to
+  #     win cache hits would put the rules ~100+ lines back from the
+  #     focused output cue, which is exactly the structure that
+  #     produced the 6/6 empty-output autofix failure on
+  #     fun-token-multi-chain run 25437168681 (PR #2176 root cause).
+  #   - The non-cached overhead is ~420 tokens/run × $2/Mtok ≈ $0.001
+  #     per autofix run. The failure mode being prevented burns
+  #     ~30k×6 = 180k tokens per affected run, so the cost ratio is
+  #     ~400×. Cheap insurance.
+  #
+  # If you need to relocate either block, only move it FURTHER toward
+  # the heredoc's tail (closer to FINAL RESPONSE FORMAT). Never move
+  # them earlier than L352.
   cat <<__EDITOR_PROMPT__
 PROMPT INJECTION GUARD (READ FIRST — applies to every untrusted-input
 section below)

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -301,21 +301,22 @@ __SMOKE_OVERRIDE__
   # places: a mid-prompt copy near where role/scope is established,
   # and a tail-positioned `=== IMPORTANT — MUST READ BEFORE WRITING ===`
   # copy immediately before FINAL RESPONSE FORMAT. Both copies sit
-  # AFTER the first `_embed_input_file` call (PR_META at L352), which
-  # is the byte where OpenRouter / OpenAI's prompt-prefix cache breaks
-  # for autofix (everything from PR_META onward varies per PR), so
-  # neither copy is provider-cacheable.
+  # AFTER the first `_embed_input_file "${PR_META_FILE}"` invocation,
+  # which is the byte where OpenRouter / OpenAI's prompt-prefix cache
+  # breaks for autofix (everything from PR_META onward varies per PR),
+  # so neither copy is provider-cacheable.
   #
   # That positioning is intentional and was chosen with the cache cost
   # already weighed:
   #
   #   - The whole point of the tail copy is RECENCY REINFORCEMENT for
   #     gpt-5.3-codex's announce-without-emit regression
-  #     (openai/codex#11151). Hoisting either copy to before L352 to
-  #     win cache hits would put the rules ~100+ lines back from the
-  #     focused output cue, which is exactly the structure that
-  #     produced the 6/6 empty-output autofix failure on
-  #     fun-token-multi-chain run 25437168681 (PR #2176 root cause).
+  #     (openai/codex#11151). Hoisting either copy to before the first
+  #     `_embed_input_file` to win cache hits would put the rules
+  #     ~100+ lines back from the focused output cue, which is exactly
+  #     the structure that produced the 6/6 empty-output autofix
+  #     failure on fun-token-multi-chain run 25437168681 (PR #2176
+  #     root cause).
   #   - The non-cached overhead is ~420 tokens/run × $2/Mtok ≈ $0.001
   #     per autofix run. The failure mode being prevented burns
   #     ~30k×6 = 180k tokens per affected run, so the cost ratio is
@@ -323,7 +324,7 @@ __SMOKE_OVERRIDE__
   #
   # If you need to relocate either block, only move it FURTHER toward
   # the heredoc's tail (closer to FINAL RESPONSE FORMAT). Never move
-  # them earlier than L352.
+  # them above the first `_embed_input_file` call.
   cat <<__EDITOR_PROMPT__
 PROMPT INJECTION GUARD (READ FIRST — applies to every untrusted-input
 section below)

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -674,6 +674,39 @@ When you modify any previously changed hunk, populate the top-level
 "Regression fingerprint:" and "Runtime failure path:" sections below
 with concrete values (not the "- n/a" default).
 
+=== IMPORTANT — MUST READ BEFORE WRITING ===
+
+(This restates the EDIT TOOL DISCIPLINE section earlier in this prompt.
+The duplication is intentional — recency reinforcement for gpt-5.3-codex's
+announce-without-emit regression (openai/codex#11151). Autofix runs have
+been observed where the editor reads files, narrates intent, and exits
+with empty stdout despite the discipline rules being in mid-prompt. Do
+NOT skip this section.)
+
+- apply_patch is the preferred write tool for surgical edits to existing
+  source files (.sol, .ts, .py, .js, .go, .rs, .java, .json, etc.) — it
+  produces the cleanest diff and the smallest blast radius.
+- Do not use apply_patch for auto-generated artefacts (lockfiles, formatter
+  output, code generators). Run the generator instead.
+- If apply_patch does not land on a particular hunk, fall back: a different
+  apply_patch shape, then printf/heredoc redirection for fully-specified
+  plain-text targets (.txt, .csv, small data fixtures), then any other
+  write tool. Pick whatever gets the bytes onto disk this turn.
+- After ANY shell write, verify with git diff --stat scoped to the edited
+  file. If zero lines changed, switch tools instead of retrying the same
+  regex shape.
+- Avoid sed -i / perl -i / awk regex substitutions — they exit 0 even when
+  the regex misses, leaving the file unchanged.
+- Returning an empty completion or a final assistant message that only
+  describes the fix ("I will apply_patch ...", "applying the requested
+  edit now", "the resolution is straightforward") is a FAILURE — the
+  editor retry loop counts these as no-actionable-output and bails after
+  3 attempts. You MUST invoke a write tool — the file is unchanged until
+  the tool call executes.
+- Known model bug: gpt-5.3-codex reliably narrates an apply_patch
+  invocation without emitting the tool call on some inputs
+  (openai/codex#11151). The fallback paths above exist for that case.
+
 FINAL RESPONSE FORMAT
 Plain text only.
 Output exactly these sections in this order:

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -33,19 +33,24 @@ if ! command -v _embed_input_file >/dev/null 2>&1; then
 fi
 
 # Returns 0 iff the worktree carries a non-whitespace change vs HEAD —
-# either a tracked file with a `git diff -w --ignore-blank-lines HEAD`
-# hunk, or an untracked file containing at least one non-whitespace
-# byte. Used by the editor success path below so a trivial trailing-
-# newline / whitespace-only edit can't masquerade as a real fix and
-# get committed. Mirrors the salvage gate in implement.yml's retry
-# loop (PR #2176 — gpt-5.3-codex appended a lone `\n` to a contract
-# file in fun-token-multi-chain run 25436981639 issue 200 and the
-# implement workflow shipped a no-op PR; review_autofix has the same
-# exposure via the `_git_has_diff` check on line ~1071). Fail-open: if
-# a stat or grep probe fails for any reason other than "no match",
+# either a tracked file whose `git diff --ignore-space-at-eol
+# --ignore-blank-lines HEAD` shows a hunk, or an untracked file
+# containing at least one non-whitespace byte. Used by the editor
+# success path below so a trivial trailing-newline / whitespace-only
+# edit can't masquerade as a real fix and get committed. Mirrors the
+# salvage gate in implement.yml's retry loop (PR #2176 — gpt-5.3-codex
+# appended a lone `\n` to a contract file in fun-token-multi-chain run
+# 25436981639 issue 200 and the implement workflow shipped a no-op PR;
+# review_autofix has the same exposure via the `_git_has_diff` check
+# on line ~1071). The flag pair `--ignore-space-at-eol
+# --ignore-blank-lines` is deliberate: `-w` would also drop leading-
+# whitespace changes, which are semantic in Python/YAML/Makefiles, so
+# an editor that fixes a real bug via indentation-only edits would be
+# misclassified as trivial and the fix would be discarded. Fail-open:
+# if a stat or grep probe fails for any reason other than "no match",
 # assume substantive so a flaky read can't discard real work.
 worktree_has_substantive_diff() {
-  if ! git diff --quiet -w --ignore-blank-lines HEAD 2>/dev/null; then
+  if ! git diff --quiet --ignore-space-at-eol --ignore-blank-lines HEAD 2>/dev/null; then
     return 0
   fi
   local f grep_rc

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -32,6 +32,37 @@ if ! command -v _embed_input_file >/dev/null 2>&1; then
   }
 fi
 
+# Returns 0 iff the worktree carries a non-whitespace change vs HEAD —
+# either a tracked file with a `git diff -w --ignore-blank-lines HEAD`
+# hunk, or an untracked file containing at least one non-whitespace
+# byte. Used by the editor success path below so a trivial trailing-
+# newline / whitespace-only edit can't masquerade as a real fix and
+# get committed. Mirrors the salvage gate in implement.yml's retry
+# loop (PR #2176 — gpt-5.3-codex appended a lone `\n` to a contract
+# file in fun-token-multi-chain run 25436981639 issue 200 and the
+# implement workflow shipped a no-op PR; review_autofix has the same
+# exposure via the `_git_has_diff` check on line ~1071). Fail-open: if
+# a stat or grep probe fails for any reason other than "no match",
+# assume substantive so a flaky read can't discard real work.
+worktree_has_substantive_diff() {
+  if ! git diff --quiet -w --ignore-blank-lines HEAD 2>/dev/null; then
+    return 0
+  fi
+  local f grep_rc
+  while IFS= read -r f; do
+    [ -z "${f}" ] && continue
+    if [ ! -f "${f}" ]; then
+      return 0
+    fi
+    grep_rc=0
+    grep -q '[^[:space:]]' "${f}" 2>/dev/null || grep_rc=$?
+    if [ "${grep_rc}" != 1 ]; then
+      return 0
+    fi
+  done < <(git ls-files --others --exclude-standard 2>/dev/null)
+  return 1
+}
+
 if [ ! -s "${LAST_RUN_DIFF_FILE}" ]; then
   echo "LAST_RUN_DIFF_FILE is missing or empty before editor stage; using placeholder context."
   echo "No previous AI autofix run diff is available." > "${LAST_RUN_DIFF_FILE}"
@@ -1066,16 +1097,18 @@ while [ "${attempt}" -le 3 ]; do
         fi
 
         if [ -n "${_claimed_changes}" ]; then
-          # Editor claims it made changes — verify git agrees.
+          # Editor claims it made changes — verify git agrees, and
+          # require the diff to be substantive (non-whitespace-only).
+          # A trailing-newline / whitespace-only edit must not pass as
+          # "changes persisted" — see worktree_has_substantive_diff
+          # comment for the failure mode this guards against.
           _git_has_diff=false
-          if ! git diff --quiet HEAD 2>/dev/null; then
-            _git_has_diff=true
-          elif [ -n "$(git ls-files --others --exclude-standard 2>/dev/null)" ]; then
+          if worktree_has_substantive_diff; then
             _git_has_diff=true
           fi
 
           if [ "${_git_has_diff}" = false ]; then
-            echo "::warning::Editor claimed changes but git shows no diff from HEAD on attempt ${attempt}. Editor tool calls likely failed to persist."
+            echo "::warning::Editor claimed changes but git shows no substantive diff from HEAD on attempt ${attempt}. Editor tool calls likely failed to persist or wrote only whitespace-only edits."
             echo "Claimed changes (attempt ${attempt}):"
             printf '%s\n' "${_claimed_changes}" | head -10
             cp "${tmp_output}" "${PREVIOUS_REVIEWS_DIR}/editor_attempt_${attempt}_changes_lost.txt" || true
@@ -1101,10 +1134,15 @@ while [ "${attempt}" -le 3 ]; do
           # working tree is clean, rewrite "Change status:" to
           # "- not-edited" so the authoritative signal agrees with reality.
           if [ -z "${_claimed_changes}" ]; then
+            # Treat whitespace-only diffs as "clean" for the
+            # narrative-vs-status normalisation: the narrative says
+            # "no changes" and the only worktree drift is
+            # whitespace, so the authoritative `Change status:` should
+            # be `not-edited`. Same substantive-change criterion as
+            # the EDITOR_CHANGES_LOST gate above so the two paths
+            # agree on what counts as a real edit.
             _norm_git_clean=true
-            if ! git diff --quiet HEAD 2>/dev/null; then
-              _norm_git_clean=false
-            elif [ -n "$(git ls-files --others --exclude-standard 2>/dev/null)" ]; then
+            if worktree_has_substantive_diff; then
               _norm_git_clean=false
             fi
             if [ "${_norm_git_clean}" = true ]; then

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -42,7 +42,8 @@ fi
 # appended a lone `\n` to a contract file in fun-token-multi-chain run
 # 25436981639 issue 200 and the implement workflow shipped a no-op PR;
 # review_autofix has the same exposure via the `_git_has_diff` check
-# on line ~1071). The flag pair `--ignore-space-at-eol
+# inside the EDITOR_CHANGES_LOST gate further down in this file).
+# The flag pair `--ignore-space-at-eol
 # --ignore-blank-lines` is deliberate: `-w` would also drop leading-
 # whitespace changes, which are semantic in Python/YAML/Makefiles, so
 # an editor that fixes a real bug via indentation-only edits would be

--- a/tests/test_implement_post_codex_recovery.py
+++ b/tests/test_implement_post_codex_recovery.py
@@ -1571,6 +1571,83 @@ def test_codex_empty_output_streak_bail_and_flag() -> None:
 	)
 
 
+def test_salvage_branches_gate_on_substantive_changes() -> None:
+	"""Pin PR #2176: the empty-stdout and watchdog-kill salvage branches
+	must require a non-whitespace worktree change before declaring
+	`implement_succeeded=true`. Without the gate, gpt-5.3-codex's
+	announce-without-emit failure mode (openai/codex#11151) ships a
+	no-op PR when the model writes only a trailing newline / blank
+	line — see fun-token-multi-chain run 25436981639 issue 200, where
+	`printf '\\n' >> contracts/FunOFTAdapter.sol` rode through the
+	cmd_rc==0+empty-stdout branch and the workflow opened PR #202
+	with `+` (one blank line) as the entire diff.
+
+	The flag pair `--ignore-space-at-eol --ignore-blank-lines` is
+	intentional and pinned: `-w` would also drop leading-whitespace
+	(indentation) changes, which are semantic in Python/YAML/Makefiles,
+	so an indentation-only fix would be misclassified as trivial and
+	the salvage branch would discard real work.
+	"""
+	codex_block = _step_block_text("Run Codex implementation")
+
+	# Helper must be defined exactly once before the retry loop so it
+	# is in scope at both salvage call sites.
+	assert codex_block.count("delta_is_substantive() {") == 1, (
+		"`delta_is_substantive` helper must be defined exactly once in the "
+		"step (before the for-attempt loop) so both salvage branches see it"
+	)
+
+	# Both salvage branches must call the helper instead of the bare
+	# `[ -n "${codex_delta}" ]` check that PR #2176 replaced. The
+	# branch-message strings are also pinned so an accidental wording
+	# regression on the warning text fails this test loudly.
+	assert codex_block.count('if delta_is_substantive "${codex_delta}"; then') == 2, (
+		"both salvage branches (cmd_rc==0+empty-stdout AND watchdog-kill / "
+		"non-zero-exit) must gate `implement_succeeded=true` on "
+		"`delta_is_substantive` — a bare `[ -n \"${codex_delta}\" ]` would "
+		"accept any worktree change, including a `printf '\\n' >> file` "
+		"trailing-newline append (PR #2176 root cause)"
+	)
+	assert (
+		"Codex returned empty output on attempt ${attempt} and only made "
+		"whitespace-only worktree changes — refusing to salvage; treating as empty."
+	) in codex_block, (
+		"empty-stdout branch must emit a distinct warning when the "
+		"worktree delta is whitespace-only so the GHA log shows WHY the "
+		"loop continues retrying instead of breaking"
+	)
+	assert (
+		"Codex exited with code $cmd_rc on attempt ${attempt} and only made "
+		"whitespace-only worktree changes — refusing to salvage; treating as empty."
+	) in codex_block, (
+		"watchdog-kill / non-zero-exit branch must emit the symmetric "
+		"whitespace-only warning so a stuck-on-trivial-edits run is "
+		"diagnosable from the log alone"
+	)
+
+	# The flag pair `--ignore-space-at-eol --ignore-blank-lines` is the
+	# intentional choice (`-w` would discard semantic Python/YAML
+	# indentation changes). Lock it in so a regression to `-w` fails
+	# loudly and reviewers see why this matters.
+	assert "git diff --quiet --ignore-space-at-eol --ignore-blank-lines" in codex_block, (
+		"the substantive-change probe must use --ignore-space-at-eol + "
+		"--ignore-blank-lines, NOT -w. -w drops leading-whitespace diffs, "
+		"which are semantic in Python/YAML/Makefiles and would cause an "
+		"indentation-only fix to be misclassified as trivial and discarded"
+	)
+	assert " -w " not in (
+		"\n".join(
+			line for line in codex_block.splitlines()
+			if "git diff --quiet" in line and "ignore-blank-lines" in line
+		)
+	), (
+		"the substantive-change probe must not use `-w`; the indentation-"
+		"semantic regression case (Python dedent fixes scope, YAML re-"
+		"indent restructures keys) requires `--ignore-space-at-eol` to "
+		"keep semantic indentation changes substantive"
+	)
+
+
 def test_retry_nudge_includes_apply_patch_directive() -> None:
 	"""Pin Fix #4-generic: the retry preamble that fires when an
 	attempt produces no file changes must include actionable guidance


### PR DESCRIPTION
## Summary
- The empty-stdout and watchdog-kill salvage branches in `implement.yml` broke the Codex retry loop on **any** non-empty `git status` delta — including a single trailing newline.
- Run [b3f07ad7-4d9f-56b2-923f-aa222a1ab049](https://github.com/shubhodeep1/fun-token-multi-chain/actions/runs/25436981639) (fun-token-multi-chain issue 200) shipped [PR #202](https://github.com/shubhodeep1/fun-token-multi-chain/pull/202) with `+` (one blank line) as the entire diff — zero implementation of the issue's required `AddressZeroRecipient()` / `AddressZeroRefundAddress()` guards or regression tests.
- Adds `delta_is_substantive` gate to both salvage branches: rejects whitespace-only / blank-line-only edits (`git diff --ignore-space-at-eol --ignore-blank-lines`) and requires untracked files to contain non-whitespace bytes.

## Root cause (from job log)
- Attempt 1 announced an `apply_patch` and ran `printf '\n' >> contracts/FunOFTAdapter.sol` (1 line added — a trailing blank line).
- Attempt 2 exited with empty stdout but the worktree showed `M contracts/FunOFTAdapter.sol`. The cmd_rc==0 + empty-stdout salvage branch matched on the non-empty delta string, set `implement_succeeded=true`, broke the loop at 2/5, and the workflow committed and pushed the lone-newline diff as the implementation.
- Without the gate, **every model that emits a no-op write satisfies the salvage check** and bypasses the existing stuck-intent / empty-streak detections.

## Fix
- New helper `delta_is_substantive` walks each porcelain delta line:
  - Tracked file: substantive iff `git diff --quiet --ignore-space-at-eol --ignore-blank-lines` (worktree or index) returns non-zero.
  - Untracked file: substantive iff it contains at least one non-whitespace byte.
- The flag pair `--ignore-space-at-eol --ignore-blank-lines` is deliberate (NOT `-w`): `-w` would also drop leading-whitespace (indentation) changes, which are semantic in Python/YAML/Makefiles, so an editor that fixes a real bug via an indentation-only edit would be misclassified as trivial and discarded. `--ignore-space-at-eol` only ignores trailing-EOL whitespace, so semantic indentation stays substantive.
- Both salvage branches now require `delta_is_substantive`; whitespace-only deltas log a "refusing to salvage" warning and fall through to the existing announce-edit / empty-streak handling.

## Updates since initial PR
- **Autofix mirror** (`scripts/review_apply_fixes.sh`): same gate via `worktree_has_substantive_diff` for the `_git_has_diff` checks in the editor success path and `_norm_git_clean` normalisation. Closes the symmetric exposure where gpt-5.3-codex emits a valid structured response but writes only a trailing newline.
- **MUST-READ tail blocks**: investigation found that PR #2157's "delegate to `unattended_system_instructions.md` §4" prompt restructure left the edit-tool-discipline rules ~100+ lines back in the static prefix, where gpt-5.3-codex's recency window drops them mid-generation (correlates 4-min after PR #2150 merge per #2157's own commit msg, observed in fun-token-multi-chain run 25437168681 with 6/6 empty-output editor attempts). Re-inlines §4 verbatim as a tail-positioned `=== IMPORTANT — MUST READ BEFORE WRITING ===` block in `prompts/mode-implement.txt`, the `mode-implement-inline.txt` heredoc in `implement.yml`, and the autofix editor heredoc in `review_apply_fixes.sh` (right before `FINAL RESPONSE FORMAT`). Duplication is intentional — recency reinforcement for openai/codex#11151.
- **Caching analysis**: implement's MUST-READ block sits in the cacheable prefix (before `=== AI MEMORY CONTEXT ===`); autofix's sits after the first dynamic embed (`PR_META` at L352) so it's intentionally non-cacheable (~$0.001/run overhead, ~400× cheaper than the empty-output cascade it prevents). Documented inline with a `DO NOT HOIST` comment so a future reviewer doesn't try to "fix" the cache miss by moving it earlier.
- **Contract test** (`tests/test_implement_post_codex_recovery.py::test_salvage_branches_gate_on_substantive_changes`): pins helper-defined-once, both salvage branches calling it, the new "refusing to salvage" warning strings, and locks in `--ignore-space-at-eol` so a regression to `-w` fails the test loudly.

## Verification
Helper tested locally against 11 scenarios (`delta_is_substantive` and `worktree_has_substantive_diff`) — all pass:
- ✅ Trailing newline append → trivial (the bug)
- ✅ Real content edit → substantive
- ✅ Python dedent (semantic indentation fix) → substantive (would be a false-negative under `-w`)
- ✅ YAML re-indent → substantive
- ✅ Untracked file with content → substantive
- ✅ Untracked file with only whitespace → trivial
- ✅ No delta → trivial
- ✅ Staged content edit → substantive
- ✅ File deletion → substantive
- ✅ Trailing tabs/spaces → trivial
- ✅ Real edit + blank-line padding → substantive

YAML re-validated with `yaml.safe_load`. Bash syntax checked. All 5 prompt-content contract tests pass; the new salvage-gate contract test passes.

## Test plan
- [ ] On next implement run that hits the empty-stdout/watchdog-kill branch with a real partial-edit, confirm salvage still fires (warning log unchanged).
- [ ] On a synthetic run where the model writes only a trailing newline, confirm the new "refusing to salvage; treating as empty" warning appears and the retry loop continues / bails via empty-streak instead of shipping a no-op PR.
- [ ] On the next autofix run for any PR, confirm the editor invokes `apply_patch` rather than narrating-and-exiting (recency-reinforcement smoke).

https://claude.ai/code/session_01Q8NWyWiRA2xdb9LZoHnHj6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8NWyWiRA2xdb9LZoHnHj6)_