### PR TITLE
Bump analyze-commit-notify timeout 30 → 60m after run #25558885206 cancellation

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3334,11 +3334,11 @@ jobs:
         # its 30m cap, run #25200117236 cancelled at 60m 11s on
         # api-redundancy with its 60m cap (now 90m, see workflow-log-
         # analysis.yml), run #25474659590 cancelled at 45m 16s on
-        # deep-audit with its prior 45m cap (now 75m), and run
-        # #25558885206 cancelled at 30m 14s on analyze-commit-notify
-        # with its prior 30m cap (now 60m). Per Copilot review on
-        # PR #1742: the previous 95m setting could still time out a
-        # healthy run that hit the worst case.
+        # deep-audit with its prior 45m cap (now 75m), and run #25558885206
+        # cancelled at 30m 14s on analyze-commit-notify with its
+        # prior 30m cap (now 60m). Per Copilot review on PR #1742:
+        # the previous 95m setting could still time out a healthy
+        # run that hit the worst case.
         timeout-minutes: 265
         env:
           WF_FILE: workflow-log-analysis.yml

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3253,8 +3253,8 @@ jobs:
     runs-on: ubuntu-latest
     # 45m was sized for the original 2-job workflow-log-analysis. The
     # workflow now has four sequential jobs (collect-logs 25m,
-    # analyze-commit-notify 30m, deep-audit 75m, api-redundancy 90m —
-    # ceiling ~220m), and run #25088541089 cancelled at 30m 16s on
+    # analyze-commit-notify 60m, deep-audit 75m, api-redundancy 90m —
+    # ceiling ~250m), and run #25088541089 cancelled at 30m 16s on
     # `deep-audit` (its previous 30m timeout-minutes), so deep-audit
     # was bumped to 45m in workflow-log-analysis.yml:603. Run #25115192726
     # then cancelled at 30m 19s on api-redundancy with that job's prior
@@ -3263,9 +3263,12 @@ jobs:
     # still in "Plan update → Draft" phase), so api-redundancy was
     # bumped to 90m. Run #25474659590 cancelled at 45m 16s on deep-audit
     # (a slow ~24m attempt + forced retry), so deep-audit was bumped
-    # 45 → 75m in workflow-log-analysis.yml. Sum of in-step DEADLINEs
-    # below (workflow-log-analysis 13800 + validation-refresh 2400 +
-    # update_workflows 600 + memory-maintenance 900 = 17700s ≈ 295m).
+    # 45 → 75m in workflow-log-analysis.yml. Run #25558885206 cancelled
+    # at 30m 14s on analyze-commit-notify with its prior 30m cap (Codex
+    # pass alone ran ~26m 31s vs the 9–13m successful-neighbour norm),
+    # so analyze-commit-notify was bumped 30 → 60m. Sum of in-step
+    # DEADLINEs below (workflow-log-analysis 15600 + validation-refresh
+    # 2400 + update_workflows 600 + memory-maintenance 900 = 19500s ≈ 325m).
     # This job also spends
     # additional wall time outside those DEADLINE windows on prerequisite
     # validation, checkout, and the per-phase run-soft-error-analyzer
@@ -3278,7 +3281,10 @@ jobs:
     # alongside the deep-audit 45 → 75m bump (run #25474659590), which
     # raised sum-of-in-step-DEADLINEs from 265m to 295m; restoring the
     # original ~65m of headroom for soft-error analyzers + queueing.
-    timeout-minutes: 360
+    # Bumped 360 → 390 alongside the analyze-commit-notify 30 → 60m bump
+    # (run #25558885206), which raised sum-of-in-step-DEADLINEs from
+    # 295m to 325m; preserving the same ~65m headroom.
+    timeout-minutes: 390
     env:
       GH_TOKEN: ${{ secrets.GH_PAT }}
       TEST_REPO: ${{ inputs.test_repo || github.repository }}
@@ -3319,19 +3325,21 @@ jobs:
         # but a per-step bound makes the failure attribute to the right
         # step instead of cancelling all sibling steps in the job.
         # Sized to the workflow-log-analysis 4-job sequential worst-case
-        # (collect-logs 25m + analyze-commit-notify 30m + deep-audit
-        # 75m + api-redundancy 90m = 220m) plus a 15m runner-queue +
+        # (collect-logs 25m + analyze-commit-notify 60m + deep-audit
+        # 75m + api-redundancy 90m = 250m) plus a 15m runner-queue +
         # step-setup buffer; release v1.0.113 watcher exited at 28m
         # while deep-audit was still running, run #25088541089
         # cancelled at 30m 16s on deep-audit with its prior 30m cap,
         # run #25115192726 cancelled at 30m 19s on api-redundancy with
         # its 30m cap, run #25200117236 cancelled at 60m 11s on
         # api-redundancy with its 60m cap (now 90m, see workflow-log-
-        # analysis.yml), and run #25474659590 cancelled at 45m 16s on
-        # deep-audit with its prior 45m cap (now 75m). Per Copilot
-        # review on PR #1742: the previous 95m setting could still
-        # time out a healthy run that hit the worst case.
-        timeout-minutes: 235
+        # analysis.yml), run #25474659590 cancelled at 45m 16s on
+        # deep-audit with its prior 45m cap (now 75m), and run
+        # #25558885206 cancelled at 30m 14s on analyze-commit-notify
+        # with its prior 30m cap (now 60m). Per Copilot review on
+        # PR #1742: the previous 95m setting could still time out a
+        # healthy run that hit the worst case.
+        timeout-minutes: 265
         env:
           WF_FILE: workflow-log-analysis.yml
           INPUTS: '{"lookback_days":"1","repos_override":"${{ inputs.test_repo || github.repository }}"}'
@@ -3343,10 +3351,10 @@ jobs:
             --field lookback_days=1 \
             --field repos_override="${TEST_REPO}" \
             --field alert_msg_level=SILENT
-          # 13800s (230m) covers the 220m worst-case audit chain
-          # (collect-logs 25m + analyze-commit-notify 30m + deep-audit
+          # 15600s (260m) covers the 250m worst-case audit chain
+          # (collect-logs 25m + analyze-commit-notify 60m + deep-audit
           # 75m + api-redundancy 90m) plus a 10m buffer for runner
-          # queueing between jobs. Step timeout-minutes above (235m)
+          # queueing between jobs. Step timeout-minutes above (265m)
           # is the outer cap that attributes a hang to this step.
           # Bumped 7200 → 8400 after deep-audit's per-job cap was
           # raised 30m → 45m in workflow-log-analysis.yml:603 (run
@@ -3362,7 +3370,11 @@ jobs:
           # raised 45m → 75m (run #25474659590 cancelled at 45m 16s on
           # deep-audit; codex attempt 1 ran ~24m and forced a retry
           # that was killed mid-attempt-2 by the 45m cap).
-          DEADLINE=$(( $(date +%s) + 13800 ))
+          # Bumped 13800 → 15600 after analyze-commit-notify's per-job
+          # cap was raised 30m → 60m (run #25558885206 cancelled at
+          # 30m 14s on analyze-commit-notify; Codex pass alone ran
+          # ~26m 31s vs the 9–13m norm).
+          DEADLINE=$(( $(date +%s) + 15600 ))
           NEW_ID=""
           while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
             NEW_ID=$(gh api "repos/${TEST_REPO}/actions/workflows/${WF_FILE}/runs?per_page=10" \

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -183,10 +183,21 @@ jobs:
     # 11m 57s, 25470798500 12m 46s), so this run hit a slow Codex pass /
     # retry under the 30m cap. Bumped 30 → 60m to mirror the api-redundancy
     # 30 → 60m precedent (run #25115192726). When this is bumped again,
-    # also propagate the +Δ minutes through test-and-mark-stable.yml's
-    # `Dispatch & watch — workflow-log-analysis` step (in-script DEADLINE
-    # in seconds, step timeout-minutes, and the job-level timeout-minutes
-    # with its sum-of-DEADLINEs comment).
+    # also propagate the +Δ minutes through every caller that watches a
+    # dispatched run of this workflow:
+    #   1. test-and-mark-stable.yml's `orphan-workflows-test` →
+    #      `Dispatch & watch — workflow-log-analysis` step (in-script
+    #      DEADLINE in seconds, step timeout-minutes, and the job-level
+    #      timeout-minutes with its sum-of-DEADLINEs comment).
+    #   2. comprehensive-test-and-release.yml's
+    #      `phase2-collect-and-analyze-logs` (and the downstream
+    #      `phase3-...` job that reuses the same watcher pattern) —
+    #      both currently capped at `timeout-minutes: 120`. The watcher
+    #      is idle-based (INACTIVITY_LIMIT = phase_timeout * 60), so a
+    #      progressing run won't trigger the soft idle exit, but the
+    #      hard 120m job cap can still cancel a healthy run whose chain
+    #      now totals up to 250m. Bump those caps if/when this worst
+    #      case becomes observable in those callers.
     timeout-minutes: 60
     outputs:
       report_file: ${{ steps.analyze.outputs.report_file }}

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -177,7 +177,17 @@ jobs:
   analyze-commit-notify:
     needs: collect-logs
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Run #25558885206 cancelled at 30m 14s on this job (Codex pass alone
+    # ran ~26m 31s — start 13:47:06, ##[error]The operation was canceled
+    # 14:13:38). Successful neighbours took only 9–13m (e.g. 25548339583
+    # 11m 57s, 25470798500 12m 46s), so this run hit a slow Codex pass /
+    # retry under the 30m cap. Bumped 30 → 60m to mirror the api-redundancy
+    # 30 → 60m precedent (run #25115192726). When this is bumped again,
+    # also propagate the +Δ minutes through test-and-mark-stable.yml's
+    # `Dispatch & watch — workflow-log-analysis` step (in-script DEADLINE
+    # in seconds, step timeout-minutes, and the job-level timeout-minutes
+    # with its sum-of-DEADLINEs comment).
+    timeout-minutes: 60
     outputs:
       report_file: ${{ steps.analyze.outputs.report_file }}
       analysis_status: ${{ steps.analyze.outputs.analysis_status }}


### PR DESCRIPTION
## Summary

Release run [#25558853263](https://github.com/shubhodeep1/coding-workflows/actions/runs/25558853263) (v1.8.2) failed in `orphan-workflows-test` because the dispatched [`workflow-log-analysis` run #25558885206](https://github.com/shubhodeep1/coding-workflows/actions/runs/25558885206) was cancelled.

**Root cause:** the cancelled run's `analyze-commit-notify` job hit its `timeout-minutes: 30` cap at 30m 14s (annotation: `The job has exceeded the maximum execution time of 30m0s`). Inside that job, the "Run workflow log analysis" Codex pass started at 13:47:06 and the runner emitted `##[error]The operation was canceled.` at 14:13:38 — ~26m 31s of Codex alone, vs the 9–13m successful-neighbour norm (e.g. 25548339583 11m 57s, 25470798500 12m 46s).

This mirrors the established precedent in this repo for `deep-audit` (30 → 45 → 75) and `api-redundancy` (30 → 60 → 90): bump the per-job cap, then propagate the +Δ minutes through the orchestrator's matching DEADLINE/step/job timeouts.

## Changes

- `.github/workflows/workflow-log-analysis.yml:177` — `analyze-commit-notify` `timeout-minutes: 30 → 60`, with comment trail referencing run #25558885206.
- `.github/workflows/test-and-mark-stable.yml:3253` — `orphan-workflows-test` job-level `timeout-minutes: 360 → 390` (sum-of-DEADLINEs 295m → 325m, preserving the documented ~65m headroom for soft-error analyzers + queueing).
- `.github/workflows/test-and-mark-stable.yml:3334` — `Dispatch & watch — workflow-log-analysis` step `timeout-minutes: 235 → 265` (worst case 220m → 250m + 15m runner-queue/setup buffer).
- `.github/workflows/test-and-mark-stable.yml:3365` — in-script `DEADLINE: 13800 → 15600 s` (worst case 250m + 10m queueing buffer).

Comment trails in both files updated to record this bump alongside the prior deep-audit and api-redundancy entries.

## Test plan

- [ ] Re-trigger the release workflow (or `orphan-workflows-test` directly via `workflow_dispatch`) and verify `analyze-commit-notify` completes within the new 60m cap.
- [ ] Confirm the four-job sequential `workflow-log-analysis` chain (collect-logs → analyze-commit-notify → deep-audit → api-redundancy) finishes inside the new 15600s in-script DEADLINE under normal Codex latency.
- [ ] Check that no other job in the release workflow regressed against the 390m job-level cap.

https://claude.ai/code/session_01MgNkzqiLGeNiBZiZieZzsb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgNkzqiLGeNiBZiZieZzsb)_