### PR TITLE
ci(release): split workflow-log-analysis dispatch into non-blocking job

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -27,8 +27,9 @@ name: Test & Mark Stable Release
       dry_run:
         description: >
           Validate only — do not push tags or create release. Also skips every
-          live-dispatch e2e job (smoke, orphan-workflows, orchestrate-decompose,
-          validate-standalone, clarify-rejects-unsolvable, alt-model) so a
+          live-dispatch e2e job (smoke, workflow-log-analysis, orphan-workflows,
+          orchestrate-decompose, validate-standalone, clarify-rejects-unsolvable,
+          alt-model) so a
           dry run never mutates the test repo. Static checks (validate-scripts)
           still run so the gate can verify scripts/lint/yaml health without
           burning live test resources or polluting GitHub state. Use
@@ -3241,50 +3242,43 @@ jobs:
       - *git-checkout-diag
 
   # ──────────────────────────────────────────────────────────────────
-  # Job 1c: Orphan workflows live-dispatch test
-  # Dispatches each user-facing workflow that the e2e smoke test does
-  # NOT exercise (workflow-log-analysis, validation-refresh,
-  # update_workflows, memory_maintenance) and waits for completion.
-  # cancel_on_pr_close is exercised inside e2e-smoke-test Phase 7.
+  # Job 1c-1: Workflow-log-analysis live-dispatch smoke gate
+  # Split out of `orphan-workflows-test` (PR #2347, follow-up to release
+  # v1.8.2 which failed when the inner `api-redundancy` job hit its 90m
+  # per-job cap and cancelled the dispatch chain). The Codex audit chain
+  # has a Codex-driven long tail that periodically blows past whatever
+  # cap the watcher uses, and a cancelled audit pass does not invalidate
+  # the release artefact — the audit is a post-hoc log inspector, not a
+  # release-correctness check. To stop those cancellations from blocking
+  # `validate` / `release` / `sync-to-main`, this dispatch lives in its
+  # own job that is intentionally NOT in `validate.needs`. It still feeds
+  # the `notify` job so operators see its result in the Telegram release
+  # message and the soft-error report artifact still flows into the
+  # consolidated report.
+  # Sum of in-step DEADLINEs below (workflow-log-analysis 15600s = 260m)
+  # plus headroom for prerequisite validation, checkout, and the
+  # run-soft-error-analyzer composite (each waits up to
+  # wait_for_completion_secs=120s and runs an OpenRouter call via
+  # scripts/analyze_soft_errors.py; log1 of run #25200117236 observed
+  # ~40s, so under OpenRouter latency variance plausibly 2–3m). The
+  # 265m step timeout-minutes attributes a hang to the dispatch step;
+  # the job-level cap below is the outer safety net.
+  # Cap derivation: 260m DEADLINE + 5m runner queueing + 3m soft-error
+  # analyser ≈ 268m → round to 280m for headroom. Previously this work
+  # lived inside orphan-workflows-test which had a 390m cap covering
+  # workflow-log-analysis + validation-refresh + update_workflows +
+  # memory_maintenance combined; the per-job split lets each cap track
+  # only its own dispatch chain.
+  # When workflow-log-analysis.yml's per-job timeouts are bumped again
+  # (deep-audit 30→45→75m, api-redundancy 30→60→90m, analyze-commit-notify
+  # 30→60m so far), bump the in-step DEADLINE and step timeout-minutes
+  # in this job too so the watcher outlives the new worst case.
   # ──────────────────────────────────────────────────────────────────
-  orphan-workflows-test:
+  workflow-log-analysis-test:
     needs: [resolve-version]
     if: ${{ !inputs.skip_e2e && !inputs.dry_run }}
     runs-on: ubuntu-latest
-    # 45m was sized for the original 2-job workflow-log-analysis. The
-    # workflow now has four sequential jobs (collect-logs 25m,
-    # analyze-commit-notify 60m, deep-audit 75m, api-redundancy 90m —
-    # ceiling ~250m), and run #25088541089 cancelled at 30m 16s on
-    # `deep-audit` (its previous 30m timeout-minutes), so deep-audit
-    # was bumped to 45m in workflow-log-analysis.yml:603. Run #25115192726
-    # then cancelled at 30m 19s on api-redundancy with that job's prior
-    # 30m cap, so api-redundancy was bumped to 60m. Run #25200117236
-    # cancelled at 60m 11s on api-redundancy with that 60m cap (Codex
-    # still in "Plan update → Draft" phase), so api-redundancy was
-    # bumped to 90m. Run #25474659590 cancelled at 45m 16s on deep-audit
-    # (a slow ~24m attempt + forced retry), so deep-audit was bumped
-    # 45 → 75m in workflow-log-analysis.yml. Run #25558885206 cancelled
-    # at 30m 14s on analyze-commit-notify with its prior 30m cap (Codex
-    # pass alone ran ~26m 31s vs the 9–13m successful-neighbour norm),
-    # so analyze-commit-notify was bumped 30 → 60m. Sum of in-step
-    # DEADLINEs below (workflow-log-analysis 15600 + validation-refresh
-    # 2400 + update_workflows 600 + memory-maintenance 900 = 19500s ≈ 325m).
-    # This job also spends
-    # additional wall time outside those DEADLINE windows on prerequisite
-    # validation, checkout, and the per-phase run-soft-error-analyzer
-    # composite actions (each waits up to wait_for_completion_secs=120s
-    # and then runs an OpenRouter call via scripts/analyze_soft_errors.py;
-    # log1 of run #25200117236 observed ~40s for one phase, so 4 phases
-    # under OpenRouter latency variance can plausibly reach 8–12m), so
-    # keep extra headroom for that work as well as runner queueing and
-    # step setup. Per Copilot review on PR #1842. Bumped 330 → 360
-    # alongside the deep-audit 45 → 75m bump (run #25474659590), which
-    # raised sum-of-in-step-DEADLINEs from 265m to 295m; restoring the
-    # original ~65m of headroom for soft-error analyzers + queueing.
-    # Bumped 360 → 390 alongside the analyze-commit-notify 30 → 60m bump
-    # (run #25558885206), which raised sum-of-in-step-DEADLINEs from
-    # 295m to 325m; preserving the same ~65m headroom.
-    timeout-minutes: 390
+    timeout-minutes: 280
     env:
       GH_TOKEN: ${{ secrets.GH_PAT }}
       TEST_REPO: ${{ inputs.test_repo || github.repository }}
@@ -3293,7 +3287,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN}" ]; then
-            echo "::error::GH_PAT secret is required for orphan-workflow dispatch"
+            echo "::error::GH_PAT secret is required for workflow-log-analysis dispatch"
             exit 1
           fi
 
@@ -3304,19 +3298,6 @@ jobs:
           ref: main
           fetch-depth: 1
 
-      # Generic helper: dispatch a workflow_dispatch workflow by file name
-      # and capture the resulting run id, then wait for completion. Each
-      # invocation runs in its own step so failures attribute to the
-      # specific workflow.
-      #
-      # Rate-limit shaping: each dispatch step opens with a brief 4s
-      # sleep so concurrent gate jobs (e2e-smoke-test, alt-model,
-      # orchestrate-decompose, etc.) don't all hit the
-      # `actions/workflows/.../runs` and `actions/runs/...` endpoints in
-      # the same instant when they happen to start within seconds of
-      # each other. The PR-review concern was that simultaneous
-      # dispatches collide; this stagger plus the existing 5–15 s polling
-      # intervals keep total API spend well below GH_PAT's 5000/hr budget.
       - name: Dispatch & watch — workflow-log-analysis
         id: dispatch_log_analysis
         # Per-step backstop in case the in-script `DEADLINE` math goes
@@ -3327,18 +3308,7 @@ jobs:
         # Sized to the workflow-log-analysis 4-job sequential worst-case
         # (collect-logs 25m + analyze-commit-notify 60m + deep-audit
         # 75m + api-redundancy 90m = 250m) plus a 15m runner-queue +
-        # step-setup buffer; release v1.0.113 watcher exited at 28m
-        # while deep-audit was still running, run #25088541089
-        # cancelled at 30m 16s on deep-audit with its prior 30m cap,
-        # run #25115192726 cancelled at 30m 19s on api-redundancy with
-        # its 30m cap, run #25200117236 cancelled at 60m 11s on
-        # api-redundancy with its 60m cap (now 90m, see workflow-log-
-        # analysis.yml), run #25474659590 cancelled at 45m 16s on
-        # deep-audit with its prior 45m cap (now 75m), and run #25558885206
-        # cancelled at 30m 14s on analyze-commit-notify with its
-        # prior 30m cap (now 60m). Per Copilot review on PR #1742:
-        # the previous 95m setting could still time out a healthy
-        # run that hit the worst case.
+        # step-setup buffer.
         timeout-minutes: 265
         env:
           WF_FILE: workflow-log-analysis.yml
@@ -3356,24 +3326,6 @@ jobs:
           # 75m + api-redundancy 90m) plus a 10m buffer for runner
           # queueing between jobs. Step timeout-minutes above (265m)
           # is the outer cap that attributes a hang to this step.
-          # Bumped 7200 → 8400 after deep-audit's per-job cap was
-          # raised 30m → 45m in workflow-log-analysis.yml:603 (run
-          # #25088541089 had cancelled at 30m 16s on deep-audit).
-          # Bumped 8400 → 10200 after api-redundancy's per-job cap was
-          # raised 30m → 60m (run #25115192726 cancelled at 30m 19s
-          # on api-redundancy with its prior 30m cap).
-          # Bumped 10200 → 12000 after api-redundancy's per-job cap was
-          # raised 60m → 90m (run #25200117236 cancelled at 60m 11s on
-          # api-redundancy with its prior 60m cap, Codex still in "Plan
-          # update → Draft" phase).
-          # Bumped 12000 → 13800 after deep-audit's per-job cap was
-          # raised 45m → 75m (run #25474659590 cancelled at 45m 16s on
-          # deep-audit; codex attempt 1 ran ~24m and forced a retry
-          # that was killed mid-attempt-2 by the 45m cap).
-          # Bumped 13800 → 15600 after analyze-commit-notify's per-job
-          # cap was raised 30m → 60m (run #25558885206 cancelled at
-          # 30m 14s on analyze-commit-notify; Codex pass alone ran
-          # ~26m 31s vs the 9–13m norm).
           DEADLINE=$(( $(date +%s) + 15600 ))
           NEW_ID=""
           while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
@@ -3412,12 +3364,81 @@ jobs:
           phase_runs: |
             workflow_log_analysis=${{ steps.dispatch_log_analysis.outputs.run_id }}
           repo: ${{ env.TEST_REPO }}
+          # Artifact name preserved verbatim (was emitted by the same
+          # name when this step lived inside orphan-workflows-test);
+          # the notify-job consolidator's
+          # `pattern: soft-error-report-${{ github.run_id }}-*` glob
+          # still picks it up unchanged.
           artifact_name: soft-error-report-${{ github.run_id }}-workflow_log_analysis
           openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
           gh_token: ${{ secrets.GH_PAT }}
           model: ${{ vars.LOG_ANALYZER_MODEL || 'openai/gpt-5.4-mini' }}
           reasoning: ${{ vars.LOG_ANALYZER_REASONING || 'medium' }}
 
+  # ──────────────────────────────────────────────────────────────────
+  # Job 1c-2: Orphan workflows live-dispatch test
+  # Dispatches each user-facing workflow that the e2e smoke test does
+  # NOT exercise — except `workflow-log-analysis`, which now lives in
+  # its own job (`workflow-log-analysis-test`) so its Codex-driven long
+  # tail can no longer block `validate` / `release` / `sync-to-main`.
+  # Remaining dispatches: validation-refresh, update_workflows,
+  # memory_maintenance.
+  # cancel_on_pr_close is exercised inside e2e-smoke-test Phase 7.
+  # ──────────────────────────────────────────────────────────────────
+  orphan-workflows-test:
+    needs: [resolve-version]
+    if: ${{ !inputs.skip_e2e && !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    # Sum of remaining in-step DEADLINEs (validation-refresh 2400s +
+    # update_workflows 600s + memory-maintenance 900s = 3900s ≈ 65m).
+    # Add headroom for prerequisite validation, checkout, and the
+    # per-phase run-soft-error-analyzer composite actions (each waits
+    # up to wait_for_completion_secs=120s and then runs an OpenRouter
+    # call; log1 of run #25200117236 observed ~40s per phase, so 3
+    # phases under OpenRouter latency variance can plausibly reach
+    # 6–9m), runner queueing, and step setup. Cap at 90m so a runaway
+    # validation-refresh / update_workflows / memory_maintenance can
+    # still be killed within a sensible budget. Down from 390m before
+    # the workflow-log-analysis split-out.
+    timeout-minutes: 90
+    env:
+      GH_TOKEN: ${{ secrets.GH_PAT }}
+      TEST_REPO: ${{ inputs.test_repo || github.repository }}
+    steps:
+      - name: Validate prerequisites
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::GH_PAT secret is required for orphan-workflow dispatch"
+            exit 1
+          fi
+
+      # Required for the run-soft-error-analyzer composite action below.
+      - name: Checkout repository (for soft-error analyser)
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 1
+
+      # Generic helper: dispatch a workflow_dispatch workflow by file name
+      # and capture the resulting run id, then wait for completion. Each
+      # invocation runs in its own step so failures attribute to the
+      # specific workflow.
+      #
+      # Rate-limit shaping: each dispatch step opens with a brief 4s
+      # sleep so concurrent gate jobs (e2e-smoke-test, alt-model,
+      # orchestrate-decompose, etc.) don't all hit the
+      # `actions/workflows/.../runs` and `actions/runs/...` endpoints in
+      # the same instant when they happen to start within seconds of
+      # each other. The PR-review concern was that simultaneous
+      # dispatches collide; this stagger plus the existing 5–15 s polling
+      # intervals keep total API spend well below GH_PAT's 5000/hr budget.
+      #
+      # Note: the `workflow-log-analysis` dispatch lives in its own
+      # `workflow-log-analysis-test` job (split out so its Codex-driven
+      # long tail can no longer block `validate` / `release` /
+      # `sync-to-main`). The dispatches that remain here are the short,
+      # deterministic ones whose failures still gate the release.
       - name: Dispatch & watch — validation-refresh
         id: dispatch_validation_refresh
         timeout-minutes: 42
@@ -4740,7 +4761,7 @@ jobs:
   # Job 4: Combined Telegram notification (runs after ALL jobs)
   # ──────────────────────────────────────────────────────────────────
   notify:
-    needs: [resolve-version, e2e-smoke-test, validate-scripts, orphan-workflows-test, orchestrate-decompose-test, validate-standalone-test, clarify-rejects-unsolvable-test, e2e-alt-model-test, validate, release, sync-to-main]
+    needs: [resolve-version, e2e-smoke-test, validate-scripts, workflow-log-analysis-test, orphan-workflows-test, orchestrate-decompose-test, validate-standalone-test, clarify-rejects-unsolvable-test, e2e-alt-model-test, validate, release, sync-to-main]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -4749,8 +4770,9 @@ jobs:
       # Replaces the historical Phase 8 LLM re-summarisation that lived
       # inside `e2e-smoke-test`. Two reasons for moving this here:
       #   1. Coverage: `notify` `needs:` every smoke-test job, so it can
-      #      see the per-phase artifacts emitted by orphan-workflows-test
-      #      (workflow_log_analysis, validation_refresh, update_workflows,
+      #      see the per-phase artifacts emitted by
+      #      workflow-log-analysis-test (workflow_log_analysis),
+      #      orphan-workflows-test (validation_refresh, update_workflows,
       #      memory_maintenance), orchestrate-decompose-test,
       #      validate-standalone-test, clarify-rejects-unsolvable-test,
       #      and e2e-alt-model-test (alt_*). Phase 8 only saw the 6 e2e
@@ -4979,6 +5001,11 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           E2E="${{ needs.e2e-smoke-test.result }}"
           SCRIPTS="${{ needs.validate-scripts.result }}"
+          # workflow-log-analysis-test is intentionally NOT in
+          # `validate.needs`, so its result does not gate the release.
+          # It IS reported here so operators see whether the post-hoc
+          # audit pass succeeded alongside the rest of the gate.
+          LOG_ANALYSIS="${{ needs.workflow-log-analysis-test.result }}"
           ORPHANS="${{ needs.orphan-workflows-test.result }}"
           ORCHESTRATE_DECOMPOSE="${{ needs.orchestrate-decompose-test.result }}"
           VALIDATE_STANDALONE="${{ needs.validate-standalone-test.result }}"
@@ -4987,6 +5014,9 @@ jobs:
           VALIDATE="${{ needs.validate.result }}"
           RELEASE="${{ needs.release.result }}"
 
+          # `LOG_ANALYSIS` is deliberately omitted from `all_supplemental_ok`
+          # — its failure must NOT flip the overall message to "FAILED".
+          # The release path is independent of it (see `validate.needs`).
           all_supplemental_ok=true
           for r in "$ORPHANS" "$ORCHESTRATE_DECOMPOSE" "$VALIDATE_STANDALONE" "$CLARIFY_REJECTS" "$ALT_MODEL"; do
             if [ -n "$r" ] && [ "$r" != "success" ] && [ "$r" != "skipped" ]; then
@@ -4994,17 +5024,28 @@ jobs:
             fi
           done
 
+          # Render an icon for log-analysis using the same scheme as the
+          # FAILED branch loop below, so the SUCCEEDED line surfaces a
+          # real ✓/⊘/✗ for the post-hoc audit even when release passed.
+          case "$LOG_ANALYSIS" in
+            success) LOG_ANALYSIS_ICON="✓" ;;
+            skipped) LOG_ANALYSIS_ICON="⊘" ;;
+            "") LOG_ANALYSIS_ICON="-" ;;
+            *) LOG_ANALYSIS_ICON="✗" ;;
+          esac
+
           # Determine overall status
           if [ "$E2E" = "success" ] && [ "$SCRIPTS" = "success" ] && [ "$VALIDATE" = "success" ] && [ "$RELEASE" = "success" ] && [ "$all_supplemental_ok" = "true" ]; then
             MSG="Release ${{ needs.resolve-version.outputs.version }} SUCCEEDED"
-            MSG+=$'\n'"e2e ✓ scripts ✓ orphans ✓ orchestrate ✓ validate-fx ✓ negative ✓ alt-model ✓ release ✓"
+            MSG+=$'\n'"e2e ✓ scripts ✓ orphans ✓ orchestrate ✓ validate-fx ✓ negative ✓ alt-model ✓ release ✓ log-analysis ${LOG_ANALYSIS_ICON}"
           else
             MSG="Release ${{ needs.resolve-version.outputs.version }} FAILED"
             STATUS_LINE=""
-            for JOB_NAME in e2e-smoke-test validate-scripts orphan-workflows-test orchestrate-decompose-test validate-standalone-test clarify-rejects-unsolvable-test e2e-alt-model-test validate release; do
+            for JOB_NAME in e2e-smoke-test validate-scripts workflow-log-analysis-test orphan-workflows-test orchestrate-decompose-test validate-standalone-test clarify-rejects-unsolvable-test e2e-alt-model-test validate release; do
               case "$JOB_NAME" in
                 e2e-smoke-test) RESULT="$E2E" ;;
                 validate-scripts) RESULT="$SCRIPTS" ;;
+                workflow-log-analysis-test) RESULT="$LOG_ANALYSIS" ;;
                 orphan-workflows-test) RESULT="$ORPHANS" ;;
                 orchestrate-decompose-test) RESULT="$ORCHESTRATE_DECOMPOSE" ;;
                 validate-standalone-test) RESULT="$VALIDATE_STANDALONE" ;;

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -185,10 +185,13 @@ jobs:
     # 30 → 60m precedent (run #25115192726). When this is bumped again,
     # also propagate the +Δ minutes through every caller that watches a
     # dispatched run of this workflow:
-    #   1. test-and-mark-stable.yml's `orphan-workflows-test` →
+    #   1. test-and-mark-stable.yml's `workflow-log-analysis-test` →
     #      `Dispatch & watch — workflow-log-analysis` step (in-script
     #      DEADLINE in seconds, step timeout-minutes, and the job-level
-    #      timeout-minutes with its sum-of-DEADLINEs comment).
+    #      timeout-minutes with its sum-of-DEADLINEs comment). This was
+    #      `orphan-workflows-test` before PR #2347 split the dispatch
+    #      out so its Codex-driven long tail no longer blocks
+    #      `validate` / `release` / `sync-to-main`.
     #   2. comprehensive-test-and-release.yml's
     #      `phase2-collect-and-analyze-logs` (and the downstream
     #      `phase3-...` job that reuses the same watcher pattern) —
@@ -1117,9 +1120,10 @@ jobs:
     # fired. Audit-prompt input size has not grown materially since the
     # 30 → 60 bump (report file 51 KB this run vs. 33–58 KB pre-bump);
     # the structural cause is xhigh deliberation latency variance, which
-    # the 60m cap couldn't absorb. The orphan-workflows poller's outer
-    # DEADLINE in test-and-mark-stable.yml (dispatch step) still covers
-    # the new 90m cap with headroom.
+    # the 60m cap couldn't absorb. The workflow-log-analysis-test
+    # poller's outer DEADLINE in test-and-mark-stable.yml (dispatch
+    # step) still covers the new 90m cap with headroom. (Was
+    # `orphan-workflows-test` before PR #2347 split this dispatch out.)
     timeout-minutes: 90
     outputs:
       api_redundancy_status: ${{ steps.api_redundancy.outputs.api_redundancy_status }}


### PR DESCRIPTION
## Summary

Decouples the `workflow-log-analysis` smoke-gate dispatch from the release path so a Codex-driven long tail in the audit chain can no longer block `validate` / `release` / `sync-to-main`. Triggered by release v1.8.2 ([run #25589394934](https://github.com/shubhodeep1/coding-workflows/actions/runs/25589394934)) failing because the nested `workflow-log-analysis` run [#25589406932](https://github.com/shubhodeep1/coding-workflows/actions/runs/25589406932) was cancelled when its `api-redundancy` job hit its 90 m per-job `timeout-minutes` cap.

## Root cause

- `orphan-workflows-test` ran four sequential dispatches (`workflow-log-analysis`, `validation-refresh`, `update_workflows`, `internal-memory-maintenance`) in one job. The first dispatch's nested `api-redundancy` job exceeded its 90 m per-job cap; the watcher saw `status=completed conclusion=cancelled` and exited 1.
- Because `validate.needs` included `orphan-workflows-test` and gated on `result == 'success'`, the cancellation cascaded → `validate` / `release` / `sync-to-main` skipped.
- This is the 5th time in recent history that a Codex slow tail has caused a release-blocking timeout on this chain (deep-audit 30 → 45 → 75 m, api-redundancy 30 → 60 → 90 m, analyze-commit-notify 30 → 60 m). Bumping the cap again only buys time; the audit pass is post-hoc and does not affect release-artefact correctness.

## Changes

`.github/workflows/test-and-mark-stable.yml`

- **New job `workflow-log-analysis-test`** containing the dispatch + watch + soft-error analyser steps (lifted verbatim from `orphan-workflows-test`). `needs: [resolve-version]`, same `if: ${{ !inputs.skip_e2e && !inputs.dry_run }}` gating, `timeout-minutes: 280` (sized for the existing 260 m in-step DEADLINE plus runner-queue + soft-error headroom).
- **`orphan-workflows-test` trimmed** — workflow-log-analysis dispatch + comments removed; `timeout-minutes: 390 → 90` to match the remaining 65 m worst-case (validation-refresh + update_workflows + memory_maintenance + soft-error analysers + queueing).
- **`validate.needs` deliberately NOT changed** — the new job is excluded so its result cannot block the release path.
- **`notify.needs`** now includes `workflow-log-analysis-test`, with a `LOG_ANALYSIS` variable rendered via the same icon scheme used in the FAILED branch loop. Appended `log-analysis ${ICON}` to the SUCCEEDED line; added the new job to the FAILED-branch `JOB_NAME` loop. `LOG_ANALYSIS` is intentionally omitted from `all_supplemental_ok` so its failure does not flip the message to "FAILED" when the release itself succeeded.
- `dry_run` input description updated to list `workflow-log-analysis` alongside the other live-dispatch e2e jobs.

`.github/workflows/workflow-log-analysis.yml`

- Two stale comment refs to `orphan-workflows-test` updated to point at `workflow-log-analysis-test`.

## Soft-error report flow

The new job uses the same `soft-error-report-${{ github.run_id }}-workflow_log_analysis` artifact name, so the `notify` job's `pattern: soft-error-report-${{ github.run_id }}-*` glob picks it up unchanged — the consolidated soft-error report still includes workflow-log-analysis findings.

## Test plan

- [ ] On next `Test & Mark Stable Release` dispatch, confirm `workflow-log-analysis-test` appears as its own job in the run.
- [ ] Confirm `validate` / `release` / `sync-to-main` proceed even if `workflow-log-analysis-test` fails (intentional decoupling).
- [ ] Confirm the consolidated soft-error report in the Telegram notification still contains `workflow_log_analysis` findings.
- [ ] Confirm the Telegram release message includes a `log-analysis ${icon}` segment in the SUCCEEDED line and a `workflow-log-analysis-test: ${icon} (${result})` entry in the FAILED branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_0196wVbWwfrSsp7sbkGkt4uz)_