### PR TITLE
fix(plan,orchestrate_poll_process): accept "- A) text (Recommended)" in auto-answer parsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,7 @@ jobs:
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_clarify_loop_guard.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_ai_memory_processed_command_entry.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_plan_clarify_blocked_output.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_plan_auto_answer_recommended_parser.py
 
       - name: Update workflows guardrails contract test
         run: |

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -1190,7 +1190,7 @@ jobs:
             }
 
             next if !$current_qid;
-            if ($line =~ /^\s*-\s*(?:\*\*)?([A-Za-z](?:\+[A-Za-z])*)(?:\*\*)?\s*[—–-].*\(RECOMMENDED\)/i) {
+            if ($line =~ /^\s*-\s*(?:\*\*)?([A-Za-z](?:\+[A-Za-z])*)(?:\*\*)?\s*[—–\-)\.:].*\(RECOMMENDED\)/i) {
               push @{ $recommended_tokens{$current_qid} }, uc($1);
             }
           }

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -1035,7 +1035,7 @@ jobs:
             next if $in_code;
             if (/^\s*(?:\*\*)?Q[0-9]+(?:\*\*)?:(?:\*\*)?\s+/i) { $q_line = $.; next; }
             if (defined $q_line && $. - $q_line <= 20 && /^\s*Choices:\s*$/i) { $has_block = 1; }
-            if (defined $q_line && $. - $q_line <= 20 && /^\s*-\s*\*\*[A-Z]\*\*\s*[—–-]/) { $has_block = 1; }
+            if (defined $q_line && $. - $q_line <= 20 && /^\s*-\s*(?:\*\*)?[A-Za-z](?:\*\*)?\s*(?:—|–|[-)\.:])/) { $has_block = 1; }
             END { exit($has_block ? 0 : 1); }
           ' "${CODEX_OUTPUT_FILE}"; then
             HAS_STRUCTURED_CLARIFICATION_BLOCK="true"

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -1035,7 +1035,7 @@ jobs:
             next if $in_code;
             if (/^\s*(?:\*\*)?Q[0-9]+(?:\*\*)?:(?:\*\*)?\s+/i) { $q_line = $.; next; }
             if (defined $q_line && $. - $q_line <= 20 && /^\s*Choices:\s*$/i) { $has_block = 1; }
-            if (defined $q_line && $. - $q_line <= 20 && /^\s*-\s*(?:\*\*)?[A-Za-z](?:\*\*)?\s*(?:—|–|[-)\.:]).*\(RECOMMENDED\)/i) { $has_block = 1; }
+            if (defined $q_line && $. - $q_line <= 20 && /^\s*-\s*(?:\*\*)?[A-Za-z](?:\+[A-Za-z])*(?:\*\*)?\s*(?:—|–|[-)\.:]).*\(RECOMMENDED\)/i) { $has_block = 1; }
             END { exit($has_block ? 0 : 1); }
           ' "${CODEX_OUTPUT_FILE}"; then
             HAS_STRUCTURED_CLARIFICATION_BLOCK="true"

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -1190,7 +1190,7 @@ jobs:
             }
 
             next if !$current_qid;
-            if ($line =~ /^\s*-\s*(?:\*\*)?([A-Za-z](?:\+[A-Za-z])*)(?:\*\*)?\s*[—–\-)\.:].*\(RECOMMENDED\)/i) {
+            if ($line =~ /^\s*-\s*(?:\*\*)?([A-Za-z](?:\+[A-Za-z])*)(?:\*\*)?\s*(?:—|–|[-)\.:]).*\(RECOMMENDED\)/i) {
               push @{ $recommended_tokens{$current_qid} }, uc($1);
             }
           }

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -1035,7 +1035,7 @@ jobs:
             next if $in_code;
             if (/^\s*(?:\*\*)?Q[0-9]+(?:\*\*)?:(?:\*\*)?\s+/i) { $q_line = $.; next; }
             if (defined $q_line && $. - $q_line <= 20 && /^\s*Choices:\s*$/i) { $has_block = 1; }
-            if (defined $q_line && $. - $q_line <= 20 && /^\s*-\s*(?:\*\*)?[A-Za-z](?:\*\*)?\s*(?:—|–|[-)\.:])/) { $has_block = 1; }
+            if (defined $q_line && $. - $q_line <= 20 && /^\s*-\s*(?:\*\*)?[A-Za-z](?:\*\*)?\s*(?:—|–|[-)\.:]).*\(RECOMMENDED\)/i) { $has_block = 1; }
             END { exit($has_block ? 0 : 1); }
           ' "${CODEX_OUTPUT_FILE}"; then
             HAS_STRUCTURED_CLARIFICATION_BLOCK="true"

--- a/prompts/mode-clarify.txt
+++ b/prompts/mode-clarify.txt
@@ -44,6 +44,12 @@ Rules:
   (`A`, `B`, `C`, or `A+C`).
 - One decision per Q-ID. Mark at least one option `(RECOMMENDED)`.
 - Do not use numeric numbering (1, 2, 3) — only Q-IDs.
+- Each option line MUST be exactly `- **A** — <description> (RECOMMENDED)`
+  on the recommended option: bullet `-`, bold letter `**A**`, em-dash `—`,
+  and the literal uppercase token `(RECOMMENDED)`. Do not substitute
+  `A)`, `A.`, `A:`, lowercase `(recommended)`, or any other separator
+  — the auto-answer parser tolerates common drift but still depends on
+  this canonical form.
 
 Output contract (exact headings):
 STATUS: NEEDS_CLARIFICATION | CLEAR

--- a/prompts/mode-plan.txt
+++ b/prompts/mode-plan.txt
@@ -61,4 +61,11 @@ Mandatory Question Format (only when emitting clarification questions):
 >
 > Reply: `Q1: A`
 
+Each option line MUST be exactly `- **A** — <description> (RECOMMENDED)` —
+keep the bullet `-`, the bold letter `**A**`, the em-dash `—`, and the
+literal uppercase token `(RECOMMENDED)` on the recommended option.
+Do not use `A)`, `A.`, `A:`, lowercase `(recommended)`, or any other
+separator after the letter: the orchestrator auto-answer parser is
+tolerant of common drift but still depends on this canonical form.
+
 Output: plain text suitable for posting as an issue comment.

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -7138,7 +7138,7 @@ extract_recommended_answers() {
       }
       $qid = $1;
     }
-    if (defined $qid && /^\s*-\s*(?:\*\*)?([A-Za-z])(?:\*\*)?\s*(?:—|–|[-)\.:]).*\(RECOMMENDED\)/i) {
+    if (defined $qid && /^\s*-\s*(?:\*\*)?([A-Za-z](?:\+[A-Za-z])*)(?:\*\*)?\s*(?:—|–|[-)\.:]).*\(RECOMMENDED\)/i) {
       push @{$rec{$qid}}, uc($1);
     }
     END {

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -7120,11 +7120,15 @@ extract_recommended_answers() {
 
   # Parse Q-blocks and pick the (RECOMMENDED) letter(s) for each.
   # When multiple options are recommended, combine with "+" (e.g. "A+C").
-  # Expected format per question:
+  # Canonical format per question:
   #   **Q1: <question>**
   #   Choices:
   #   - **A** — <desc> (RECOMMENDED)
   #   - **B** — <desc>
+  # The bullet regex also tolerates LLM drift: optional bold around the
+  # letter, and any of "—", "–", "-", ")", ".", ":" as the separator
+  # between the letter and the description (so "- A) text (Recommended)"
+  # is accepted as well as "- **A** — text (RECOMMENDED)").
   printf '%s' "${clarify_body}" | perl -ne '
     BEGIN { @order = (); %rec = (); $qid = undef; }
     if (/^\s*\*?\*?Q(\d+)/i) {
@@ -7134,8 +7138,8 @@ extract_recommended_answers() {
       }
       $qid = $1;
     }
-    if (defined $qid && /^\s*-\s*\*\*([A-Z])\*\*\s*.*\(RECOMMENDED\)/i) {
-      push @{$rec{$qid}}, $1;
+    if (defined $qid && /^\s*-\s*(?:\*\*)?([A-Za-z])(?:\*\*)?\s*[—–\-)\.:].*\(RECOMMENDED\)/i) {
+      push @{$rec{$qid}}, uc($1);
     }
     END {
       # Flush the last question

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -7138,7 +7138,7 @@ extract_recommended_answers() {
       }
       $qid = $1;
     }
-    if (defined $qid && /^\s*-\s*(?:\*\*)?([A-Za-z])(?:\*\*)?\s*[—–\-)\.:].*\(RECOMMENDED\)/i) {
+    if (defined $qid && /^\s*-\s*(?:\*\*)?([A-Za-z])(?:\*\*)?\s*(?:—|–|[-)\.:]).*\(RECOMMENDED\)/i) {
       push @{$rec{$qid}}, uc($1);
     }
     END {

--- a/tests/test_plan_auto_answer_recommended_parser.py
+++ b/tests/test_plan_auto_answer_recommended_parser.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Behavior tests for the orchestrator auto-answer (RECOMMENDED) parsers.
+
+Two parsers in the repo extract the ``(RECOMMENDED)`` letter for each
+``Q-ID`` from a clarification-questions comment, so the orchestrator can
+auto-answer without a human:
+
+- The Perl heredoc inside ``.github/workflows/plan.yml`` (parses the
+  Codex output file and emits ``status=ok|error`` plus
+  ``mapping=Q1->A, Q2->B`` / ``answer=Q1: A, Q2: B``).
+- The ``extract_recommended_answers`` helper in
+  ``scripts/orchestrate_poll_process.sh`` (parses the latest
+  clarification comment via ``perl -ne`` and emits ``Q1: A`` /
+  ``Q1: A+B`` lines, one per Q-ID with at least one ``(RECOMMENDED)``
+  bullet).
+
+Both must accept LLM drift in option-bullet formatting:
+``- **A** — …``, ``- A — …``, ``- A) …``, ``- A. …``,
+``- A: …``. The original strict regex tripped on ``- A) …``
+output produced by Codex on issue
+``shubhodeep1/tele-funtoken-msg-scoring#2812`` (run 25560150330) and
+forced a human ``/answer``; this file pins coverage so the next regex
+tweak can't silently regress.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLAN_WF = REPO_ROOT / ".github" / "workflows" / "plan.yml"
+POLL_PROCESS = REPO_ROOT / "scripts" / "orchestrate_poll_process.sh"
+PROMPT_PLAN = REPO_ROOT / "prompts" / "mode-plan.txt"
+PROMPT_CLARIFY = REPO_ROOT / "prompts" / "mode-clarify.txt"
+
+
+def _read(path: Path) -> str:
+	return path.read_text(encoding="utf-8")
+
+
+def _extract_plan_yml_perl_heredoc() -> str:
+	wf = _read(PLAN_WF)
+	m = re.search(
+		r"perl\s*-\s*\"\$\{CODEX_OUTPUT_FILE\}\"\s*>\s*\"\$\{PARSE_RESULT_FILE\}\"\s*<<'PERL'\n(.*?)\n\s*PERL\b",
+		wf,
+		re.DOTALL,
+	)
+	assert m, "Failed to locate auto-answer Perl heredoc in plan.yml"
+	return m.group(1)
+
+
+def _run_plan_parser(input_text: str) -> dict[str, str]:
+	body = _extract_plan_yml_perl_heredoc()
+	with tempfile.TemporaryDirectory() as tmp:
+		tmp_path = Path(tmp)
+		script = tmp_path / "parser.pl"
+		script.write_text(body, encoding="utf-8")
+		input_file = tmp_path / "input.txt"
+		input_file.write_text(input_text, encoding="utf-8")
+		proc = subprocess.run(
+			["perl", str(script), str(input_file)],
+			capture_output=True,
+			text=True,
+			check=True,
+		)
+	result: dict[str, str] = {}
+	for line in proc.stdout.splitlines():
+		if "=" in line:
+			key, _, value = line.partition("=")
+			result[key.strip()] = value.strip()
+	return result
+
+
+def _extract_poll_perl_program() -> str:
+	source = _read(POLL_PROCESS)
+	m = re.search(
+		r"clarify_body\}\"\s*\|\s*perl\s*-ne\s*'(.*?)'\s*\n\s*\}\s*\n",
+		source,
+		re.DOTALL,
+	)
+	assert m, "Failed to locate perl -ne program in orchestrate_poll_process.sh"
+	return m.group(1)
+
+
+def _run_poll_parser(input_text: str) -> str:
+	program = _extract_poll_perl_program()
+	proc = subprocess.run(
+		["perl", "-ne", program],
+		input=input_text,
+		capture_output=True,
+		text=True,
+		check=True,
+	)
+	return proc.stdout
+
+
+_TEMPLATE_FORM = (
+	"Q1: Which baseline?\n"
+	"- **A** — first option (RECOMMENDED)\n"
+	"- **B** — second option\n"
+)
+
+_DASH_FORM = (
+	"Q1: Which baseline?\n"
+	"- A — first option (Recommended)\n"
+	"- B — second option\n"
+)
+
+_PAREN_FORM = (
+	"Q1: Which baseline?\n"
+	"- A) first option (Recommended)\n"
+	"- B) second option\n"
+)
+
+_PERIOD_FORM = (
+	"Q1: Which baseline?\n"
+	"- A. first option (Recommended)\n"
+	"- B. second option\n"
+)
+
+_COLON_FORM = (
+	"Q1: Which baseline?\n"
+	"- A: first option (Recommended)\n"
+	"- B: second option\n"
+)
+
+
+def test_plan_parser_accepts_template_form() -> None:
+	r = _run_plan_parser(_TEMPLATE_FORM)
+	assert r.get("status") == "ok", r
+	assert r.get("mapping") == "Q1->A", r
+	assert r.get("answer") == "Q1: A", r
+
+
+def test_plan_parser_accepts_dash_no_bold() -> None:
+	r = _run_plan_parser(_DASH_FORM)
+	assert r.get("status") == "ok", r
+	assert r.get("mapping") == "Q1->A", r
+
+
+def test_plan_parser_accepts_paren_form() -> None:
+	r = _run_plan_parser(_PAREN_FORM)
+	assert r.get("status") == "ok", r
+	assert r.get("mapping") == "Q1->A", r
+
+
+def test_plan_parser_accepts_period_form() -> None:
+	r = _run_plan_parser(_PERIOD_FORM)
+	assert r.get("status") == "ok", r
+	assert r.get("mapping") == "Q1->A", r
+
+
+def test_plan_parser_accepts_colon_form() -> None:
+	r = _run_plan_parser(_COLON_FORM)
+	assert r.get("status") == "ok", r
+	assert r.get("mapping") == "Q1->A", r
+
+
+def test_plan_parser_errors_when_no_recommended() -> None:
+	body = "Q1: Pick one\n- A — first\n- B — second\n"
+	r = _run_plan_parser(body)
+	assert r.get("status") == "error", r
+	assert r.get("reason") == "Missing recommended option for Q1", r
+
+
+def test_plan_parser_errors_when_multiple_recommended() -> None:
+	body = (
+		"Q1: Pick one\n"
+		"- A — first (Recommended)\n"
+		"- B — second (Recommended)\n"
+	)
+	r = _run_plan_parser(body)
+	assert r.get("status") == "error", r
+	assert r.get("reason") == "Multiple recommended options for Q1", r
+
+
+def test_plan_parser_errors_when_no_qids() -> None:
+	r = _run_plan_parser("nothing here\n- A — text (Recommended)\n")
+	assert r.get("status") == "error", r
+	assert r.get("reason") == "No Q-ID blocks detected", r
+
+
+def test_plan_parser_handles_real_codex_output_from_issue_2812() -> None:
+	# Verbatim Q1 line from
+	# https://github.com/shubhodeep1/tele-funtoken-msg-scoring/issues/2812#issuecomment-4407063583
+	# (failing run https://github.com/.../actions/runs/25560150330).
+	body = (
+		"Q1: Which code baseline should implementation planning target?\n"
+		"Choices:\n"
+		"- A) Current checked-out ref `main@40b4bdf28894d86465996f319f909bbfeda5ce60` (Recommended) — plan against the code that is actually present now.\n"
+		"- B) A different branch/commit — provide the exact branch name or commit SHA.\n"
+		"- C) The issue text is authoritative — re-run after the integration ref is corrected.\n"
+	)
+	r = _run_plan_parser(body)
+	assert r.get("status") == "ok", r
+	assert r.get("mapping") == "Q1->A", r
+	assert r.get("answer") == "Q1: A", r
+
+
+def test_plan_parser_skips_recommended_lines_inside_code_fences() -> None:
+	body = (
+		"Q1: Real question\n"
+		"```\n"
+		"- A — illustrative example (Recommended)\n"
+		"```\n"
+		"- B — actual option (Recommended)\n"
+	)
+	r = _run_plan_parser(body)
+	assert r.get("status") == "ok", r
+	assert r.get("mapping") == "Q1->B", r
+
+
+def test_poll_parser_accepts_template_form() -> None:
+	out = _run_poll_parser(_TEMPLATE_FORM)
+	assert out.strip() == "Q1: A", out
+
+
+def test_poll_parser_accepts_dash_no_bold() -> None:
+	out = _run_poll_parser(_DASH_FORM)
+	assert out.strip() == "Q1: A", out
+
+
+def test_poll_parser_accepts_paren_form() -> None:
+	out = _run_poll_parser(_PAREN_FORM)
+	assert out.strip() == "Q1: A", out
+
+
+def test_poll_parser_accepts_period_form() -> None:
+	out = _run_poll_parser(_PERIOD_FORM)
+	assert out.strip() == "Q1: A", out
+
+
+def test_poll_parser_accepts_colon_form() -> None:
+	out = _run_poll_parser(_COLON_FORM)
+	assert out.strip() == "Q1: A", out
+
+
+def test_poll_parser_joins_multiple_recommended_with_plus() -> None:
+	body = (
+		"Q1: Pick one\n"
+		"- A — first (Recommended)\n"
+		"- B — second\n"
+		"- C — third (RECOMMENDED)\n"
+	)
+	out = _run_poll_parser(body)
+	assert out.strip() == "Q1: A+C", out
+
+
+def test_poll_parser_silent_on_no_recommended() -> None:
+	body = "Q1: Pick one\n- A — first\n- B — second\n"
+	out = _run_poll_parser(body)
+	assert out.strip() == "", out
+
+
+def test_poll_parser_uppercases_lowercase_letter() -> None:
+	body = "Q1: Pick one\n- a) first (Recommended)\n"
+	out = _run_poll_parser(body)
+	assert out.strip() == "Q1: A", out
+
+
+def test_prompt_template_documents_canonical_recommended_form() -> None:
+	plan_prompt = _read(PROMPT_PLAN)
+	clarify_prompt = _read(PROMPT_CLARIFY)
+	for prompt in (plan_prompt, clarify_prompt):
+		assert "**A** — \\<description\\> (RECOMMENDED)" in prompt
+		assert "Each option line MUST be exactly" in prompt
+
+
+def main() -> int:
+	tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+	for test in tests:
+		test()
+	print(f"{len(tests)} passed")
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_plan_auto_answer_recommended_parser.py
+++ b/tests/test_plan_auto_answer_recommended_parser.py
@@ -279,6 +279,20 @@ def test_structured_block_detector_rejects_input_with_no_qid() -> None:
 	)
 
 
+def test_structured_block_detector_rejects_prose_bullets_without_recommended() -> None:
+	# Without `(RECOMMENDED)` on the bullet, a single-letter prose item
+	# after a Q-ID-shaped line must not falsely trigger the heuristic —
+	# otherwise the workflow sets needs_clarification=true and runs the
+	# auto-answer parser on output that is not a real clarification.
+	for body in (
+		"Q1: How does this work?\n- A. Just a single-letter prose item\n",
+		"Q1: How does this work?\n- A) Some context here, no recommended marker\n",
+		"Q1: How does this work?\n- A: caption text\n",
+		"Q1: How does this work?\n- A — text without the marker\n",
+	):
+		assert not _run_structured_block_detector(body), body
+
+
 def test_structured_block_detector_skips_lines_inside_code_fences() -> None:
 	# A bullet inside ``` ... ``` should not satisfy the heuristic on its
 	# own; only a Q-ID followed by an out-of-fence bullet should match.
@@ -327,6 +341,27 @@ def test_poll_parser_joins_multiple_recommended_with_plus() -> None:
 	)
 	out = _run_poll_parser(body)
 	assert out.strip() == "Q1: A+C", out
+
+
+def test_poll_parser_accepts_same_line_chord() -> None:
+	# The prompt rules call out `A+C` as a valid letter-only answer.
+	# When Codex emits a same-line chord recommendation
+	# (`- A+B — text (Recommended)`), the parser must capture the chord
+	# rather than silently skip the bullet (previously the single-letter
+	# capture rejected the line because `+` isn't in the separator class).
+	body = "Q1: Pick one\n- A+B — text (Recommended)\n"
+	out = _run_poll_parser(body)
+	assert out.strip() == "Q1: A+B", out
+
+
+def test_poll_parser_combines_same_line_chord_with_other_recommended_bullets() -> None:
+	body = (
+		"Q1: Pick one\n"
+		"- A+B — chord option (Recommended)\n"
+		"- C — third (RECOMMENDED)\n"
+	)
+	out = _run_poll_parser(body)
+	assert out.strip() == "Q1: A+B+C", out
 
 
 def test_poll_parser_silent_on_no_recommended() -> None:

--- a/tests/test_plan_auto_answer_recommended_parser.py
+++ b/tests/test_plan_auto_answer_recommended_parser.py
@@ -201,6 +201,20 @@ def test_plan_parser_handles_real_codex_output_from_issue_2812() -> None:
 	assert r.get("answer") == "Q1: A", r
 
 
+def test_plan_parser_rejects_utf8_punctuation_sharing_em_dash_leading_byte() -> None:
+	# The em-dash "—" is U+2014 = bytes E2 80 94 in UTF-8; en-dash "–" is
+	# U+2013 = E2 80 93. A naive byte-mode character class like
+	# ``[—–\-)\.:]`` decomposes to the byte set {E2, 80, 93, 94, -, ),
+	# ., :} and accidentally matches the leading byte of unrelated UTF-8
+	# punctuation such as U+2018 (left single quote, bytes E2 80 98).
+	# The alternation form ``(?:—|–|[-)\.:])`` matches em-/en-dash as
+	# whole 3-byte sequences and avoids the false positive.
+	body = "Q1: Pick one\n- A ‘foo’ (Recommended)\n"
+	r = _run_plan_parser(body)
+	assert r.get("status") == "error", r
+	assert r.get("reason") == "Missing recommended option for Q1", r
+
+
 def test_plan_parser_skips_recommended_lines_inside_code_fences() -> None:
 	body = (
 		"Q1: Real question\n"
@@ -260,6 +274,14 @@ def test_poll_parser_uppercases_lowercase_letter() -> None:
 	body = "Q1: Pick one\n- a) first (Recommended)\n"
 	out = _run_poll_parser(body)
 	assert out.strip() == "Q1: A", out
+
+
+def test_poll_parser_rejects_utf8_punctuation_sharing_em_dash_leading_byte() -> None:
+	# Same byte-class hazard as the plan.yml parser: ensure the script's
+	# alternation form does not falsely accept U+2018 etc.
+	body = "Q1: Pick one\n- A ‘foo’ (Recommended)\n"
+	out = _run_poll_parser(body)
+	assert out.strip() == "", out
 
 
 def test_prompt_template_documents_canonical_recommended_form() -> None:

--- a/tests/test_plan_auto_answer_recommended_parser.py
+++ b/tests/test_plan_auto_answer_recommended_parser.py
@@ -75,6 +75,30 @@ def _run_plan_parser(input_text: str) -> dict[str, str]:
 	return result
 
 
+def _extract_structured_block_perl_program() -> str:
+	wf = _read(PLAN_WF)
+	m = re.search(
+		r"HAS_STRUCTURED_CLARIFICATION_BLOCK=\"false\"\s*\n\s*if perl -ne '(.*?)'\s*\"\$\{CODEX_OUTPUT_FILE\}\";\s*then",
+		wf,
+		re.DOTALL,
+	)
+	assert m, "Failed to locate structured-block detection perl in plan.yml"
+	return m.group(1)
+
+
+def _run_structured_block_detector(input_text: str) -> bool:
+	program = _extract_structured_block_perl_program()
+	with tempfile.TemporaryDirectory() as tmp:
+		input_file = Path(tmp) / "input.txt"
+		input_file.write_text(input_text, encoding="utf-8")
+		proc = subprocess.run(
+			["perl", "-ne", program, str(input_file)],
+			capture_output=True,
+			text=True,
+		)
+	return proc.returncode == 0
+
+
 def _extract_poll_perl_program() -> str:
 	source = _read(POLL_PROCESS)
 	m = re.search(
@@ -228,6 +252,47 @@ def test_plan_parser_skips_recommended_lines_inside_code_fences() -> None:
 	assert r.get("mapping") == "Q1->B", r
 
 
+def test_structured_block_detector_accepts_template_form() -> None:
+	assert _run_structured_block_detector(
+		"Q1: Pick one\nChoices:\n- **A** — text (RECOMMENDED)\n"
+	)
+
+
+def test_structured_block_detector_accepts_paren_form() -> None:
+	# Mirrors the failing tele-funtoken-msg-scoring#2812 codex output.
+	# Without this fix, a Codex emission that uses `- A) ...` and omits
+	# `STATUS: NEEDS_CLARIFICATION` would set needs_clarification=false.
+	assert _run_structured_block_detector(
+		"Q1: Pick one\n- A) text (Recommended)\n"
+	)
+
+
+def test_structured_block_detector_accepts_dash_no_bold_form() -> None:
+	assert _run_structured_block_detector(
+		"Q1: Pick one\n- A — text (Recommended)\n"
+	)
+
+
+def test_structured_block_detector_rejects_input_with_no_qid() -> None:
+	assert not _run_structured_block_detector(
+		"Some prose without a Q-ID.\n- A — looks like a bullet (Recommended)\n"
+	)
+
+
+def test_structured_block_detector_skips_lines_inside_code_fences() -> None:
+	# A bullet inside ``` ... ``` should not satisfy the heuristic on its
+	# own; only a Q-ID followed by an out-of-fence bullet should match.
+	body = (
+		"Q1: Real question\n"
+		"```\n"
+		"- A — illustrative example (Recommended)\n"
+		"```\n"
+	)
+	# No bullet outside the fence and no Choices: line, so the block is
+	# not detected.
+	assert not _run_structured_block_detector(body)
+
+
 def test_poll_parser_accepts_template_form() -> None:
 	out = _run_poll_parser(_TEMPLATE_FORM)
 	assert out.strip() == "Q1: A", out
@@ -288,8 +353,16 @@ def test_prompt_template_documents_canonical_recommended_form() -> None:
 	plan_prompt = _read(PROMPT_PLAN)
 	clarify_prompt = _read(PROMPT_CLARIFY)
 	for prompt in (plan_prompt, clarify_prompt):
+		# Pre-existing blockquote template (escaped angle brackets so
+		# `<description>` renders literally inside the blockquote).
 		assert "**A** — \\<description\\> (RECOMMENDED)" in prompt
-		assert "Each option line MUST be exactly" in prompt
+		# New explicit canonical-form instruction (added in this change).
+		# The placeholder lives inside a backtick code span where markdown
+		# does not parse HTML, so the angle brackets stay unescaped.
+		assert (
+			"Each option line MUST be exactly `- **A** — <description> (RECOMMENDED)`"
+			in prompt
+		)
 
 
 def main() -> int:

--- a/tests/test_plan_auto_answer_recommended_parser.py
+++ b/tests/test_plan_auto_answer_recommended_parser.py
@@ -279,6 +279,21 @@ def test_structured_block_detector_rejects_input_with_no_qid() -> None:
 	)
 
 
+def test_structured_block_detector_accepts_same_line_chord_form() -> None:
+	# Codex can emit a chord recommendation on a single bullet
+	# (`- A+B — desc (Recommended)`); both the auto-answer parser at
+	# line 1193 and the poll parser accept that shape. Without chord
+	# support, a Codex emission that omits `STATUS: NEEDS_CLARIFICATION`
+	# and the `Choices:` literal would be missed by the fallback
+	# detector and the workflow would set needs_clarification=false.
+	assert _run_structured_block_detector(
+		"Q1: Pick one\n- A+B — chord recommendation (Recommended)\n"
+	)
+	assert _run_structured_block_detector(
+		"Q1: Pick one\n- **A+C** — chord with bold (RECOMMENDED)\n"
+	)
+
+
 def test_structured_block_detector_rejects_prose_bullets_without_recommended() -> None:
 	# Without `(RECOMMENDED)` on the bullet, a single-letter prose item
 	# after a Q-ID-shaped line must not falsely trigger the heuristic —


### PR DESCRIPTION
## Summary

Both auto-answer parsers (the Perl heredoc in `.github/workflows/plan.yml` and `extract_recommended_answers` in `scripts/orchestrate_poll_process.sh`) rejected codex output that used `- A) text (Recommended)` formatting, forcing fallback to a human `/answer` even when option A was clearly marked. plan.yml's regex required a dash-class separator (`[—–-]`) after the letter; the script's regex required bolded `**A**`.

Reproduced on `shubhodeep1/tele-funtoken-msg-scoring#2812`, run [25560150330](https://github.com/shubhodeep1/tele-funtoken-msg-scoring/actions/runs/25560150330) (against `@stable` = `v1.8.1` = `e325da3`):

1. Poller emits `/answer [auto-answered-by-poller]` with no Q→letter pairs (script regex didn't match — required `**A**`).
2. Plan re-clarifies; codex emits `- A) … (Recommended) — …` for Q1/Q2/Q3.
3. plan.yml parser rejects the lines with `Missing recommended option for Q1` (workflow regex didn't accept `)` separator).
4. Issue is parked for human `/answer` even though A was clearly recommended.

## Changes

- **`.github/workflows/plan.yml:1193`** — broaden the separator class from `[—–-]` to `[—–\-)\.:]`. Single-letter capture, `(RECOMMENDED)` requirement, and `^[A-Z]$` downstream validation are unchanged.
- **`scripts/orchestrate_poll_process.sh:7137`** — align the sibling helper with the same pattern: optional bold around the letter, accept any of `—`, `–`, `-`, `)`, `.`, `:` as separator. Also `uc($1)` for consistent uppercase output and refresh the docstring.
- **`prompts/mode-plan.txt`, `prompts/mode-clarify.txt`** — spell out the canonical `- **A** — <description> (RECOMMENDED)` form so codex drifts less often (belt-and-braces; the parser change is the actual fix).
- **`tests/test_plan_auto_answer_recommended_parser.py`** *(new, 19 tests)* — extracts and runs the actual Perl heredoc and the script's `perl -ne` program against representative inputs:
  - template / dash-no-bold / paren / period / colon forms (all parsers must accept)
  - the verbatim Q1 line from issue 2812
  - error paths: missing-recommended, multiple-recommended, no-Q-IDs, code-fence skipping
  - script-only: chord join (`A+C`), silent-no-recommended, lowercase letter uppercased
  - prompt contracts: canonical-form sentence is present in both prompt files

## Test plan

- [x] `python3 tests/test_plan_auto_answer_recommended_parser.py` → 19 passed
- [x] `python3 tests/test_plan_clarify_blocked_output.py` → 4 passed (no regression)
- [x] `bash -n scripts/orchestrate_poll_process.sh` → ok
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/plan.yml'))"` → ok
- [x] False-positive guards verified against `- abc) …`, `- 1. …`, free-text `(RECOMMENDED)`, and indented bullets
- [ ] CI on this PR

## Notes

- No README/agents.md update needed: the externally-visible behavior described at `README.md:1056` is unchanged — this PR widens the parser's *acceptance set* but the auto-answer / human-fallback contract still reads the same.
- After merge, the moving `stable` tag should be rolled forward via the existing release process so consumer repos pinning `@stable` pick up the fix.

https://claude.ai/code/session_01K7poqNGSG8acjC1reqJ9Gu

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7poqNGSG8acjC1reqJ9Gu)_