### PR TITLE
chore: remove "do not create test scripts" rule from CLAUDE.md §5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,6 @@ conditions, idempotency, deployment safety.
 
 - Do NOT change formats, types, or unrelated logic.
 - Do NOT reformat files unless required for the fix.
-- Do NOT create test scripts unless asked.
 - Extend existing mechanisms — never compete with them.
 
 ---


### PR DESCRIPTION
## Summary
- Removes the line `Do NOT create test scripts unless asked.` from §5 (Minimal Change Set) in `CLAUDE.md`.
- Scope is limited to `CLAUDE.md` (interactive Claude Code sessions). The same rule still exists in `codex.md` and `unattended_system_instructions.md` and was left untouched per the user's explicit scope.

## Test plan
- [ ] Confirm the line is gone from `CLAUDE.md` §5.
- [ ] Confirm no other section numbers/content changed (§6 naming-immutability is respected).


---
_Generated by [Claude Code](https://claude.ai/code/session_013hSQcpESEpEproeKb4etN5)_