### PR TITLE
fix: prevent EDITOR_CHANGES_LOST false positive on audit-converged commits

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -921,7 +921,7 @@ jobs:
             echo "SUPPORT_AGENTS_FILE=${SUPPORT_ROOT_DIR}/agents.md"
           } >> "$GITHUB_ENV"
 
-          REQUIRED_BOOTSTRAP_SCRIPTS="gh_helpers.sh git_ref_health_check.sh generate_symbol_diff_summary.py render_prompt.sh tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py review_run_reviewers.sh review_apply_fixes.sh review_rb_judge.sh review_commit_changes.sh review_conflict_prepare.sh review_conflict_resolve.sh check_workflow_script_refs.py check_resolver_diff.sh summarize_reviewer_consensus.sh check_external_branch_advance.sh post_review_comment.sh targeted_file_context.py write_codex_config.sh"
+          REQUIRED_BOOTSTRAP_SCRIPTS="gh_helpers.sh git_ref_health_check.sh generate_symbol_diff_summary.py render_prompt.sh tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py review_run_reviewers.sh review_apply_fixes.sh review_rb_judge.sh review_commit_changes.sh review_conflict_prepare.sh review_conflict_resolve.sh check_workflow_script_refs.py check_resolver_diff.sh summarize_reviewer_consensus.sh check_external_branch_advance.sh post_review_comment.sh targeted_file_context.py write_codex_config.sh detect_editor_changes_lost.sh"
           # Optional bootstrap scripts: allowed to be missing from both
           # refs.  The bootstrap emits a warning and continues — callers
           # that depend on these must themselves tolerate absence.  Keep
@@ -3195,11 +3195,18 @@ jobs:
         # NOT a "clean review" signal and must block auto-merge.
         # See: PR #1136, #1137 where this mismatch caused premature
         # auto-merge of un-fixed PRs.
-        # LEDGER_ONLY_COMMIT=true: the commit contains only the autofix
-        # ledger, which is a bookkeeping write — not a productive edit — so
-        # this safety check must still run to validate the editor's no-op
-        # claim before downstream clean-review gates fire. See PR #1472.
-        if: "!cancelled() && (steps.commit_changes.outputs.did_commit != 'true' || env.LEDGER_ONLY_COMMIT == 'true') && env.PR_CLOSED != 'true' && env.AUTOFIX_STALE_BASE_SKIP != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true'"
+        # LEDGER_ONLY_COMMIT_STRICT=true: the commit's only tracked path is
+        # the autofix ledger, which is a bookkeeping write — not a
+        # productive edit — so this safety check must still run to validate
+        # the editor's no-op claim before downstream clean-review gates
+        # fire.  See PR #1472.  We deliberately read the STRICT flag here
+        # (not LEDGER_ONLY_COMMIT) because the non-strict flag is also set
+        # by the audit-convergence branch in
+        # scripts/review_commit_changes.sh, which can fire on commits that
+        # DID land real source-file edits.  Running this detector against
+        # such a commit produces a false-positive EDITOR_CHANGES_LOST alert
+        # (bitsafe.io PR #177 / run 25653654000).
+        if: "!cancelled() && (steps.commit_changes.outputs.did_commit != 'true' || env.LEDGER_ONLY_COMMIT_STRICT == 'true') && env.PR_CLOSED != 'true' && env.AUTOFIX_STALE_BASE_SKIP != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true'"
         run: |
           set -euo pipefail
 
@@ -3366,7 +3373,14 @@ jobs:
               # informational log line and do not block auto-merge.
               # Keeps the hard failure only when there is real evidence
               # of lost edits. See: fun-token-multi-chain PR #117.
-              recheck_script="${GITHUB_WORKSPACE}/scripts/detect_editor_changes_lost.sh"
+              #
+              # The script is bootstrapped to ${SUPPORT_SCRIPTS_DIR} by the
+              # bootstrap step (REQUIRED_BOOTSTRAP_SCRIPTS).  Reading from
+              # ${GITHUB_WORKSPACE}/scripts/ would silently skip the recheck
+              # in every consumer repo (only the workflow-source repo
+              # vendors this path), which is how the bitsafe.io PR #177 /
+              # run 25653654000 false positive escaped this safety net.
+              recheck_script="${SUPPORT_SCRIPTS_DIR}/detect_editor_changes_lost.sh"
               if [ -x "${recheck_script}" ]; then
                 recheck_result="$(bash "${recheck_script}" "${EDITOR_SUMMARY_FILE}" 2>/dev/null || echo "true")"
                 if [ "${recheck_result}" = "false" ]; then

--- a/scripts/review_commit_changes.sh
+++ b/scripts/review_commit_changes.sh
@@ -22,8 +22,23 @@
 #   GITHUB_REPOSITORY                 owner/repo slug (auto-set by GitHub Actions).
 #
 # Outputs:
-#   $GITHUB_ENV:     DID_COMMIT, LEDGER_ONLY_COMMIT.
-#   $GITHUB_OUTPUT:  did_commit, ledger_only_commit.
+#   $GITHUB_ENV:     DID_COMMIT, LEDGER_ONLY_COMMIT, LEDGER_ONLY_COMMIT_STRICT.
+#   $GITHUB_OUTPUT:  did_commit, ledger_only_commit, ledger_only_commit_strict.
+#
+#   LEDGER_ONLY_COMMIT signals "this commit should NOT trigger an rb_judge
+#   rerun" and is `true` for BOTH (a) the commit's only tracked path is the
+#   review-issue ledger, AND (b) the editor's per-file audit reports the
+#   autofix loop has converged (applied=0, already_applied≥1).  Existing
+#   consumers (auto-merge, retrigger-guard, continuation-dispatch skip) read
+#   this flag.
+#
+#   LEDGER_ONLY_COMMIT_STRICT signals ONLY (a) — the commit's tracked paths
+#   equal the ledger path.  Callers that need to know "did the editor's
+#   productive edits actually land?" (the EDITOR_CHANGES_LOST detector in
+#   review_autofix.yml) MUST read this strict flag; reading
+#   LEDGER_ONLY_COMMIT causes a false positive when the audit-convergence
+#   branch fires on a commit that DID land real source-file edits
+#   (bitsafe.io PR #177 / run 25653654000).
 #   ${COMMITTED_FILES_FILE}:  one "- <path>" line per committed file, or a single marker line.
 #
 # Failure modes:
@@ -71,6 +86,8 @@ echo "DID_COMMIT=false" >> "$GITHUB_ENV"
 echo "did_commit=false" >> "$GITHUB_OUTPUT"
 echo "LEDGER_ONLY_COMMIT=false" >> "$GITHUB_ENV"
 echo "ledger_only_commit=false" >> "$GITHUB_OUTPUT"
+echo "LEDGER_ONLY_COMMIT_STRICT=false" >> "$GITHUB_ENV"
+echo "ledger_only_commit_strict=false" >> "$GITHUB_OUTPUT"
 
 if [ "${CAN_PUSH:-false}" != "true" ]; then
   echo "Skipping commit/push: branch is not writable from this workflow."
@@ -502,6 +519,8 @@ PY
     echo "Commit contains only the review-issue ledger (${LEDGER_PATH_FOR_DETECTOR}); marking as editor no-op for downstream clean-review gates."
     echo "LEDGER_ONLY_COMMIT=true" >> "$GITHUB_ENV"
     echo "ledger_only_commit=true" >> "$GITHUB_OUTPUT"
+    echo "LEDGER_ONLY_COMMIT_STRICT=true" >> "$GITHUB_ENV"
+    echo "ledger_only_commit_strict=true" >> "$GITHUB_OUTPUT"
   else
     # Audit-driven convergence detector.  When every per-file audit entry
     # in the editor summary reports `issues applied: 0` AND the cumulative
@@ -548,9 +567,20 @@ PY
     if [ "${_audit_convergence_applies}" = "true" ]; then
       echo "LEDGER_ONLY_COMMIT=true" >> "$GITHUB_ENV"
       echo "ledger_only_commit=true" >> "$GITHUB_OUTPUT"
+      # Strict flag stays false: audit convergence is NOT the same as
+      # "only the ledger was committed".  Callers that gate on whether
+      # the editor's productive edits actually landed (the
+      # EDITOR_CHANGES_LOST detector in review_autofix.yml) MUST read
+      # the strict flag to avoid a false positive on commits that
+      # contain real source-file diffs alongside a converged audit
+      # (bitsafe.io PR #177 / run 25653654000).
+      echo "LEDGER_ONLY_COMMIT_STRICT=false" >> "$GITHUB_ENV"
+      echo "ledger_only_commit_strict=false" >> "$GITHUB_OUTPUT"
     else
       echo "LEDGER_ONLY_COMMIT=false" >> "$GITHUB_ENV"
       echo "ledger_only_commit=false" >> "$GITHUB_OUTPUT"
+      echo "LEDGER_ONLY_COMMIT_STRICT=false" >> "$GITHUB_ENV"
+      echo "ledger_only_commit_strict=false" >> "$GITHUB_OUTPUT"
     fi
   fi
 fi

--- a/tests/test_detect_editor_changes_lost.py
+++ b/tests/test_detect_editor_changes_lost.py
@@ -383,8 +383,23 @@ def test_apply_fixes_contains_editor_input_authority_contract() -> None:
 
 def test_workflow_uses_defense_in_depth_shim() -> None:
 	wf = REVIEW_AUTOFIX_WF.read_text(encoding="utf-8")
-	assert "scripts/detect_editor_changes_lost.sh" in wf, (
-		"Expected review_autofix.yml to invoke the defense-in-depth shim"
+	# The shim must be installed by the bootstrap step so consumer
+	# repos — not just the workflow-source repo — actually have the
+	# script on disk at runtime.  Reading it from a non-bootstrapped
+	# path silently no-ops the recheck in every consumer (bitsafe.io
+	# PR #177 / run 25653654000 escape).
+	bootstrap_line = next(
+		(line for line in wf.splitlines() if "REQUIRED_BOOTSTRAP_SCRIPTS=" in line),
+		"",
+	)
+	assert "detect_editor_changes_lost.sh" in bootstrap_line, (
+		"Expected detect_editor_changes_lost.sh in REQUIRED_BOOTSTRAP_SCRIPTS so the shim is reachable in consumer repos"
+	)
+	# The recheck must read from the bootstrapped directory; the
+	# previous `${GITHUB_WORKSPACE}/scripts/` path only exists in the
+	# workflow-source repo and silently failed in every consumer.
+	assert '${SUPPORT_SCRIPTS_DIR}/detect_editor_changes_lost.sh' in wf, (
+		"Expected review_autofix.yml to invoke the defense-in-depth shim from SUPPORT_SCRIPTS_DIR"
 	)
 	assert "treating as false positive (no warning, auto-merge not blocked)" in wf
 


### PR DESCRIPTION
## Summary

Fixes the false-positive `EDITOR_CHANGES_LOST` alert observed on
[bitsafe.io PR #177](https://github.com/shubhodeep1/bitsafe.io/issues/177)
([run 25653654000](https://github.com/shubhodeep1/bitsafe.io/actions/runs/25653654000)),
where the editor successfully landed real source-file edits in commit
`30d9923` (3 files, +58/−122) but the autofix workflow re-dispatched a
fresh review and emitted a Telegram warning claiming "Editor tool calls
failed to persist."

Two independent upstream bugs interacted:

**Bug 1 — `LEDGER_ONLY_COMMIT` is semantically overloaded.**
`scripts/review_commit_changes.sh` sets `LEDGER_ONLY_COMMIT=true` for
two distinct cases:
- **(a)** the commit's only tracked path equals the review-issue ledger
  (correct meaning per PR #1472), and
- **(b)** the editor's per-file audit reports convergence
  (`applied=0`, `already_applied≥1`) — "autofix loop convergence",
  unrelated to whether the ledger was the only path committed.

The `EDITOR_CHANGES_LOST` detector at `review_autofix.yml:3202` only
wants meaning (a) — "did the editor's productive edits land?" — but
reading the overloaded flag causes a false positive when (b) fires on
a commit that DID land real source-file edits.

**Bug 2 — the defense-in-depth recheck never runs in consumers.**
`scripts/detect_editor_changes_lost.sh` exists upstream and (per its
PR #117 header) was designed to catch exactly this class of false
positive, but `review_autofix.yml:3376` looked for it at
`${GITHUB_WORKSPACE}/scripts/`, while bootstrap installs scripts to
`${SUPPORT_SCRIPTS_DIR}` and the script wasn't in
`REQUIRED_BOOTSTRAP_SCRIPTS` to begin with. The `if [ -x ... ]` test
silently failed and the recheck never executed in any consumer repo.

## Fix design — additive (§6-compliant)

Per CLAUDE.md §6 (backward compatibility / naming immutability), this
PR adds a new flag alongside the existing one rather than narrowing
`LEDGER_ONLY_COMMIT`'s semantics:

- **New:** `LEDGER_ONLY_COMMIT_STRICT` (env + step output) is set true
  **only** when the commit's tracked paths equal the ledger path
  (meaning (a)). Set false in every other code path, including audit
  convergence.
- **Unchanged:** `LEDGER_ONLY_COMMIT` continues to be set true for both
  (a) and (b). Every existing consumer — auto-merge gate
  (`review_autofix.yml:3428`), retrigger-guard /
  continuation-dispatch skip (`L4023`, `L4249`, `L4512-4528`, `L4641`)
  — keeps its current convergence-skip behaviour.
- **Changed only at the EDITOR_CHANGES_LOST gate** (`L3209`): switched
  from `env.LEDGER_ONLY_COMMIT == 'true'` to
  `env.LEDGER_ONLY_COMMIT_STRICT == 'true'`. This is the single
  consumer that needs to distinguish (a) from (b).

For Bug 2, the recheck is now bootstrapped via
`REQUIRED_BOOTSTRAP_SCRIPTS` and read from `${SUPPORT_SCRIPTS_DIR}`.
This single change would have downgraded the run-25653654000 alert on
its own (per `detect_editor_changes_lost.sh:106-148`: when working
tree is clean and every narrative path is in the committed set, the
shim returns `false`).

## Files changed

- `scripts/review_commit_changes.sh`
  - L25-40: docstring expanded to document both flags and their
    intended semantics.
  - L87-90: initialise `LEDGER_ONLY_COMMIT_STRICT=false` alongside the
    existing legacy default.
  - L520-523: in the path-match branch, set strict=true alongside
    legacy=true.
  - L568-583: in the audit-convergence branch, leave legacy=true
    (preserve existing behaviour) and explicitly set strict=false with
    an inline comment citing PR #177 / run 25653654000. In the
    not-converged else branch, set both to false for symmetry.
- `.github/workflows/review_autofix.yml`
  - L924: append `detect_editor_changes_lost.sh` to
    `REQUIRED_BOOTSTRAP_SCRIPTS`.
  - L3198-3209: rewrote the detector-gate comment to explain the
    strict-flag rationale; switched the `if:` expression to read
    `env.LEDGER_ONLY_COMMIT_STRICT`.
  - L3376-3383: retargeted `recheck_script` from
    `${GITHUB_WORKSPACE}/scripts/` to `${SUPPORT_SCRIPTS_DIR}/` so the
    bootstrapped script is actually reachable; added a comment citing
    the run-25653654000 escape.

No other workflow gates were touched, so existing behaviour is
preserved across every other consumer (auto-merge, retrigger guard,
continuation dispatch).

## Evidence verified at upstream

Verified against `20c9849c` (= `stable` = `v1.8.7`, matches the
failing run's `UPSTREAM_SHA`). Also confirmed the bug pre-dates v1.8.7
(no commits between `v1.8.6` and `v1.8.7` touched the relevant files)
and is still present at `main` HEAD (no commits between `20c9849c` and
the PR branch base touched the relevant files).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/review_autofix.yml'))"` — YAML parses.
- [x] `bash -n scripts/review_commit_changes.sh` — shell syntax clean.
- [x] `scripts/check_workflow_script_refs.py` — all workflow script
      references resolve (catches the bootstrap-list addition).
- [ ] Live verification: next autofix run on any consumer repo where
      the audit-convergence branch fires on a commit with real source
      diffs should NOT emit `EDITOR_CHANGES_LOST=true`. The strict
      flag will be `false`, the gate at L3209 will skip the detector
      step entirely, and downstream clean-review gates fire as before.
- [ ] Belt-and-suspenders: even if a future overload of the strict
      flag occurs, the defense-in-depth recheck now actually runs in
      consumer repos thanks to the bootstrap fix.

## Open follow-ups

- The previous-stable channel (`v1.8.6` / `6e02c2f`) has the same bug.
  If a backport channel is maintained, consider cherry-picking.
- The recheck's "clean porcelain" assumption at
  `detect_editor_changes_lost.sh:106` could break if the workflow ever
  chains additional uncommitted edits (e.g. lint autofix) between the
  commit step and the detector step. Not the case today; worth a quick
  re-audit if that flow changes.

https://claude.ai/code/session_015WCqcFzY5LECFaZgxkqLCf

---
_Generated by [Claude Code](https://claude.ai/code/session_015WCqcFzY5LECFaZgxkqLCf)_