### PR TITLE
fix(workflows): pin Codex platform binary via shared install-codex action

### DIFF
--- a/.github/actions/install-codex/action.yml
+++ b/.github/actions/install-codex/action.yml
@@ -1,0 +1,39 @@
+name: Install Codex CLI
+description: |
+  Install the @openai/codex CLI deterministically by pinning both the entry
+  package (which ships bin/codex.js) and the platform-specific binary tarball
+  under the alias name the entry script resolves at runtime
+  (@openai/codex-linux-x64). This avoids the npm CLI bug where global installs
+  silently skip optionalDependencies (npm/cli#4828), which produced
+  "Missing optional dependency @openai/codex-linux-x64" failures across
+  reusable workflows.
+
+inputs:
+  codex_version:
+    description: Pinned Codex CLI version (e.g. v0.114.0).
+    required: false
+    default: v0.114.0
+
+runs:
+  using: composite
+  steps:
+    - name: Install Codex CLI (entry + platform binary)
+      shell: bash
+      env:
+        CODEX_VERSION: ${{ inputs.codex_version }}
+      run: |
+        set -euo pipefail
+
+        # Strip a leading "v" if the caller supplied a tag-style version, since
+        # the platform tarball is published without it (e.g. 0.114.0-linux-x64).
+        version="${CODEX_VERSION#v}"
+
+        # Install both packages explicitly so the platform binary is never
+        # left to npm's optionalDependencies resolution.
+        npm install -g \
+          "@openai/codex@${CODEX_VERSION}" \
+          "@openai/codex-linux-x64@npm:@openai/codex@${version}-linux-x64" \
+          --no-audit --no-fund
+
+        # Fail fast if the install did not produce a runnable binary.
+        codex --version

--- a/.github/actions/setup-runtime/action.yml
+++ b/.github/actions/setup-runtime/action.yml
@@ -50,14 +50,15 @@ runs:
       with:
         python-version: ${{ inputs.python_version }}
 
-    - name: Install Codex CLI and core tools
+    - name: Install Codex CLI
+      uses: shubhodeep1/coding-workflows/.github/actions/install-codex@stable
+      with:
+        codex_version: ${{ inputs.codex_version }}
+
+    - name: Install OS-level core tools
       shell: bash
-      env:
-        CODEX_VERSION: ${{ inputs.codex_version }}
       run: |
         set -euo pipefail
-
-        npm install -g "@openai/codex@${CODEX_VERSION}" --include=optional --no-audit --no-fund
 
         missing_tools=()
         for tool in jq curl gh; do

--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -154,10 +154,9 @@ jobs:
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@${SERVER_HOST}/${GITHUB_REPOSITORY}"
 
       - name: Install Codex CLI
-        run: |
-          set -euo pipefail
-          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
-          npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
+        uses: shubhodeep1/coding-workflows/.github/actions/install-codex@stable
+        with:
+          codex_version: ${{ vars.CODEX_VERSION || 'v0.114.0' }}
 
       - name: Resolve workflow support ref
         run: |

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -87,10 +87,9 @@ jobs:
 
       - name: Install dependencies
         if: env.SKIP_IMPLEMENT != 'true'
-        run: |
-          set -euo pipefail
-          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
-          npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
+        uses: shubhodeep1/coding-workflows/.github/actions/install-codex@stable
+        with:
+          codex_version: ${{ vars.CODEX_VERSION || 'v0.114.0' }}
 
       - name: Create runtime workspace
         if: env.SKIP_IMPLEMENT != 'true'

--- a/.github/workflows/orchestrate_clarify_respond.yml
+++ b/.github/workflows/orchestrate_clarify_respond.yml
@@ -194,10 +194,9 @@ jobs:
 
       - name: Install Codex CLI
         if: steps.check_orchestrator.outputs.is_orchestrator == 'true'
-        run: |
-          set -euo pipefail
-          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
-          npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
+        uses: shubhodeep1/coding-workflows/.github/actions/install-codex@stable
+        with:
+          codex_version: ${{ vars.CODEX_VERSION || 'v0.114.0' }}
 
       - name: Resolve workflow support ref
         if: steps.check_orchestrator.outputs.is_orchestrator == 'true'

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -60,12 +60,15 @@ jobs:
 
       - name: Install Codex CLI
         if: steps.cache-codex.outputs.cache-hit != 'true'
+        uses: shubhodeep1/coding-workflows/.github/actions/install-codex@stable
+        with:
+          codex_version: ${{ env.CODEX_VERSION }}
+
+      - name: Persist Codex CLI to tool cache
+        if: steps.cache-codex.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
-          # Persist to tool cache for future runs
           CODEX_BIN="$(which codex)"
-          CODEX_DIR="$(dirname "${CODEX_BIN}")"
           mkdir -p "${{ runner.tool_cache }}/codex"
           cp -r "$(npm root -g)/@openai/codex" "${{ runner.tool_cache }}/codex/package"
           cp "${CODEX_BIN}" "${{ runner.tool_cache }}/codex/codex"

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1095,11 +1095,14 @@ jobs:
             echo "PR_CLOSED=true" >> "$GITHUB_ENV"
           fi
 
-      - name: Install dependencies
+      - name: Install Codex CLI
+        uses: shubhodeep1/coding-workflows/.github/actions/install-codex@stable
+        with:
+          codex_version: ${{ vars.CODEX_VERSION || 'v0.114.0' }}
+
+      - name: Install OS-level dependencies
         run: |
           set -euo pipefail
-          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
-          npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
           sudo apt-get update
           sudo apt-get install -y jq curl python3
 

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -204,9 +204,14 @@ jobs:
 
       - name: Install Codex CLI
         if: steps.cache-codex.outputs.cache-hit != 'true'
+        uses: shubhodeep1/coding-workflows/.github/actions/install-codex@stable
+        with:
+          codex_version: ${{ env.CODEX_VERSION }}
+
+      - name: Persist Codex CLI to tool cache
+        if: steps.cache-codex.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
           CODEX_BIN="$(which codex)"
           mkdir -p "${{ runner.tool_cache }}/codex"
           cp -r "$(npm root -g)/@openai/codex" "${{ runner.tool_cache }}/codex/package"
@@ -676,9 +681,14 @@ jobs:
 
       - name: Install Codex CLI
         if: steps.cache-codex.outputs.cache-hit != 'true'
+        uses: shubhodeep1/coding-workflows/.github/actions/install-codex@stable
+        with:
+          codex_version: ${{ env.CODEX_VERSION }}
+
+      - name: Persist Codex CLI to tool cache
+        if: steps.cache-codex.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
           CODEX_BIN="$(which codex)"
           mkdir -p "${{ runner.tool_cache }}/codex"
           cp -r "$(npm root -g)/@openai/codex" "${{ runner.tool_cache }}/codex/package"
@@ -1015,9 +1025,14 @@ jobs:
 
       - name: Install Codex CLI
         if: steps.cache-codex.outputs.cache-hit != 'true'
+        uses: shubhodeep1/coding-workflows/.github/actions/install-codex@stable
+        with:
+          codex_version: ${{ env.CODEX_VERSION }}
+
+      - name: Persist Codex CLI to tool cache
+        if: steps.cache-codex.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          npm install -g @openai/codex@"${CODEX_VERSION}" --include=optional --no-audit --no-fund
           CODEX_BIN="$(which codex)"
           mkdir -p "${{ runner.tool_cache }}/codex"
           cp -r "$(npm root -g)/@openai/codex" "${{ runner.tool_cache }}/codex/package"


### PR DESCRIPTION
## Summary

Run [25441973385](https://github.com/shubhodeep1/coding-workflows/actions/runs/25441973385) (clarify on issue #2178) failed because `npm install -g @openai/codex@v0.114.0 --include=optional` silently skipped the platform-specific dep `@openai/codex-linux-x64`. Codex then crashed on every `codex exec` attempt with:

```
Error: Missing optional dependency @openai/codex-linux-x64.
Reinstall Codex: npm install -g @openai/codex@latest
```

This is the npm CLI bug [npm/cli#4828](https://github.com/npm/cli/issues/4828): `--include=optional` is unreliable for global installs. Same install pattern is duplicated across nine sites in this repo, so the failure mode reproduces randomly across `clarify`, `plan`, `implement`, `review_autofix`, `orchestrate_clarify_respond`, `workflow-log-analysis`, and `setup-runtime`. PR #1543 added `--include=optional` everywhere; that was necessary but not sufficient.

## Root cause evidence

- npm install completed but added only 1 package, not 2 — log L271: `added 1 package in 12s` (the optional `@openai/codex-linux-x64` alias was skipped).
- All 3 codex exec attempts hit the same error — log L1249/L1264/L1279.
- `@openai/codex@0.114.0` declares optionalDependencies as npm aliases, e.g. `"@openai/codex-linux-x64": "npm:@openai/codex@0.114.0-linux-x64"`. The aliased target is published; the bug is the install resolver, not the package.
- The platform tarball (`@openai/codex@0.114.0-linux-x64`) ships only the native binary at `vendor/x86_64-unknown-linux-musl/codex/codex` and declares **no `bin` entry** — so installing it alone does **not** put `codex` on PATH. The executable lives in the entry `@openai/codex` package's `bin/codex.js`, which `require.resolve('@openai/codex-linux-x64')` to delegate. Pinning only the platform tarball ("option C") is a non-fix on its own; both packages are required.

## Fix

Introduce `.github/actions/install-codex` (composite action) whose install command pins **both** packages explicitly under the alias name `bin/codex.js` resolves at runtime — no reliance on `optionalDependencies`:

```bash
npm install -g \
  "@openai/codex@${CODEX_VERSION}" \
  "@openai/codex-linux-x64@npm:@openai/codex@${version}-linux-x64" \
  --no-audit --no-fund
codex --version
```

All nine inline install sites now `uses:` the shared action via `shubhodeep1/coding-workflows/.github/actions/install-codex@stable`:

- `.github/workflows/clarify.yml`
- `.github/workflows/plan.yml`
- `.github/workflows/implement.yml`
- `.github/workflows/review_autofix.yml`
- `.github/workflows/orchestrate_clarify_respond.yml`
- `.github/workflows/workflow-log-analysis.yml` (×3)
- `.github/actions/setup-runtime/action.yml`

`setup-runtime` and `review_autofix` had a single `Install dependencies` step that mixed the codex install with `apt-get` invocations; those are split into a `uses:` step + a separate apt step (logically equivalent, no behavior change beyond the install fix).

## Residual scope (intentional, out of scope)

`plan.yml` and `workflow-log-analysis.yml` have cache-restore steps that call `npm install -g "<runner.tool_cache>/codex/package" --include=optional --no-audit --no-fund` on cache hits. The cache only stores the entry `@openai/codex` package directory, not the platform tarball, so cache-hit paths retain the same npm-bug exposure they had before this PR. Fresh-install paths (cache-miss) are now fully fixed, which covers any cache-key bump (e.g. `vars.CODEX_VERSION` change). Fixing the cache-restore path is a follow-up.

## Test plan

- [ ] CI green on this PR.
- [ ] After promote-main-to-stable, re-trigger a clarify run on a fresh under-specified issue and confirm `codex --version` succeeds and the workflow exits 0 (no `Missing optional dependency` error).
- [ ] Trigger an `implement` and `plan` run; confirm cache-miss path runs the new action and `codex --version` succeeds.
- [ ] Trigger a `workflow-log-analysis` run; confirm all three job paths use the action.

https://claude.ai/code/session_018qHDfwnr58xD8yNMZA2orT

---
_Generated by [Claude Code](https://claude.ai/code/session_018qHDfwnr58xD8yNMZA2orT)_