### PR TITLE
fix(review_apply_fixes): tolerate {{SEMBLE_PREFETCH}} leakage from inlined prompt-template content [stable]

### DIFF
--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -811,17 +811,11 @@ _cleanup_prompt_budget
 editor_prompt_rendered="$(mktemp)"
 (
   cd "${SUPPORT_ROOT_DIR}"
-  # `SEMBLE_PREFETCH=""` opts this caller out of the unresolved-
-  # `{{SEMBLE_PREFETCH}}` guard in scripts/render_prompt.sh. The editor
-  # heredoc above does NOT itself use the placeholder, but
-  # targeted_file_context.py inlines prompt-template files (e.g.
-  # prompts/mode-judge.txt) verbatim into the editor prompt body, and
-  # those judge templates legitimately contain a standalone
-  # `{{SEMBLE_PREFETCH}}` line. Without an explicit empty value, the
-  # render script's `[ "${SEMBLE_PREFETCH+x}" = "x" ]` check stays false,
-  # the case statement passes the line through unchanged, and the final
-  # guard regex aborts the editor stage on data leakage rather than
-  # genuine wiring drift (run 25613659201 / PR #2392).
+  # The editor heredoc itself uses no `{{SEMBLE_PREFETCH}}`, but
+  # targeted_file_context.py can inline judge-prompt templates verbatim
+  # into the editor prompt body. Set SEMBLE_PREFETCH="" so any inlined
+  # placeholder lines are treated as resolved by render_prompt versions
+  # that support the placeholder, instead of tripping a strict guard.
   SEMBLE_PREFETCH="" bash "${SUPPORT_SCRIPTS_DIR}/render_prompt.sh" "${EDITOR_PROMPT_BODY_FILE}"
 ) > "${editor_prompt_rendered}"
 mv "${editor_prompt_rendered}" "${EDITOR_PROMPT_BODY_FILE}"

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -811,7 +811,18 @@ _cleanup_prompt_budget
 editor_prompt_rendered="$(mktemp)"
 (
   cd "${SUPPORT_ROOT_DIR}"
-  bash "${SUPPORT_SCRIPTS_DIR}/render_prompt.sh" "${EDITOR_PROMPT_BODY_FILE}"
+  # `SEMBLE_PREFETCH=""` opts this caller out of the unresolved-
+  # `{{SEMBLE_PREFETCH}}` guard in scripts/render_prompt.sh. The editor
+  # heredoc above does NOT itself use the placeholder, but
+  # targeted_file_context.py inlines prompt-template files (e.g.
+  # prompts/mode-judge.txt) verbatim into the editor prompt body, and
+  # those judge templates legitimately contain a standalone
+  # `{{SEMBLE_PREFETCH}}` line. Without an explicit empty value, the
+  # render script's `[ "${SEMBLE_PREFETCH+x}" = "x" ]` check stays false,
+  # the case statement passes the line through unchanged, and the final
+  # guard regex aborts the editor stage on data leakage rather than
+  # genuine wiring drift (run 25613659201 / PR #2392).
+  SEMBLE_PREFETCH="" bash "${SUPPORT_SCRIPTS_DIR}/render_prompt.sh" "${EDITOR_PROMPT_BODY_FILE}"
 ) > "${editor_prompt_rendered}"
 mv "${editor_prompt_rendered}" "${EDITOR_PROMPT_BODY_FILE}"
 


### PR DESCRIPTION
## Summary
Stable-targeted port of PR #2422. Sets `SEMBLE_PREFETCH=""` on the `scripts/render_prompt.sh` invocation in `scripts/review_apply_fixes.sh` so the editor stage tolerates `{{SEMBLE_PREFETCH}}` lines that get inlined verbatim into the editor prompt body via `targeted_file_context.py`.

This is the only file change — minimal diff against `stable` (cherry-picked from `claude/investigate-pr-autofix-failure-NpFDk`):

```
scripts/review_apply_fixes.sh | 7 ++++++-
1 file changed, 6 insertions(+), 1 deletion(-)
```

## Root cause
In-flight PR #2392 introduces:
1. Strict unresolved-`{{SEMBLE_PREFETCH}}` guard in `scripts/render_prompt.sh` (exits 1 unless `SEMBLE_PREFETCH` is explicitly set).
2. A standalone `{{SEMBLE_PREFETCH}}` line in the judge templates (`prompts/mode-judge.txt`, `mode-judge-review-blocked.txt`, `mode-judge-stall-recovery.txt`).

`scripts/targeted_file_context.py::_append_inlined_file_block` inlines file contents verbatim (`output.extend(text.splitlines())`) into `editor_prompt_body.txt`. `scripts/review_apply_fixes.sh` then runs `render_prompt.sh` on that body without setting `SEMBLE_PREFETCH` — the editor heredoc itself never uses the placeholder. The render script's case statement passes the leaked `{{SEMBLE_PREFETCH}}` line through unchanged, then the final guard regex matches and aborts the editor stage.

Failing run: https://github.com/shubhodeep1/coding-workflows/actions/runs/25613659201
> `Unresolved SEMBLE_PREFETCH placeholder in rendered output for /tmp/codex-pr-25613659201-1-27458/editor_prompt_body.txt`
> `##[error]Process completed with exit code 1.`

## Why land on `stable` (not `main`)
The autofix workflow downloads support scripts at the PR's `SCRIPT_REF` resolved via `shubhodeep1/coding-workflows@stable`. Landing on `main` alone wouldn't help PR #2392's autofix — the fix needs to be present in stable for the next autofix retrigger to pick it up. Once on stable, the regular forward-merge-stable-to-main job will propagate it back to main.

## Forward-compatibility
- A no-op against current `stable`'s `render_prompt.sh`, which doesn't reference `SEMBLE_PREFETCH` yet.
- Becomes a guard-disabling empty substitution once PR #2392's `render_prompt.sh` changes reach this code path.

## Test plan
- [x] Reproduce the failure with PR-2392's `render_prompt.sh` and a synthetic body containing the inlined judge-template snippet — exits 1 with the exact run-25613659201 error string.
- [x] Re-run with `SEMBLE_PREFETCH=""` (the patched call) — exits 0; the inlined `{{SEMBLE_PREFETCH}}` line becomes an empty line; surrounding inlined content unchanged.
- [x] `bash -n scripts/review_apply_fixes.sh` passes.
- [ ] On merge into `stable`, the next PR-2392 autofix retrigger will pick up the fix via the workflow's `SCRIPT_REF` resolution.

Supersedes PR #2422 (which targeted `main`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmFivfTSyBjMVoeVcSxr3X)_