### PR TITLE
fix(plan,review_rb_judge): teach planner to handle review-blocked reissues

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -865,19 +865,21 @@ jobs:
           - Review-blocked reissues: if the issue body contains
             `Type: review-blocked-reissue` (footer block produced by the review-blocked
             judge), the file paths and line numbers cited in the body refer to the
-            closed PR's prior implementation and are intentionally absent from `main`.
-            Treat them as guidance about what the new implementation must (re)create or
-            change, NOT as prerequisite files that must already exist. Do NOT emit
-            `BLOCKED:` for "files referenced in the issue do not exist on main" in this
-            case — produce a normal plan that re-creates the relevant files. The plan
-            must call out the files-to-create explicitly under "Files likely to change."
+            closed PR's prior implementation and are intentionally absent from the
+            current planning ref. Treat them as guidance about what the new
+            implementation must (re)create or change, NOT as prerequisite files that
+            must already exist. Do NOT emit `BLOCKED:` for "files referenced in the
+            issue do not exist on the current ref" in this case — produce a normal
+            plan that re-creates the relevant files. The plan must call out the
+            files-to-create explicitly under "Files likely to change."
           - If required input is external and non-synthesizable by the auto-answerer
             (for example branch name, commit SHA, credential, or external URL) AND the
             input is required to plan the change itself (not merely referenced as
             context that the new implementation will replace), do not emit Q/Choices;
             emit exactly `BLOCKED: <short reason>`. Missing source files on the current
             ref are NOT external inputs — they are codebase state the plan can address;
-            flag them under CONFLICT DETECTION above and continue planning.
+            note them under "Risks and edge cases" as a conflict (per the CONFLICT
+            DETECTION rule above) and continue planning.
           - Surface the planning ref context (`git rev-parse HEAD` and symbolic branch)
             from the planning context and do not assume `main`.
           - If checked-out ref mismatches Integration branch metadata, emit exactly

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -862,9 +862,22 @@ jobs:
             in reasoning.
           - Map each interpreted answer back to its corresponding Q<ID> clarification question
             before creating the plan.
+          - Review-blocked reissues: if the issue body contains
+            `Type: review-blocked-reissue` (footer block produced by the review-blocked
+            judge), the file paths and line numbers cited in the body refer to the
+            closed PR's prior implementation and are intentionally absent from `main`.
+            Treat them as guidance about what the new implementation must (re)create or
+            change, NOT as prerequisite files that must already exist. Do NOT emit
+            `BLOCKED:` for "files referenced in the issue do not exist on main" in this
+            case — produce a normal plan that re-creates the relevant files. The plan
+            must call out the files-to-create explicitly under "Files likely to change."
           - If required input is external and non-synthesizable by the auto-answerer
-            (for example branch name, commit SHA, credential, or external URL), do not
-            emit Q/Choices; emit exactly `BLOCKED: <short reason>`.
+            (for example branch name, commit SHA, credential, or external URL) AND the
+            input is required to plan the change itself (not merely referenced as
+            context that the new implementation will replace), do not emit Q/Choices;
+            emit exactly `BLOCKED: <short reason>`. Missing source files on the current
+            ref are NOT external inputs — they are codebase state the plan can address;
+            flag them under CONFLICT DETECTION above and continue planning.
           - Surface the planning ref context (`git rev-parse HEAD` and symbolic branch)
             from the planning context and do not assume `main`.
           - If checked-out ref mismatches Integration branch metadata, emit exactly

--- a/prompts/mode-judge-review-blocked.txt
+++ b/prompts/mode-judge-review-blocked.txt
@@ -43,8 +43,10 @@ Rules:
   the PR is closed. Either (a) phrase guidance in terms of behaviour and
   acceptance criteria rather than file:line addresses, or (b) when file:line
   refs are necessary for clarity, prefix them with "in the closed PR
-  (#<n>):" so downstream planners do not interpret them as prerequisites on
-  main. Do NOT cite paths/lines as bare `apps/x/y.ts:NN` without that prefix.
+  (#<number>):" — replace `<number>` with the actual closed PR number from
+  the context (the PR you are about to close) — so downstream planners do
+  not interpret them as prerequisites on main. Do NOT cite paths/lines as
+  bare `apps/x/y.ts:NN` without that prefix.
 - Prefer merge (A) over fix (B) when remaining issues are non-critical.
 - Prefer fix (B) over close_and_reissue (C) when the fix is straightforward.
 

--- a/prompts/mode-judge-review-blocked.txt
+++ b/prompts/mode-judge-review-blocked.txt
@@ -45,8 +45,8 @@ Rules:
   refs are necessary for clarity, prefix them with "in the closed PR
   (#<number>):" — replace `<number>` with the actual closed PR number from
   the context (the PR you are about to close) — so downstream planners do
-  not interpret them as prerequisites on main. Do NOT cite paths/lines as
-  bare `apps/x/y.ts:NN` without that prefix.
+  not interpret them as prerequisites on the base/current ref. Do NOT cite
+  paths/lines as bare `apps/x/y.ts:NN` without that prefix.
 - Prefer merge (A) over fix (B) when remaining issues are non-critical.
 - Prefer fix (B) over close_and_reissue (C) when the fix is straightforward.
 

--- a/prompts/mode-judge-review-blocked.txt
+++ b/prompts/mode-judge-review-blocked.txt
@@ -38,6 +38,13 @@ Rules:
   just describe what to change — apply the fixes directly using file writes.
 - For option C (close_and_reissue): write a detailed issue body that explains
   what went wrong and provides specific implementation guidance.
+- For option C (close_and_reissue): the new issue body's file/line refs will
+  point at the closed PR's branch and will NOT exist on the base branch after
+  the PR is closed. Either (a) phrase guidance in terms of behaviour and
+  acceptance criteria rather than file:line addresses, or (b) when file:line
+  refs are necessary for clarity, prefix them with "in the closed PR
+  (#<n>):" so downstream planners do not interpret them as prerequisites on
+  main. Do NOT cite paths/lines as bare `apps/x/y.ts:NN` without that prefix.
 - Prefer merge (A) over fix (B) when remaining issues are non-critical.
 - Prefer fix (B) over close_and_reissue (C) when the fix is straightforward.
 

--- a/prompts/mode-plan.txt
+++ b/prompts/mode-plan.txt
@@ -21,19 +21,20 @@ Rules:
 - Review-blocked reissues: if the issue body contains
   `Type: review-blocked-reissue` (footer block produced by the review-blocked
   judge), the file paths and line numbers cited in the body refer to the
-  closed PR's prior implementation and are intentionally absent from `main`.
-  Treat them as guidance about what the new implementation must (re)create or
-  change, NOT as prerequisite files that must already exist. Do NOT emit
-  `BLOCKED:` for "files referenced in the issue do not exist on main" in this
-  case — produce a normal plan that re-creates the relevant files. The plan
-  must call out the files-to-create explicitly under "Files likely to change."
+  closed PR's prior implementation and are intentionally absent from the
+  current planning ref. Treat them as guidance about what the new
+  implementation must (re)create or change, NOT as prerequisite files that
+  must already exist. Do NOT emit `BLOCKED:` for "files referenced in the
+  issue do not exist on the current ref" in this case — produce a normal
+  plan that re-creates the relevant files. The plan must call out the
+  files-to-create explicitly under "Files likely to change."
 - If a required input is external and non-synthesizable (branch name,
   commit SHA, credential, external URL) AND the input is required to plan
   the change itself (not merely referenced as context that the new
   implementation will replace): emit exactly `BLOCKED: <short reason>`.
   Missing source files on the current ref are NOT external inputs — they are
-  codebase state the plan can address; flag them under CONFLICT DETECTION
-  and continue planning.
+  codebase state the plan can address; note them under "Risks and edge cases"
+  as a conflict and continue planning.
 - Scope-too-large gate: if the honest estimate exceeds 60 minutes, do NOT
   emit a plan; emit exactly
   `BLOCKED: scope-too-large; estimate=<N> minutes; recommend splitting into sequential sub-issues`.

--- a/prompts/mode-plan.txt
+++ b/prompts/mode-plan.txt
@@ -18,8 +18,22 @@ Rules:
 - If any answer is missing, contradictory, or unclear: emit clarification
   questions in the mandatory `Q<ID>` / Choices format (see Mandatory Question
   Format below).
+- Review-blocked reissues: if the issue body contains
+  `Type: review-blocked-reissue` (footer block produced by the review-blocked
+  judge), the file paths and line numbers cited in the body refer to the
+  closed PR's prior implementation and are intentionally absent from `main`.
+  Treat them as guidance about what the new implementation must (re)create or
+  change, NOT as prerequisite files that must already exist. Do NOT emit
+  `BLOCKED:` for "files referenced in the issue do not exist on main" in this
+  case — produce a normal plan that re-creates the relevant files. The plan
+  must call out the files-to-create explicitly under "Files likely to change."
 - If a required input is external and non-synthesizable (branch name,
-  commit SHA, credential, external URL): emit exactly `BLOCKED: <short reason>`.
+  commit SHA, credential, external URL) AND the input is required to plan
+  the change itself (not merely referenced as context that the new
+  implementation will replace): emit exactly `BLOCKED: <short reason>`.
+  Missing source files on the current ref are NOT external inputs — they are
+  codebase state the plan can address; flag them under CONFLICT DETECTION
+  (see plan.yml inline block) and continue planning.
 - Scope-too-large gate: if the honest estimate exceeds 60 minutes, do NOT
   emit a plan; emit exactly
   `BLOCKED: scope-too-large; estimate=<N> minutes; recommend splitting into sequential sub-issues`.

--- a/prompts/mode-plan.txt
+++ b/prompts/mode-plan.txt
@@ -33,7 +33,7 @@ Rules:
   implementation will replace): emit exactly `BLOCKED: <short reason>`.
   Missing source files on the current ref are NOT external inputs — they are
   codebase state the plan can address; flag them under CONFLICT DETECTION
-  (see plan.yml inline block) and continue planning.
+  and continue planning.
 - Scope-too-large gate: if the honest estimate exceeds 60 minutes, do NOT
   emit a plan; emit exactly
   `BLOCKED: scope-too-large; estimate=<N> minutes; recommend splitting into sequential sub-issues`.


### PR DESCRIPTION
## Summary

The planner emits `BLOCKED:` when an orchestrator-managed review-blocked reissue (`Type: review-blocked-reissue`) cites file:line refs that came from the closed PR's branch. Those paths are by definition absent from `main` on the new ref, but the planning prompt's "external & non-synthesizable input" rule fires anyway and short-circuits the auto-answer flow, leaving the issue stalled in clarification.

Fixes the producer-consumer pair:

- **`prompts/mode-plan.txt`** + the inline duplicate in **`.github/workflows/plan.yml`**: add an explicit *Review-blocked reissues* rule, and narrow the `BLOCKED:` rule so missing-from-`main` file refs are routed to `CONFLICT DETECTION` (which already exists) and the plan proceeds, re-creating the cited files.
- **`prompts/mode-judge-review-blocked.txt`** (defense-in-depth): when the judge picks `close_and_reissue`, prefix unavoidable closed-PR file:line refs with `"in the closed PR (#<n>):"` so any downstream tool that consumes the body verbatim does not treat them as prerequisites on `main`.

## Repro

`bitsafe.io` issue [#63](https://github.com/shubhodeep1/bitsafe.io/issues/63) / AI Plan run [25552849965](https://github.com/shubhodeep1/bitsafe.io/actions/runs/25552849965) emitted:

> `BLOCKED: referenced apps/api and infra/do-app-spec.yaml sources are absent from checkout main at 3a444f86…`

…against issue body footer `Type: review-blocked-reissue` (produced by `scripts/review_rb_judge.sh:658-660`). With this change the planner treats those refs as files-to-create instead and continues planning, flagging the absence under the existing `CONFLICT DETECTION` block.

## Files changed

- `prompts/mode-plan.txt` — Rules block: add review-blocked rule (L21-29), narrow BLOCKED rule (L30-36).
- `.github/workflows/plan.yml` — inline `Rules:` heredoc (the planner prompt assembled in the `Run Codex planning` step): same two edits, mirrored.
- `prompts/mode-judge-review-blocked.txt` — Rules block: add option-C closed-PR file-ref guidance (L41-47).

## Backward compatibility

- §6 — additive only. No identifiers renamed; the existing `BLOCKED:` rule is narrowed (a stricter precondition) but its emission contract is unchanged. The `Type: review-blocked-reissue` footer is already produced verbatim by `scripts/review_rb_judge.sh:658-660` — no producer change required.

## Test plan

- [ ] Planner against a `Type: review-blocked-reissue` body with `apps/x:NN` refs that don't exist on `main` should produce a normal plan listing those paths under "Files likely to change," not `BLOCKED:`.
- [ ] Planner with a real external-input gap (e.g. missing branch name in clarify answers) still emits `BLOCKED:` as before.
- [ ] Judge `close_and_reissue` outputs prefix closed-PR file refs with `"in the closed PR (#<n>):"` (or use behaviour-only guidance).
- [ ] Re-run planning against `bitsafe.io` issue #63 (or an equivalent reissue) and confirm orchestrator auto-answer eligibility is no longer skipped.

https://claude.ai/code/session_01GdJz9Utsp37yyL91CzGxTi

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdJz9Utsp37yyL91CzGxTi)_