### PR TITLE
fix(review_autofix): bash-n guard the resolver entry-point against unresolved merge markers

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3792,7 +3792,46 @@ jobs:
           CONFLICT_RESOLVER_REASONING_EFFORT: ${{ vars.THINKING_LEVEL_CONFLICT_RESOLVER || 'xhigh' }}
         run: |
           set -euo pipefail
-          bash "${SUPPORT_SCRIPTS_DIR}/review_conflict_resolve.sh"
+          # Bootstrap guard for the workflow-source-repo case
+          # (IS_WORKFLOW_SOURCE_REPO=true): SUPPORT_SCRIPTS_DIR resolves
+          # to the in-tree "scripts" dir, so when the prior
+          # review_conflict_prepare.sh merge replay lists
+          # scripts/review_conflict_resolve.sh among its unmerged paths
+          # (forward-merge stable→main PRs that touch the resolver
+          # itself), the on-disk copy at SUPPORT_SCRIPTS_DIR contains
+          # raw `<<<<<<< HEAD` / `=======` / `>>>>>>>` markers and bash
+          # aborts with "syntax error near unexpected token '<<<'"
+          # before the resolver can even start — observed on PR #2451
+          # run 25637785576 (job 63633abc-d9f8-54e0-a184-111777ae010a)
+          # where line 625's `else` clause was misparsed as a here-string.
+          # The .codex-workflow-src/ checkout (pinned to SCRIPT_REF) is
+          # untouched by the merge replay because review_conflict_prepare.sh
+          # explicitly stashes and restores it around the merge, so it
+          # holds a clean, parseable copy of the resolver script. Fall
+          # back to that copy when the in-tree script fails `bash -n`.
+          # The Codex resolver invoked below still reads the conflicted
+          # in-tree path to see the markers it needs to resolve — only
+          # the bash interpreter loading the resolver script switches
+          # source. Consumer repos (SUPPORT_SCRIPTS_DIR points outside
+          # the working tree) are unaffected: their in-tree script is
+          # never overwritten, `bash -n` always passes, and this block
+          # is a no-op.
+          RESOLVER_SCRIPT="${SUPPORT_SCRIPTS_DIR}/review_conflict_resolve.sh"
+          if ! bash -n "${RESOLVER_SCRIPT}" 2>/dev/null; then
+            if [ -f ".codex-workflow-src/scripts/review_conflict_resolve.sh" ] \
+               && bash -n ".codex-workflow-src/scripts/review_conflict_resolve.sh" 2>/dev/null; then
+              echo "::warning::${RESOLVER_SCRIPT} failed bash syntax check (likely unresolved conflict markers from the merge replay); falling back to .codex-workflow-src/scripts/review_conflict_resolve.sh (SCRIPT_REF=${SCRIPT_REF:-unknown})."
+              RESOLVER_SCRIPT=".codex-workflow-src/scripts/review_conflict_resolve.sh"
+            elif [ -f ".codex-workflow-src-main/scripts/review_conflict_resolve.sh" ] \
+                 && bash -n ".codex-workflow-src-main/scripts/review_conflict_resolve.sh" 2>/dev/null; then
+              echo "::warning::${RESOLVER_SCRIPT} failed bash syntax check and SCRIPT_REF copy is unavailable/unparseable; falling back to .codex-workflow-src-main/scripts/review_conflict_resolve.sh."
+              RESOLVER_SCRIPT=".codex-workflow-src-main/scripts/review_conflict_resolve.sh"
+            else
+              echo "::error::${RESOLVER_SCRIPT} contains unresolved conflict markers and no clean fallback copy is available in .codex-workflow-src/ or .codex-workflow-src-main/."
+              exit 2
+            fi
+          fi
+          bash "${RESOLVER_SCRIPT}"
 
       - name: Cache linked issues references
         # Claude-branch-review mode skips all the downstream label-mutating


### PR DESCRIPTION
## Root cause

PR #2451 / run 25637785576 (job `63633abc-d9f8-54e0-a184-111777ae010a`) failed the conflict-resolver step with:

```
scripts/review_conflict_resolve.sh: line 625: syntax error near unexpected token `<<<'
##[error]Process completed with exit code 2.
```

The flow:

1. The job is `review_autofix` on the workflow-source-repo (`IS_WORKFLOW_SOURCE_REPO=true`), so `SUPPORT_SCRIPTS_DIR` resolves to the in-tree `scripts/` directory.
2. The editor produced an `[ai-autofix]` commit `64bedcb` on top of the PR head `319cc085`.
3. The "Detect merge conflicts" step's merge replay found 9 unmerged paths between `64bedcb` and `origin/main` — including `scripts/review_conflict_resolve.sh` itself (both sides modified the resolver).
4. `review_conflict_prepare.sh` then ran its own merge replay (resolver allowlist of 9 entries) and intentionally left the conflict state in the working tree so the Codex resolver can see the markers.
5. The next workflow step ran `bash "${SUPPORT_SCRIPTS_DIR}/review_conflict_resolve.sh"` — but that file now contains raw `<<<<<<< HEAD` / `=======` / `>>>>>>>` markers, and bash aborts on the first marker line (parses `<<<` as an unexpected here-string redirection token).

This is unique to forward-merge stable→main PRs on this repo where the merge conflict set intersects the resolver bootstrap path. Consumer repos are unaffected — their `SUPPORT_SCRIPTS_DIR` lives outside the working tree (`${RUNNER_TEMP}/coding-workflows-runtime-…/scripts`) and is never overwritten by the merge replay.

## Fix

Guard the resolver invocation with `bash -n` and fall back to the `.codex-workflow-src/scripts/` copy (pinned to `SCRIPT_REF`, stashed and restored around the merge replay in `review_conflict_prepare.sh`) when the in-tree script fails the syntax check. Final fallback is `.codex-workflow-src-main/scripts/`, then hard-error.

The Codex resolver invoked from the clean fallback still reads the conflicted in-tree path (`scripts/review_conflict_resolve.sh`) to see the markers it needs to resolve — only the bash interpreter loading the resolver entry-point switches source. The resolver's own conflict gets resolved and committed normally.

## Verification

- Reproduced the exact failure locally: `bash -n` exits non-zero on a file containing `<<<<<<< HEAD` markers and emits the same `syntax error near unexpected token '<<<'` message with exit code 2.
- YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- `bash -n` on the inline `run:` block of the modified step passes.
- The fallback path `.codex-workflow-src/scripts/review_conflict_resolve.sh` is confirmed populated by `actions/checkout@v5` early in the job (`path: .codex-workflow-src`) and preserved through the merge replay by `review_conflict_prepare.sh` lines 83-101 (stash to `RESOLVE_STASH`) + lines 230-234 (restore).

## Test plan

- [ ] Trigger a new forward-merge stable→main PR (or re-run on PR #2451 after rebase) and confirm the resolver step starts cleanly and produces a `[ai-merge-resolve]` commit.
- [ ] Confirm consumer-repo runs continue to no-op through the new guard (`bash -n` passes on the runtime-fetched script).

---
_Generated by [Claude Code](https://claude.ai/code/session_0119DJniGH2SEp8gXxWRCQbi)_