### PR TITLE
fix(review_rb_judge): propagate ai:orchestrator-managed to review-blocked reissues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,11 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_apply_fixes_smoke_deterministic.py
 
+      - name: Review-blocked judge label propagation contract test
+        run: |
+          set -euo pipefail
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_rb_judge_label_propagation.py
+
       - name: Summariser sandbox-mode pin contract test
         run: |
           set -euo pipefail

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -175,6 +175,12 @@ while IFS= read -r issue_number; do
   if [ -z "${FIRST_ISSUE_BODY}" ]; then
     FIRST_ISSUE_BODY="${BODY}"
   fi
+  # Stop once we have the first issue number and a non-empty body.
+  # Subsequent linked issues are not used by review_rb_judge.sh; the
+  # FIRST_ISSUE_LABELS_JSON capture above is already pinned to
+  # FIRST_ISSUE on the first iteration, so the break preserves
+  # parent-label propagation semantics.
+  [ -n "${FIRST_ISSUE}" ] && [ -n "${FIRST_ISSUE_BODY}" ] && break
 done <<< "${ISSUE_NUMBERS}"
 
 if [ -z "${FIRST_ISSUE}" ]; then

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -158,12 +158,20 @@ fi
 
 FIRST_ISSUE=""
 FIRST_ISSUE_BODY=""
+# Labels of the parent (FIRST_ISSUE) issue.  Captured from the same
+# REST GET that already fetches the body so the close_and_reissue
+# branch below can propagate orchestrator-lineage labels without
+# issuing an extra API call (see CLAUDE.md §15 — extend an existing
+# call rather than adding a new one).
+FIRST_ISSUE_LABELS_JSON="[]"
 while IFS= read -r issue_number; do
   [ -n "${issue_number}" ] || continue
+  ISSUE_META_JSON="$(_safe_gh_jq "repos/${REPOSITORY}/issues/${issue_number}" || echo '{}')"
+  BODY="$(printf '%s' "${ISSUE_META_JSON}" | jq -r '.body // ""' 2>/dev/null || echo "")"
   if [ -z "${FIRST_ISSUE}" ]; then
     FIRST_ISSUE="${issue_number}"
+    FIRST_ISSUE_LABELS_JSON="$(printf '%s' "${ISSUE_META_JSON}" | jq -c '[(.labels // [])[]?.name]' 2>/dev/null || echo '[]')"
   fi
-  BODY="$(_safe_gh_jq "repos/${REPOSITORY}/issues/${issue_number}" --jq '.body // ""' || echo "")"
   if [ -z "${FIRST_ISSUE_BODY}" ]; then
     FIRST_ISSUE_BODY="${BODY}"
   fi
@@ -645,10 +653,27 @@ ${RB_FIX_DESC}"
 - Replaces: ${FIRST_ISSUE:+#${FIRST_ISSUE} }(PR #${PR_NUMBER} closed — approach rework)
 - Type: review-blocked-reissue"
 
+      # Propagate ai:orchestrator-managed from the parent issue when it
+      # carries that label.  Without this, an orchestrator-managed
+      # parent's reissue lands with only ai:clarification (added later
+      # by clarify.yml on issues.opened) and the orchestrator-managed
+      # auto-answer fast path in clarify.yml never fires — the reissue
+      # stalls in clarification while the orchestrator's parallel
+      # judge-addition issue silently delivers the same work.  Standalone
+      # (non-orchestrator) reissues do NOT inherit this label so their
+      # human-driven clarify semantics are preserved.
+      RB_PROPAGATE_LABELS=()
+      if printf '%s' "${FIRST_ISSUE_LABELS_JSON}" | jq -e 'index("ai:orchestrator-managed")' >/dev/null 2>&1; then
+        ensure_label_exists "ai:orchestrator-managed" "${REPOSITORY}"
+        RB_PROPAGATE_LABELS+=("--label" "ai:orchestrator-managed")
+        echo "Propagating ai:orchestrator-managed from parent issue #${FIRST_ISSUE} to review-blocked reissue."
+      fi
+
       NEW_URL="$(gh_retry gh issue create \
         --repo "${REPOSITORY}" \
         --title "${NEW_ISSUE_TITLE}" \
-        --body "${FULL_NEW_BODY}")"
+        --body "${FULL_NEW_BODY}" \
+        ${RB_PROPAGATE_LABELS[@]+"${RB_PROPAGATE_LABELS[@]}"})"
       echo "Created replacement issue: ${NEW_URL}"
     else
       echo "::warning::Judge chose close_and_reissue but provided no new issue details."

--- a/tests/test_review_rb_judge_label_propagation.py
+++ b/tests/test_review_rb_judge_label_propagation.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Regression tests for the review-blocked reissue label-propagation fix.
+
+Background
+----------
+scripts/review_rb_judge.sh handles three judge actions: merge, fix, and
+close_and_reissue.  The close_and_reissue branch creates a replacement
+issue via `gh issue create`.  Before this fix, the `gh issue create`
+call passed no `--label` flag — the reissue inherited only
+`ai:clarification` (added later by clarify.yml on issues.opened) and
+NOT `ai:orchestrator-managed` from the parent.
+
+The auto-answer fast path in clarify.yml gates strictly on
+`has_label("ai:orchestrator-managed") && !forced_reclarify && !is_closed`
+(see clarify.yml: "Decide clarify route" step).  Without that label,
+an orchestrator-managed parent's review-blocked reissue would stall
+in clarification forever — emitting standalone-stall heartbeats while
+the orchestrator's parallel judge-addition issue (which IS labelled
+`ai:orchestrator-managed` by orchestrate_poll_process.sh) silently
+delivered the same work.  See downstream evidence in
+shubhodeep1/bitsafe.io issues #41/#43/#44.
+
+The fix
+-------
+1. The body-fetch loop now captures parent labels in the same REST
+   GET (no extra API call per CLAUDE.md §15) into FIRST_ISSUE_LABELS_JSON.
+2. The close_and_reissue branch checks FIRST_ISSUE_LABELS_JSON for
+   `ai:orchestrator-managed` via `jq -e 'index(...)'`; on hit, it
+   appends `--label ai:orchestrator-managed` to the `gh issue create`
+   call.  Standalone reissues (parent without the label) get no
+   `--label` so their human-driven clarify semantics are preserved.
+
+These tests pin both halves so a future refactor cannot silently
+re-orphan the reissue lineage.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RB_JUDGE_SCRIPT = REPO_ROOT / "scripts" / "review_rb_judge.sh"
+
+
+def _rb_judge_text() -> str:
+	return RB_JUDGE_SCRIPT.read_text(encoding="utf-8")
+
+
+def _extract_close_and_reissue_branch() -> str:
+	"""Pull the body of the `close_and_reissue)` case arm out of the
+	real script.  We anchor on the next case label (`*)`) so we don't
+	swallow the catch-all branch."""
+	text = _rb_judge_text()
+	match = re.search(
+		r"  close_and_reissue\)\n(?P<branch>.*?)\n    ;;\n\n  \*\)",
+		text,
+		re.DOTALL,
+	)
+	if not match:
+		raise AssertionError(
+			"could not extract close_and_reissue branch from review_rb_judge.sh"
+		)
+	return match.group("branch")
+
+
+def test_loop_captures_first_issue_labels_json() -> None:
+	"""The body-fetch loop must populate FIRST_ISSUE_LABELS_JSON from
+	the parent issue's labels.  Static check: a future refactor that
+	drops the labels capture would silently disable the propagation."""
+	src = _rb_judge_text()
+
+	assert "FIRST_ISSUE_LABELS_JSON=" in src, (
+		"review_rb_judge.sh must declare FIRST_ISSUE_LABELS_JSON; the "
+		"close_and_reissue branch reads it to decide whether to "
+		"propagate ai:orchestrator-managed to the reissue."
+	)
+	# The loop must populate it from the same `_safe_gh_jq` call that
+	# fetches the body — adding a separate `gh api` call would violate
+	# CLAUDE.md §15 (GitHub API call hygiene).
+	assert "ISSUE_META_JSON=" in src, (
+		"review_rb_judge.sh body-fetch loop must store the full issue "
+		"JSON so labels and body can be extracted client-side without a "
+		"second API call (§15)."
+	)
+	assert "[(.labels // [])[]?.name]" in src, (
+		"review_rb_judge.sh must extract label names from the parent "
+		"issue JSON via the canonical jq filter; otherwise the "
+		"close_and_reissue branch's `index(\"ai:orchestrator-managed\")` "
+		"check would never see a hit."
+	)
+
+
+def test_close_and_reissue_branch_gates_on_orchestrator_managed_label() -> None:
+	"""The propagation gate must be exactly
+	`index("ai:orchestrator-managed")` against FIRST_ISSUE_LABELS_JSON,
+	not a wider/looser check (e.g. any `ai:` label) — that would
+	mislabel standalone review-blocked reissues."""
+	branch = _extract_close_and_reissue_branch()
+
+	assert "FIRST_ISSUE_LABELS_JSON" in branch, (
+		"close_and_reissue branch must reference FIRST_ISSUE_LABELS_JSON; "
+		"otherwise it cannot decide whether to propagate the label."
+	)
+	assert 'jq -e \'index("ai:orchestrator-managed")\'' in branch, (
+		"close_and_reissue branch must gate label propagation strictly "
+		"on the parent carrying ai:orchestrator-managed — widening the "
+		"gate would mislabel standalone (non-orchestrator) reissues."
+	)
+	assert '--label" "ai:orchestrator-managed"' in branch or \
+		'"--label" "ai:orchestrator-managed"' in branch, (
+		"close_and_reissue branch must append `--label ai:orchestrator-managed` "
+		"to the gh issue create args when the gate fires."
+	)
+
+
+def _install_mock_gh(bin_dir: Path, state_file: Path) -> None:
+	gh_script = r'''#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+state_path = Path(os.environ["MOCK_GH_STATE_FILE"])
+if state_path.exists():
+	state = json.loads(state_path.read_text(encoding="utf-8"))
+else:
+	state = {}
+args = sys.argv[1:]
+
+
+def save() -> None:
+	state_path.write_text(json.dumps(state), encoding="utf-8")
+
+
+def first_value(flag: str) -> str:
+	for i, arg in enumerate(args):
+		if arg == flag and i + 1 < len(args):
+			return args[i + 1]
+	return ""
+
+
+state.setdefault("calls", []).append(args)
+
+if args[:2] == ["issue", "create"]:
+	repo = first_value("--repo") or "owner/repo"
+	next_num = int(state.get("next_issue_number", 4301))
+	state["next_issue_number"] = next_num + 1
+	state.setdefault("issue_create_args", []).append(args)
+	save()
+	print(f"https://github.com/{repo}/issues/{next_num}")
+	sys.exit(0)
+
+if args[:2] == ["pr", "close"]:
+	state.setdefault("pr_close_args", []).append(args)
+	save()
+	sys.exit(0)
+
+if args[:2] == ["label", "create"]:
+	state.setdefault("label_create_args", []).append(args)
+	save()
+	sys.exit(0)
+
+if args[:1] == ["api"]:
+	state.setdefault("api_calls", []).append(args)
+	save()
+	# This mock is invoked only by the close_and_reissue branch under
+	# test, which never calls `gh api` directly — _safe_gh_jq is stubbed
+	# in the harness so the body-fetch loop is bypassed.  Anything that
+	# does land here (e.g. _resilient_phase_swap label PUT) is a no-op.
+	sys.exit(0)
+
+save()
+sys.exit(0)
+'''
+	mock_path = bin_dir / "gh"
+	mock_path.write_text(gh_script, encoding="utf-8")
+	mock_path.chmod(0o755)
+	state_file.write_text("{}", encoding="utf-8")
+
+
+def _build_harness(branch: str, runtime_dir: Path, github_output: Path) -> str:
+	"""Wrap the extracted close_and_reissue branch in a self-contained
+	bash harness with stubs for the helpers it depends on."""
+	return f"""#!/usr/bin/env bash
+set -euo pipefail
+
+gh_retry() {{ "$@"; }}
+ensure_label_exists() {{ printf '%s\\n' "$1" >> "${{ENSURE_LABELS_FILE}}"; }}
+_resilient_phase_swap() {{ :; }}
+_safe_gh_jq() {{ :; }}
+
+GITHUB_OUTPUT="{github_output}"
+
+case "${{RB_ACTION}}" in
+  close_and_reissue)
+{branch}
+    ;;
+esac
+"""
+
+
+def _run_close_and_reissue(parent_label_set: list[str]) -> dict:
+	"""Run the close_and_reissue branch with FIRST_ISSUE_LABELS_JSON
+	pre-seeded to ``parent_label_set`` and return the captured gh
+	mock state."""
+	branch = _extract_close_and_reissue_branch()
+
+	with tempfile.TemporaryDirectory(prefix="test_review_rb_judge_") as td:
+		tmp_path = Path(td)
+		runtime_dir = tmp_path / "runtime"
+		bin_dir = tmp_path / "bin"
+		runtime_dir.mkdir(parents=True, exist_ok=True)
+		bin_dir.mkdir(parents=True, exist_ok=True)
+
+		gh_state_file = runtime_dir / "gh_state.json"
+		_install_mock_gh(bin_dir, gh_state_file)
+
+		labels_file = runtime_dir / "ensure_labels.txt"
+		labels_file.write_text("", encoding="utf-8")
+		github_output = runtime_dir / "github_output.txt"
+		github_output.write_text("", encoding="utf-8")
+
+		script_path = runtime_dir / "rb_branch_harness.sh"
+		script_path.write_text(
+			_build_harness(branch, runtime_dir, github_output),
+			encoding="utf-8",
+		)
+		script_path.chmod(0o755)
+
+		judge_json = json.dumps({
+			"action": "close_and_reissue",
+			"justification": "rework needed",
+			"new_issue": {
+				"title": "Reissue: redo approach",
+				"body": "Try again with smaller scope.",
+			},
+		})
+
+		env = {
+			"PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+			"MOCK_GH_STATE_FILE": str(gh_state_file),
+			"ENSURE_LABELS_FILE": str(labels_file),
+			"REPOSITORY": "owner/repo",
+			"PR_NUMBER": "42",
+			"ISSUE_NUMBERS": "41",
+			"FIRST_ISSUE": "41",
+			"FIRST_ISSUE_LABELS_JSON": json.dumps(parent_label_set),
+			"JUDGE_JSON": judge_json,
+			"RB_ACTION": "close_and_reissue",
+		}
+		run_env = os.environ.copy()
+		run_env.update(env)
+
+		proc = subprocess.run(
+			["bash", str(script_path)],
+			cwd=str(tmp_path),
+			env=run_env,
+			text=True,
+			capture_output=True,
+			timeout=60,
+		)
+		assert proc.returncode == 0, (
+			f"harness exited {proc.returncode}\n"
+			f"stdout:\n{proc.stdout}\n\nstderr:\n{proc.stderr}"
+		)
+
+		state = json.loads(gh_state_file.read_text(encoding="utf-8"))
+		state["_ensure_labels"] = labels_file.read_text(encoding="utf-8").strip().splitlines()
+		state["_stdout"] = proc.stdout
+		return state
+
+
+def test_orchestrator_managed_parent_propagates_label_to_reissue() -> None:
+	"""Parent carries ai:orchestrator-managed → reissue must be
+	created with `--label ai:orchestrator-managed`.  Without this, the
+	auto-answer fast path in clarify.yml never fires and the reissue
+	stalls in clarification."""
+	state = _run_close_and_reissue(["ai:orchestrator-managed", "ai:closed"])
+
+	creates = state.get("issue_create_args", [])
+	assert len(creates) == 1, (
+		f"expected exactly one `gh issue create` call, got {len(creates)}: {creates}"
+	)
+	args = creates[0]
+	assert "--label" in args, (
+		f"reissue must carry --label when parent is orchestrator-managed; "
+		f"got args: {args}"
+	)
+	# Find the value that follows --label
+	idx = args.index("--label")
+	assert args[idx + 1] == "ai:orchestrator-managed", (
+		f"reissue --label must be exactly 'ai:orchestrator-managed'; "
+		f"got: {args[idx + 1]!r}"
+	)
+
+	# ensure_label_exists must be called for the propagated label so the
+	# repo has the label definition before `gh issue create` references it.
+	assert "ai:orchestrator-managed" in state["_ensure_labels"], (
+		"ensure_label_exists must be invoked for ai:orchestrator-managed "
+		"before the gh issue create call; otherwise a fresh consumer repo "
+		"could 422 on an unknown label."
+	)
+
+
+def test_standalone_parent_does_not_propagate_orchestrator_managed_label() -> None:
+	"""Parent does NOT carry ai:orchestrator-managed → reissue must be
+	created WITHOUT that label.  Standalone clarifications must keep
+	their human-driven semantics — widening the propagation would
+	mislabel non-orchestrator reissues as orchestrator-managed and
+	cause clarify.yml to auto-answer human PRs."""
+	state = _run_close_and_reissue(["bug", "good first issue"])
+
+	creates = state.get("issue_create_args", [])
+	assert len(creates) == 1, (
+		f"expected exactly one `gh issue create` call, got {len(creates)}: {creates}"
+	)
+	args = creates[0]
+	assert "ai:orchestrator-managed" not in args, (
+		f"standalone reissue must NOT carry ai:orchestrator-managed; "
+		f"got args: {args}"
+	)
+
+
+def test_empty_parent_label_set_does_not_propagate() -> None:
+	"""No linked-issue labels (e.g. parent fetch failed → empty array)
+	→ reissue must be created without `--label ai:orchestrator-managed`.
+	Conservative fail-closed default; an extra label on a reissue is
+	harder to undo than its absence."""
+	state = _run_close_and_reissue([])
+
+	creates = state.get("issue_create_args", [])
+	assert len(creates) == 1
+	args = creates[0]
+	assert "ai:orchestrator-managed" not in args, (
+		f"reissue must NOT inherit ai:orchestrator-managed when parent "
+		f"label set is empty; got args: {args}"
+	)

--- a/tests/test_review_rb_judge_label_propagation.py
+++ b/tests/test_review_rb_judge_label_propagation.py
@@ -130,10 +130,13 @@ def test_close_and_reissue_branch_gates_on_orchestrator_managed_label() -> None:
 		"on the parent carrying ai:orchestrator-managed — widening the "
 		"gate would mislabel standalone (non-orchestrator) reissues."
 	)
-	assert '--label" "ai:orchestrator-managed"' in branch or \
-		'"--label" "ai:orchestrator-managed"' in branch, (
+	# Pin the exact bash array assignment that appends the label flag
+	# pair to `gh issue create`.  Matching the literal source line is
+	# clearer than a quote-escaped substring search and catches both a
+	# missing `--label` arg and a wrong label name in one assertion.
+	assert 'RB_PROPAGATE_LABELS+=("--label" "ai:orchestrator-managed")' in branch, (
 		"close_and_reissue branch must append `--label ai:orchestrator-managed` "
-		"to the gh issue create args when the gate fires."
+		"to the gh issue create args via the RB_PROPAGATE_LABELS array."
 	)
 
 

--- a/tests/test_review_rb_judge_label_propagation.py
+++ b/tests/test_review_rb_judge_label_propagation.py
@@ -341,3 +341,27 @@ def test_empty_parent_label_set_does_not_propagate() -> None:
 		f"reissue must NOT inherit ai:orchestrator-managed when parent "
 		f"label set is empty; got args: {args}"
 	)
+
+
+def main() -> int:
+	# Direct `python3 tests/<file>.py` entrypoint — the repo's CI runs
+	# tests via that pattern (see ci.yml) rather than pytest discovery,
+	# so without this block the assertions never execute under CI.
+	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+	passed = 0
+	failed = 0
+	for func in test_funcs:
+		name = func.__name__
+		try:
+			func()
+			print(f"  PASS  {name}")
+			passed += 1
+		except Exception as exc:
+			print(f"  FAIL  {name}: {exc}")
+			failed += 1
+	print(f"\n{passed} passed, {failed} failed, {passed + failed} total")
+	return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_review_rb_judge_label_propagation.py
+++ b/tests/test_review_rb_judge_label_propagation.py
@@ -69,6 +69,24 @@ def _extract_close_and_reissue_branch() -> str:
 	return match.group("branch")
 
 
+def _extract_body_fetch_loop() -> str:
+	"""Pull the FIRST_ISSUE / FIRST_ISSUE_BODY / FIRST_ISSUE_LABELS_JSON
+	body-fetch loop out of the real script.  Anchored on the
+	`FIRST_ISSUE=""` declaration through the loop's `done` line so the
+	regex follows the loop's lexical block."""
+	text = _rb_judge_text()
+	match = re.search(
+		r'(?P<loop>FIRST_ISSUE=""\n.*?done <<< "\$\{ISSUE_NUMBERS\}")',
+		text,
+		re.DOTALL,
+	)
+	if not match:
+		raise AssertionError(
+			"could not extract body-fetch loop from review_rb_judge.sh"
+		)
+	return match.group("loop")
+
+
 def test_loop_captures_first_issue_labels_json() -> None:
 	"""The body-fetch loop must populate FIRST_ISSUE_LABELS_JSON from
 	the parent issue's labels.  Static check: a future refactor that
@@ -167,12 +185,44 @@ if args[:2] == ["label", "create"]:
 	sys.exit(0)
 
 if args[:1] == ["api"]:
+	# Find the path arg (first non-flag, non-flag-value).  We treat the
+	# first positional after `api` as the path.  Caller-configured
+	# `api_responses` is keyed by substring match against that path.
+	path = ""
+	for arg in args[1:]:
+		if not arg.startswith("-"):
+			path = arg
+			break
 	state.setdefault("api_calls", []).append(args)
+	api_responses = state.get("api_responses", {}) or {}
+	matched = None
+	for pattern, resp in api_responses.items():
+		if pattern and pattern in path:
+			matched = resp
+			break
 	save()
-	# This mock is invoked only by the close_and_reissue branch under
-	# test, which never calls `gh api` directly — _safe_gh_jq is stubbed
-	# in the harness so the body-fetch loop is bypassed.  Anything that
-	# does land here (e.g. _resilient_phase_swap label PUT) is a no-op.
+	if matched is not None:
+		# Honour `--jq` server-side filtering: emit the filtered string,
+		# not the raw JSON, so callers that pre-fix used `--jq '.body'`
+		# still see the same shape (this matters for tests that exercise
+		# behaviour beyond the loop refactor).
+		jq_filter = ""
+		for i, arg in enumerate(args):
+			if arg == "--jq" and i + 1 < len(args):
+				jq_filter = args[i + 1]
+				break
+		if jq_filter:
+			# Limited support: handle `.body // ""` and `.state` to keep
+			# the mock predictable; anything else falls through to raw
+			# JSON so a future test can extend behaviour as needed.
+			if jq_filter == ".body // \"\"" or jq_filter == ".body":
+				print(matched.get("body", ""))
+			elif jq_filter == ".state":
+				print(matched.get("state", ""))
+			else:
+				print(json.dumps(matched))
+		else:
+			print(json.dumps(matched))
 	sys.exit(0)
 
 save()
@@ -340,6 +390,196 @@ def test_empty_parent_label_set_does_not_propagate() -> None:
 	assert "ai:orchestrator-managed" not in args, (
 		f"reissue must NOT inherit ai:orchestrator-managed when parent "
 		f"label set is empty; got args: {args}"
+	)
+
+
+def _run_body_fetch_loop(issue_responses: dict[str, dict], issue_numbers: str) -> dict:
+	"""Run the real body-fetch loop block against a mocked `gh api` so
+	the actual jq pipeline (`[(.labels // [])[]?.name]` plus the body
+	extract) is exercised end-to-end.
+
+	``issue_responses`` maps an API path substring (e.g.
+	``"issues/41"``) to the mocked GitHub issue JSON the mock returns.
+	``issue_numbers`` is the newline-separated string fed to the loop's
+	``ISSUE_NUMBERS`` reader.
+
+	Returns the captured ``FIRST_ISSUE``, ``FIRST_ISSUE_BODY``, and
+	``FIRST_ISSUE_LABELS_JSON`` values."""
+	loop = _extract_body_fetch_loop()
+
+	with tempfile.TemporaryDirectory(prefix="test_rb_judge_loop_") as td:
+		tmp_path = Path(td)
+		runtime_dir = tmp_path / "runtime"
+		bin_dir = tmp_path / "bin"
+		runtime_dir.mkdir(parents=True, exist_ok=True)
+		bin_dir.mkdir(parents=True, exist_ok=True)
+
+		gh_state_file = runtime_dir / "gh_state.json"
+		_install_mock_gh(bin_dir, gh_state_file)
+		gh_state_file.write_text(
+			json.dumps({"api_responses": issue_responses}),
+			encoding="utf-8",
+		)
+
+		capture_file = runtime_dir / "captured.env"
+		# _safe_gh_jq is the gh_helpers.sh wrapper.  Substitute a thin
+		# bash function that forwards directly to the mocked `gh api`
+		# so the loop's actual jq filters run against real shell output.
+		harness = f"""#!/usr/bin/env bash
+set -euo pipefail
+
+_safe_gh_jq() {{ gh api "$@"; }}
+
+ISSUE_NUMBERS="${{ISSUE_NUMBERS_INPUT}}"
+
+{loop}
+
+{{
+  printf 'FIRST_ISSUE=%s\\n' "${{FIRST_ISSUE}}"
+  printf 'FIRST_ISSUE_BODY=%s\\n' "${{FIRST_ISSUE_BODY}}"
+  printf 'FIRST_ISSUE_LABELS_JSON=%s\\n' "${{FIRST_ISSUE_LABELS_JSON}}"
+}} > "${{CAPTURE_FILE}}"
+"""
+		script_path = runtime_dir / "loop_harness.sh"
+		script_path.write_text(harness, encoding="utf-8")
+		script_path.chmod(0o755)
+
+		env = {
+			"PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+			"MOCK_GH_STATE_FILE": str(gh_state_file),
+			"REPOSITORY": "owner/repo",
+			"ISSUE_NUMBERS_INPUT": issue_numbers,
+			"CAPTURE_FILE": str(capture_file),
+		}
+		run_env = os.environ.copy()
+		run_env.update(env)
+
+		proc = subprocess.run(
+			["bash", str(script_path)],
+			cwd=str(tmp_path),
+			env=run_env,
+			text=True,
+			capture_output=True,
+			timeout=60,
+		)
+		assert proc.returncode == 0, (
+			f"loop harness exited {proc.returncode}\n"
+			f"stdout:\n{proc.stdout}\n\nstderr:\n{proc.stderr}"
+		)
+
+		captured = {}
+		for raw in capture_file.read_text(encoding="utf-8").splitlines():
+			if "=" in raw:
+				k, _, v = raw.partition("=")
+				captured[k] = v
+		return captured
+
+
+def test_loop_jq_filter_extracts_orchestrator_managed_from_realistic_payload() -> None:
+	"""End-to-end runtime test: feed the real body-fetch loop a
+	GitHub-shape issue JSON via mocked `gh api` and assert the actual
+	jq filter populates FIRST_ISSUE_LABELS_JSON with the parent's
+	label names.
+
+	Without this, the other runtime tests (which pre-seed
+	FIRST_ISSUE_LABELS_JSON via env and stub _safe_gh_jq to a no-op)
+	would not catch a future jq-filter typo or a GitHub-shape change
+	in the `.labels` field — the propagation gate would silently see
+	`[]` and skip."""
+	captured = _run_body_fetch_loop(
+		issue_responses={
+			"issues/41": {
+				"number": 41,
+				"title": "Orchestrator-managed parent",
+				"body": "Build feature X.",
+				"state": "closed",
+				"labels": [
+					{"id": 1, "name": "ai:orchestrator-managed", "color": "bfdadc"},
+					{"id": 2, "name": "ai:closed", "color": "6a737d"},
+				],
+			},
+		},
+		issue_numbers="41",
+	)
+	assert captured.get("FIRST_ISSUE") == "41"
+	assert captured.get("FIRST_ISSUE_BODY") == "Build feature X."
+	labels = json.loads(captured.get("FIRST_ISSUE_LABELS_JSON", "[]"))
+	assert labels == ["ai:orchestrator-managed", "ai:closed"], (
+		f"expected the loop's jq filter to extract both label names from a "
+		f"realistic GitHub /issues/N response; got {labels}"
+	)
+
+
+def test_loop_jq_filter_handles_null_labels_field() -> None:
+	"""GitHub shape variation: some payloads return ``"labels": null``
+	(rare but documented).  The `// []` defensive default in the jq
+	filter must collapse that to an empty list, not error out — a
+	future filter rewrite that dropped the safe default would silently
+	break propagation here."""
+	captured = _run_body_fetch_loop(
+		issue_responses={
+			"issues/41": {
+				"number": 41,
+				"body": "Body present",
+				"labels": None,
+			},
+		},
+		issue_numbers="41",
+	)
+	assert captured.get("FIRST_ISSUE") == "41"
+	assert json.loads(captured.get("FIRST_ISSUE_LABELS_JSON", "null")) == []
+
+
+def test_loop_jq_filter_handles_missing_labels_key() -> None:
+	"""If the labels key is absent entirely (defensive: malformed or
+	stripped response), the filter must yield an empty list — not
+	error and not propagate stale state from a previous iteration."""
+	captured = _run_body_fetch_loop(
+		issue_responses={
+			"issues/41": {
+				"number": 41,
+				"body": "Body present",
+			},
+		},
+		issue_numbers="41",
+	)
+	assert json.loads(captured.get("FIRST_ISSUE_LABELS_JSON", "null")) == []
+
+
+def test_loop_pins_labels_to_first_issue_even_when_body_comes_from_later_issue() -> None:
+	"""When the first linked issue has an empty body, the loop falls
+	back to a later issue's body — pre-existing behaviour.  The
+	label-propagation fix MUST keep FIRST_ISSUE_LABELS_JSON pinned to
+	the first issue's labels (which match the reissue footer's
+	``Replaces #FIRST_ISSUE``), not jump to the later issue's labels.
+
+	This nails down the contract grok-4.1-fast flagged on PR #2267:
+	labels follow FIRST_ISSUE, not whichever issue contributed the body."""
+	captured = _run_body_fetch_loop(
+		issue_responses={
+			"issues/41": {
+				"number": 41,
+				"body": "",
+				"labels": [{"name": "ai:orchestrator-managed"}],
+			},
+			"issues/42": {
+				"number": 42,
+				"body": "Fallback body",
+				"labels": [{"name": "bug"}],
+			},
+		},
+		issue_numbers="41\n42",
+	)
+	assert captured.get("FIRST_ISSUE") == "41", (
+		"FIRST_ISSUE must be the first linked issue, not the body-source"
+	)
+	assert captured.get("FIRST_ISSUE_BODY") == "Fallback body", (
+		"pre-existing behaviour: empty first body → fall back to next issue's body"
+	)
+	labels = json.loads(captured.get("FIRST_ISSUE_LABELS_JSON", "[]"))
+	assert labels == ["ai:orchestrator-managed"], (
+		f"FIRST_ISSUE_LABELS_JSON must follow FIRST_ISSUE (#41), not the "
+		f"body-source (#42); got {labels}"
 	)
 
 


### PR DESCRIPTION
## Symptom (reproduced downstream)

In `shubhodeep1/bitsafe.io`, an orchestrator-managed parent issue (#41) was closed via `review_rb_judge` with decision `close_and_reissue`. The reissue (#43) was opened with footer:

```
**Review-blocked reissue metadata**
- Replaces: #41 (PR #42 closed — approach rework)
- Type: review-blocked-reissue
```

…but with **only** the `ai:clarification` label. Parent #41 had `ai:orchestrator-managed`. Because the reissue lacked that label, the auto-answer path in `clarify.yml`'s "Decide clarify route" step gated out — see comment 4403451237 on the sibling issue #44, which states the gate verbatim:

> Auto answer was posted because this issue is labeled ai:orchestrator-managed and this run was not a forced human /reclarify.

Result: #43 stalled in clarification (emitted `AI_STANDALONE_STALL_STATE_V1` heartbeats forever) while a parallel "judge-addition" issue #44 — created by the orchestrator poller WITH `ai:orchestrator-managed` (`orchestrate_poll_process.sh:9842`) — silently delivered the same work via PR #45. The reissue lineage was effectively orphaned.

## Root cause

`scripts/review_rb_judge.sh:648-651` (pre-fix) called `gh issue create` with no `--label` flag. The only label the reissue ever got was `ai:clarification`, added later by `clarify.yml:421` on the `issues.opened` event. The auto-answer fast path at `clarify.yml:331-364` is gated strictly on:

```
SKIP_CODEX = !is_closed && has_label("ai:orchestrator-managed") && !forced_reclarify
```

Without the label, the reissue followed the human-driven clarify path forever.

## Fix

1. **`scripts/review_rb_judge.sh:160-178`** — the body-fetch loop now captures parent labels into `FIRST_ISSUE_LABELS_JSON` from the same REST GET that already fetches the body. No extra API call, per CLAUDE.md §15 (extend an existing call rather than adding a new one). Server-side `--jq '.body // ""'` is replaced with a single full-JSON fetch and two client-side `jq` extracts (body + labels).

2. **`scripts/review_rb_judge.sh:656-672`** — the `close_and_reissue` branch now checks `FIRST_ISSUE_LABELS_JSON` for `ai:orchestrator-managed` via `jq -e 'index(...)'`. On hit, it calls `ensure_label_exists` and appends `--label ai:orchestrator-managed` to the `gh issue create` call. Standalone (non-orchestrator) reissues get no `--label` so their human-driven clarify semantics are preserved — `scripts/review_rb_judge.sh` is also invoked from `review_autofix.yml:3818` outside the orchestrator stall ladder, so unconditional propagation (shape b) was the wrong choice.

3. **`tests/test_review_rb_judge_label_propagation.py`** — new regression test, 5 cases:
   - Static: loop populates `FIRST_ISSUE_LABELS_JSON`.
   - Static: gate is exactly `index("ai:orchestrator-managed")`.
   - Runtime: orchestrator-managed parent → reissue carries `--label ai:orchestrator-managed`.
   - Runtime: standalone parent → reissue does NOT carry the label.
   - Runtime: empty parent labels → reissue does NOT carry the label (fail-closed default).

   Reversing the script change reproduces 3 failures, confirming the test catches the original bug.

## Cross-checks performed

- **Auto-answer gate** (`clarify.yml:331-364`): exactly `has_label("ai:orchestrator-managed") && !forced_reclarify && !is_closed`. No body-regex or `tg_phase:` requirement (no such labels exist anywhere in the repo).
- **Parallel correct path** (`orchestrate_poll_process.sh:9842-9847`): the orchestrator's inline RB-judge already passes both `ai:clarification` and `ai:orchestrator-managed`, confirming the desired behaviour. The body-footer divergence (`**Review-blocked reissue metadata**` vs. `**Orchestrator metadata**`) makes the buggy code path unambiguously identifiable in the downstream symptom.
- **Stall-recovery loop** (`orchestrate_lib.py:918-922 STALL_RECOVERY_ACTIONS["ai:review-blocked"]` and `orchestrate_poll_process.sh:7535 _dispatch_rb_judge_for_pr`): both fire-and-forget via `gh workflow run`; neither inspects the reissue afterward, so the label addition is invisible to them.
- **Bash array under `set -u`**: `${RB_PROPAGATE_LABELS[@]+"${RB_PROPAGATE_LABELS[@]}"}` is the safe expansion for an empty array. Existing scripts in the repo already use bash 4.4+ array patterns; GitHub runners use bash 5.2.

## Out-of-scope

- Body-footer divergence (the dispatch path's reissue still has only `Replaces:` + `Type:` and no `Tracking issue: #N`). The orchestrator's per-cycle wave-state remap at `orchestrate_poll_process.sh:9853-9859` may not relink the reissue into `state.json`. Label-only fix here unblocks the auto-answer; if wave-state linkage matters, a follow-up should add the `Tracking issue:` footer.
- Retroactively re-labelling already-orphaned reissues (per the original task: "Don't paper over the symptom").

## Test plan

- [x] `bash -n scripts/review_rb_judge.sh` — passes (also passes the script's own pre-flight syntax check).
- [x] `pytest tests/test_review_rb_judge_label_propagation.py` — 5/5 pass.
- [x] Reverted fix → 3/5 fail (orchestrator-parent runtime + 2 static checks), 2/5 still pass (the absence-of-label tests are correctly invariant). Confirms the suite catches the regression.
- [x] Adjacent review tests (`test_review_autofix_*`, `test_review_apply_fixes_*`) — unaffected. (3 unrelated failures in `test_review_pipeline_integration.py` due to a missing `gawk` binary in the local sandbox; not a regression.)

https://claude.ai/code/session_01SCVNrXbC7hBP89QvyFHkNq

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCVNrXbC7hBP89QvyFHkNq)_