### PR TITLE
fix(test-and-mark-stable): poll orchestrate-decompose lookups to absorb GitHub API indexing lag

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3696,12 +3696,29 @@ jobs:
           # references this run's GITHUB_RUN_ID (the project_description
           # we sent embeds it, and the body includes project_summary
           # which typically carries it through).
-          TRACKING_NUMBER=$(gh api \
-            "repos/${TEST_REPO}/issues?state=open&labels=ai:orchestrator-tracking&since=${DISPATCH_START_ISO}&per_page=50" \
-            --jq "[.[] | select(.body // \"\" | contains(\"${GITHUB_RUN_ID}\"))] | sort_by(.created_at) | last | .number // empty" \
-            2>/dev/null || echo "")
+          # GitHub's /repos/{}/{}/issues endpoint with `since=` + `labels=`
+          # filters has eventual-consistency lag: a freshly-created issue
+          # can take tens of seconds to surface in subsequent filtered list
+          # calls under release-day API load. The orchestrate run completes
+          # within ~1s of creating the tracking issue ("Create tracking
+          # issue" → "Dispatch Wave 1" runs in ~20s inside the orchestrate
+          # bootstrap), so the immediate post-run lookup races the index.
+          # Runs 25542750558 and 25477674617 both failed here even though
+          # the tracking issue had been created seconds earlier (verified
+          # via direct issue lookup). Poll up to 90s with 5s backoff to
+          # absorb the lag instead of one-shot-failing.
+          TRACKING_NUMBER=""
+          TRACKING_DEADLINE=$(( $(date +%s) + 90 ))
+          while [ "$(date +%s)" -lt "${TRACKING_DEADLINE}" ]; do
+            TRACKING_NUMBER=$(gh api \
+              "repos/${TEST_REPO}/issues?state=open&labels=ai:orchestrator-tracking&since=${DISPATCH_START_ISO}&per_page=50" \
+              --jq "[.[] | select(.body // \"\" | contains(\"${GITHUB_RUN_ID}\"))] | sort_by(.created_at) | last | .number // empty" \
+              2>/dev/null || echo "")
+            [ -n "${TRACKING_NUMBER}" ] && break
+            sleep 5
+          done
           if [ -z "${TRACKING_NUMBER}" ]; then
-            echo "::error::Could not locate tracking issue for run ${GITHUB_RUN_ID} (label=ai:orchestrator-tracking, since=${DISPATCH_START_ISO}, body must contain ${GITHUB_RUN_ID})"
+            echo "::error::Could not locate tracking issue for run ${GITHUB_RUN_ID} after 90s polling (label=ai:orchestrator-tracking, since=${DISPATCH_START_ISO}, body must contain ${GITHUB_RUN_ID})"
             exit 1
           fi
           echo "tracking_issue=${TRACKING_NUMBER}" >> "$GITHUB_OUTPUT"
@@ -3717,16 +3734,28 @@ jobs:
           # `ai:orchestrator-managed` label, so we list those directly.
           # `since=${DISPATCH_START_ISO}` and the body filter scope the
           # match to children opened by THIS dispatch, never an older run.
-          CHILDREN_JSON=$(gh api \
-            "repos/${TEST_REPO}/issues?state=all&labels=ai:orchestrator-managed&since=${DISPATCH_START_ISO}&per_page=100" \
-            --jq "[.[] | select(.pull_request | not) | select(.body // \"\" | contains(\"Tracking issue: #${TRACKING_NUMBER}\")) | .number]" \
-            2>/dev/null || echo "[]")
-          CHILDREN=$(echo "${CHILDREN_JSON}" | jq -r 'sort | unique | join(",")' 2>/dev/null || echo "")
+          # Same eventual-consistency caveat as the tracking-issue lookup
+          # above: the Wave 1 children are created ~3-4s after the tracking
+          # issue, so the filtered list call can still race the index even
+          # after the tracking-issue lookup succeeds. Poll up to 90s with
+          # 5s backoff until at least 2 children are visible.
+          CHILDREN=""
+          CHILD_COUNT=0
+          CHILDREN_DEADLINE=$(( $(date +%s) + 90 ))
+          while [ "$(date +%s)" -lt "${CHILDREN_DEADLINE}" ]; do
+            CHILDREN_JSON=$(gh api \
+              "repos/${TEST_REPO}/issues?state=all&labels=ai:orchestrator-managed&since=${DISPATCH_START_ISO}&per_page=100" \
+              --jq "[.[] | select(.pull_request | not) | select(.body // \"\" | contains(\"Tracking issue: #${TRACKING_NUMBER}\")) | .number]" \
+              2>/dev/null || echo "[]")
+            CHILDREN=$(echo "${CHILDREN_JSON}" | jq -r 'sort | unique | join(",")' 2>/dev/null || echo "")
+            CHILD_COUNT=$(echo "${CHILDREN}" | tr ',' '\n' | grep -c .)
+            [ "${CHILD_COUNT}" -ge 2 ] && break
+            sleep 5
+          done
           echo "child_issues=${CHILDREN}" >> "$GITHUB_OUTPUT"
           # Decomposition assertion: at least two distinct child issues.
-          CHILD_COUNT=$(echo "${CHILDREN}" | tr ',' '\n' | grep -c .)
           if [ "${CHILD_COUNT}" -lt 2 ]; then
-            echo "::error::Decomposition produced ${CHILD_COUNT} child issue(s); expected >= 2 (queried label=ai:orchestrator-managed since=${DISPATCH_START_ISO} body~='Tracking issue: #${TRACKING_NUMBER}')"
+            echo "::error::Decomposition produced ${CHILD_COUNT} child issue(s) after 90s polling; expected >= 2 (queried label=ai:orchestrator-managed since=${DISPATCH_START_ISO} body~='Tracking issue: #${TRACKING_NUMBER}')"
             exit 1
           fi
           echo "✓ Decomposition produced ${CHILD_COUNT} child issues: ${CHILDREN}"

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3707,20 +3707,32 @@ jobs:
           # the tracking issue had been created seconds earlier (verified
           # via direct issue lookup). Poll up to 90s with 5s backoff to
           # absorb the lag instead of one-shot-failing.
+          # Capture each iteration's stderr to a file (overwritten each
+          # round so we surface the LAST failure on timeout). Without
+          # this, persistent non-flaky failures (expired GH_PAT, 401/403,
+          # rate limits, 5xx) silently burn the 90s budget and we'd
+          # report a misleading "could not locate tracking issue" error.
           TRACKING_NUMBER=""
+          TRACKING_ERR_FILE=$(mktemp)
           TRACKING_DEADLINE=$(( $(date +%s) + 90 ))
           while [ "$(date +%s)" -lt "${TRACKING_DEADLINE}" ]; do
             TRACKING_NUMBER=$(gh api \
               "repos/${TEST_REPO}/issues?state=open&labels=ai:orchestrator-tracking&since=${DISPATCH_START_ISO}&per_page=50" \
               --jq "[.[] | select(.body // \"\" | contains(\"${GITHUB_RUN_ID}\"))] | sort_by(.created_at) | last | .number // empty" \
-              2>/dev/null || echo "")
+              2>"${TRACKING_ERR_FILE}" || echo "")
             [ -n "${TRACKING_NUMBER}" ] && break
             sleep 5
           done
           if [ -z "${TRACKING_NUMBER}" ]; then
+            if [ -s "${TRACKING_ERR_FILE}" ]; then
+              echo "::warning::last gh api stderr during tracking-issue polling:"
+              sed 's/^/  /' "${TRACKING_ERR_FILE}" || true
+            fi
+            rm -f "${TRACKING_ERR_FILE}"
             echo "::error::Could not locate tracking issue for run ${GITHUB_RUN_ID} after 90s polling (label=ai:orchestrator-tracking, since=${DISPATCH_START_ISO}, body must contain ${GITHUB_RUN_ID})"
             exit 1
           fi
+          rm -f "${TRACKING_ERR_FILE}"
           echo "tracking_issue=${TRACKING_NUMBER}" >> "$GITHUB_OUTPUT"
           # Discover child issues by their orchestrator-managed back-reference
           # rather than by parsing the tracking-issue body. The tracking body
@@ -3739,14 +3751,18 @@ jobs:
           # issue, so the filtered list call can still race the index even
           # after the tracking-issue lookup succeeds. Poll up to 90s with
           # 5s backoff until at least 2 children are visible.
+          # Capture each iteration's stderr (overwritten each round) so a
+          # persistent non-flaky failure surfaces on timeout instead of
+          # being misreported as "produced 0 child issue(s)".
           CHILDREN=""
           CHILD_COUNT=0
+          CHILDREN_ERR_FILE=$(mktemp)
           CHILDREN_DEADLINE=$(( $(date +%s) + 90 ))
           while [ "$(date +%s)" -lt "${CHILDREN_DEADLINE}" ]; do
             CHILDREN_JSON=$(gh api \
               "repos/${TEST_REPO}/issues?state=all&labels=ai:orchestrator-managed&since=${DISPATCH_START_ISO}&per_page=100" \
               --jq "[.[] | select(.pull_request | not) | select(.body // \"\" | contains(\"Tracking issue: #${TRACKING_NUMBER}\")) | .number]" \
-              2>/dev/null || echo "[]")
+              2>"${CHILDREN_ERR_FILE}" || echo "[]")
             CHILDREN=$(echo "${CHILDREN_JSON}" | jq -r 'sort | unique | join(",")' 2>/dev/null || echo "")
             CHILD_COUNT=$(echo "${CHILDREN}" | tr ',' '\n' | grep -c .)
             [ "${CHILD_COUNT}" -ge 2 ] && break
@@ -3755,9 +3771,15 @@ jobs:
           echo "child_issues=${CHILDREN}" >> "$GITHUB_OUTPUT"
           # Decomposition assertion: at least two distinct child issues.
           if [ "${CHILD_COUNT}" -lt 2 ]; then
+            if [ -s "${CHILDREN_ERR_FILE}" ]; then
+              echo "::warning::last gh api stderr during child-issue polling:"
+              sed 's/^/  /' "${CHILDREN_ERR_FILE}" || true
+            fi
+            rm -f "${CHILDREN_ERR_FILE}"
             echo "::error::Decomposition produced ${CHILD_COUNT} child issue(s) after 90s polling; expected >= 2 (queried label=ai:orchestrator-managed since=${DISPATCH_START_ISO} body~='Tracking issue: #${TRACKING_NUMBER}')"
             exit 1
           fi
+          rm -f "${CHILDREN_ERR_FILE}"
           echo "✓ Decomposition produced ${CHILD_COUNT} child issues: ${CHILDREN}"
 
       - name: "Soft-error analyser (orchestrate-decompose)"


### PR DESCRIPTION
## Summary

- `orchestrate-decompose-test` failed in Release v1.8.1 (run [25542750558](https://github.com/shubhodeep1/coding-workflows/actions/runs/25542750558)) with `::error::Could not locate tracking issue for run 25542750558 …`, even though the orchestrator successfully created tracking issue [#2271](https://github.com/shubhodeep1/coding-workflows/issues/2271) at `07:23:50Z` with the correct `ai:orchestrator-tracking` label and the run ID embedded in its body.
- Root cause: GitHub's `/repos/{owner}/{repo}/issues` endpoint with `since=` + `labels=` filters has eventual-consistency lag — under release-day API load a freshly-created issue can take tens of seconds to surface in subsequent filtered list calls. The test queries within ~1s of orchestrate completion (which itself is ~20s after issue creation), so the one-shot lookup races the index. Run [25477674617](https://github.com/shubhodeep1/coding-workflows/actions/runs/25477674617) hit the identical pattern.
- Fix: wrap both flaky filtered-list lookups (tracking issue + Wave 1 children) in 90s/5s poll loops. No query semantics change; only the empty-result handling switches from one-shot-fail to bounded retry. Three of the previous four runs of the same code passed, confirming the code is correct — just race-prone.

## Evidence

- Failed step log L245 (run 25542750558, job 74972087501): `##[error]Could not locate tracking issue for run 25542750558 (label=ai:orchestrator-tracking, since=2026-05-08T07:21:53Z, body must contain 25542750558)`
- Direct lookup confirmed `#2271` was created at `07:23:50Z` with `labels=["ai:orchestrator-tracking","ai:validated"]` and body containing `25542750558` four times.
- Same flake hit run 25477674617 at the same step with the same error message.

## Files changed

- `.github/workflows/test-and-mark-stable.yml` (~lines 3699–3760): wrap `TRACKING_NUMBER` and `CHILDREN_JSON` lookups in 90s/5s poll loops; preserve existing query payloads and error-message wording (suffixed with `after 90s polling` so the diagnostic remains greppable).

## Test plan

- [ ] Re-run `Test & Mark Stable Release` and confirm `orchestrate-decompose-test` passes.
- [ ] Watch `validate-scripts` (YAML lint + shellcheck) on this PR — the edit was bash-syntax-checked locally.
- [ ] Inspect the soft-error report on the next release run for any unexpected entries under `orchestrate-decompose`.

https://claude.ai/code/session_013qDzYCSQiCHeQC5qPmbJcj

---
_Generated by [Claude Code](https://claude.ai/code/session_013qDzYCSQiCHeQC5qPmbJcj)_