### PR TITLE
fix(review_autofix): bash-n guard the resolver entry-point against unresolved merge markers

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3799,21 +3799,47 @@ jobs:
           # The same sanitisation pattern (%/\r escaping, whitespace
           # collapse) the "Detect merge conflicts" step uses for its
           # `git merge` stderr annotation applies here.
-          _resolver_check_err=""
-          if ! _resolver_check_err="$(bash -n "${RESOLVER_SCRIPT}" 2>&1 >/dev/null)"; then
-            _err_oneline="$(printf '%s' "${_resolver_check_err}" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//; s/%/%25/g; s/\r/%0D/g')"
-            _err_oneline="${_err_oneline:-<no stderr captured>}"
-            if [ -f ".codex-workflow-src/scripts/review_conflict_resolve.sh" ] \
-               && bash -n ".codex-workflow-src/scripts/review_conflict_resolve.sh" 2>/dev/null; then
-              echo "::warning::${RESOLVER_SCRIPT} failed bash syntax check [bash -n: ${_err_oneline}] — likely unresolved conflict markers from the merge replay; falling back to .codex-workflow-src/scripts/review_conflict_resolve.sh (SCRIPT_REF=${SCRIPT_REF:-unknown})."
-              RESOLVER_SCRIPT=".codex-workflow-src/scripts/review_conflict_resolve.sh"
-            elif [ -f ".codex-workflow-src-main/scripts/review_conflict_resolve.sh" ] \
-                 && bash -n ".codex-workflow-src-main/scripts/review_conflict_resolve.sh" 2>/dev/null; then
-              echo "::warning::${RESOLVER_SCRIPT} failed bash syntax check [bash -n: ${_err_oneline}] and SCRIPT_REF copy is unavailable/unparseable; falling back to .codex-workflow-src-main/scripts/review_conflict_resolve.sh."
-              RESOLVER_SCRIPT=".codex-workflow-src-main/scripts/review_conflict_resolve.sh"
+          #
+          # Probe a candidate resolver path and echo one of:
+          #   ok | missing | parse_fail:<sanitized one-line stderr>
+          # The state string is embedded verbatim in the
+          # warning/error annotation below so the triple-failure path
+          # (in-tree corrupted AND both fallbacks unavailable or
+          # unparseable) reports each fallback's distinct state +
+          # captured stderr — addresses #2466 review feedback that
+          # the prior implementation suppressed fallback stderr and
+          # conflated missing-file with parse-failure under a single
+          # "unavailable/unparseable" label.
+          _probe_resolver() {
+            local path="$1" err
+            if [ ! -f "${path}" ]; then
+              printf '%s\n' "missing"
+              return
+            fi
+            if err="$(bash -n "${path}" 2>&1 >/dev/null)"; then
+              printf '%s\n' "ok"
             else
-              echo "::error::${RESOLVER_SCRIPT} failed bash syntax check [bash -n: ${_err_oneline}] and no clean fallback copy is available in .codex-workflow-src/ or .codex-workflow-src-main/."
-              exit 2
+              err="$(printf '%s' "${err}" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//; s/%/%25/g; s/\r/%0D/g')"
+              printf 'parse_fail:%s\n' "${err:-<no stderr captured>}"
+            fi
+          }
+          _primary_state="$(_probe_resolver "${RESOLVER_SCRIPT}")"
+          if [ "${_primary_state}" != "ok" ]; then
+            _fb1=".codex-workflow-src/scripts/review_conflict_resolve.sh"
+            _fb2=".codex-workflow-src-main/scripts/review_conflict_resolve.sh"
+            _fb1_state="$(_probe_resolver "${_fb1}")"
+            if [ "${_fb1_state}" = "ok" ]; then
+              echo "::warning::Resolver entry-point check: ${RESOLVER_SCRIPT}=${_primary_state} (likely unresolved conflict markers from the merge replay); falling back to ${_fb1} (SCRIPT_REF=${SCRIPT_REF:-unknown})."
+              RESOLVER_SCRIPT="${_fb1}"
+            else
+              _fb2_state="$(_probe_resolver "${_fb2}")"
+              if [ "${_fb2_state}" = "ok" ]; then
+                echo "::warning::Resolver entry-point check: ${RESOLVER_SCRIPT}=${_primary_state}; ${_fb1}=${_fb1_state}; falling back to ${_fb2}."
+                RESOLVER_SCRIPT="${_fb2}"
+              else
+                echo "::error::Resolver entry-point check: ${RESOLVER_SCRIPT}=${_primary_state}; ${_fb1}=${_fb1_state}; ${_fb2}=${_fb2_state}. No clean resolver entry-point available."
+                exit 2
+              fi
             fi
           fi
           bash "${RESOLVER_SCRIPT}"

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3765,7 +3765,46 @@ jobs:
           CONFLICT_RESOLVER_REASONING_EFFORT: ${{ vars.THINKING_LEVEL_CONFLICT_RESOLVER || 'xhigh' }}
         run: |
           set -euo pipefail
-          bash "${SUPPORT_SCRIPTS_DIR}/review_conflict_resolve.sh"
+          # Bootstrap guard for the workflow-source-repo case
+          # (IS_WORKFLOW_SOURCE_REPO=true): SUPPORT_SCRIPTS_DIR resolves
+          # to the in-tree "scripts" dir, so when the prior
+          # review_conflict_prepare.sh merge replay lists
+          # scripts/review_conflict_resolve.sh among its unmerged paths
+          # (forward-merge stable→main PRs that touch the resolver
+          # itself), the on-disk copy at SUPPORT_SCRIPTS_DIR contains
+          # raw `<<<<<<< HEAD` / `=======` / `>>>>>>>` markers and bash
+          # aborts with "syntax error near unexpected token '<<<'"
+          # before the resolver can even start — observed on PR #2451
+          # run 25637785576 (job 63633abc-d9f8-54e0-a184-111777ae010a)
+          # where line 625's `else` clause was misparsed as a here-string.
+          # The .codex-workflow-src/ checkout (pinned to SCRIPT_REF) is
+          # untouched by the merge replay because review_conflict_prepare.sh
+          # explicitly stashes and restores it around the merge, so it
+          # holds a clean, parseable copy of the resolver script. Fall
+          # back to that copy when the in-tree script fails `bash -n`.
+          # The Codex resolver invoked below still reads the conflicted
+          # in-tree path to see the markers it needs to resolve — only
+          # the bash interpreter loading the resolver script switches
+          # source. Consumer repos (SUPPORT_SCRIPTS_DIR points outside
+          # the working tree) are unaffected: their in-tree script is
+          # never overwritten, `bash -n` always passes, and this block
+          # is a no-op.
+          RESOLVER_SCRIPT="${SUPPORT_SCRIPTS_DIR}/review_conflict_resolve.sh"
+          if ! bash -n "${RESOLVER_SCRIPT}" 2>/dev/null; then
+            if [ -f ".codex-workflow-src/scripts/review_conflict_resolve.sh" ] \
+               && bash -n ".codex-workflow-src/scripts/review_conflict_resolve.sh" 2>/dev/null; then
+              echo "::warning::${RESOLVER_SCRIPT} failed bash syntax check (likely unresolved conflict markers from the merge replay); falling back to .codex-workflow-src/scripts/review_conflict_resolve.sh (SCRIPT_REF=${SCRIPT_REF:-unknown})."
+              RESOLVER_SCRIPT=".codex-workflow-src/scripts/review_conflict_resolve.sh"
+            elif [ -f ".codex-workflow-src-main/scripts/review_conflict_resolve.sh" ] \
+                 && bash -n ".codex-workflow-src-main/scripts/review_conflict_resolve.sh" 2>/dev/null; then
+              echo "::warning::${RESOLVER_SCRIPT} failed bash syntax check and SCRIPT_REF copy is unavailable/unparseable; falling back to .codex-workflow-src-main/scripts/review_conflict_resolve.sh."
+              RESOLVER_SCRIPT=".codex-workflow-src-main/scripts/review_conflict_resolve.sh"
+            else
+              echo "::error::${RESOLVER_SCRIPT} contains unresolved conflict markers and no clean fallback copy is available in .codex-workflow-src/ or .codex-workflow-src-main/."
+              exit 2
+            fi
+          fi
+          bash "${RESOLVER_SCRIPT}"
 
       - name: Cache linked issues references
         # Claude-branch-review mode skips all the downstream label-mutating

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3790,17 +3790,29 @@ jobs:
           # never overwritten, `bash -n` always passes, and this block
           # is a no-op.
           RESOLVER_SCRIPT="${SUPPORT_SCRIPTS_DIR}/review_conflict_resolve.sh"
-          if ! bash -n "${RESOLVER_SCRIPT}" 2>/dev/null; then
+          # Capture bash -n stderr (instead of redirecting to /dev/null)
+          # and surface a sanitized single-line copy in every fallback
+          # annotation so operators debugging a workflow run can tell
+          # an unresolved-merge-marker failure apart from a truncated
+          # file, a missing dependency reference, or any other
+          # parse-time issue without having to re-run the job locally.
+          # The same sanitisation pattern (%/\r escaping, whitespace
+          # collapse) the "Detect merge conflicts" step uses for its
+          # `git merge` stderr annotation applies here.
+          _resolver_check_err=""
+          if ! _resolver_check_err="$(bash -n "${RESOLVER_SCRIPT}" 2>&1 >/dev/null)"; then
+            _err_oneline="$(printf '%s' "${_resolver_check_err}" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//; s/%/%25/g; s/\r/%0D/g')"
+            _err_oneline="${_err_oneline:-<no stderr captured>}"
             if [ -f ".codex-workflow-src/scripts/review_conflict_resolve.sh" ] \
                && bash -n ".codex-workflow-src/scripts/review_conflict_resolve.sh" 2>/dev/null; then
-              echo "::warning::${RESOLVER_SCRIPT} failed bash syntax check (likely unresolved conflict markers from the merge replay); falling back to .codex-workflow-src/scripts/review_conflict_resolve.sh (SCRIPT_REF=${SCRIPT_REF:-unknown})."
+              echo "::warning::${RESOLVER_SCRIPT} failed bash syntax check [bash -n: ${_err_oneline}] — likely unresolved conflict markers from the merge replay; falling back to .codex-workflow-src/scripts/review_conflict_resolve.sh (SCRIPT_REF=${SCRIPT_REF:-unknown})."
               RESOLVER_SCRIPT=".codex-workflow-src/scripts/review_conflict_resolve.sh"
             elif [ -f ".codex-workflow-src-main/scripts/review_conflict_resolve.sh" ] \
                  && bash -n ".codex-workflow-src-main/scripts/review_conflict_resolve.sh" 2>/dev/null; then
-              echo "::warning::${RESOLVER_SCRIPT} failed bash syntax check and SCRIPT_REF copy is unavailable/unparseable; falling back to .codex-workflow-src-main/scripts/review_conflict_resolve.sh."
+              echo "::warning::${RESOLVER_SCRIPT} failed bash syntax check [bash -n: ${_err_oneline}] and SCRIPT_REF copy is unavailable/unparseable; falling back to .codex-workflow-src-main/scripts/review_conflict_resolve.sh."
               RESOLVER_SCRIPT=".codex-workflow-src-main/scripts/review_conflict_resolve.sh"
             else
-              echo "::error::${RESOLVER_SCRIPT} contains unresolved conflict markers and no clean fallback copy is available in .codex-workflow-src/ or .codex-workflow-src-main/."
+              echo "::error::${RESOLVER_SCRIPT} failed bash syntax check [bash -n: ${_err_oneline}] and no clean fallback copy is available in .codex-workflow-src/ or .codex-workflow-src-main/."
               exit 2
             fi
           fi


### PR DESCRIPTION
> Retargets #2466 from `main` → `stable` per request. Same fix, plus a follow-up commit addressing Copilot's review comment on #2466 (capture `bash -n` stderr into the fallback annotations).

## Root cause

PR #2451 / run 25637785576 (job `63633abc-d9f8-54e0-a184-111777ae010a`) failed the conflict-resolver step with:

```
scripts/review_conflict_resolve.sh: line 625: syntax error near unexpected token `<<<'
##[error]Process completed with exit code 2.
```

The flow:

1. The job is `review_autofix` on the workflow-source-repo (`IS_WORKFLOW_SOURCE_REPO=true`), so `SUPPORT_SCRIPTS_DIR` resolves to the in-tree `scripts/` directory.
2. The editor produced an `[ai-autofix]` commit `64bedcb` on top of the PR head `319cc085`.
3. The "Detect merge conflicts" step's merge replay found 9 unmerged paths between `64bedcb` and `origin/main` — including `scripts/review_conflict_resolve.sh` itself (both sides modified the resolver).
4. `review_conflict_prepare.sh` then ran its own merge replay (resolver allowlist of 9 entries) and intentionally left the conflict state in the working tree so the Codex resolver can see the markers.
5. The next workflow step ran `bash "${SUPPORT_SCRIPTS_DIR}/review_conflict_resolve.sh"` — but that file now contains raw `<<<<<<< HEAD` / `=======` / `>>>>>>>` markers, and bash aborts on the first marker line (parses `<<<` as an unexpected here-string redirection token).

This is unique to forward-merge stable→main PRs on this repo where the merge conflict set intersects the resolver bootstrap path. Consumer repos are unaffected — their `SUPPORT_SCRIPTS_DIR` lives outside the working tree (`${RUNNER_TEMP}/coding-workflows-runtime-…/scripts`) and is never overwritten by the merge replay.

## Fix

1. **Guard with `bash -n`, fall back to the SCRIPT_REF checkout.** When the in-tree resolver fails the syntax check, switch the bash interpreter's source to `.codex-workflow-src/scripts/review_conflict_resolve.sh` (pinned to `SCRIPT_REF`, stashed and restored around the merge replay in `review_conflict_prepare.sh` lines 83-101 / 230-234 so it is never overwritten). Final fallback to `.codex-workflow-src-main/scripts/...`, then hard-error.
2. **Capture `bash -n` stderr into annotations** (addressing #2466 review feedback): instead of dropping the parse error on `/dev/null`, capture it and include a sanitized one-line copy in every `::warning::` / `::error::` annotation so operators can tell an unresolved-merge-marker failure apart from a truncated file or other parse-time issue without re-running locally. Reuses the existing `%/\r` escape + whitespace-collapse pattern from the "Detect merge conflicts" step.

Codex still reads the conflicted in-tree script to see the markers it needs to resolve — only the bash interpreter loading the resolver entry-point switches source. The resolver's own conflict gets resolved and committed normally.

## Verification

- Reproduced the exact failure locally: `bash -n` exits non-zero on a file containing `<<<<<<< HEAD` markers and emits exactly `syntax error near unexpected token '<<<'` with exit code 2.
- Stderr capture pattern verified locally: captured value is `<path>: line 3: syntax error near unexpected token '<<<' <path>: line 3: '<<<<<<< HEAD'` after sanitisation.
- YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- The fallback path `.codex-workflow-src/scripts/review_conflict_resolve.sh` is populated by `actions/checkout@v5` early in the job (`path: .codex-workflow-src`) and preserved through the merge replay.

## Test plan

- [ ] Trigger a new forward-merge stable→main PR (or re-run on PR #2451 after rebase) and confirm the resolver step starts cleanly and produces a `[ai-merge-resolve]` commit.
- [ ] Confirm consumer-repo runs continue to no-op through the new guard (`bash -n` passes on the runtime-fetched script).

---
_Generated by [Claude Code](https://claude.ai/code/session_0119DJniGH2SEp8gXxWRCQbi)_