### PR TITLE
fix(codex): move --ask-for-approval before `exec` (Codex CLI v0.114.0 flag-position regression)

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -761,7 +761,7 @@ jobs:
           max_attempts=3
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "Codex clarify attempt ${attempt}/${max_attempts}..."
-            if cat "${CODEX_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
+            if cat "${CODEX_PROMPT_FILE}" | codex --ask-for-approval never exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
               if grep -q '[^[:space:]]' "${CODEX_OUTPUT_FILE}"; then
                 echo "Codex clarify succeeded on attempt ${attempt}."
                 break

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1339,7 +1339,7 @@ jobs:
             attempt_log_file="${RUNTIME_DIR}/codex_log_attempt_${attempt}.txt"
             : > "${attempt_log_file}"
             (
-              exec codex exec --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access < "${PROMPT_FILE_TO_USE}"
+              exec codex --ask-for-approval never exec --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${PROMPT_FILE_TO_USE}"
             ) > "${CODEX_OUTPUT_FILE}" 2> >(
               while IFS= read -r line || [ -n "$line" ]; do
                 printf '%s' "$(date +%s)" > "${hb_file}.tmp" && mv -f "${hb_file}.tmp" "${hb_file}" 2>/dev/null
@@ -1907,7 +1907,7 @@ jobs:
 
             REPAIR_OUTPUT_FILE="${RUNTIME_DIR}/post_codex_repair_output_attempt_${attempt}.txt"
             REPAIR_LOG_FILE="${RUNTIME_DIR}/post_codex_repair_log_attempt_${attempt}.txt"
-            if ! codex exec --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access < "${REPAIR_PROMPT_FILE}" > "${REPAIR_OUTPUT_FILE}" 2> >(tee -a "${REPAIR_LOG_FILE}" >&2); then
+            if ! codex --ask-for-approval never exec --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${REPAIR_PROMPT_FILE}" > "${REPAIR_OUTPUT_FILE}" 2> >(tee -a "${REPAIR_LOG_FILE}" >&2); then
               echo "::warning::Post-Codex repair attempt ${attempt} failed while invoking Codex."
               continue
             fi
@@ -3120,7 +3120,7 @@ jobs:
 
           for _summary_attempt in 1 2 3; do
             cat "${ISSUE_SUMMARY_PROMPT_FILE}" "${RUNTIME_DIR}/issue_context_for_summary.txt" \
-              | codex exec --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access > "${ISSUE_SUMMARY_FILE}" || true
+              | codex --ask-for-approval never exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${ISSUE_SUMMARY_FILE}" || true
             if [ -s "${ISSUE_SUMMARY_FILE}" ] && grep -q '^### AI Issue Summary' "${ISSUE_SUMMARY_FILE}"; then
               echo "Summary generated on attempt ${_summary_attempt}."
               break

--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -571,7 +571,7 @@ jobs:
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "Codex orchestrate attempt ${attempt}/${max_attempts}..."
             attempt_ok=0
-            if cat "${CODEX_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
+            if cat "${CODEX_PROMPT_FILE}" | codex --ask-for-approval never exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
               if ! grep -q '[^[:space:]]' "${CODEX_OUTPUT_FILE}"; then
                 echo "::warning::Codex returned empty output on attempt ${attempt}."
                 last_status="empty output"

--- a/.github/workflows/orchestrate_clarify_respond.yml
+++ b/.github/workflows/orchestrate_clarify_respond.yml
@@ -632,7 +632,7 @@ jobs:
           max_attempts=3
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "Codex clarify-respond attempt ${attempt}/${max_attempts}..."
-            if cat "${CODEX_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
+            if cat "${CODEX_PROMPT_FILE}" | codex --ask-for-approval never exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
               if grep -q '[^[:space:]]' "${CODEX_OUTPUT_FILE}"; then
                 echo "Codex clarify-respond succeeded on attempt ${attempt}."
                 break
@@ -692,8 +692,8 @@ jobs:
             } > "${RUNTIME_DIR}/critic_prompt.txt"
 
             CRITIC_MODEL="${MODEL_EDITOR}"
-            if cat "${RUNTIME_DIR}/critic_prompt.txt" | codex exec \
-              --model "${CRITIC_MODEL}" --ask-for-approval never --sandbox danger-full-access > "${RUNTIME_DIR}/critic_output.txt" 2>/dev/null; then
+            if cat "${RUNTIME_DIR}/critic_prompt.txt" | codex --ask-for-approval never exec \
+              --model "${CRITIC_MODEL}" --sandbox danger-full-access > "${RUNTIME_DIR}/critic_output.txt" 2>/dev/null; then
               if grep -q 'VERDICT: REJECT' "${RUNTIME_DIR}/critic_output.txt"; then
                 echo "::warning::Self-critique rejected the decision. Appending critique and re-running."
                 CRITIC_REASON="$(grep -A5 'REASON:' "${RUNTIME_DIR}/critic_output.txt" || echo "No reason provided")"
@@ -705,8 +705,8 @@ jobs:
                   echo "Revise your decisions to address this feedback."
                 } > "${CODEX_PROMPT_FILE}.v2"
 
-                if cat "${CODEX_PROMPT_FILE}.v2" | codex exec \
-                  --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2>/dev/null; then
+                if cat "${CODEX_PROMPT_FILE}.v2" | codex --ask-for-approval never exec \
+                  --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2>/dev/null; then
                   echo "Revised decision produced after self-critique."
                 else
                   echo "::warning::Revised Codex call failed; using original output."

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -914,7 +914,7 @@ jobs:
           max_attempts=3
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "Codex planning attempt ${attempt}/${max_attempts}..."
-            if cat "${CODEX_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
+            if cat "${CODEX_PROMPT_FILE}" | codex --ask-for-approval never exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
               if grep -q '[^[:space:]]' "${CODEX_OUTPUT_FILE}"; then
                 PLAN_LINES="$(wc -l < "${CODEX_OUTPUT_FILE}")"
                 echo "Codex planning succeeded on attempt ${attempt} (${PLAN_LINES} lines of output)."

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -470,7 +470,7 @@ jobs:
           for attempt in $(seq 1 "${max_attempts}"); do
             analyze_attempts_used="${attempt}"
             set +e
-            codex exec --model "${WORKFLOW_EDITOR_MODEL}" --ask-for-approval never --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" > "${REPORT_FILE}" 2> >(tee -a /tmp/workflow-analysis-codex.log >&2)
+            codex --ask-for-approval never exec --model "${WORKFLOW_EDITOR_MODEL}" --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" > "${REPORT_FILE}" 2> >(tee -a /tmp/workflow-analysis-codex.log >&2)
             ANALYZE_EXIT=$?
             set -e
             if [ "${ANALYZE_EXIT}" -eq 0 ] && grep -q '[^[:space:]]' "${REPORT_FILE}"; then
@@ -830,7 +830,7 @@ jobs:
           AUDIT_EXIT=0
           for attempt in $(seq 1 "${max_attempts}"); do
             set +e
-            codex exec --model "${WORKFLOW_EDITOR_MODEL}" --ask-for-approval never --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" > "${SECTION_FILE}" 2> >(tee -a /tmp/workflow-audit-codex.log >&2)
+            codex --ask-for-approval never exec --model "${WORKFLOW_EDITOR_MODEL}" --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" > "${SECTION_FILE}" 2> >(tee -a /tmp/workflow-audit-codex.log >&2)
             AUDIT_EXIT=$?
             set -e
             if [ "${AUDIT_EXIT}" -eq 0 ] && grep -q '[^[:space:]]' "${SECTION_FILE}"; then
@@ -1145,7 +1145,7 @@ jobs:
           API_EXIT=0
           for attempt in $(seq 1 "${max_attempts}"); do
             set +e
-            codex exec --model "${WORKFLOW_EDITOR_MODEL}" --ask-for-approval never --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" > "${SECTION_FILE}" 2> >(tee -a /tmp/workflow-api-redundancy-codex.log >&2)
+            codex --ask-for-approval never exec --model "${WORKFLOW_EDITOR_MODEL}" --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" > "${SECTION_FILE}" 2> >(tee -a /tmp/workflow-api-redundancy-codex.log >&2)
             API_EXIT=$?
             set -e
             if [ "${API_EXIT}" -eq 0 ] && grep -q '[^[:space:]]' "${SECTION_FILE}"; then

--- a/scripts/implement_diagnose_post_codex_failure.sh
+++ b/scripts/implement_diagnose_post_codex_failure.sh
@@ -438,7 +438,7 @@ PY
 }
 
 DIAGNOSE_SUCCESS=false
-if timeout "${IMPLEMENT_DIAGNOSE_TIMEOUT_SEC}"s codex exec --model "${DIAGNOSE_MODEL}" --ask-for-approval never --sandbox danger-full-access \
+if timeout "${IMPLEMENT_DIAGNOSE_TIMEOUT_SEC}"s codex --ask-for-approval never exec --model "${DIAGNOSE_MODEL}" --sandbox danger-full-access \
   < "${IMPLEMENT_DIAGNOSE_PROMPT_FILE}" > "${IMPLEMENT_DIAGNOSE_OUTPUT_FILE}" \
   2> >(tee -a "${IMPLEMENT_DIAGNOSE_LOG_FILE}" >&2); then
   if extract_last_json_with_key "${IMPLEMENT_DIAGNOSE_OUTPUT_FILE}" "status" "${IMPLEMENT_DIAGNOSE_RESULT_FILE}"; then

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -2792,7 +2792,7 @@ invoke_judge_for_integration_conflict() {
     echo "   short diagnosis in the commit message."
   } > "${prompt_file}"
 
-  if cat "${prompt_file}" | codex exec --model "${MODEL_EDITOR:-openai/gpt-5.3-codex}" --ask-for-approval never --sandbox danger-full-access > "${output_file}" 2>> "${RUNTIME_DIR}/integration_judge.log"; then
+  if cat "${prompt_file}" | codex --ask-for-approval never exec --model "${MODEL_EDITOR:-openai/gpt-5.3-codex}" --sandbox danger-full-access > "${output_file}" 2>> "${RUNTIME_DIR}/integration_judge.log"; then
     echo "  [integration-heal] Judge exec completed for PR #${final_pr}."
     rm -f "${prompt_file}" "${output_file}" "${judge_static_file}"
     return 0
@@ -5622,7 +5622,7 @@ invoke_stall_judge() {
     if [ -n "${MOCK_STALL_JUDGE_JSON:-}" ]; then
       printf '%s\n' "${MOCK_STALL_JUDGE_JSON}" > "${stall_judge_output_file}"
     else
-      codex exec --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access < "${stall_judge_prompt_file}" > "${stall_judge_output_file}" 2>> "${RUNTIME_DIR}/stall_judge.log" || true
+      codex --ask-for-approval never exec --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${stall_judge_prompt_file}" > "${stall_judge_output_file}" 2>> "${RUNTIME_DIR}/stall_judge.log" || true
     fi
     if grep -q '[^[:space:]]' "${stall_judge_output_file}"; then
       judge_success="true"
@@ -9354,7 +9354,7 @@ ${FOLLOWUP_BLOCK_REASON}"
       RB_JUDGE_SUCCESS=false
       for attempt in 1 2; do
         echo "  Review-blocked judge attempt ${attempt}/2..."
-        cat "${RB_JUDGE_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access > "${RB_JUDGE_OUTPUT_FILE}" 2>/dev/null || true
+        cat "${RB_JUDGE_PROMPT_FILE}" | codex --ask-for-approval never exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${RB_JUDGE_OUTPUT_FILE}" 2>/dev/null || true
         if grep -q '[^[:space:]]' "${RB_JUDGE_OUTPUT_FILE}"; then
           RB_JUDGE_SUCCESS=true
           break
@@ -10747,7 +10747,7 @@ ${PR_DIFF}
     # The pipeline may return 141 (SIGPIPE) when the prompt is larger
     # than the OS pipe buffer and codex closes stdin before cat finishes.
     # This is harmless — check the output file regardless of exit code.
-    cat "${JUDGE_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access > "${JUDGE_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/judge_log.txt" >&2) || true
+    cat "${JUDGE_PROMPT_FILE}" | codex --ask-for-approval never exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${JUDGE_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/judge_log.txt" >&2) || true
     if grep -q '[^[:space:]]' "${JUDGE_OUTPUT_FILE}"; then
       JUDGE_SUCCESS=true
       break

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -1030,7 +1030,7 @@ while [ "${attempt}" -le 3 ]; do
   # Run codex: stdout → tmp_output, stderr → FIFO (heartbeat reader).
   (
     trap '' PIPE
-    exec codex exec --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access < "${EDITOR_PROMPT_FILE}" 2>"${_hb_fifo}"
+    exec codex --ask-for-approval never exec --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${EDITOR_PROMPT_FILE}" 2>"${_hb_fifo}"
   ) > "${tmp_output}" &
   codex_bg_pid=$!
   echo "${codex_bg_pid}" > "${codex_pid_file}"

--- a/scripts/review_conflict_resolve.sh
+++ b/scripts/review_conflict_resolve.sh
@@ -536,7 +536,7 @@ while [ "${attempt}" -le "${INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS}" ]; do
   fi
 
   tmp_output="$(mktemp)"
-  if ! codex exec --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access "$(cat "${_effective_prompt_file}")" > "${tmp_output}"; then
+  if ! codex --ask-for-approval never exec --model "${MODEL_EDITOR}" --sandbox danger-full-access "$(cat "${_effective_prompt_file}")" > "${tmp_output}"; then
     rm -f "${tmp_output}"
     if [ "${attempt}" -eq "${INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS}" ]; then
       echo "Conflict resolver failed after retries."

--- a/scripts/review_consolidate.sh
+++ b/scripts/review_consolidate.sh
@@ -143,7 +143,7 @@ cmd_rc=0
 
 if ! CODEX_HOME="${consolidator_codex_home}" \
 	timeout "${REVIEW_CONSOLIDATOR_TIMEOUT_SECS}" \
-	"${codex_bin}" exec --model "${REVIEW_CONSOLIDATOR_MODEL}" --ask-for-approval never --sandbox danger-full-access \
+	"${codex_bin}" --ask-for-approval never exec --model "${REVIEW_CONSOLIDATOR_MODEL}" --sandbox danger-full-access \
 	< "${CONSOLIDATOR_PROMPT_FILE}" > "${tmp_out}" 2> "${tmp_err}"; then
 	cmd_rc=$?
 fi

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -520,7 +520,7 @@ case "${RB_ACTION}" in
         sed -i "s/model_reasoning_effort = \".*\"/model_reasoning_effort = \"${JUDGE_REASONING_EFFORT}\"/" "${HOME}/.codex/config.toml"
       fi
 
-      if codex exec --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access < "${RB_FIX_PROMPT}" > "${RB_FIX_OUTPUT}" 2>/dev/null; then
+      if codex --ask-for-approval never exec --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${RB_FIX_PROMPT}" > "${RB_FIX_OUTPUT}" 2>/dev/null; then
         echo "Fix codex completed."
       else
         echo "::warning::Fix codex failed for PR #${PR_NUMBER}."

--- a/scripts/self_heal_validation.sh
+++ b/scripts/self_heal_validation.sh
@@ -152,7 +152,7 @@ fi
 SELF_HEAL_LLM_SUCCESS=false
 for _llm_attempt in 1 2; do
 	echo "self-heal: LLM call attempt ${_llm_attempt}/2" >> "${SELF_HEAL_LOG_FILE}"
-	if cat "${SELF_HEAL_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access > "${SELF_HEAL_OUTPUT_FILE}" 2>> "${SELF_HEAL_LOG_FILE}"; then
+	if cat "${SELF_HEAL_PROMPT_FILE}" | codex --ask-for-approval never exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${SELF_HEAL_OUTPUT_FILE}" 2>> "${SELF_HEAL_LOG_FILE}"; then
 		# Extract the last JSON object that contains a "target_prompt" key.
 		# Use json.JSONDecoder.raw_decode() which is string/escape-aware
 		# (the earlier brace-depth counter mis-handled JSON strings that

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -2044,7 +2044,7 @@ else
     DISCOVER_ATTEMPTS_USED="${attempt}"
     echo "Validation hint discovery attempt ${attempt}/${MAX_CODEX_ATTEMPTS}"
     set +e
-    cat "${DISCOVER_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access > "${DISCOVER_OUTPUT_FILE}" 2> >(tee -a "${DISCOVER_LOG_FILE}" >&2)
+    cat "${DISCOVER_PROMPT_FILE}" | codex --ask-for-approval never exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${DISCOVER_OUTPUT_FILE}" 2> >(tee -a "${DISCOVER_LOG_FILE}" >&2)
     DISCOVER_EXIT=$?
     set -e
 
@@ -2707,7 +2707,7 @@ for attempt in $(seq 1 "${MAX_CODEX_ATTEMPTS}"); do
   DIAGNOSE_ATTEMPTS_USED="${attempt}"
   echo "Validation diagnosis attempt ${attempt}/${MAX_CODEX_ATTEMPTS}"
   set +e
-  cat "${DIAGNOSE_PROMPT_FILE}" | codex exec --model "${MODEL_EDITOR}" --ask-for-approval never --sandbox danger-full-access > "${DIAGNOSE_OUTPUT_FILE}" 2> >(tee -a "${DIAGNOSE_LOG_FILE}" >&2)
+  cat "${DIAGNOSE_PROMPT_FILE}" | codex --ask-for-approval never exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${DIAGNOSE_OUTPUT_FILE}" 2> >(tee -a "${DIAGNOSE_LOG_FILE}" >&2)
   DIAGNOSE_EXIT=$?
   set -e
 

--- a/tests/test_review_pipeline_integration.py
+++ b/tests/test_review_pipeline_integration.py
@@ -55,13 +55,19 @@ def _install_mock_codex(mock_bin_dir: Path, *, consolidator_fixture: str | None)
 		shutil.copy2(FIXTURES / consolidator_fixture, output_file)
 
 	codex_script = mock_bin_dir / "codex"
+	# Scan every arg for `exec` rather than checking $1, since the
+	# canonical Codex CLI v0.114.0+ invocation places `--ask-for-approval`
+	# (a top-level flag) before the `exec` subcommand:
+	#     codex --ask-for-approval never exec --model X --sandbox Y
+	# Anchoring on $1 would only match the legacy form (broken on
+	# v0.114.0+) and silently mis-mock the production layout.
 	codex_script.write_text(
 		"#!/usr/bin/env bash\n"
 		"set -euo pipefail\n\n"
-		"if [ \"${1:-}\" != \"exec\" ]; then\n"
-		"\techo \"mock-codex supports only exec\" >&2\n"
-		"\texit 2\n"
-		"fi\n"
+		"case \" $* \" in\n"
+		"\t*\" exec \"*) ;;\n"
+		"\t*) echo \"mock-codex supports only exec\" >&2; exit 2 ;;\n"
+		"esac\n"
 		"if [ -n \"${MOCK_CODEX_OUTPUT_FILE:-}\" ] && [ -f \"${MOCK_CODEX_OUTPUT_FILE}\" ]; then\n"
 		"\tcat \"${MOCK_CODEX_OUTPUT_FILE}\"\n"
 		"fi\n",

--- a/tests/test_write_codex_config.py
+++ b/tests/test_write_codex_config.py
@@ -376,6 +376,69 @@ def test_no_codex_exec_site_uses_deprecated_full_auto_flag() -> None:
 		)
 
 
+def test_no_codex_exec_site_places_ask_for_approval_after_exec() -> None:
+	"""Guard against re-introduction of the v0.114.0 flag-position regression.
+
+	Codex CLI v0.114.0 enforces flag positioning strictly: `--ask-for-approval`
+	is a TOP-LEVEL flag (must precede the `exec` subcommand). PR #2205 placed
+	`--ask-for-approval never --sandbox danger-full-access` AFTER `exec` across
+	24 codex invocation sites, which the parser rejects with:
+
+	    error: unexpected argument '--ask-for-approval' found
+	    Usage: codex exec --model <MODEL> [PROMPT]
+
+	This took down orchestrator/clarify/implement/plan/validate workflows in
+	one bulk edit. A grep guard here would have caught the regression before
+	the PR landed.
+
+	The valid layout is:
+	    codex --ask-for-approval never exec --model X --sandbox Y
+	The invalid layout is:
+	    codex exec --model X --ask-for-approval never --sandbox Y
+	    codex exec ... \\<newline>... --ask-for-approval never ... (multi-line)
+	"""
+	# `git grep -P -z` does NOT span lines (the -z flag controls output
+	# delimiter, not record boundary), so we read the relevant files
+	# directly and run a multi-line regex over each. The pattern matches
+	# `<prefix> exec` followed by an optional `\<newline><indent>` line
+	# continuation, then `--model ...` containing `--ask-for-approval`
+	# before the next newline (or before the next backslash-continued
+	# logical line ends).
+	pat = re.compile(
+		r'(codex|"\$\{codex_bin\}") exec\s+(\\\n\s+)?--model[^\n]*--ask-for-approval',
+	)
+	scan_dirs = [
+		REPO_ROOT / ".github" / "workflows",
+		REPO_ROOT / "scripts",
+	]
+	# write_codex_config.sh's docstring intentionally mentions the bad
+	# pattern in prose to document why we moved away from it.
+	exempt = {REPO_ROOT / "scripts" / "write_codex_config.sh"}
+	offenders: list[str] = []
+	for d in scan_dirs:
+		for path in sorted(d.rglob("*")):
+			if not path.is_file():
+				continue
+			if path in exempt:
+				continue
+			if path.suffix not in (".sh", ".yml", ".yaml"):
+				continue
+			text = path.read_text()
+			for m in pat.finditer(text):
+				line_no = text.count("\n", 0, m.start()) + 1
+				snippet = m.group(0).replace("\n", "\\n")
+				rel = path.relative_to(REPO_ROOT)
+				offenders.append(f"{rel}:{line_no}: {snippet}")
+	assert not offenders, (
+		"`--ask-for-approval` is a TOP-LEVEL Codex flag and must precede "
+		"the `exec` subcommand on Codex CLI v0.114.0+, otherwise the "
+		"parser rejects the invocation with `unexpected argument "
+		"'--ask-for-approval' found`. Use the layout `codex "
+		"--ask-for-approval never exec --model X --sandbox Y`. "
+		"Offending sites:\n  " + "\n  ".join(offenders)
+	)
+
+
 def main() -> int:
 	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
 	passed = 0

--- a/tests/test_write_codex_config.py
+++ b/tests/test_write_codex_config.py
@@ -399,13 +399,17 @@ def test_no_codex_exec_site_places_ask_for_approval_after_exec() -> None:
 	"""
 	# `git grep -P -z` does NOT span lines (the -z flag controls output
 	# delimiter, not record boundary), so we read the relevant files
-	# directly and run a multi-line regex over each. The pattern matches
-	# `<prefix> exec` followed by an optional `\<newline><indent>` line
-	# continuation, then `--model ...` containing `--ask-for-approval`
-	# before the next newline (or before the next backslash-continued
-	# logical line ends).
-	pat = re.compile(
-		r'(codex|"\$\{codex_bin\}") exec\s+(\\\n\s+)?--model[^\n]*--ask-for-approval',
+	# directly. Step 1 normalises shell line-continuations
+	# (`\<newline><indent>` → single space) so a single multi-line codex
+	# invocation collapses into one logical line. Step 2 runs a simple
+	# regex over each logical line: any `<prefix> exec` followed by
+	# `--ask-for-approval` BEFORE the next newline is a bug, regardless
+	# of where `--model` (or any other flag) sits in between. This
+	# catches both same-line regressions and multi-line continuations
+	# where `--ask-for-approval` lands on a later `\`-continued line.
+	# Catches the `--ask-for-approval` BEFORE `--model` ordering too.
+	bad = re.compile(
+		r'(?:codex|"\$\{codex_bin\}") exec[^\n]*--ask-for-approval',
 	)
 	scan_dirs = [
 		REPO_ROOT / ".github" / "workflows",
@@ -423,12 +427,39 @@ def test_no_codex_exec_site_places_ask_for_approval_after_exec() -> None:
 				continue
 			if path.suffix not in (".sh", ".yml", ".yaml"):
 				continue
-			text = path.read_text()
-			for m in pat.finditer(text):
-				line_no = text.count("\n", 0, m.start()) + 1
-				snippet = m.group(0).replace("\n", "\\n")
+			raw = path.read_text(encoding="utf-8")
+			# Map each char position in the normalised text back to a
+			# physical line in the original file so error messages cite
+			# the actual file:line of the broken `exec` token.
+			normalised_chars: list[str] = []
+			origin_line: list[int] = []
+			line_no = 1
+			i = 0
+			while i < len(raw):
+				ch = raw[i]
+				if ch == "\\" and i + 1 < len(raw) and raw[i + 1] == "\n":
+					# Line continuation: collapse `\<newline><indent>`
+					# into a single space, advance past the indent.
+					normalised_chars.append(" ")
+					origin_line.append(line_no)
+					line_no += 1
+					i += 2
+					while i < len(raw) and raw[i] in (" ", "\t"):
+						i += 1
+					continue
+				normalised_chars.append(ch)
+				origin_line.append(line_no)
+				if ch == "\n":
+					line_no += 1
+				i += 1
+			normalised = "".join(normalised_chars)
+			for m in bad.finditer(normalised):
+				phys_line = origin_line[m.start()] if m.start() < len(origin_line) else line_no
+				snippet = m.group(0)
+				if len(snippet) > 200:
+					snippet = snippet[:200] + "..."
 				rel = path.relative_to(REPO_ROOT)
-				offenders.append(f"{rel}:{line_no}: {snippet}")
+				offenders.append(f"{rel}:{phys_line}: {snippet}")
 	assert not offenders, (
 		"`--ask-for-approval` is a TOP-LEVEL Codex flag and must precede "
 		"the `exec` subcommand on Codex CLI v0.114.0+, otherwise the "


### PR DESCRIPTION
## Summary

PR #2205 replaced the deprecated `--full-auto` shim with the explicit pair `--ask-for-approval never --sandbox danger-full-access` across 24 Codex CLI sites — but placed both flags **after** `exec`. Codex CLI v0.114.0 (the version pinned in every workflow via `vars.CODEX_VERSION || 'v0.114.0'`) rejects this:

```
error: unexpected argument '--ask-for-approval' found
Usage: codex exec --model <MODEL> [PROMPT]
```

`--ask-for-approval` is a **top-level** Codex flag (must precede `exec`); only `--sandbox`/`-s` is a valid `exec` subcommand flag. Reproduced locally against `@openai/codex@v0.114.0` — the failing form errors with the exact CI message; `codex --ask-for-approval never exec --model X --sandbox Y` parses cleanly.

## Failure evidence

- **Run 25473127144** (Internal: AI Orchestrate) — decomposer Codex step exhausted 3 attempts with the flag-parser error.
- **Runs 25473129175 / 25473125487 / 25473129346** (clarify for issues #2207 / #2206 / #2208) — same parser error.
- **Last green orchestrate run 25470796473** (75 min before failures) used the pre-#2205 `--full-auto` form, locating the regression at PR #2205.

## Fix

Uniform transformation across 14 files / 24 sites:

```diff
- codex exec --model "${X}" --ask-for-approval never --sandbox danger-full-access
+ codex --ask-for-approval never exec --model "${X}" --sandbox danger-full-access
```

`--sandbox` stays on the `exec` line (it's a valid `exec` subcommand flag per `codex exec --help`). Two multi-line continuation forms in `orchestrate_clarify_respond.yml` were patched in the same pass. The corrected layout matches the already-working invocations in `scripts/review_run_reviewers.sh:957` and `scripts/summarize_reviewer_consensus.sh:307`.

The existing test guard `test_no_codex_exec_site_uses_deprecated_full_auto_flag` in `tests/test_write_codex_config.py` still passes — `--full-auto` was not re-introduced.

## Files changed

- `.github/workflows/clarify.yml` (1)
- `.github/workflows/implement.yml` (3)
- `.github/workflows/orchestrate.yml` (1)
- `.github/workflows/orchestrate_clarify_respond.yml` (3, incl. 2 multi-line)
- `.github/workflows/plan.yml` (1)
- `.github/workflows/workflow-log-analysis.yml` (3)
- `scripts/implement_diagnose_post_codex_failure.sh` (1)
- `scripts/orchestrate_poll_process.sh` (4)
- `scripts/review_apply_fixes.sh` (1)
- `scripts/review_conflict_resolve.sh` (1)
- `scripts/review_consolidate.sh` (1)
- `scripts/review_rb_judge.sh` (1)
- `scripts/self_heal_validation.sh` (1)
- `scripts/validate_process.sh` (2)

## Test plan

- [ ] Re-run `Internal: AI Orchestrate` workflow — decomposer step should now succeed.
- [ ] Re-trigger clarify on a test issue — `Run Codex` step should not error on flag parsing.
- [ ] `Test & Mark Stable Release` end-to-end — orchestrate-decompose-test, clarify-rejects-unsolvable-test, e2e-smoke-test, e2e-alt-model-test should all pass.
- [ ] `tests/test_write_codex_config.py::test_no_codex_exec_site_uses_deprecated_full_auto_flag` continues to pass.

https://claude.ai/code/session_0179kkfZBgsm1tVcBm88UTZT

---
_Generated by [Claude Code](https://claude.ai/code/session_0179kkfZBgsm1tVcBm88UTZT)_