### PR TITLE
fix(e2e-smoke): bump Phase 2 wait-for-plan timeout 30m → 60m (GitHub event lag)

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -47,6 +47,19 @@ name: Test & Mark Stable Release
         required: false
         type: number
         default: 30
+      plan_timeout:
+        description: >
+          Max minutes of *inactivity* for Phase 2 (Wait for plan). Higher
+          default than `phase_timeout` because the plan trigger relies on
+          GitHub `issue_comment` event delivery — observed to lag up to
+          ~38 min in the wild (run 25477674617). The timer still resets
+          on any detected progress (label/comment/plan-run changes), so
+          a healthy plan completes well before the cap. Falls back to
+          `phase_timeout` when unset, so existing dispatchers that only
+          override `phase_timeout` keep the previous behaviour.
+        required: false
+        type: number
+        default: 60
       review_timeout:
         description: >
           Max minutes of *inactivity* before the review & autofix phase
@@ -308,6 +321,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_PAT }}
       TEST_REPO: ${{ inputs.test_repo || github.repository }}
       PHASE_TIMEOUT: ${{ inputs.phase_timeout || 30 }}
+      PLAN_PHASE_TIMEOUT: ${{ inputs.plan_timeout || inputs.phase_timeout || 60 }}
       REVIEW_TIMEOUT: ${{ inputs.review_timeout || inputs.phase_timeout || 30 }}
       POLL_INTERVAL: 10
       # Wrapper-workflow filename used by the smoke gate to dispatch
@@ -569,8 +583,8 @@ jobs:
         run: |
           set -euo pipefail
           echo "Waiting for plan to finish on issue #${ISSUE_NUMBER}..."
-          echo "Inactivity timeout: ${PHASE_TIMEOUT} minutes"
-          INACTIVITY_LIMIT=$((PHASE_TIMEOUT * 60))
+          echo "Inactivity timeout: ${PLAN_PHASE_TIMEOUT} minutes"
+          INACTIVITY_LIMIT=$((PLAN_PHASE_TIMEOUT * 60))
           LAST_ACTIVITY=$(date +%s)
           PREV_STATE=""
           RATE_LIMIT_BACKOFF=0
@@ -708,7 +722,7 @@ jobs:
 
             # Inactivity timeout
             if [ $IDLE -ge $INACTIVITY_LIMIT ]; then
-              echo "::error::Plan phase stalled — no activity for ${PHASE_TIMEOUT} minutes"
+              echo "::error::Plan phase stalled — no activity for ${PLAN_PHASE_TIMEOUT} minutes"
               echo "status=timeout" >> "$GITHUB_OUTPUT"
               exit 1
             fi


### PR DESCRIPTION
## Summary

`Test & Mark Stable Release` run [25477674617](https://github.com/shubhodeep1/coding-workflows/actions/runs/25477674617) failed in `e2e-smoke-test` at **Phase 2: Wait for plan to complete**:

```
##[error]Plan phase stalled — no activity for 30 minutes
```

### Root cause — GitHub `issue_comment` event-delivery lag

- Issue #2221 was created at `05:26:45Z`. Clarify ran successfully and the auto-`/answer` comment was posted at `05:28:06Z` — body starts with `/answer`, posted by `shubhodeep1` (PAT, `User`), satisfying every branch of `internal-plan.yml`'s and `plan.yml`'s `if:`.
- The Phase 2 poller logged `plan_run: unknown, labels: ai:planning` for the entire 30-minute window: no `Internal: AI Plan` workflow run was ever created during that window.
- Phase 2's 30-minute inactivity cap fired at `05:58:40Z` and the e2e-smoke-test step exited 1.
- The `Internal: AI Plan` run for the same comment finally appeared at `06:06:18Z` (run id `25478866946`, event `issue_comment`) — **38 minutes** after the comment, and **8 minutes** after the timeout already failed the job. It then completed successfully, confirming the workflow itself is healthy.
- Cross-check: the parallel alt-model smoke on issue #2222 posted its own auto-`/answer` at `05:28:03Z` and didn't see its first issue_comment-triggered run until `05:34:11Z` — a ~6-minute event-delivery lag in the same window. That ran was within the 30m cap so alt-model passed.

This was a GitHub-side `issue_comment` event-delivery delay on 2026-05-07T05:28Z, hitting #2221 worse than #2222.

### Fix

Per-decision (smoke test only): bump Phase 2's inactivity cap by adding a new `plan_timeout` `workflow_dispatch` input (default `60`) and a `PLAN_PHASE_TIMEOUT` env scoped to the `e2e-smoke-test` job. Phase 2's `INACTIVITY_LIMIT`, the startup banner, and the stall-error message now reference `PLAN_PHASE_TIMEOUT` instead of `PHASE_TIMEOUT`. Every other phase (clarify, implement, RB sim) keeps `PHASE_TIMEOUT` unchanged, and `plan_timeout` falls back to `phase_timeout` when unset — backward compatible.

- `.github/workflows/test-and-mark-stable.yml` — new `plan_timeout` input (L51–61), new `PLAN_PHASE_TIMEOUT` env on the e2e-smoke-test job (L324), Phase 2 step now reads `PLAN_PHASE_TIMEOUT` (L586/L587/L725).

## Test plan

- [ ] Manually dispatch `Test & Mark Stable Release` on `stable` (or via `dry_run=true` if just validating wiring) and confirm Phase 2 logs `Inactivity timeout: 60 minutes`.
- [ ] Confirm other phases still log `Inactivity timeout: 30 minutes` (no accidental cross-pollination).
- [ ] If the underlying GitHub event-delivery lag recurs, the smoke test now tolerates up to 60 min of lag instead of 30 — verify by inspecting the next nightly stable-mark run.
- [ ] No README/agents.md changes — neither file documents `phase_timeout`/`plan_timeout` today.

https://claude.ai/code/session_01BqzsoojWKAmSigDY6RmaRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqzsoojWKAmSigDY6RmaRj)_