### PR TITLE
fix(workflow-log-analysis): retry-with-rename on concurrent report push

### DIFF
--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -200,7 +200,11 @@ jobs:
     #      case becomes observable in those callers.
     timeout-minutes: 60
     outputs:
-      report_file: ${{ steps.analyze.outputs.report_file }}
+      # commit_report may rename REPORT_FILE on a concurrent-write
+      # collision; downstream jobs (deep-audit, api-redundancy) must see
+      # the post-rename path, so prefer commit_report's output and fall
+      # back to analyze.outputs.report_file when commit_report did not run.
+      report_file: ${{ steps.commit_report.outputs.report_file || steps.analyze.outputs.report_file }}
       analysis_status: ${{ steps.analyze.outputs.analysis_status }}
     env:
       CODEX_VERSION: ${{ vars.CODEX_VERSION || 'v0.114.0' }}
@@ -583,6 +587,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "No report changes to commit."
             echo "committed=false" >> "$GITHUB_OUTPUT"
+            echo "report_file=${REPORT_FILE}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -592,10 +597,61 @@ jobs:
             commit_msg="chore: add workflow log analysis report"
           fi
           git commit -m "${commit_msg}"
-          git pull --rebase origin "${TARGET_BRANCH}"
-          git push origin "HEAD:${TARGET_BRANCH}"
+
+          # Concurrent runs of this workflow can each pick the same dated
+          # suffix (e.g. "...-3.md") because the suffix is derived from
+          # the local checkout in the analyze step, before Codex runs for
+          # 30+ minutes. By push time, another run may have already
+          # published the same path on TARGET_BRANCH, which makes
+          # `git pull --rebase` abort with an add/add conflict.
+          # Retry-with-rename: fetch the latest tip, and if our path
+          # already exists upstream, rename our report to the next free
+          # suffix (considering both the local checkout and origin),
+          # amend the commit, and retry the rebase + push. The retry
+          # bound covers the small race window between fetch and push.
+          REPORT_BASE=""
+          if [[ "${REPORT_FILE}" =~ ^(analysis/workflow-optimization-[0-9]{4}-[0-9]{2}-[0-9]{2})(-[0-9]+)?\.md$ ]]; then
+            REPORT_BASE="${BASH_REMATCH[1]}"
+          fi
+          push_attempt=0
+          push_max_attempts=5
+          while : ; do
+            push_attempt=$((push_attempt + 1))
+            git fetch origin "${TARGET_BRANCH}" --depth=1
+
+            if [ -n "${REPORT_BASE}" ] && git cat-file -e "FETCH_HEAD:${REPORT_FILE}" 2>/dev/null; then
+              next_suffix=2
+              while [ -e "${REPORT_BASE}-${next_suffix}.md" ] \
+                 || git cat-file -e "FETCH_HEAD:${REPORT_BASE}-${next_suffix}.md" 2>/dev/null; do
+                next_suffix=$((next_suffix + 1))
+              done
+              NEW_REPORT_FILE="${REPORT_BASE}-${next_suffix}.md"
+              echo "INFO: '${REPORT_FILE}' already exists on origin/${TARGET_BRANCH}; renaming to '${NEW_REPORT_FILE}' to avoid concurrent-write collision."
+              git mv -- "${REPORT_FILE}" "${NEW_REPORT_FILE}"
+              REPORT_FILE="${NEW_REPORT_FILE}"
+              git commit --amend --no-edit
+            fi
+
+            if git pull --rebase origin "${TARGET_BRANCH}" \
+               && git push origin "HEAD:${TARGET_BRANCH}"; then
+              break
+            fi
+
+            # Clean up an in-progress rebase so the next iteration starts
+            # from a known state.
+            if [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then
+              git rebase --abort || true
+            fi
+
+            if [ "${push_attempt}" -ge "${push_max_attempts}" ]; then
+              echo "::error::Could not push workflow log analysis report after ${push_attempt} attempt(s) (target=${TARGET_BRANCH}, file=${REPORT_FILE})."
+              exit 1
+            fi
+            echo "::warning::Workflow log analysis report push attempt ${push_attempt} failed; retrying."
+          done
 
           echo "committed=true" >> "$GITHUB_OUTPUT"
+          echo "report_file=${REPORT_FILE}" >> "$GITHUB_OUTPUT"
 
       - name: Send Telegram notification
         if: always()
@@ -618,7 +674,10 @@ jobs:
           source scripts/tg_helpers.sh
 
           ANALYSIS_STATUS="${{ steps.analyze.outputs.analysis_status || '' }}"
-          REPORT_FILE="${{ steps.analyze.outputs.report_file || '' }}"
+          # commit_report may rename REPORT_FILE on a concurrent-write
+          # collision; use its output when present so the Telegram link
+          # points at the file that was actually pushed.
+          REPORT_FILE="${{ steps.commit_report.outputs.report_file || steps.analyze.outputs.report_file || '' }}"
           REPORT_URL=""
           if [ -n "${REPORT_FILE}" ]; then
             REPORT_URL="${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/${REPORT_FILE}"


### PR DESCRIPTION
Superseded by #2340 — retargeted onto `stable` per request. Branch retained for history; rebased copy on `claude/fix-orphan-workflows-test-stable-1IvMV` is the live one.

(Original description preserved below.)

---

## Summary

- Release v1.8.2 (run [25568050819](https://github.com/shubhodeep1/coding-workflows/actions/runs/25568050819)) failed because `orphan-workflows-test` dispatched a `workflow-log-analysis` run ([25568083133](https://github.com/shubhodeep1/coding-workflows/actions/runs/25568083133)) which exited 1 at "Commit and push report".
- Root cause: two parallel `workflow-log-analysis` runs each derived the same dated suffix `analysis/workflow-optimization-2026-05-08-3.md` because the suffix is computed in the `analyze` step from the local checkout, before Codex runs for 30+ minutes. The first run pushed; the second hit `CONFLICT (add/add)` during `git pull --rebase origin main` and the `set -e` step terminated.
- Fix: in `analyze-commit-notify` → `commit_report`, after `git commit`, fetch `origin/${TARGET_BRANCH}` and check if our `REPORT_FILE` already exists upstream. If yes, derive the next free suffix from both the local working tree and origin tip, `git mv` to that path, `git commit --amend --no-edit`, then `git pull --rebase && git push`. Wrap in a 5-attempt loop to cover the small race window between fetch and push. Expose the post-rename path via a new `commit_report.outputs.report_file` output so downstream jobs (`deep-audit`, `api-redundancy`) and the in-job Telegram notifier point at the file actually pushed.

https://claude.ai/code/session_0141DETcYxuqDBS7qupLmHsH