### PR TITLE
Bump deep-audit timeout 45m → 75m (cascade orphan-watcher caps)

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3237,17 +3237,20 @@ jobs:
     runs-on: ubuntu-latest
     # 45m was sized for the original 2-job workflow-log-analysis. The
     # workflow now has four sequential jobs (collect-logs 25m,
-    # analyze-commit-notify 30m, deep-audit 45m, api-redundancy 90m —
-    # ceiling ~190m), and run #25088541089 cancelled at 30m 16s on
+    # analyze-commit-notify 30m, deep-audit 75m, api-redundancy 90m —
+    # ceiling ~220m), and run #25088541089 cancelled at 30m 16s on
     # `deep-audit` (its previous 30m timeout-minutes), so deep-audit
     # was bumped to 45m in workflow-log-analysis.yml:603. Run #25115192726
     # then cancelled at 30m 19s on api-redundancy with that job's prior
     # 30m cap, so api-redundancy was bumped to 60m. Run #25200117236
     # cancelled at 60m 11s on api-redundancy with that 60m cap (Codex
     # still in "Plan update → Draft" phase), so api-redundancy was
-    # bumped to 90m. Sum of in-step DEADLINEs below (workflow-log-analysis
-    # 12000 + validation-refresh 2400 + update_workflows 600 +
-    # memory-maintenance 900 = 15900s ≈ 265m). This job also spends
+    # bumped to 90m. Run #25474659590 cancelled at 45m 16s on deep-audit
+    # (a slow ~24m attempt + forced retry), so deep-audit was bumped
+    # 45 → 75m in workflow-log-analysis.yml. Sum of in-step DEADLINEs
+    # below (workflow-log-analysis 13800 + validation-refresh 2400 +
+    # update_workflows 600 + memory-maintenance 900 = 17700s ≈ 295m).
+    # This job also spends
     # additional wall time outside those DEADLINE windows on prerequisite
     # validation, checkout, and the per-phase run-soft-error-analyzer
     # composite actions (each waits up to wait_for_completion_secs=120s
@@ -3255,8 +3258,11 @@ jobs:
     # log1 of run #25200117236 observed ~40s for one phase, so 4 phases
     # under OpenRouter latency variance can plausibly reach 8–12m), so
     # keep extra headroom for that work as well as runner queueing and
-    # step setup. Per Copilot review on PR #1842.
-    timeout-minutes: 330
+    # step setup. Per Copilot review on PR #1842. Bumped 330 → 360
+    # alongside the deep-audit 45 → 75m bump (run #25474659590), which
+    # raised sum-of-in-step-DEADLINEs from 265m to 295m; restoring the
+    # original ~65m of headroom for soft-error analyzers + queueing.
+    timeout-minutes: 360
     env:
       GH_TOKEN: ${{ secrets.GH_PAT }}
       TEST_REPO: ${{ inputs.test_repo || github.repository }}
@@ -3298,17 +3304,18 @@ jobs:
         # step instead of cancelling all sibling steps in the job.
         # Sized to the workflow-log-analysis 4-job sequential worst-case
         # (collect-logs 25m + analyze-commit-notify 30m + deep-audit
-        # 45m + api-redundancy 90m = 190m) plus a 15m runner-queue +
+        # 75m + api-redundancy 90m = 220m) plus a 15m runner-queue +
         # step-setup buffer; release v1.0.113 watcher exited at 28m
         # while deep-audit was still running, run #25088541089
         # cancelled at 30m 16s on deep-audit with its prior 30m cap,
         # run #25115192726 cancelled at 30m 19s on api-redundancy with
-        # its 30m cap, and run #25200117236 cancelled at 60m 11s on
+        # its 30m cap, run #25200117236 cancelled at 60m 11s on
         # api-redundancy with its 60m cap (now 90m, see workflow-log-
-        # analysis.yml). Per Copilot review on PR #1742: the previous
-        # 95m setting could still time out a healthy run that hit the
-        # worst case.
-        timeout-minutes: 205
+        # analysis.yml), and run #25474659590 cancelled at 45m 16s on
+        # deep-audit with its prior 45m cap (now 75m). Per Copilot
+        # review on PR #1742: the previous 95m setting could still
+        # time out a healthy run that hit the worst case.
+        timeout-minutes: 235
         env:
           WF_FILE: workflow-log-analysis.yml
           INPUTS: '{"lookback_days":"1","repos_override":"${{ inputs.test_repo || github.repository }}"}'
@@ -3320,10 +3327,10 @@ jobs:
             --field lookback_days=1 \
             --field repos_override="${TEST_REPO}" \
             --field alert_msg_level=SILENT
-          # 12000s (200m) covers the 190m worst-case audit chain
+          # 13800s (230m) covers the 220m worst-case audit chain
           # (collect-logs 25m + analyze-commit-notify 30m + deep-audit
-          # 45m + api-redundancy 90m) plus a 10m buffer for runner
-          # queueing between jobs. Step timeout-minutes above (205m)
+          # 75m + api-redundancy 90m) plus a 10m buffer for runner
+          # queueing between jobs. Step timeout-minutes above (235m)
           # is the outer cap that attributes a hang to this step.
           # Bumped 7200 → 8400 after deep-audit's per-job cap was
           # raised 30m → 45m in workflow-log-analysis.yml:603 (run
@@ -3335,7 +3342,11 @@ jobs:
           # raised 60m → 90m (run #25200117236 cancelled at 60m 11s on
           # api-redundancy with its prior 60m cap, Codex still in "Plan
           # update → Draft" phase).
-          DEADLINE=$(( $(date +%s) + 12000 ))
+          # Bumped 12000 → 13800 after deep-audit's per-job cap was
+          # raised 45m → 75m (run #25474659590 cancelled at 45m 16s on
+          # deep-audit; codex attempt 1 ran ~24m and forced a retry
+          # that was killed mid-attempt-2 by the 45m cap).
+          DEADLINE=$(( $(date +%s) + 13800 ))
           NEW_ID=""
           while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
             NEW_ID=$(gh api "repos/${TEST_REPO}/actions/workflows/${WF_FILE}/runs?per_page=10" \

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -638,7 +638,16 @@ jobs:
     # tripped. 45m absorbs the observed margin and leaves room for slow
     # codex calls without changing the watcher's overall ceiling beyond
     # what test-and-mark-stable.yml already accommodates.
-    timeout-minutes: 45
+    # Bumped 45 → 75 after run #25474659590 cancelled at 45m 16s on
+    # deep-audit. Recent successful single-attempt durations (jobs API)
+    # were 14–27m; in that run, codex attempt 1 ran ~24m and failed
+    # validation (empty stdout / non-zero exit), forcing a retry that
+    # was then killed by the 45m cap mid-attempt-2. 75m fits the full
+    # MAX_CODEX_ATTEMPTS=3 ladder at the observed worst-case ~25m per
+    # attempt plus the 10s/20s exponential backoff. Cascade bumped the
+    # orphan-watcher step timeout (205 → 235m) and in-script DEADLINE
+    # (12000 → 13800s) in test-and-mark-stable.yml.
+    timeout-minutes: 75
     outputs:
       audit_status: ${{ steps.audit.outputs.audit_status }}
     env:


### PR DESCRIPTION
## Summary

Fixes the `orphan-workflows-test` failure in run [25474642232](https://github.com/shubhodeep1/coding-workflows/actions/runs/25474642232/job/74745475536), which was a downstream effect of the `deep-audit` job hitting its 45m `timeout-minutes` cap in dispatched run [25474659590](https://github.com/shubhodeep1/coding-workflows/actions/runs/25474659590).

## Root cause (evidence-based)

- `orphan-workflows-test` job 74745475536 reported `status=completed conclusion=cancelled` for the workflow it was watching, then exited 1 at `test-and-mark-stable.yml:3361`.
- The dispatched `workflow-log-analysis` run had `deep-audit` annotated `The job has exceeded the maximum execution time of 45m0s`.
- Inside `deep-audit`, codex attempt 1 ran ~24m (started 03:48:12, "tokens used 472,165" at 04:11:57) and triggered a 10s backoff retry (matching `CODEX_RETRY_BACKOFF_BASE_SECS * 2^0` at `workflow-log-analysis.yml:836-841`), implying empty stdout or a non-zero exit. Attempt 2 started 04:12:07 and was killed at 04:33:07 by the 45m cap.
- Recent successful single-attempt deep-audit durations (jobs API): 16m33s, 26m50s, 15m06s, 13m54s, 22m26s, 24m12s, 14m36s — i.e., a slow-but-healthy single attempt (~25m) plus a forced retry guarantees timeout under the 45m cap.
- The cap was already bumped 30 → 45 once for the same root cause (run #25088541089), per the existing comment block at `workflow-log-analysis.yml:635-640`.

## Changes

- **`.github/workflows/workflow-log-analysis.yml`**: `deep-audit` `timeout-minutes` 45 → 75. Sized to fit `MAX_CODEX_ATTEMPTS=3` at the observed worst-case ~25m per attempt plus exponential backoff.
- **`.github/workflows/test-and-mark-stable.yml`** (orphan-workflows-test cascade):
  - `dispatch_log_analysis` step `timeout-minutes` 205 → 235m.
  - In-script `DEADLINE` 12000 → 13800s (230m).
  - Job-level `timeout-minutes` 330 → 360, restoring the original ~65m headroom for soft-error analyzers + queueing after the in-step DEADLINE sum grew 265m → 295m.
- Updated the existing change-history comment blocks in both files to record this bump alongside the prior ones.

## Test plan

- [ ] Trigger `Test & Mark Stable Release` (`workflow_dispatch`) and confirm the `orphan-workflows-test` job's `Dispatch & watch — workflow-log-analysis` step now tolerates a deep-audit retry without hitting the 45m cap.
- [ ] Confirm a typical successful deep-audit run still completes well under the new 75m cap (recent runs: 14–27m).

https://claude.ai/code/session_01HikjR1L7BRgq38XeXeL3Qt

---
_Generated by [Claude Code](https://claude.ai/code/session_01HikjR1L7BRgq38XeXeL3Qt)_