### PR TITLE
fix(stable/e2e-alt-model): treat ai:done as success in clarify→plan→implement wait

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -4352,8 +4352,11 @@ jobs:
             # Success: the implement phase produced a PR and either is
             # mid-review or done. The alt-model gate doesn't need to wait
             # for review_autofix — that's already covered by the main e2e.
-            if echo "${LABELS}" | grep -qE 'ai:in-review|ai:ready-to-merge|ai:merged'; then
-              echo "✓ Alt-model run reached review/merge stage"
+            # `ai:done` is the canonical "implement PR created" terminal for
+            # this gate (set in implement.yml after create_pr); `ai:in-review`
+            # is retained for forward-compat but is not currently emitted.
+            if echo "${LABELS}" | grep -qE 'ai:done|ai:in-review|ai:ready-to-merge|ai:merged'; then
+              echo "✓ Alt-model run reached implement-done/review/merge stage"
               exit 0
             fi
             if echo "${LABELS}" | grep -qE 'ai:clarify-failed|ai:plan-failed|ai:implement-failed'; then


### PR DESCRIPTION
## Summary

The `e2e-alt-model-test` job in `Test & Mark Stable Release` timed out in [run 25643130622 / job 75266926234](https://github.com/shubhodeep1/coding-workflows/actions/runs/25643130622/job/75266926234) even though the alt-model run executed clarify → plan → implement successfully.

The wait loop in `Wait for clarify→plan→implement (alt-model)` (`test-and-mark-stable.yml:4355`) treated only `ai:in-review|ai:ready-to-merge|ai:merged` as success, but:

- `ai:done` ("Implementation PR created") is the canonical terminal label the implement phase emits in `implement.yml:3213-3217` after `create_pr` succeeds.
- `ai:in-review` is **not a defined label** in this codebase — it appears nowhere in `scripts/label_helpers.sh` (`_AI_LABEL_COLORS`, `_AI_LABEL_DESCS`, `_AI_PHASE_LABELS`) and is only referenced by this one regex.
- The step's own comment already says: *"Success: the implement phase produced a PR and either is mid-review or done. The alt-model gate doesn't need to wait for review_autofix — that's already covered by the main e2e."*

In the failing run, the issue progressed `none → ai:clarification → ai:planning → ai:awaiting-approval → ai:implementing → ai:done` and then sat at `ai:done` for ~66 minutes until the 4500s deadline elapsed.

## Fix

Add `ai:done` to the success regex. `ai:in-review` is kept for forward-compat (harmless — it's never emitted today). The success message is updated to reflect the additional terminal.

## Test plan

- [ ] Re-run `Test & Mark Stable Release` workflow_dispatch — `e2e-alt-model-test` should exit `0` shortly after the alt-model issue reaches `ai:done` (typically <15 min total, not 75 min).
- [ ] Confirm `e2e-smoke-test` (which uses its own multi-phase waits) is unaffected.
- [ ] Confirm the failure-label branch (`ai:clarify-failed|ai:plan-failed|ai:implement-failed`) still trips when an alt-model run fails.

https://claude.ai/code/session_01WnMjFzwiQLJ4zneU6q6LLW

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnMjFzwiQLJ4zneU6q6LLW)_