### PR TITLE
fix(review_autofix): retry git fetch in Checkout PR head step

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2107,7 +2107,33 @@ jobs:
           bash "${SUPPORT_SCRIPTS_DIR}/git_ref_health_check.sh" repair
 
           CURRENT_BRANCH="$(git branch --show-current || true)"
-          git fetch --no-tags --prune origin "refs/heads/${HEAD_REF}:refs/remotes/origin/${HEAD_REF}"
+
+          # Retry git fetch against transient github.com errors (5xx,
+          # connection resets, DNS hiccups). A single ~minute-long
+          # GitHub-side blip otherwise kills a 15-minute autofix run
+          # with exit 128 (observed in run 25674867638, where two
+          # consecutive HTTPS calls returned "remote: Internal Server
+          # Error" / HTTP 500 within ~105s and the unguarded fetch
+          # failed the whole job). Backoff follows the project standard
+          # for git fetch/pull retries: 2s, 4s, 8s, 16s across 4
+          # attempts. Same shape as the existing push-retry fetch loop
+          # later in this file (search "fetch_attempt").
+          fetch_attempt=1
+          fetch_max_attempts=4
+          fetch_backoff=2
+          while true; do
+            if git fetch --no-tags --prune origin "refs/heads/${HEAD_REF}:refs/remotes/origin/${HEAD_REF}"; then
+              break
+            fi
+            if [ "${fetch_attempt}" -ge "${fetch_max_attempts}" ]; then
+              echo "::error::git fetch origin refs/heads/${HEAD_REF}:refs/remotes/origin/${HEAD_REF} failed after ${fetch_max_attempts} attempts; giving up."
+              exit 1
+            fi
+            echo "::warning::git fetch origin refs/heads/${HEAD_REF}:refs/remotes/origin/${HEAD_REF} failed (attempt ${fetch_attempt}/${fetch_max_attempts}); retrying in ${fetch_backoff}s."
+            sleep "${fetch_backoff}"
+            fetch_attempt=$((fetch_attempt + 1))
+            fetch_backoff=$((fetch_backoff * 2))
+          done
 
           if [ "${CURRENT_BRANCH}" = "${HEAD_REF}" ]; then
             git reset --hard "refs/remotes/origin/${HEAD_REF}"


### PR DESCRIPTION
## Summary

`review_autofix.yml`'s "Checkout PR head branch" step ran an unguarded
`git fetch ... origin refs/heads/${HEAD_REF}:refs/remotes/origin/${HEAD_REF}`.
A single transient github.com 5xx during that fetch fails the entire
15-minute autofix run with exit 128, even when the next attempt would
have succeeded.

Wraps the fetch in a 4-attempt exponential-backoff retry loop (2s, 4s,
8s, 16s) matching the documented project standard for `git fetch`/`git
pull` retries and the existing push-retry fetch loop later in the same
file.

## Root cause

Run [25674867638](https://github.com/shubhodeep1/coding-workflows/actions/runs/25674867638)
(PR #2509) failed at the "Checkout PR head branch" step with exit code
128. The job's `git-ref-health repair` call ran first and its
`git remote prune origin` hit `remote: Internal Server Error` /
`fatal: ... The requested URL returned error: 500` (already fail-soft
in `scripts/git_ref_health_check.sh:20-23`, swallowed as a warning).
~105 s later the next `git fetch` on the same step hit the same 500
and — with `set -euo pipefail` and no retry around it — failed the
entire reviewer + editor + commit + push pipeline that would otherwise
have run.

Other autofix runs nearby were unaffected, so this was a transient
GitHub-side blip rather than a sustained outage — exactly the failure
mode retry guards exist for.

## Change

`.github/workflows/review_autofix.yml:2110` →
`.github/workflows/review_autofix.yml:2121-2136` (new retry loop;
fetch invocation unchanged on `:2125`).

- `set -euo pipefail` is preserved; on the success path the loop
  `break`s as soon as `git fetch` returns 0.
- On the failure path the step still ultimately exits 1 after 4
  attempts (~30 s of total sleep + the failed fetches themselves), so
  a genuine connectivity / auth issue still surfaces as a hard
  failure with a clear `::error::` annotation instead of a silent
  pass.
- Each retry emits a `::warning::` annotation including the attempt
  number and backoff so operators can tell whether a passing run had
  to retry.
- No identifier renames (§6 honored). No DB/index/contract changes
  (§10 N/A). YAML uses 2-space indentation (§9).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/review_autofix.yml'))"` — YAML parses.
- [x] Extracted the step's `run:` script and ran `bash -n` — bash syntax OK.
- [ ] CI run on this PR — every existing `review_autofix`-touching test
      under `tests/test_review_autofix_*.py` /
      `tests/test_workflow_checkout_integration_ref_audit.py` /
      `tests/test_review_semble_contract.py` still passes.
- [ ] Next happy-path autofix run completes the "Checkout PR head
      branch" step without an extra retry warning (verifying the
      success path is unchanged when fetch returns 0 first try).

https://claude.ai/code/session_016XKhMfVN6E8vLqNZEq5Mpe


---
_Generated by [Claude Code](https://claude.ai/code/session_016XKhMfVN6E8vLqNZEq5Mpe)_