### PR TITLE
fix(post_review_comment): recover from open-then-push race so consensus lands on PR

### DIFF
--- a/scripts/post_review_comment.sh
+++ b/scripts/post_review_comment.sh
@@ -133,13 +133,22 @@ echo "post_review_comment: ledger=${REVIEWER_CONSENSUS_FILE} bytes=${LEDGER_BYTE
 if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]] && [ -n "${HEAD_REF}" ]; then
 	resolved_pr=""
 	owner="${REPOSITORY%/*}"
+	# URL-percent-encode HEAD_REF for the query parameter. Git allows
+	# branch names containing query-reserved characters (& # + % ? space
+	# etc.), and a `feat&test` ref would otherwise turn the query into
+	# ?state=open&head=owner:feat&test=  — collapsing to head=owner:feat
+	# server-side, the lookup misses the PR, and we'd fall through to
+	# commit-comment routing (the original bug this script is fixing).
+	# jq is already a workflow dependency; @uri matches RFC 3986
+	# percent-encoding and / → %2F decodes back server-side.
+	encoded_head_ref="$(jq -nr --arg ref "${HEAD_REF}" '$ref | @uri')"
 	# Let gh_retry's stderr (auth errors, rate-limit warnings, permanent
 	# failures after retry exhaustion) flow through to the workflow log
 	# for observability. The numeric regex on resolved_pr below still
 	# fails open to commit-comment route on any empty / non-numeric
 	# output, so no observability gain costs us behavioural safety.
 	if resolved_pr="$(HEAD_SHA="${HEAD_SHA}" gh_retry gh api \
-		"repos/${REPOSITORY}/pulls?state=open&head=${owner}:${HEAD_REF}" \
+		"repos/${REPOSITORY}/pulls?state=open&head=${owner}:${encoded_head_ref}" \
 		--jq '[.[] | select(.head.sha == env.HEAD_SHA) | .number] | first // empty')" \
 		&& [[ "${resolved_pr}" =~ ^[0-9]+$ ]]; then
 		echo "post_review_comment: resolved PR_NUMBER=${resolved_pr} from HEAD_REF=${HEAD_REF} HEAD_SHA=${HEAD_SHA} (open-then-push race recovery)"

--- a/scripts/post_review_comment.sh
+++ b/scripts/post_review_comment.sh
@@ -129,10 +129,15 @@ echo "post_review_comment: ledger=${REVIEWER_CONSENSUS_FILE} bytes=${LEDGER_BYTE
 if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]] && [ -n "${HEAD_REF}" ]; then
 	resolved_pr=""
 	owner="${REPOSITORY%/*}"
+	# Let gh_retry's stderr (auth errors, rate-limit warnings, permanent
+	# failures after retry exhaustion) flow through to the workflow log
+	# for observability. The numeric regex on resolved_pr below still
+	# fails open to commit-comment route on any empty / non-numeric
+	# output, so no observability gain costs us behavioural safety.
 	if resolved_pr="$(HEAD_SHA="${HEAD_SHA}" gh_retry gh api \
 		"repos/${REPOSITORY}/pulls?state=open&head=${owner}:${HEAD_REF}" \
-		--jq '[.[] | select(.head.sha == env.HEAD_SHA) | .number] | first // empty' \
-		2>/dev/null)" && [[ "${resolved_pr}" =~ ^[0-9]+$ ]]; then
+		--jq '[.[] | select(.head.sha == env.HEAD_SHA) | .number] | first // empty')" \
+		&& [[ "${resolved_pr}" =~ ^[0-9]+$ ]]; then
 		echo "post_review_comment: resolved PR_NUMBER=${resolved_pr} from HEAD_REF=${HEAD_REF} HEAD_SHA=${HEAD_SHA} (open-then-push race recovery)"
 		PR_NUMBER="${resolved_pr}"
 	else

--- a/scripts/post_review_comment.sh
+++ b/scripts/post_review_comment.sh
@@ -71,6 +71,10 @@ if [ -z "${REPOSITORY}" ]; then
 	echo "::error::post_review_comment: REPOSITORY must be set (e.g. owner/repo); GITHUB_REPOSITORY also empty." >&2
 	exit 2
 fi
+if ! [[ "${REPOSITORY}" =~ ^[^/]+/[^/]+$ ]]; then
+	echo "::error::post_review_comment: REPOSITORY must be in 'owner/repo' format; got '${REPOSITORY}'." >&2
+	exit 2
+fi
 if [ -z "${HEAD_SHA:-}" ]; then
 	echo "::error::post_review_comment: HEAD_SHA must be set (the commit the review covers)." >&2
 	exit 2

--- a/scripts/post_review_comment.sh
+++ b/scripts/post_review_comment.sh
@@ -108,7 +108,7 @@ if grep -Fq "(No reviewer outputs available for this pass.)" "${REVIEWER_CONSENS
 fi
 
 LEDGER_BYTES="$(wc -c < "${REVIEWER_CONSENSUS_FILE}" | tr -d '[:space:]')"
-echo "post_review_comment: ledger=${REVIEWER_CONSENSUS_FILE} bytes=${LEDGER_BYTES} pr=${PR_NUMBER:-<none>} sha=${HEAD_SHA}"
+echo "post_review_comment: ledger=${REVIEWER_CONSENSUS_FILE} bytes=${LEDGER_BYTES} sha=${HEAD_SHA} pr_in=${PR_NUMBER:-<none>}"
 
 # ── Open-then-push race recovery ────────────────────────────────────────
 # review_autofix.yml's caller (internal-review.yml resolve-claude-branch-pr)
@@ -165,7 +165,7 @@ if [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
 else
 	ROUTE="commit"
 fi
-echo "post_review_comment: route=${ROUTE}"
+echo "post_review_comment: route=${ROUTE} pr=${PR_NUMBER:-<none>}"
 
 # ── Build header / trailer envelope ─────────────────────────────────────
 RUN_URL=""

--- a/scripts/post_review_comment.sh
+++ b/scripts/post_review_comment.sh
@@ -6,8 +6,11 @@
 # Routing (matches CLAUDE.md Q3 decision: PR-comment when an open PR exists,
 # fall back to commit comment otherwise):
 #   * If PR_NUMBER is set + numeric → POST to /repos/{repo}/issues/{pr}/comments
-#   * Else (push event without an open PR for the head SHA) → POST to
-#     /repos/{repo}/commits/{sha}/comments
+#   * Else, re-check for an open PR on HEAD_REF whose head.sha == HEAD_SHA
+#     (open-then-push race recovery: review_autofix's caller checks for a
+#     PR once at push time, but the PR is often opened seconds later while
+#     the ~hour-long review proceeds). On match → POST to that PR.
+#   * Else (no matching open PR) → POST to /repos/{repo}/commits/{sha}/comments
 #
 # Chunking (matches Q4: chunk on finding boundaries; never mid-finding):
 #   GitHub caps a single comment body at 65 536 chars. We aim for a soft
@@ -102,6 +105,40 @@ fi
 
 LEDGER_BYTES="$(wc -c < "${REVIEWER_CONSENSUS_FILE}" | tr -d '[:space:]')"
 echo "post_review_comment: ledger=${REVIEWER_CONSENSUS_FILE} bytes=${LEDGER_BYTES} pr=${PR_NUMBER:-<none>} sha=${HEAD_SHA}"
+
+# ── Open-then-push race recovery ────────────────────────────────────────
+# review_autofix.yml's caller (internal-review.yml resolve-claude-branch-pr)
+# checks for an open PR exactly once, ~milliseconds after the push event
+# fires. When the user pushes the branch and opens the PR a few seconds
+# later (the open-then-push race documented in PR #1729 for concurrency),
+# the resolve job sees no PR, the codex-agent runs in claude-branch-review
+# mode with PR_NUMBER="", and the consensus ledger lands on the commit
+# comment thread instead of the PR. The review takes ~30–60 minutes, so
+# by the time we post the PR almost always exists.
+#
+# Re-check here, at the actual routing decision point, so we capture any
+# PR opened during the entire review window. Reuse the same head-ref
+# query pattern as resolve-claude-branch-pr (internal-review.yml line 99)
+# and add a head.sha guard so a force-push during the review (PR head
+# advanced past what we reviewed) still falls through to the commit
+# comment route — posting a stale-SHA review on a force-pushed PR would
+# mislead readers.
+#
+# Fail-open: any API error / empty result falls through to the existing
+# commit-comment route, which is the current behaviour.
+if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]] && [ -n "${HEAD_REF}" ]; then
+	resolved_pr=""
+	owner="${REPOSITORY%/*}"
+	if resolved_pr="$(HEAD_SHA="${HEAD_SHA}" gh_retry gh api \
+		"repos/${REPOSITORY}/pulls?state=open&head=${owner}:${HEAD_REF}" \
+		--jq '[.[] | select(.head.sha == env.HEAD_SHA) | .number] | first // empty' \
+		2>/dev/null)" && [[ "${resolved_pr}" =~ ^[0-9]+$ ]]; then
+		echo "post_review_comment: resolved PR_NUMBER=${resolved_pr} from HEAD_REF=${HEAD_REF} HEAD_SHA=${HEAD_SHA} (open-then-push race recovery)"
+		PR_NUMBER="${resolved_pr}"
+	else
+		echo "post_review_comment: no matching open PR for HEAD_REF=${HEAD_REF} HEAD_SHA=${HEAD_SHA}; routing to commit comment"
+	fi
+fi
 
 # ── Routing decision ────────────────────────────────────────────────────
 ROUTE=""


### PR DESCRIPTION
## Summary

Run [25661879657](https://github.com/shubhodeep1/coding-workflows/actions/runs/25661879657) (codex-agent, claude-branch-review mode) finished its 55-minute review on PR #2514's head SHA but posted the consensus ledger as a **commit comment**, leaving PR #2514 with zero review comments. The user asked why.

**Root cause — open-then-push race.** `internal-review.yml`'s `resolve-claude-branch-pr` job checks `gh api ".../pulls?state=open&head=…"` exactly once, ~milliseconds after the `push` event fires. For run 25661879657, the push fired at `2026-05-11T09:27:45Z`; PR #2514 was opened at `2026-05-11T09:28:07Z` — **22 s later**. The resolve job saw no PR, set `proceed=true`, and `review-claude-branch-push` invoked `review_autofix.yml` with `pr_number=""`. `post_review_comment.sh` then routed strictly on `PR_NUMBER` (empty) and fell through to the commit-comment endpoint, even though a perfectly matching open PR existed by the time we posted.

## Fix

Re-check for the PR at the actual routing decision point in `post_review_comment.sh` (the ~hour-long review window dwarfs the millisecond-scale resolve check, so re-checking at posting time captures any PR opened during the review).

- Query: same `gh api repos/{repo}/pulls?state=open&head=owner:HEAD_REF` shape used by `internal-review.yml:99` (CLAUDE.md §15 — reuse existing pattern instead of inventing a new one).
- Filter: `.head.sha == env.HEAD_SHA`. If a force-push moved the PR head during the review, the SHA guard fails and we fall through to commit comment instead of posting a stale-SHA review on a PR that has advanced past it.
- Fail-open: any API error / empty result falls through to the current commit-comment route, so a transient GitHub blip can never silently drop the consensus.

No workflow YAML changes; the PR_NUMBER-set path is untouched.

## Evidence

- PR #2514 `createdAt`: `2026-05-11T09:28:07Z` (`gh pr view 2514 --json createdAt`)
- Run 25661879657 `createdAt`: `2026-05-11T09:27:45Z`; `event=push`; same `headSha=b35f77e80de0b3e79b139eea3569c170c1c3366f` (`gh run view 25661879657 --json …`)
- Commit `b35f77e8` has 1 commit comment posted at `2026-05-11T10:22:40Z` matching the `<!-- claude-branch-review:v1 sha=… -->` marker; PR #2514 has zero comments.
- `internal-review.yml` lines 75–118: one-shot `pulls?state=open&head=…` lookup, no re-check.
- `scripts/post_review_comment.sh` lines 106–113 (pre-fix): route decided strictly on `PR_NUMBER`, no re-lookup.

## Test plan

- [x] `bash -n scripts/post_review_comment.sh` — clean.
- [x] Local jq spot-check: `env.HEAD_SHA` filter returns the matching PR number on hit and an empty string on miss.
- [ ] Next push to a `claude/**` branch where the PR is opened during the review will exercise the recovery path and post the consensus on the PR. The log line `post_review_comment: resolved PR_NUMBER=<n> from HEAD_REF=… HEAD_SHA=… (open-then-push race recovery)` confirms the fix fired.

https://claude.ai/code/session_013x2D9x7zyr8CX52wnRpXMZ

---
_Generated by [Claude Code](https://claude.ai/code/session_013x2D9x7zyr8CX52wnRpXMZ)_