### PR TITLE
fix(review_autofix): back-fill linked-issue context from PR body when GraphQL returns empty

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1428,10 +1428,64 @@ jobs:
             fi
           fi
 
+          # Body-text fallback: when GraphQL closingIssuesReferences returns
+          # empty (which happens systematically for orchestrator-managed PRs
+          # whose base is `orchestrator/project-<n>` rather than the default
+          # branch — GitHub's closingIssuesReferences only resolves closing
+          # keywords for default-branch-targeted PRs), parse the PR body for
+          # explicit Closes/Fixes/Resolves + #N or in-repo issue URL refs
+          # and back-fill issue title+body via REST.
+          # Scope: only LINKED_ISSUE_CONTEXT_FILE (used for editor/reviewer
+          # prompt context) is affected.  LINKED_ISSUES_JSON (used for
+          # downstream labeling and auto-merge gating) keeps GraphQL-only
+          # semantics — labeling-by-keyword is itself default-branch-gated
+          # by GitHub, so back-filling there would alter unrelated semantics.
+          # Same regex as the smoke-test detection step (case-insensitive
+          # closing keywords + #N or repo-scoped issue URL).  URL prefix is
+          # restricted to the current repository so a cross-repo
+          # `Closes <other-repo>/issues/N` reference cannot route an
+          # unrelated number into this repo's lookup.
+          # API cost: bounded by the count of distinct closing references in
+          # the PR body (typically 1-2); each match issues one
+          # `gh api repos/.../issues/<n>` REST call.  Failures are logged
+          # and skipped (fail-open).
+          _linked_context_raw="${_linked_raw}"
+          if [ "${_linked_context_raw}" = "[]" ] && [ -s "${PR_META_FILE}" ]; then
+            _pr_body_for_fallback="$(jq -r '.body // ""' "${PR_META_FILE}")"
+            if [ -n "${_pr_body_for_fallback}" ]; then
+              _fallback_numbers="$(printf '%s\n' "${_pr_body_for_fallback}" \
+                | grep -oiP '\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?):?\s+(?:https?://[^[:space:]]+/${{ github.repository }}/issues/|#)\K\d+\b' \
+                | sort -un || true)"
+              if [ -n "${_fallback_numbers}" ]; then
+                _fallback_json='[]'
+                while IFS= read -r _fb_num; do
+                  [ -z "${_fb_num}" ] && continue
+                  _fb_issue_tmp="$(mktemp)"
+                  if gh_retry "${_fb_issue_tmp}" api "repos/${{ github.repository }}/issues/${_fb_num}" \
+                    --jq '{number: (.number // 0), title: (.title // ""), body: (.body // "")}'; then
+                    _fb_issue_obj="$(cat "${_fb_issue_tmp}" 2>/dev/null || echo '')"
+                    if [ -n "${_fb_issue_obj}" ]; then
+                      _fallback_json="$(printf '%s' "${_fallback_json}" \
+                        | jq --argjson o "${_fb_issue_obj}" '. + [$o]' 2>/dev/null \
+                        || printf '%s' "${_fallback_json}")"
+                    fi
+                  else
+                    echo "::warning::Linked-issue body-text fallback: gh api repos/${{ github.repository }}/issues/${_fb_num} failed; skipping"
+                  fi
+                  rm -f "${_fb_issue_tmp}"
+                done <<< "${_fallback_numbers}"
+                if [ "${_fallback_json}" != "[]" ]; then
+                  _linked_context_raw="${_fallback_json}"
+                  echo "Linked-issue body-text fallback resolved $(printf '%s' "${_fallback_json}" | jq 'length') issue(s) for context (GraphQL closingIssuesReferences returned empty — likely non-default base branch)."
+                fi
+              fi
+            fi
+          fi
+
           # Build linked issue context file for reviewer/editor prompts.
           # Use a temp file to avoid ARG_MAX failures on large issue bodies.
           _linked_json_file="$(mktemp)"
-          printf '%s' "${_linked_raw}" > "${_linked_json_file}"
+          printf '%s' "${_linked_context_raw}" > "${_linked_json_file}"
           PYTHONDONTWRITEBYTECODE=1 python3 - "${_linked_json_file}" "${LINKED_ISSUE_CONTEXT_FILE}" <<'PYLINKED'
           import json, sys
           json_path = sys.argv[1]

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1440,23 +1440,36 @@ jobs:
           # downstream labeling and auto-merge gating) keeps GraphQL-only
           # semantics — labeling-by-keyword is itself default-branch-gated
           # by GitHub, so back-filling there would alter unrelated semantics.
-          # Same regex as the smoke-test detection step (case-insensitive
-          # closing keywords + #N or repo-scoped issue URL).  URL prefix is
-          # restricted to the current repository so a cross-repo
-          # `Closes <other-repo>/issues/N` reference cannot route an
-          # unrelated number into this repo's lookup.
-          # API cost: bounded by the count of distinct closing references in
-          # the PR body (typically 1-2); each match issues one
-          # `gh api repos/.../issues/<n>` REST call.  Failures are logged
-          # and skipped (fail-open).
+          # Trigger: GraphQL returned exactly `[]`.  A non-empty (even
+          # partial) GraphQL result is trusted as authoritative and the
+          # body is NOT scanned, matching the brief's intent (only fix the
+          # case where GitHub resolved nothing).
+          # Regex (case-insensitive closing keywords + #N or repo-scoped
+          # github.com issue URL): host is anchored to `github.com` and
+          # the repo path is PCRE-escaped via python's re.escape before
+          # splicing in, so neither a non-GitHub URL with the same path
+          # nor a future repo rename containing regex metacharacters can
+          # route an unrelated number into this repo's lookup.
+          # API cost: each distinct closing reference costs one
+          # `gh api repos/.../issues/<n>` REST call; capped at
+          # _FALLBACK_MAX_ISSUES (truncation logged) to bound the worst
+          # case against verbose or adversarial PR bodies.  Failures are
+          # logged and skipped (fail-open).
           _linked_context_raw="${_linked_raw}"
           if [ "${_linked_context_raw}" = "[]" ] && [ -s "${PR_META_FILE}" ]; then
             _pr_body_for_fallback="$(jq -r '.body // ""' "${PR_META_FILE}")"
             if [ -n "${_pr_body_for_fallback}" ]; then
+              _fb_repo_pcre="$(PYTHONDONTWRITEBYTECODE=1 python3 -c 'import re,sys; sys.stdout.write(re.escape(sys.argv[1]))' '${{ github.repository }}')"
               _fallback_numbers="$(printf '%s\n' "${_pr_body_for_fallback}" \
-                | grep -oiP '\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?):?\s+(?:https?://[^[:space:]]+/${{ github.repository }}/issues/|#)\K\d+\b' \
+                | grep -oiP "\\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?):?\\s+(?:https?://github\\.com/${_fb_repo_pcre}/issues/|#)\\K\\d+\\b" \
                 | sort -un || true)"
               if [ -n "${_fallback_numbers}" ]; then
+                _FALLBACK_MAX_ISSUES=20
+                _fallback_total="$(printf '%s\n' "${_fallback_numbers}" | wc -l | tr -d '[:space:]')"
+                if [ "${_fallback_total:-0}" -gt "${_FALLBACK_MAX_ISSUES}" ]; then
+                  echo "::warning::Linked-issue body-text fallback: PR body referenced ${_fallback_total} distinct in-repo issues; capping fetches at ${_FALLBACK_MAX_ISSUES}."
+                  _fallback_numbers="$(printf '%s\n' "${_fallback_numbers}" | head -n "${_FALLBACK_MAX_ISSUES}")"
+                fi
                 _fallback_json='[]'
                 while IFS= read -r _fb_num; do
                   [ -z "${_fb_num}" ] && continue


### PR DESCRIPTION
## Summary

- GitHub's GraphQL `closingIssuesReferences` only resolves closing keywords for PRs targeting the default branch, so orchestrator-managed PRs (base = `orchestrator/project-<n>`) systematically lose linked-issue context for the editor and every reviewer across every autofix iteration.
- When the GraphQL fetch returns `[]`, parse the PR body for explicit `Closes`/`Fixes`/`Resolves` + `#N` or in-repo issue URL references (same regex as the smoke-test detection step) and back-fill issue title+body via `gh api repos/.../issues/<n>`.
- Scope is intentionally narrow: only `LINKED_ISSUE_CONTEXT_FILE` (editor/reviewer prompt context) is back-filled. `LINKED_ISSUES_JSON` (downstream labeling and auto-merge gating) keeps GraphQL-only semantics — labeling-by-keyword is itself default-branch-gated by GitHub, so back-filling there would alter unrelated semantics.

## Reproducer (live)

`tele-funtoken-msg-scoring#2799`, run `25538571413`: PR body contains `Closes <issue-url>` for `#2798`, but the autofix log shows `Linked issue context bytes: 23` (literal placeholder `No linked issues found.`) on all four iterations because the PR's base is `orchestrator/project-2791`, not `main`.

## Files changed

- `.github/workflows/review_autofix.yml:1431-1483` — new body-text fallback block; the existing python file write at `1487` now reads `_linked_context_raw` instead of `_linked_raw`.

## Safety

- URL alternative in the regex is restricted to `${{ github.repository }}` — a cross-repo `Closes <other-repo>/issues/N` cannot route an unrelated number into this repo's lookup.
- API cost bounded by the count of distinct closing references in the PR body (typically 1-2); each match issues one REST call.
- All failures are logged and skipped (fail-open). The fallback never blocks the workflow.
- `LINKED_ISSUES_JSON` env var unchanged → no impact on the post-review label/auto-merge logic at `review_autofix.yml:519`, `650`, `3707`, `scripts/review_rb_judge.sh:150`, or `issue_pr_status.yml:192`.

## Test plan

- [ ] Validation/CI green on this branch.
- [ ] Verify on a follow-up orchestrator-managed PR: log line `Linked-issue body-text fallback resolved <N> issue(s) for context` appears, and `Linked issue context bytes:` is no longer 23.
- [ ] Confirm `LINKED_ISSUES_JSON` env behavior is unchanged on a default-branch PR (GraphQL path still authoritative; fallback does not fire when GraphQL returns issues).
- [ ] Confirm fallback does not fire for default-branch PRs where GraphQL already returns the linked issues.

https://claude.ai/code/session_01VAh7kUQs5g5AugWHLKm9Z8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAh7kUQs5g5AugWHLKm9Z8)_