### PR TITLE
fix(e2e-smoke): include 'self-healing' in wait-review name filter

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1269,12 +1269,25 @@ jobs:
             # the bait SHA.) The dispatched run's head_sha matches
             # BAIT_SHA because we dispatch with --ref "${BRANCH}" and
             # GitHub records the ref's tip SHA at dispatch time.
+            #
+            # `self-healing` is part of the regex because review_autofix.yml
+            # ("Codex PR Self-Healing Semantic Agent") is dispatched directly
+            # by its own post_commit_retrigger after the editor commits the
+            # fix — that engine run is the canonical successor at PIN_SHA on
+            # repos where review_autofix.yml exists locally (coding-workflows
+            # itself, plus consumer repos that copy/sync it). Without this
+            # token the engine's name does not match `Review|review|autofix`,
+            # so the wait loop never sees the post-commit successor run and
+            # ages out at REVIEW_TIMEOUT — observed on run-25445414047 where
+            # PIN_SHA advanced to the editor commit but the engine
+            # workflow_dispatch run at that SHA was filtered out and the
+            # poll timed out 30m later.
             if [ -n "${PIN_SHA:-}" ]; then
               REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&per_page=100" \
-                --jq "[.workflow_runs[] | select(.name | test(\"Review|review|autofix\"; \"i\")) | select(.head_sha == \"${PIN_SHA}\")] | sort_by(.created_at) | last" || echo "")
+                --jq "[.workflow_runs[] | select(.name | test(\"Review|review|autofix|self-healing\"; \"i\")) | select(.head_sha == \"${PIN_SHA}\")] | sort_by(.created_at) | last" || echo "")
             else
               REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&event=pull_request&per_page=5" \
-                --jq '[.workflow_runs[] | select(.name | test("Review|review|autofix"; "i"))] | sort_by(.created_at) | last' || echo "")
+                --jq '[.workflow_runs[] | select(.name | test("Review|review|autofix|self-healing"; "i"))] | sort_by(.created_at) | last' || echo "")
             fi
 
             # If rate-limited, skip this cycle entirely (don't corrupt state)


### PR DESCRIPTION
## Summary

Fixes a 30-minute false-failure in the E2E smoke test's wait-review phase when `review_autofix.yml`'s `post_commit_retrigger` dispatches the engine directly after the editor commits its fix.

- The wait-review jq filter (`test("Review|review|autofix"; "i")`) does not match `review_autofix.yml`'s display name **"Codex PR Self-Healing Semantic Agent"**, so after `PIN_SHA` advances to the editor's fix-commit SHA the loop finds no matching run and ages out at `REVIEW_TIMEOUT` — even though the engine's `workflow_dispatch` run at that SHA completed successfully.
- Adding `self-healing` to the alternation closes the gap without matching unrelated workflows (`CI`, `Plan`, `Implement`).

## Evidence

Run **25445414047** (job log Azure URL provided by `/analyze-log`):
- L1483: bait pushed → `BAIT_SHA=69ab3d5`
- L1957: `↪ PR head advanced past pin (69ab3d5 → 795d34c)`
- Run `25446179625` (`Codex PR Self-Healing Semantic Agent`, `workflow_dispatch`, `head_sha=795d34c`) completed `success` at 16:04:10 — well within the 30m window
- L2156: `##[error]Review run pin was advanced from BAIT_SHA=… to PIN_SHA=795d34c… but no successor run … appeared within 30m`
- L2161: diagnostic confirms the engine run was on the branch but filtered out by name

## Test plan

- [ ] Re-run E2E smoke test — wait-review must observe the post-commit-retrigger engine run at the advanced PIN_SHA and exit `success` instead of `no_review_triggered`
- [ ] Verify regex still rejects unrelated workflows (`CI`, `Internal: AI Plan`, `Internal: AI Implement`) — confirmed locally with `jq` against representative names

https://claude.ai/code/session_01AgwTHQUsENFx8cqHhHAF6W

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgwTHQUsENFx8cqHhHAF6W)_