### PR TITLE
fix(internal-review): scope workflow-level cancel-in-progress to claude/** branches

### DIFF
--- a/.github/workflows/internal-review.yml
+++ b/.github/workflows/internal-review.yml
@@ -47,7 +47,7 @@ permissions:
 # re-triggers for different PRs would cancel each other.
 concurrency:
   group: ${{ github.event_name == 'workflow_dispatch' && format('internal-review-dispatch-pr-{0}', github.event.inputs.pr_number) || format('internal-review-{0}', github.head_ref || github.ref_name) }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.actor != (vars.AUTOFIX_BOT_LOGIN || 'codex') }}
 
 jobs:
   review:

--- a/.github/workflows/internal-review.yml
+++ b/.github/workflows/internal-review.yml
@@ -47,7 +47,7 @@ permissions:
 # re-triggers for different PRs would cancel each other.
 concurrency:
   group: ${{ github.event_name == 'workflow_dispatch' && format('internal-review-dispatch-pr-{0}', github.event.inputs.pr_number) || format('internal-review-{0}', github.head_ref || github.ref_name) }}
-  cancel-in-progress: ${{ github.actor != (vars.AUTOFIX_BOT_LOGIN || 'codex') }}
+  cancel-in-progress: ${{ startsWith(github.head_ref || github.ref_name, 'claude/') }}
 
 jobs:
   review:


### PR DESCRIPTION
## Summary

Fix the autofix continuation race in `internal-review.yml` by scoping the workflow-level `cancel-in-progress` to `claude/**` head/ref only. Productive `[ai-autofix]` commits on non-claude branches (`ai/**`, `fix/**`, `orchestrator/**`, …) can now finish their in-run `workflow_dispatch` continuation step instead of being cancelled by the `pull_request.synchronize` event their own push generates.

## Repro evidence

PR #2265 (head `0e2f810…` on branch `ai/issue-2264`, base `orchestrator/project-2263`):

- **Run 25535269023** (synchronize on `6acfbdd`): reviewers + editor + commit + push all succeeded; the trailing `Re-trigger review via workflow_dispatch` step was cancelled at 04:05:00 UTC after sleeping 18s (`AUTOFIX_CONTINUATION_SETTLE_SECS=10 + AUTOFIX_RETRIGGER_PEER_WAIT_SECS=8`), before any `AUTOFIX_DISPATCH_ISSUED` / `AUTOFIX_CONTINUATION_DISPATCH_ISSUED` line was emitted. Final job conclusion = cancelled for this reason only.
- **Run 25536046600** (synchronize on `0e2f810`, fired by Run 1's push at 04:04:42): gate emitted `AUTOFIX_GATE_SKIP reason=self_triggered_autofix … head_prefix=[ai-autofix] author_login=codex committer_login=codex bot_login=codex` and `codex-agent` was correctly skipped via `if: needs.gate.outputs.should_run == 'true'` (`review_autofix.yml:736`).

With no continuation dispatched on the autofix SHA, the cycle stalled until the orchestrator stall cron recovered it.

## Root cause

`internal-review.yml:48-50` workflow-level concurrency uses `group: internal-review-${head_ref}` with `cancel-in-progress: true`. Run 1 and Run 2 share group `internal-review-ai/issue-2264`, so Run 2's start cancels Run 1 mid-sleep, killing the continuation step before it can `gh workflow run` the dispatch (which would land in the separate `internal-review-dispatch-pr-{N}` group and bypass the self-trigger gate skip — see `review_autofix.yml:4252-4308`). The job-level concurrency at `review_autofix.yml:734-735` (`cancel-in-progress: false` for non-claude branches) does not save the run because the workflow-level cancel kills everything.

## Why we can't drop `cancel-in-progress: true` entirely

The same workflow runs on `claude/**` branches, where it dedupes the documented open-then-push race (PR #1729, comment block at `internal-review.yml:35-47`) — both a `push` event and a `pull_request:opened` event for the same head SHA otherwise spawn a duplicate `codex-agent (claude-branch-review)` run.

## Why an `actor`-based exemption was rejected

The first attempt (commit `ab2fb9e`) used `github.actor != 'codex'`. Verified broken via API:

- Run 25535269023: `actor=shubhodeep1, triggering_actor=shubhodeep1`
- Run 25536046600 (synchronize fired by codex's autofix push): `actor=shubhodeep1, triggering_actor=shubhodeep1`

Reason: `GH_PAT` is owned by shubhodeep1, so codex's autofix push is authenticated as shubhodeep1 — `github.actor` reflects the auth credential, not the git author/committer. The gate's `author_login=codex` log line comes from a server-side commit-API email→user resolution (`codex@users.noreply.github.com` → user `codex`), which is unavailable in expression-context. The expression therefore evaluated to `'shubhodeep1' != 'codex'` = `true` and Run 1 was still cancelled. Caught by the claude-branch-review (`qwen_qwen3_6-plus`, confidence=5) on this PR.

## The change

`.github/workflows/internal-review.yml:50`:

```diff
-  cancel-in-progress: true
+  cancel-in-progress: ${{ startsWith(github.head_ref || github.ref_name, 'claude/') }}
```

Behaviour matrix:

| Event | head_ref / ref_name | cancel-in-progress | Outcome |
|---|---|---|---|
| `push` on `claude/**` | `claude/foo` (ref_name) | `true` | preserves PR #1729 dedup |
| `pull_request.opened` on `claude/**` | `claude/foo` (head_ref) | `true` | preserves PR #1729 dedup |
| `pull_request.synchronize` on `claude/**` | `claude/foo` (head_ref) | `true` | unchanged |
| `pull_request.synchronize` on `ai/**`, `fix/**`, `orchestrator/**`, … | non-claude (head_ref) | `false` | autofix continuation race fixed |
| `pull_request.opened` on non-claude | non-claude (head_ref) | `false` | no race exists (push trigger only fires for `claude/**`) |
| `workflow_dispatch` | (different group `internal-review-dispatch-pr-{N}`) | `false` | unaffected by either group |

Trade-off: human rapid-fire pushes on non-claude branches no longer cancel the older run at the workflow level. They queue at the job level (`pr-autofix-${PR}` with `cancel-in-progress: false`), so each commit gets its own full reviewer panel sequentially. This costs LLM budget on stale-commit reviews in that narrow case, but is correct (no half-finished autofix continuations) and preserves the full `claude/**` open-then-push race protection.

## Test plan

- [ ] On the next orchestrator-driven autofix iteration on a non-claude branch (e.g. `ai/**`), verify in run logs that the productive Run emits `AUTOFIX_CONTINUATION_DISPATCH_ISSUED` and `AUTOFIX_DISPATCH_ISSUED reason=no_peer_detected … continuation=true` (i.e. the step completes instead of being cancelled).
- [ ] On the same iteration, verify the synchronize-event peer Run still emits `AUTOFIX_GATE_SKIP reason=self_triggered_autofix` and skips `codex-agent` (no behavioural regression on the gate-skip path).
- [ ] Verify a new dispatched run on the autofix SHA appears in the `internal-review-dispatch-pr-{N}` concurrency group.
- [ ] Verify a second push on a `claude/**` branch (no PR) still cancels the prior run (open-then-push race protection intact).
- [ ] Verify `pull_request:opened` on a `claude/**` branch right after the matching push still cancels the push-leg run (PR #1729 race intact).

## Constraints checked (CLAUDE.md)

- §5 / §6: single-line expression change, no renames, no unrelated reformatting.
- §9: 2-space YAML indentation preserved.
- §15: no new `gh` API calls — `github.head_ref` / `github.ref_name` are expression-context values.
- §7: file changed — `.github/workflows/internal-review.yml:50` (one line).
- README.md / agents.md: the "Concurrency" warning at `README.md:314-320` describes the inner `pr-autofix-${PR}` job-level group, not this workflow-level group; the "Autofix retrigger dedup" / "Self-triggered autofix skip" sections describe gate-skip log prefixes that are unchanged. The comment block at `internal-review.yml:35-47` describing the PR #1729 race is still accurate (cancel still applies to `claude/**`). No sentence is rendered inaccurate.

https://claude.ai/code/session_01KAPCfbVRTf6JqiUvgFDxma