### PR TITLE
fix(review_conflict_resolve): step reasoning effort down on per-attempt-timer kills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,11 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_conflict_resolve_retry_prelude_render.py
 
+      - name: Review conflict-resolve reasoning step-down contract test
+        run: |
+          set -euo pipefail
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_conflict_resolve_reasoning_step_down.py
+
       - name: Review apply-fixes smoke deterministic contract test
         run: |
           set -euo pipefail

--- a/.github/workflows/mark-stable.yml
+++ b/.github/workflows/mark-stable.yml
@@ -219,6 +219,7 @@ jobs:
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_stall_recovery_pr_lookup.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_conflict_resolve_smoke_deterministic.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_conflict_resolve_retry_prelude_render.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_conflict_resolve_reasoning_step_down.py
 
       - name: Prompt files integrity
         run: |

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3208,6 +3208,7 @@ jobs:
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_stall_recovery_pr_lookup.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_conflict_resolve_smoke_deterministic.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_conflict_resolve_retry_prelude_render.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_conflict_resolve_reasoning_step_down.py
 
       - name: Prompt files integrity
         run: |

--- a/scripts/review_conflict_resolve.sh
+++ b/scripts/review_conflict_resolve.sh
@@ -212,51 +212,105 @@ case "${_resolver_reasoning_effort}" in
     ;;
 esac
 _codex_config="${HOME}/.codex/config.toml"
-# Fail-open guard around the rewrite: a sed/grep failure (permissions,
-# unexpected file shape, missing GNU sed) should fall through to a
-# ::warning:: rather than abort the resolver step under set -e — same
-# spirit as the missing-config branch below. Robust grep/sed patterns
-# tolerate whitespace and quoting variants so a non-canonical config
-# (e.g. unquoted value, extra spaces) is still updated rather than
-# silently no-op'd, which would re-introduce the empty-stdout failure
-# this fix is meant to prevent. Post-edit verification reads the file
-# back and emits a warning if the resolver value is missing.
-if [ -f "${_codex_config}" ]; then
-  _rewrite_ok=1
+
+# _apply_resolver_reasoning_effort <level>
+#
+# Rewrite ~/.codex/config.toml so the next codex invocation runs at
+# <level> (one of xhigh|high|medium|none) with
+# model_reasoning_summary = "auto" (the anti-empty-stdout safeguard).
+#
+# Extracted from the once-per-step prelude so the retry loop can
+# downgrade the level after a per-attempt-timer kill — see
+# _next_lower_reasoning_effort below and the timeout step-down
+# block inside the resolver loop. The original PR-#2453 prelude
+# rewrote config.toml exactly once; an attempt that timed out at
+# `high` would then retry at the same `high`, repeating the
+# hung-thinking failure mode rather than giving the next attempt
+# a real chance to finish under the per-attempt budget.
+#
+# Fail-open: sed/grep failure (permissions, unexpected file shape,
+# missing GNU sed) surfaces a ::warning:: rather than aborting the
+# resolver step under set -e. Robust grep/sed patterns tolerate
+# whitespace and quoting variants so a non-canonical config is
+# still updated rather than silently no-op'd, which would
+# re-introduce the empty-stdout failure mode this fix prevents.
+# Post-edit verification reads the file back and emits a warning
+# if either expected line is missing.
+_apply_resolver_reasoning_effort()
+{
+  _arr_level="${1:?reasoning level required}"
+  case "${_arr_level}" in
+    xhigh|high|medium|none) ;;
+    *)
+      echo "::warning::_apply_resolver_reasoning_effort: invalid level '${_arr_level}'; falling back to high."
+      _arr_level="high"
+      ;;
+  esac
+  if [ ! -f "${_codex_config}" ]; then
+    echo "::warning::Codex config ${_codex_config} not found before resolver loop; reasoning effort override (${_arr_level}) skipped."
+    return 0
+  fi
+  _arr_rewrite_ok=1
   {
     if grep -qE '^[[:space:]]*model_reasoning_effort[[:space:]]*=' "${_codex_config}"; then
-      sed -i "s|^[[:space:]]*model_reasoning_effort[[:space:]]*=.*|model_reasoning_effort = \"${_resolver_reasoning_effort}\"|" "${_codex_config}"
+      sed -i "s|^[[:space:]]*model_reasoning_effort[[:space:]]*=.*|model_reasoning_effort = \"${_arr_level}\"|" "${_codex_config}"
     else
-      printf '\nmodel_reasoning_effort = "%s"\n' "${_resolver_reasoning_effort}" >> "${_codex_config}"
+      printf '\nmodel_reasoning_effort = "%s"\n' "${_arr_level}" >> "${_codex_config}"
     fi
     if grep -qE '^[[:space:]]*model_reasoning_summary[[:space:]]*=' "${_codex_config}"; then
       sed -i 's|^[[:space:]]*model_reasoning_summary[[:space:]]*=.*|model_reasoning_summary = "auto"|' "${_codex_config}"
     else
       sed -i '/^[[:space:]]*model_reasoning_effort[[:space:]]*=/a model_reasoning_summary = "auto"' "${_codex_config}"
     fi
-  } || _rewrite_ok=0
+  } || _arr_rewrite_ok=0
 
-  if [ "${_rewrite_ok}" -eq 0 ]; then
+  if [ "${_arr_rewrite_ok}" -eq 0 ]; then
     echo "::warning::Codex config rewrite failed for ${_codex_config}; resolver will run with whatever reasoning the editor step left in place."
-  else
-    # Independent checks (not elif) so both mismatches surface together
-    # if the rewrite somehow produced neither expected line.
-    _verify_ok=1
-    if ! grep -qE "^model_reasoning_effort = \"${_resolver_reasoning_effort}\"$" "${_codex_config}"; then
-      echo "::warning::Codex config rewrite did not produce the expected model_reasoning_effort = \"${_resolver_reasoning_effort}\" line; resolver may run with stale reasoning."
-      _verify_ok=0
-    fi
-    if ! grep -qE '^model_reasoning_summary = "auto"$' "${_codex_config}"; then
-      echo "::warning::Codex config rewrite did not produce the expected model_reasoning_summary = \"auto\" line; the anti-empty-stdout safeguard may be unset."
-      _verify_ok=0
-    fi
-    if [ "${_verify_ok}" -eq 1 ]; then
-      echo "Conflict resolver reasoning effort set to ${_resolver_reasoning_effort} (model_reasoning_summary=auto)."
-    fi
+    return 0
   fi
-else
-  echo "::warning::Codex config ${_codex_config} not found before resolver loop; reasoning effort override skipped."
-fi
+  # Independent checks (not elif) so both mismatches surface together
+  # if the rewrite somehow produced neither expected line.
+  _arr_verify_ok=1
+  if ! grep -qE "^model_reasoning_effort = \"${_arr_level}\"$" "${_codex_config}"; then
+    echo "::warning::Codex config rewrite did not produce the expected model_reasoning_effort = \"${_arr_level}\" line; resolver may run with stale reasoning."
+    _arr_verify_ok=0
+  fi
+  if ! grep -qE '^model_reasoning_summary = "auto"$' "${_codex_config}"; then
+    echo "::warning::Codex config rewrite did not produce the expected model_reasoning_summary = \"auto\" line; the anti-empty-stdout safeguard may be unset."
+    _arr_verify_ok=0
+  fi
+  if [ "${_arr_verify_ok}" -eq 1 ]; then
+    echo "Conflict resolver reasoning effort set to ${_arr_level} (model_reasoning_summary=auto)."
+  fi
+}
+
+# _next_lower_reasoning_effort <level>
+#
+# Echo the next-lower level on the README.md "Thinking levels"
+# ladder: xhigh → high → medium → none. At the floor, echo "none"
+# unchanged so the caller can detect "already at floor" via string
+# comparison without a separate sentinel. Defensive default for
+# unexpected input returns "high" because that is the resolver's
+# repo-wide default and matches the validation fallback above.
+_next_lower_reasoning_effort()
+{
+  case "${1:-}" in
+    xhigh)  printf '%s\n' high ;;
+    high)   printf '%s\n' medium ;;
+    medium) printf '%s\n' none ;;
+    none)   printf '%s\n' none ;;
+    *)      printf '%s\n' high ;;
+  esac
+}
+
+# _current_reasoning_effort tracks the level used by the most-
+# recent codex invocation. It starts at the validated env-provided
+# value and is mutated by the in-loop step-down block when the
+# previous attempt was timeout-killed. The original
+# _resolver_reasoning_effort is preserved as the "initial" level
+# for log-line provenance.
+_current_reasoning_effort="${_resolver_reasoning_effort}"
+_apply_resolver_reasoning_effort "${_current_reasoning_effort}"
 
 RESOLVER_ATTEMPT_BASE_MISSING_FILE="${RUNTIME_DIR}/resolver_attempt_base_missing.txt"
 RESOLVER_RETRY_PROMPT_FILE="${RUNTIME_DIR}/resolver_retry_prompt.txt"
@@ -750,6 +804,35 @@ while [ "${attempt}" -le "${INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS}" ]; do
         echo "Conflict resolver retry ${attempt}/${INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS}: rebuilt retry prompt (prev failure_kind=${_prev_attempt_failure_kind:-unset})."
         ;;
     esac
+    # Step-down reasoning effort after a per-attempt-timer kill.
+    #
+    # The timeout-aware prelude (PR #2453) only changes the prompt:
+    # it nudges the model to be decisive and call apply_patch
+    # early. It does not change codex's reasoning level. Production
+    # runs (most recently the review_autofix run linked to PR #155
+    # of shubhodeep1/bitsafe.io, log at 2026-05-11) show xhigh/high
+    # attempts routinely consume the entire 50-min per-attempt
+    # budget on multi-file conflicts, so attempt 2 at the same
+    # level reliably hits the same wall.
+    #
+    # Walk the README.md "Thinking levels" ladder one step on each
+    # consecutive timeout: xhigh → high → medium → none. At the
+    # floor (none) we keep retrying at none and log that the
+    # ladder is exhausted; never raise the level on a recovery, so
+    # a single transient timeout doesn't cascade the rest of the
+    # run into floor-level reasoning. Non-timeout failure kinds
+    # (exec_error, validation) leave the level unchanged — they're
+    # not evidence that thinking budget was the bottleneck.
+    if [ "${_prev_attempt_failure_kind:-}" = "timeout" ]; then
+      _next_level="$(_next_lower_reasoning_effort "${_current_reasoning_effort}")"
+      if [ "${_next_level}" != "${_current_reasoning_effort}" ]; then
+        echo "Conflict resolver retry ${attempt}/${INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS}: stepping reasoning effort down ${_current_reasoning_effort} → ${_next_level} after timeout-killed previous attempt (initial level ${_resolver_reasoning_effort})."
+        _current_reasoning_effort="${_next_level}"
+        _apply_resolver_reasoning_effort "${_current_reasoning_effort}"
+      else
+        echo "Conflict resolver retry ${attempt}/${INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS}: previous attempt timed out at reasoning level ${_current_reasoning_effort} (ladder floor reached); not stepping down further."
+      fi
+    fi
   else
     _effective_prompt_file="${CONFLICT_RESOLVER_PROMPT_FILE}"
   fi

--- a/scripts/review_conflict_resolve.sh
+++ b/scripts/review_conflict_resolve.sh
@@ -238,7 +238,9 @@ _codex_config="${HOME}/.codex/config.toml"
 # if either expected line is missing.
 _apply_resolver_reasoning_effort()
 {
-  _arr_level="${1:?reasoning level required}"
+  local _arr_level="${1:?reasoning level required}"
+  local _arr_rewrite_ok
+  local _arr_verify_ok
   case "${_arr_level}" in
     xhigh|high|medium|none) ;;
     *)

--- a/tests/test_review_conflict_resolve_reasoning_step_down.py
+++ b/tests/test_review_conflict_resolve_reasoning_step_down.py
@@ -243,3 +243,27 @@ def test_next_lower_ladder_returns_expected_levels() -> None:
 			"to itself (floor) and unknown inputs falling back "
 			"to `high` (the resolver's repo-wide default)."
 		)
+
+
+def main() -> int:
+	"""Allow this file to run via `python3 tests/<file>` (the
+	CI/release allowlist invocation pattern in .github/workflows/
+	ci.yml, mark-stable.yml, and test-and-mark-stable.yml) without
+	requiring pytest on the runner. Mirrors the sibling
+	test_review_conflict_resolve_retry_prelude_render.py shape."""
+	test_apply_helper_defined_and_uses_codex_config()
+	test_next_lower_helper_defined()
+	test_initial_apply_call_uses_current_effort_tracker()
+	test_loop_step_down_is_gated_on_timeout_failure_kind()
+	test_next_lower_ladder_returns_expected_levels()
+	print(
+		"OK: review_conflict_resolve reasoning-effort step-down "
+		"contract holds (helper definitions, _current_reasoning_effort "
+		"tracker, timeout-gated step-down, xhigh→high→medium→none "
+		"ladder)"
+	)
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_review_conflict_resolve_reasoning_step_down.py
+++ b/tests/test_review_conflict_resolve_reasoning_step_down.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Contract tests for the resolver-loop reasoning step-down on
+per-attempt-timer kills.
+
+PR #2453 added the `timeout-aware` retry prelude so the model's
+prompt acknowledges a previous attempt was killed by the
+per-attempt timer.  But the prelude only changes the prompt — it
+does not change codex's reasoning level.  The job log linked to
+shubhodeep1/bitsafe.io PR #155 (workflow run dated 2026-05-11)
+showed attempt 1 at `xhigh` consuming the entire 3000s per-
+attempt budget without invoking `apply_patch`, and attempt 2
+queued at the same `xhigh` level — the prelude alone could not
+break the hung-thinking failure mode.
+
+scripts/review_conflict_resolve.sh therefore walks the README.md
+"Thinking levels" ladder one step down (xhigh → high → medium →
+none) on every consecutive timeout-classified retry.  These
+tests pin three contracts at the source level:
+
+  1. `_apply_resolver_reasoning_effort` and
+     `_next_lower_reasoning_effort` are defined and exercised
+     against the codex config file (`_codex_config`) — the
+     ladder cannot work without both helpers.
+  2. The retry loop's step-down block is gated on
+     `_prev_attempt_failure_kind == "timeout"` (so non-timeout
+     failure kinds — exec_error, validation — do not falsely
+     downgrade the level).
+  3. The ladder itself returns the expected next level for every
+     input (xhigh → high, high → medium, medium → none, none →
+     none, invalid → high).  The ladder helper is extracted into
+     a sourceable shell snippet and exercised in a subprocess
+     because that catches regressions where the literal `case`
+     arms drift from the README.md ladder.
+
+Source-level contract pinning mirrors the pattern in
+`test_review_conflict_resolve_retry_prelude_render.py` —
+robust to renderer-style refactors that swap how the override
+is applied without changing its semantics.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RESOLVE_SCRIPT = REPO_ROOT / "scripts" / "review_conflict_resolve.sh"
+
+
+def _resolve_script_text() -> str:
+	return RESOLVE_SCRIPT.read_text(encoding="utf-8")
+
+
+def test_apply_helper_defined_and_uses_codex_config() -> None:
+	"""`_apply_resolver_reasoning_effort` must exist and operate on
+	the validated `_codex_config` path. Without this helper the
+	retry loop cannot rewrite the reasoning level between
+	attempts, defeating the whole step-down."""
+	src = _resolve_script_text()
+	assert "_apply_resolver_reasoning_effort()" in src, (
+		"scripts/review_conflict_resolve.sh must define "
+		"`_apply_resolver_reasoning_effort()` so the retry loop "
+		"can re-rewrite ~/.codex/config.toml with a new reasoning "
+		"level between attempts.  If this helper is gone, "
+		"step-down silently no-ops and we regress to the "
+		"pre-step-down behaviour of retrying at the same level."
+	)
+	# The helper must touch _codex_config — otherwise it could not
+	# affect the next codex invocation.
+	apply_idx = src.find("_apply_resolver_reasoning_effort()")
+	# Bound the slice by the next top-level function header so an
+	# accidental capture of unrelated _codex_config references
+	# elsewhere in the file does not satisfy the contract.
+	end_marker = "\n_next_lower_reasoning_effort()"
+	end_idx = src.find(end_marker, apply_idx)
+	assert end_idx != -1, (
+		"Could not locate `_next_lower_reasoning_effort()` after "
+		"`_apply_resolver_reasoning_effort()`; if the layout was "
+		"refactored, update this test's slicing anchor."
+	)
+	body = src[apply_idx:end_idx]
+	assert "${_codex_config}" in body, (
+		"`_apply_resolver_reasoning_effort()` must read/write "
+		"${_codex_config}; otherwise it cannot affect the next "
+		"codex invocation."
+	)
+	# Defence-in-depth: the helper must validate its input against
+	# the same xhigh|high|medium|none allowlist used at startup,
+	# so an in-loop bug that passes an unexpected level cannot
+	# corrupt the TOML.
+	assert "xhigh|high|medium|none" in body, (
+		"`_apply_resolver_reasoning_effort()` must validate its "
+		"level argument against the xhigh|high|medium|none "
+		"allowlist before interpolating into sed — same defence "
+		"applied to CONFLICT_RESOLVER_REASONING_EFFORT at startup."
+	)
+
+
+def test_next_lower_helper_defined() -> None:
+	"""`_next_lower_reasoning_effort` must exist as a separate
+	helper so it is independently testable and re-usable from any
+	future caller (e.g. a related step-down on the editor side)."""
+	src = _resolve_script_text()
+	assert "_next_lower_reasoning_effort()" in src, (
+		"scripts/review_conflict_resolve.sh must define "
+		"`_next_lower_reasoning_effort()` — the retry loop reads "
+		"its return value to decide the next attempt's level."
+	)
+
+
+def test_initial_apply_call_uses_current_effort_tracker() -> None:
+	"""The once-per-step prelude must seed `_current_reasoning_effort`
+	from the validated env-provided level AND call the helper.
+	If either is missing, the retry loop's step-down has nothing
+	to start from and the initial codex invocation runs with
+	whatever reasoning the editor step left in place."""
+	src = _resolve_script_text()
+	assert '_current_reasoning_effort="${_resolver_reasoning_effort}"' in src, (
+		"`_current_reasoning_effort` must be seeded from the "
+		"validated `_resolver_reasoning_effort` so the retry loop "
+		"step-down ladder starts at the operator-chosen level."
+	)
+	assert '_apply_resolver_reasoning_effort "${_current_reasoning_effort}"' in src, (
+		"The once-per-step prelude must call "
+		"`_apply_resolver_reasoning_effort \"${_current_reasoning_effort}\"` "
+		"to keep the initial config-rewrite behaviour after the "
+		"refactor — without this call the resolver inherits the "
+		"editor's reasoning level on attempt 1."
+	)
+
+
+def test_loop_step_down_is_gated_on_timeout_failure_kind() -> None:
+	"""The step-down block must only fire when
+	`_prev_attempt_failure_kind == "timeout"`. Triggering it on
+	exec_error or validation failures would be actively harmful:
+	those failure kinds are not evidence that thinking budget was
+	the bottleneck, and downgrading after a transient codex crash
+	would cascade the rest of the run into floor-level reasoning."""
+	src = _resolve_script_text()
+	# Locate the loop body — bounded by the resolver loop header
+	# and the closing `done` — and check the step-down block is
+	# inside it and gated on timeout.
+	loop_header = (
+		'while [ "${attempt}" -le "${INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS}" ]; do'
+	)
+	loop_idx = src.find(loop_header)
+	assert loop_idx != -1, (
+		"Resolver retry loop header not found; if the loop was "
+		"renamed, update this test's slicing anchor."
+	)
+	# The step-down block must exist and live inside the loop body.
+	gate = 'if [ "${_prev_attempt_failure_kind:-}" = "timeout" ]; then'
+	gate_idx = src.find(gate, loop_idx)
+	assert gate_idx != -1, (
+		"Resolver loop must contain a step-down block gated on "
+		"`_prev_attempt_failure_kind == \"timeout\"`. Without the "
+		"gate the ladder would fire on exec_error / validation "
+		"failures and falsely downgrade reasoning for transient "
+		"codex crashes."
+	)
+	# Inside the gate, the next-level computation must be present.
+	# Bound the slice by the gate's closing `fi` to keep this check
+	# load-bearing.
+	# The fi for this gate is the second-following `fi` after the
+	# inner if-else; search forwards for the conservative pattern
+	# `      fi` (six-space indent matching the loop body indent).
+	# We use a lighter pattern: a forward search for the helper
+	# invocation, bounded loosely by the next blank-line block.
+	tail = src[gate_idx:gate_idx + 2000]
+	assert '_next_lower_reasoning_effort "${_current_reasoning_effort}"' in tail, (
+		"Step-down block must call `_next_lower_reasoning_effort` "
+		"with the current level — passing a stale literal would "
+		"not advance the ladder on consecutive timeouts."
+	)
+	assert '_apply_resolver_reasoning_effort "${_current_reasoning_effort}"' in tail, (
+		"Step-down block must re-apply the new level via "
+		"`_apply_resolver_reasoning_effort` so the next codex "
+		"invocation actually picks it up."
+	)
+	# Floor-handling: the block must log a distinct message when
+	# the next-lower level equals the current level (ladder
+	# exhausted at `none`). Without this branch the operator log
+	# would silently no-op every time, masking the fact that the
+	# resolver is stuck at floor.
+	assert "ladder floor reached" in tail, (
+		"Step-down block must explicitly log when the ladder "
+		"floor (`none`) has been reached so the operator log "
+		"shows the difference between a successful downgrade and "
+		"a stuck-at-floor retry."
+	)
+
+
+def test_next_lower_ladder_returns_expected_levels() -> None:
+	"""Behavioural test: extract `_next_lower_reasoning_effort`
+	from the script and exercise it for every README.md level
+	plus an invalid input. The ladder is xhigh → high → medium →
+	none with `none` mapping to `none` (floor) and an invalid
+	input falling back to `high` (the repo-wide default)."""
+	src = _resolve_script_text()
+	# Splice out the helper definition so we can source it
+	# without running the rest of the script (which has
+	# `set -euo pipefail` and unrelated side effects). Match
+	# from the function header to the line that contains only
+	# the closing brace — `[^}]*` cannot be used here because the
+	# body legitimately contains `}` inside `${1:-}` parameter
+	# expansions.
+	match = re.search(
+		r"^_next_lower_reasoning_effort\(\)\n\{\n.*?\n\}\n",
+		src,
+		flags=re.DOTALL | re.MULTILINE,
+	)
+	assert match is not None, (
+		"Could not extract `_next_lower_reasoning_effort()` from "
+		"the script for behavioural testing. The function body "
+		"must use brace-on-next-line style (consistent with §9 "
+		"code style) and end on a line containing only the "
+		"closing brace."
+	)
+	helper_src = match.group(0)
+	expectations = [
+		("xhigh", "high"),
+		("high", "medium"),
+		("medium", "none"),
+		("none", "none"),
+		("garbage", "high"),
+		("", "high"),
+	]
+	for level_in, level_out in expectations:
+		script = f"{helper_src}\n_next_lower_reasoning_effort {level_in!r}\n"
+		result = subprocess.run(
+			["bash", "-c", script],
+			check=True,
+			capture_output=True,
+			text=True,
+		)
+		got = result.stdout.strip()
+		assert got == level_out, (
+			f"_next_lower_reasoning_effort({level_in!r}) returned "
+			f"{got!r}; expected {level_out!r}. The ladder is "
+			"xhigh → high → medium → none, with `none` mapping "
+			"to itself (floor) and unknown inputs falling back "
+			"to `high` (the resolver's repo-wide default)."
+		)


### PR DESCRIPTION
## Summary

Walk the README.md "Thinking levels" ladder one step down on each consecutive timeout-classified resolver retry: **xhigh → high → medium → none**. PR #2453 added the timeout-aware retry prelude, but the prelude only changes the prompt — it does not change codex's reasoning level, so an attempt that times out at `xhigh` retries at the same `xhigh` and reliably hits the same wall.

## Motivation

The review_autofix run linked to shubhodeep1/bitsafe.io PR #155 (job log dated 2026-05-11) showed:

- Attempt 1 at `xhigh` consumed the entire 3000s per-attempt budget without invoking `apply_patch` on a 6-file hedge-module conflict.
- Attempt 2 queued at the same `xhigh` level; the step-level 60-min timeout (since raised to 170 min in PR #2453) fired before it could complete.

The existing timeout-aware prelude nudges the model to be decisive and call `apply_patch` early, but the underlying reasoning budget is what is exhausted on these multi-file conflicts. Lowering the level after a timeout kill is the standard escape hatch.

## Implementation

- Extract the once-per-step `~/.codex/config.toml` rewrite into `_apply_resolver_reasoning_effort` so it can be reinvoked per-attempt with a fresh level. Preserve the fail-open `::warning::` behaviour and the `xhigh|high|medium|none` validation.
- Add `_next_lower_reasoning_effort` as a standalone helper so the ladder is independently testable.
- Track the live level in `_current_reasoning_effort`, seeded from the validated `_resolver_reasoning_effort` (preserved for log-line provenance).
- Inside the retry loop, when `_prev_attempt_failure_kind == "timeout"`, advance one ladder step and re-apply. Floor (`none`) maps to itself and emits a distinct `ladder floor reached` log so a stuck-at-floor retry is distinguishable from a downgrade.
- Non-timeout failure kinds (`exec_error`, `validation`) leave the level unchanged — they are not evidence that thinking budget was the bottleneck, and downgrading on a transient codex crash would cascade the rest of the run into floor-level reasoning.

## Files changed

- `scripts/review_conflict_resolve.sh:200-309` — helper extraction + ladder + `_current_reasoning_effort` tracker.
- `scripts/review_conflict_resolve.sh:800-830` — in-loop step-down block gated on `timeout` failure_kind.
- `tests/test_review_conflict_resolve_reasoning_step_down.py` — new contract + behavioural tests (5 tests, all passing).

## Test plan

- [x] `bash -n scripts/review_conflict_resolve.sh` passes.
- [x] `pytest tests/test_review_conflict_resolve_reasoning_step_down.py` — 5/5 pass.
- [x] `pytest tests/test_review_conflict_resolve_retry_prelude_render.py tests/test_review_conflict_resolve_smoke_deterministic.py tests/test_review_autofix_smoke_conflict_resolver_override.py` — 17/17 pass.
- [x] `pytest tests/ -k "review_autofix or review_conflict"` — 52/53 pass; the single failure (`test_review_autofix_merge_precheck::test_known_ci_artifacts_removed_in_resolve_step`) is pre-existing on `stable` and unrelated to this change.

## Notes for reviewers

- Base branch: `stable` (per user instruction "fix needs to be based on stable branch, not main").
- Sibling fixes already on stable: PR #2453 (step timeout 60→170 min + timeout-aware prelude), PR #2449 (default xhigh→high), PR #2467 (bash-n guard). This change is the natural follow-on: the prelude is in place, but a same-level retry still hits the same budget wall.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Ep14eEhY1L732rX4XBWqg)_