### PR TITLE
Resolve merge conflicts and integrate main changes for stall-judge, phase-attempts, and standalone state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
         run: |
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_poll_process.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_stall_loop_and_churn_fixes.py
 
       - name: Merge probe unit tests
         run: |

--- a/.github/workflows/mark-stable.yml
+++ b/.github/workflows/mark-stable.yml
@@ -214,6 +214,7 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_lib.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_poll_process.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_stall_loop_and_churn_fixes.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_mark_stable_release_tag_refspec_contract.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_targeted_file_context.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_stall_recovery_pr_lookup.py

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3203,6 +3203,7 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_lib.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_poll_process.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_stall_loop_and_churn_fixes.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_mark_stable_release_tag_refspec_contract.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_targeted_file_context.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_stall_recovery_pr_lookup.py

--- a/scripts/orchestrate_lib.py
+++ b/scripts/orchestrate_lib.py
@@ -1627,7 +1627,7 @@ def detect_stalls(
 
 	Returns a list of dicts, each containing:
 		id, github_issue, phase, recovery_action,
-		stall_duration_minutes, stall_recovery_count
+		stall_duration_minutes, stall_recovery_count, phase_attempts_count
 	"""
 	current_wave_idx = state.get("current_wave", 1) - 1
 	waves = state.get("waves", [])
@@ -1688,15 +1688,38 @@ def detect_stalls(
 		else:
 			phase_attempts_count = 0
 		phase_attempts_count = max(0, phase_attempts_count)
+
+		# Determine recovery action.  Apply the per-phase cap (when one is
+		# configured) to both the per-recovery counter and the phase-lifetime
+		# counter — otherwise a phase that the operator deliberately exempted
+		# from the default 5-attempt cap (e.g. ai:done with
+		# MAX_STALL_RECOVERIES_DONE=99) would still be hard-closed here at 5,
+		# bypassing the override.
+		#
+		# Phase-attempt cap routing (Codex P2, PR #2522, line 1705): when
+		# the phase oscillates (e.g. ai:review-blocked → ai:done →
+		# ai:review-blocked), update_issue_timestamps resets
+		# stall_recovery_count but phase_attempts_count keeps climbing.
+		# That makes it possible for phase_attempts to cap BEFORE
+		# recovery_count ever reaches stall_judge_trigger_count, so the
+		# old `elif phase_attempts_count >= effective_max: action = "skip"`
+		# would silently force a destructive skip without ever invoking
+		# the judge.  Route the phase-attempt-cap path through
+		# RUN_STALL_JUDGE_ACTION whenever the judge is enabled — the
+		# judge gets one chance to override (close_and_reissue, escalate,
+		# or unlock more attempts) before the ladder forces skip.  When
+		# the judge is disabled, fall back to the original behaviour
+		# (silent skip).
 		effective_max = _phase_specific_max_recoveries(
 			phase, max_recoveries, max_recoveries_by_phase
 		)
-
-		# Determine recovery action
 		if recovery_count >= effective_max:
 			action = "skip"
 		elif phase_attempts_count >= effective_max:
-			action = "skip"
+			if enable_stall_judge and stall_judge_trigger_count >= 1:
+				action = RUN_STALL_JUDGE_ACTION
+			else:
+				action = "skip"
 		elif enable_stall_judge and stall_judge_trigger_count >= 1 and recovery_count >= stall_judge_trigger_count:
 			action = RUN_STALL_JUDGE_ACTION
 		else:
@@ -2472,10 +2495,18 @@ def cmd_check_stalls(args: argparse.Namespace) -> int:
 		}
 
 	max_recoveries_by_phase: dict[str, int] | None = None
-	if getattr(args, "max_recoveries_by_phase_json", None):
-		max_recoveries_by_phase = {
-			k: int(v) for k, v in json.loads(args.max_recoveries_by_phase_json).items()
-		}
+	max_recoveries_by_phase_json = getattr(args, "max_recoveries_by_phase_json", None)
+	if max_recoveries_by_phase_json:
+		raw = json.loads(max_recoveries_by_phase_json)
+		if isinstance(raw, dict):
+			max_recoveries_by_phase = {}
+			for k, v in raw.items():
+				try:
+					iv = int(v)
+				except (TypeError, ValueError):
+					continue
+				if iv >= 1:
+					max_recoveries_by_phase[k] = iv
 
 	stalls = detect_stalls(
 		state, issue_labels, threshold, now_ts, max_recoveries,
@@ -2575,7 +2606,7 @@ def build_parser() -> argparse.ArgumentParser:
 	p_stalls.add_argument("--threshold-minutes", required=True, help="Fallback stall threshold in minutes (used when a phase has no specific override)")
 	p_stalls.add_argument("--phase-thresholds-json", default=None, help='Optional JSON: {"ai:clarification": 60, "ai:implementing": 120, ...}. Per-phase overrides.')
 	p_stalls.add_argument("--max-recoveries", default="5", help="Max recovery attempts per issue")
-	p_stalls.add_argument("--max-recoveries-by-phase-json", default=None, help='Optional JSON: {"ai:done": 99, ...}. Per-phase recovery-cap overrides.')
+	p_stalls.add_argument("--max-recoveries-by-phase-json", default=None, help='Optional JSON: {"ai:done": 99}. Per-phase caps override --max-recoveries for the named phases (applied to both stall_recovery_count and phase_attempts).')
 	p_stalls.add_argument("--stall-judge-trigger-count", default="2", help="Recovery-count threshold to switch stall recovery to run_stall_judge")
 	p_stalls.add_argument("--enable-stall-judge", default="true", choices=("true", "false"), help="Enable/disable stall judge escalation action")
 	p_stalls.add_argument(

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1016,6 +1016,13 @@ if ! [[ "${CONFLICT_DISPATCH_COOLDOWN_SECS}" =~ ^[0-9]+$ ]] || [ "${CONFLICT_DIS
   echo "::warning::CONFLICT_DISPATCH_COOLDOWN_SECS must be a non-negative integer; defaulting to 900"
   CONFLICT_DISPATCH_COOLDOWN_SECS="900"
 fi
+# Strip any leading zeros so the downstream arithmetic expansion at
+# line ~3639 (`$(( CONFLICT_DISPATCH_COOLDOWN_SECS * ... ))`) treats
+# the value as base-10.  Without this, an operator value like "0900"
+# trips bash's "value too great for base" error and aborts the
+# poller before integration self-healing can run (Codex P2,
+# PR #2522 line 3603).
+CONFLICT_DISPATCH_COOLDOWN_SECS=$(( 10#${CONFLICT_DISPATCH_COOLDOWN_SECS} ))
 
 INTEGRATION_CONFLICT_MAX_RETRIES="${INTEGRATION_CONFLICT_MAX_RETRIES:-3}"
 if ! [[ "${INTEGRATION_CONFLICT_MAX_RETRIES}" =~ ^[0-9]+$ ]] || [ "${INTEGRATION_CONFLICT_MAX_RETRIES}" -lt 1 ]; then
@@ -1077,21 +1084,54 @@ if ! [[ "${MAX_BUDGET_NEUTRAL_OVERRIDES}" =~ ^[0-9]+$ ]]; then
   echo "::warning::MAX_BUDGET_NEUTRAL_OVERRIDES must be a non-negative integer; defaulting to 2"
   MAX_BUDGET_NEUTRAL_OVERRIDES="2"
 fi
+# Strip leading zeros so the downstream `-ge` comparison (line ~5724
+# / ~7666) treats the value as base-10.  Without this, an operator
+# value like "08" trips bash's "value too great for base" error
+# (claude-branch-review PR #2522; mirrors the MAX_STALL_RECOVERIES_DONE
+# / CONFLICT_DISPATCH_COOLDOWN_SECS canonicalisation pattern).
+MAX_BUDGET_NEUTRAL_OVERRIDES=$(( 10#${MAX_BUDGET_NEUTRAL_OVERRIDES} ))
 
 # MAX_JUDGE_REPLAY caps how many consecutive cached judge decisions the
 # orchestrator will replay before forcing escalate_human. The judge
-# decision cache (see invoke_stall_judge) keyed on
-# sha256({issue_num, head_sha, phase, last_conclusion,
-# recent_comments_hash}) skips the LLM call when the same inputs
-# reproduce — but if the cached decision is wrong (the judge picked
-# resolve_merge_conflict on a hot-file collision the resolver can't
-# fix), replaying it forever wastes budget. After this many replays,
-# the judge cache is bypassed and the issue is escalated.
+# decision cache (see invoke_stall_judge) is keyed on sha256 of a
+# NORMALIZED view of the diagnostics JSON, not the raw blob: the
+# hash input strips inputs that change every cycle even when the
+# substance of the stall is unchanged so MAX_JUDGE_REPLAY can fire
+# on repeated identical stalls.  Specifically, the hash input
+# includes issue/phase, linked-PR state (including head_sha),
+# head/base ref, recent_review_workflow_outcomes, current_wave, and
+# the stable subset of prior_recovery_actions / recent_tracking_comments;
+# it EXCLUDES:
+#   * stall_minutes (ticks every poll cycle).
+#   * recovery_count (advances after every action that consumes
+#     budget).
+#   * prior_recovery_actions[stall_recovery_count] (mirrors the same
+#     counter at the wave-issue level).
+#   * The orchestrator's own "## 🧑‍⚖️ Stall Judge — Issue #N"
+#     tracking comments AND <!-- ORCHESTRATOR_STATE_V1/V2/AI_STANDALONE_STALL_STATE_V1 -->
+#     state snapshots — all of which the orchestrator writes between
+#     ticks and would otherwise churn the hash on its own output.
+# Meaningful changes (a new commit on the branch, mergeability
+# flipping, a human comment, a different workflow outcome, an
+# operator added/changed answer) therefore DO invalidate the cached
+# decision automatically.  When the same inputs reproduce, the
+# replay skips the LLM — but if the cached decision is wrong (e.g.
+# the judge picked resolve_merge_conflict on a hot-file collision
+# the resolver can't fix), replaying forever wastes budget; after
+# this many replays the cache is bypassed and the issue is
+# escalated (with a sticky force_escalate marker so the
+# terminalization is not silently downgraded on the next tick).
 MAX_JUDGE_REPLAY="${MAX_JUDGE_REPLAY:-2}"
 if ! [[ "${MAX_JUDGE_REPLAY}" =~ ^[0-9]+$ ]]; then
   echo "::warning::MAX_JUDGE_REPLAY must be a non-negative integer; defaulting to 2"
   MAX_JUDGE_REPLAY="2"
 fi
+# Strip leading zeros so the downstream `-ge` comparison (line ~6435)
+# treats the value as base-10.  Without this, an operator value like
+# "08" trips bash's "value too great for base" error
+# (claude-branch-review PR #2522; mirrors the MAX_STALL_RECOVERIES_DONE
+# / CONFLICT_DISPATCH_COOLDOWN_SECS canonicalisation pattern).
+MAX_JUDGE_REPLAY=$(( 10#${MAX_JUDGE_REPLAY} ))
 
 post_tracking_comment() {
   local comment_body="$1"
@@ -3301,40 +3341,164 @@ _refresh_integration_resolver_tooling() {
 # Returns 0 if healing progressed (dispatch queued, cooldown active,
 # or judge invoked), 1 if the circuit breaker has tripped and the
 # state was marked failed.
-# _list_integration_conflict_files — enumerate the filenames that would
-# conflict if <default_branch> were merged into <integration_branch>.
-# Uses ``git merge-tree --write-tree --name-only`` for a stateless
-# three-way merge probe (same technique as probe_sibling_merge_conflicts
-# at line 304+).  Echoes one file path per line on stdout; returns 0
-# when conflicts were detected, 1 otherwise (including unavailable git
-# version, missing refs, or a clean merge).  Used by
-# heal_integration_branch_conflict (Q2c) to short-circuit the first-line
-# resolver on hot-file collisions.
+# _list_integration_conflict_files — enumerate the filenames that
+# would conflict when reconciling <integration_branch> with
+# <default_branch>.  The git invocation is
+# `git merge-tree --write-tree --name-only <default_branch> <integration_branch>`,
+# which technically computes "merge integration_branch INTO
+# default_branch", but the conflict-FILES set is symmetric (the
+# same paths conflict regardless of which side is the "target"),
+# so the function's contract — "would these branches reconcile
+# cleanly?" — applies in either direction.  Used by
+# heal_integration_branch_conflict (Q2c) where the goal is to
+# bring default_branch's history into integration_branch; the
+# function tells us which files block that merge.  Echoes one file
+# path per line on stdout; returns 0 when conflicts were detected,
+# 1 otherwise (including unavailable git version, missing refs, a
+# clean merge, or a probe failure — fail-open).  The technique
+# mirrors probe_sibling_merge_conflicts (~line 304); both invoke
+# the same stateless three-way `git merge-tree` probe.  Used by
+# heal_integration_branch_conflict (Q2c) to short-circuit the
+# first-line resolver on hot-file collisions.
 _list_integration_conflict_files() {
   local integration_branch="$1"
   local default_branch="$2"
 
   [ -n "${integration_branch}" ] && [ -n "${default_branch}" ] || return 1
   command -v git >/dev/null 2>&1 || return 1
-  if ! git merge-tree --write-tree --name-only --no-messages HEAD HEAD >/dev/null 2>&1; then
+  # Feature-probe for `--write-tree`. Use `-h` so we read git's own help
+  # text (which lists supported switches) rather than `git merge-tree`
+  # with no args, which exits non-zero on a usage error. The poller
+  # runs with `set -o pipefail`, so a non-zero LHS would propagate as
+  # the pipeline status and make `if ! pipeline` fire even when grep
+  # found the switch — wrap the LHS in `|| true` to neutralize that
+  # before grep evaluates the help text.
+  if ! { git merge-tree -h 2>&1 || true; } | grep -q -- '--write-tree'; then
     return 1
   fi
 
   local ib_ref="refs/remotes/origin/${integration_branch}"
   local db_ref="refs/remotes/origin/${default_branch}"
-  git fetch --no-tags --quiet origin "${integration_branch}" "${default_branch}" 2>/dev/null || true
+  # Use --filter=blob:none so the per-tick conflict probe fetches only the
+  # commits + trees needed by `git merge-tree --name-only --no-messages`,
+  # not the blob contents (which the probe never reads).  We deliberately
+  # do NOT use --depth=1: `git merge-tree --write-tree` needs the merge-
+  # base, and a shallow fetch can strand the lookup so the probe falls back
+  # to a tree-vs-tree diff and over-reports conflicts — defeating the
+  # ≤3-conflicts hot-file short-circuit in heal_integration_branch_conflict
+  # below.
+  # Use explicit refspecs `+refs/heads/<b>:refs/remotes/origin/<b>`
+  # rather than bare branch names: `git fetch origin <b1> <b2>` without
+  # refspecs only updates FETCH_HEAD and may leave
+  # refs/remotes/origin/<b> missing or stale in single-branch /
+  # shallow clones (the orchestrator's CI checkout context), so the
+  # subsequent rev-parse checks would fail-open and the hot-file
+  # short-circuit could never fire even on a live conflict (Codex P2,
+  # PR #2522, line 3352).  The leading `+` is the
+  # `+`/`--force` flag: this script force-updates bot branches with
+  # `--force-with-lease` in the premerge/rebase paths, so the
+  # remote-tracking ref can be ahead of a rewritten branch tip.
+  # Without `+`, a non-fast-forward update is silently refused, the
+  # fetch failure is swallowed by `|| true`, and rev-parse passes
+  # against a stale tip — making the new merge-tree probe judge the
+  # wrong branch tip (Codex P2, PR #2522, line 3363).
+  local _ib_refspec="+refs/heads/${integration_branch}:refs/remotes/origin/${integration_branch}"
+  local _db_refspec="+refs/heads/${default_branch}:refs/remotes/origin/${default_branch}"
+  # Fail closed when BOTH fetch attempts fail (network blip, auth
+  # transient).  The previous `|| true` swallowed all errors,
+  # leaving the subsequent rev-parse checks to pass against
+  # whatever local remote-tracking refs were already present —
+  # potentially many minutes behind the real branch tip — so the
+  # hot-file probe could route a stale-state conflict (or miss a
+  # current one) to the wrong handler (Codex P2, PR #2522 line
+  # 3382).  Returning 1 lets the caller fail-open into the
+  # first-line resolver path, matching the existing missing-refs
+  # contract.
+  local _conflict_probe_fetch_ok="false"
+  if git fetch --no-tags --filter=blob:none --quiet origin "${_ib_refspec}" "${_db_refspec}" 2>/dev/null; then
+    _conflict_probe_fetch_ok="true"
+  elif git fetch --no-tags --quiet origin "${_ib_refspec}" "${_db_refspec}" 2>/dev/null; then
+    _conflict_probe_fetch_ok="true"
+  fi
+  if [ "${_conflict_probe_fetch_ok}" != "true" ]; then
+    return 1
+  fi
   git rev-parse --verify --quiet "${ib_ref}" >/dev/null 2>&1 || return 1
   git rev-parse --verify --quiet "${db_ref}" >/dev/null 2>&1 || return 1
 
-  local out
-  if out="$(git merge-tree --write-tree --name-only --no-messages "${db_ref}" "${ib_ref}" 2>/dev/null)"; then
-    # Exit 0 from merge-tree means the merge is clean.
-    return 1
+  # The orchestrator runs under `set -euo pipefail`, and we need
+  # `git merge-tree` to return exit 1 (conflicts detected) WITHOUT
+  # killing the script before `rc=$?` runs.  Today's only caller wraps
+  # this in `if VAR=$(_list_integration_conflict_files ...)` which
+  # already disables errexit inside the function body, but defensive
+  # coding — disable errexit just for this call so the function is
+  # safe to call from any context (Copilot review, PR #2522
+  # line 3359).  Capture the entry errexit state via `$-` and only
+  # restore it if it was set, so calling this function from a
+  # context that already disabled `-e` doesn't unexpectedly
+  # re-enable it (Copilot review, PR #2522 line 3444).
+  local out rc
+  local _had_errexit="false"
+  case "$-" in *e*) _had_errexit="true" ;; esac
+  set +e
+  out="$(git merge-tree --write-tree --name-only --no-messages "${db_ref}" "${ib_ref}" 2>/dev/null)"
+  rc=$?
+  if [ "${_had_errexit}" = "true" ]; then
+    set -e
   fi
-  # On conflict, modern git prints the written tree SHA on the first
-  # line followed by conflict paths. Strip the SHA line when present.
-  printf '%s\n' "${out}" | sed '/^$/d' | awk 'NR==1 && /^[[:xdigit:]]{40}([[:xdigit:]]{24})?$/ {next} {print}'
-  return 0
+  case "${rc}" in
+    0)
+      # Clean merge — no conflicts.
+      return 1
+      ;;
+    1)
+      # Conflicts detected. Strip the leading written-tree SHA line
+      # (modern git merge-tree --write-tree always emits the tree OID
+      # on line 1, then conflict paths on lines 2+), preserving any
+      # path whose name happens to be 40-or-64 hex chars by ONLY
+      # stripping when there is a subsequent line.  Without the
+      # multi-line gate, a real conflict file named e.g.
+      # 0123456789abcdef0123456789abcdef01234567 would be silently
+      # dropped from the conflict list and the hot-file short-circuit
+      # would undercount, misrouting an actual hot-file conflict to
+      # the first-line resolver (claude-branch-review consensus,
+      # PR #2522).  The SHA test uses length() instead of an
+      # `[[:xdigit:]]{40}` repetition because some awk builds (BWK awk
+      # on certain distros) panic compiling bracket-class repetitions
+      # with `REcompile() - panic: values still on machine stack`.
+      # rc==1 with no paths after stripping is anomalous and treated
+      # as a probe failure (fail-open) so the caller's hot-file
+      # short-circuit cannot fire on imaginary conflicts.
+      local cleaned line_count first_line stripped
+      cleaned="$(printf '%s\n' "${out}" | sed '/^$/d')"
+      # `grep -c .` on empty stdin prints "0" but exits 1, so `|| echo 0`
+      # would APPEND a second "0" and yield the 3-char string "0\n0",
+      # breaking the numeric `-ge` test below.  Use `|| true` so grep's
+      # own count output is the only thing in line_count (Copilot
+      # review, PR #2522 line 3396).
+      line_count="$(printf '%s\n' "${cleaned}" | grep -c . 2>/dev/null || true)"
+      [[ "${line_count}" =~ ^[0-9]+$ ]] || line_count="0"
+      first_line="$(printf '%s\n' "${cleaned}" | head -n 1)"
+      if [ "${line_count}" -ge 2 ] \
+         && printf '%s' "${first_line}" | awk '/^[0-9a-fA-F]+$/ && (length($0)==40 || length($0)==64) {exit 0} {exit 1}'; then
+        stripped="$(printf '%s\n' "${cleaned}" | tail -n +2)"
+      else
+        stripped="${cleaned}"
+      fi
+      if [ -z "${stripped}" ]; then
+        return 1
+      fi
+      printf '%s\n' "${stripped}"
+      return 0
+      ;;
+    *)
+      # rc>=128: fatal probe error (broken git binary, OOM, malformed
+      # ref pair, unsupported merge-tree subcommand on this version).
+      # Fail-open per the function-header contract — the caller must
+      # not short-circuit the resolver on a probe we could not run.
+      return 1
+      ;;
+  esac
 }
 
 heal_integration_branch_conflict() {
@@ -3415,10 +3579,30 @@ Final PR #${final_pr} (\`${integration_branch}\` -> \`${default_branch}\`) hit t
       local _ihb_conflict_files
       if _ihb_conflict_files="$(_list_integration_conflict_files "${integration_branch}" "${default_branch}" 2>/dev/null)"; then
         local _ihb_conflict_count
-        _ihb_conflict_count="$(printf '%s\n' "${_ihb_conflict_files}" | sed '/^$/d' | wc -l)"
-        if [ "${_ihb_conflict_count}" -gt 0 ] && [ "${_ihb_conflict_count}" -le 3 ] && [ -f ".github/ai/hot_files.json" ]; then
+        _ihb_conflict_count="$(printf '%s\n' "${_ihb_conflict_files}" | sed '/^$/d' | wc -l | tr -d '[:space:]')"
+        if [[ "${_ihb_conflict_count}" =~ ^[0-9]+$ ]] && [ "${_ihb_conflict_count}" -gt 0 ] && [ "${_ihb_conflict_count}" -le 3 ] && [ -f ".github/ai/hot_files.json" ]; then
           local _ihb_hot_files
-          _ihb_hot_files="$(jq -r '.hot_files[]? // empty' .github/ai/hot_files.json 2>/dev/null || echo "")"
+          # Normalize hot-file registry entries the same way
+          # scripts/orchestrate_lib.py:208-210 does on the canonical
+          # loader path: trim whitespace, replace `\` with `/`, and
+          # strip leading `./` (possibly multiple).  Consumer repos
+          # are documented to accept entries like
+          # `./scripts/orchestrate_poll_process.sh` or
+          # `scripts\orchestrate_poll_process.sh`, but `git
+          # merge-tree --name-only` emits paths in canonical form
+          # (no leading ./, forward slashes only) — so the previous
+          # raw exact-string match silently missed any
+          # non-canonical hot-file entry and routed the conflict to
+          # the first-line resolver instead of the judge (Codex P2,
+          # PR #2522 line 3536).
+          _ihb_hot_files="$(jq -r '
+            (.hot_files // [])[]?
+            | select(type == "string")
+            | sub("^\\s+"; "") | sub("\\s+$"; "")
+            | gsub("\\\\"; "/")
+            | sub("^(\\./)+"; "")
+            | select(length > 0)
+          ' .github/ai/hot_files.json 2>/dev/null || echo "")"
           if [ -n "${_ihb_hot_files}" ]; then
             local _ihb_hot_hit="false"
             local _ihb_cf
@@ -3478,9 +3662,19 @@ Final PR #${final_pr} (\`${integration_branch}\` -> \`${default_branch}\`) could
   # gate is 15m on the first dispatch, climbing to 4h after four
   # retries. This stops the multi-hour fixed-interval loop where main
   # keeps moving and each dispatch fires on the same 15-minute beat.
+  # `dispatch_count` is incremented IMMEDIATELY after the first
+  # successful dispatch (line ~3687 below), so the SECOND attempt
+  # already sees `dispatch_count=1` here.  Subtract one before
+  # shifting — clamped to 0 — so the first retry waits the
+  # documented 1× interval rather than 2× (Codex P2, PR #2522,
+  # line 3640).
   local elapsed=$((now_ts - last_ts))
-  local _backoff_shift="${dispatch_count}"
-  [[ "${_backoff_shift}" =~ ^[0-9]+$ ]] || _backoff_shift=0
+  local _backoff_shift_raw="${dispatch_count}"
+  [[ "${_backoff_shift_raw}" =~ ^[0-9]+$ ]] || _backoff_shift_raw=0
+  local _backoff_shift=0
+  if [ "${_backoff_shift_raw}" -gt 1 ]; then
+    _backoff_shift=$(( _backoff_shift_raw - 1 ))
+  fi
   if [ "${_backoff_shift}" -gt 4 ]; then
     _backoff_shift=4
   fi
@@ -3508,11 +3702,20 @@ Final PR #${final_pr} (\`${integration_branch}\` -> \`${default_branch}\`) could
   _dispatch_review_for_conflicts "${final_pr}" "${integration_branch}" || dispatch_rc=$?
 
   if [ "${dispatch_rc}" -eq 2 ]; then
-    jq --argjson ts "${now_ts}" \
-      '.integration_sync_status = "healing" |
-       .integration_conflict_dispatch_ts = $ts' \
+    # Only update the sync status here — DO NOT refresh
+    # integration_conflict_dispatch_ts.  An in-flight resolver fires
+    # the rc=2 dedupe path on every poll tick while it runs; if we
+    # advanced the timestamp here, the exponential backoff computed
+    # against (now - dispatch_ts) at line 3578+ would keep resetting
+    # to ~0 elapsed for the lifetime of the resolver run.  After a
+    # resolver that runs for an hour, the next real retry would then
+    # wait the FULL exponential cooldown (up to ~4h at
+    # dispatch_count>=4) measured from the moment it finished rather
+    # than from the original dispatch — almost doubling the gap
+    # between real attempts (Codex P2, PR #2522, line 3575).
+    jq '.integration_sync_status = "healing"' \
       "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
-    echo "  [integration-heal] Resolver already in flight for PR #${final_pr}; skipping dispatch this tick."
+    echo "  [integration-heal] Resolver already in flight for PR #${final_pr}; skipping dispatch this tick (cooldown timer unchanged)."
     return 0
   fi
 
@@ -3556,11 +3759,37 @@ mark_integration_sync_clean() {
   ensure_integration_conflict_state_fields
   local prev_status
   prev_status="$(jq -r '.integration_sync_status // "clean"' "${STATE_FILE}")"
-  if [ "${prev_status}" != "clean" ]; then
+  # Always clear the per-episode counters when clean state is
+  # observed, not only on the non-clean → clean transition.  Legacy
+  # state files (written by versions before the post-heal reset
+  # existed) can have `integration_sync_status = clean` but
+  # `integration_conflict_dispatch_count` / `dispatch_ts` left over
+  # from an earlier episode.  Without this broader reset, the next
+  # fresh conflict episode inherits a non-zero dispatch_count, and
+  # the exponential-backoff calculation at line ~3645 immediately
+  # caps the cooldown at 16× — delaying the first real retry by
+  # 4 hours instead of the documented 15-minute first interval
+  # (Codex P2, PR #2522 line 3774).  integration_conflict_total_dispatches
+  # is the lifetime cap and is intentionally NOT reset here.
+  local prev_dispatch_count prev_dispatch_ts prev_unresolved_ticks
+  prev_dispatch_count="$(jq -r '.integration_conflict_dispatch_count // 0' "${STATE_FILE}")"
+  prev_dispatch_ts="$(jq -r '.integration_conflict_dispatch_ts // 0' "${STATE_FILE}")"
+  prev_unresolved_ticks="$(jq -r '.integration_conflict_unresolved_ticks // 0' "${STATE_FILE}")"
+  if [ "${prev_status}" != "clean" ] \
+     || [ "${prev_dispatch_count}" != "0" ] \
+     || [ "${prev_dispatch_ts}" != "0" ] \
+     || [ "${prev_unresolved_ticks}" != "0" ]; then
     jq '.integration_sync_status = "clean" |
         .integration_sync_last_error = "" |
-        .integration_conflict_unresolved_ticks = 0' \
+        .integration_conflict_unresolved_ticks = 0 |
+        .integration_conflict_dispatch_count = 0 |
+        .integration_conflict_dispatch_ts = 0' \
       "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
+  fi
+  # Only post the user-facing "resolved" comment on the actual
+  # non-clean → clean transition; legacy stale-counter migrations
+  # are silent operational cleanup.
+  if [ "${prev_status}" != "clean" ]; then
     post_tracking_comment "## ✅ Integration self-healing resolved
 
 \`${default_branch}\` now merges cleanly into the integration branch. Final merge will proceed on the next poll tick."
@@ -5106,8 +5335,25 @@ _extract_standalone_state_json_from_comments() {
       status_since_ts: ((.status_since_ts // 0) | tonumber),
       stall_recovery_count: ((.stall_recovery_count // 0) | tonumber),
       phase_attempts: (if (.phase_attempts | type) == "object" then .phase_attempts else {} end),
-      conflict_override_count: (if (.conflict_override_count | type) == "object" then .conflict_override_count else {} end),
-      updated_ts: ((.updated_ts // 0) | tonumber)
+      updated_ts: ((.updated_ts // 0) | tonumber),
+      # Preserve the per-head-SHA conflict-override counter across poll
+      # cycles.  Without this, every cycle reads the comment back
+      # through this whitelist and the counter is discarded to 0
+      # before the standalone override-cap (Codex P2, PR #2522, line
+      # 7339) runs again, so MAX_BUDGET_NEUTRAL_OVERRIDES never trips
+      # for a PR that stays conflicted at the same head_sha.  The
+      # cap write keys this object by head_sha, so carrying it
+      # forward as-is preserves the cycle history.  Defensive
+      # type-check: only carry forward when the value is actually an
+      # object — malformed state comments otherwise inject arbitrary
+      # types that the cap-read jq would error on and silently
+      # fail-open (claude-branch-review PR #2522).
+      conflict_override_count: (
+        if ((.conflict_override_count // null) | type) == "object"
+        then .conflict_override_count
+        else {}
+        end
+      )
     }
   ' 2>/dev/null || echo '{"schema_version":1,"last_seen_phase":"","status_since_ts":0,"stall_recovery_count":0,"phase_attempts":{},"conflict_override_count":{}}'
 }
@@ -5166,19 +5412,44 @@ ${STANDALONE_STATE_MARKER_CLOSE}"
 recovery_action_for_phase() {
   local phase="$1"
   local recovery_count="$2"
-  local effective_max_recoveries="${MAX_STALL_RECOVERIES_PER_ISSUE}"
+  # Optional 3rd argument: the phase-lifetime counter (survives phase
+  # oscillation per update_issue_timestamps).  Threading it to the
+  # Python helper below lets `resolve_stall_recovery_action` enforce
+  # the phase-lifetime cap exactly the same way detect_stalls does
+  # (claude-branch-review, PR #2522 line 5418).  Defaults to 0 for
+  # back-compat with callers that don't have the counter handy —
+  # notably the standalone-stall path, whose state schema does not
+  # currently carry phase_attempts.
+  local phase_attempts_count="${3:-0}"
+  [[ "${phase_attempts_count}" =~ ^[0-9]+$ ]] || phase_attempts_count="0"
 
   [[ "${recovery_count}" =~ ^[0-9]+$ ]] || recovery_count="0"
-  if [ "${phase}" = "ai:done" ]; then
-    effective_max_recoveries="${MAX_STALL_RECOVERIES_DONE}"
+  # Compute the per-phase effective cap, mirroring the Python helper's
+  # _phase_specific_max_recoveries (scripts/orchestrate_lib.py).
+  # Without this, the shell short-circuits to "skip" at the global cap
+  # before the Python helper below can apply the per-phase override, so
+  # a transient judge parse/codex failure falling through to this
+  # helper from invoke_stall_judge can hard-close an ai:done review PR
+  # via the ladder even when MAX_STALL_RECOVERIES_DONE permits more
+  # recoveries.  We only honour the override when it is strictly
+  # numeric and >=1 to match the Python guard.
+  local _phase_effective_max="${MAX_STALL_RECOVERIES_PER_ISSUE}"
+  if [ "${phase}" = "ai:done" ] \
+     && [[ "${MAX_STALL_RECOVERIES_DONE}" =~ ^[0-9]+$ ]] \
+     && [ "${MAX_STALL_RECOVERIES_DONE}" -ge 1 ]; then
+    _phase_effective_max="${MAX_STALL_RECOVERIES_DONE}"
   fi
-  if [ "${recovery_count}" -ge "${effective_max_recoveries}" ]; then
+  if [ "${recovery_count}" -ge "${_phase_effective_max}" ]; then
+    echo "skip"
+    return
+  fi
+  if [ "${phase_attempts_count}" -ge "${_phase_effective_max}" ]; then
     echo "skip"
     return
   fi
 
   local action
-  action="$(python3 - "$phase" "$recovery_count" "$effective_max_recoveries" "$ENABLE_STALL_HUMAN_TERMINALIZATION" "$MAX_STALL_RECOVERIES_DONE" <<'PY'
+  action="$(python3 - "$phase" "$recovery_count" "$MAX_STALL_RECOVERIES_PER_ISSUE" "$ENABLE_STALL_HUMAN_TERMINALIZATION" "$MAX_STALL_RECOVERIES_DONE" "$phase_attempts_count" <<'PY'
 import sys
 sys.path.insert(0, 'scripts')
 from orchestrate_lib import resolve_stall_recovery_action
@@ -5188,12 +5459,14 @@ recovery_count = int(sys.argv[2])
 max_recoveries = int(sys.argv[3])
 enable_human_terminalization = sys.argv[4].lower() == "true"
 max_done = int(sys.argv[5])
+phase_attempts_count = int(sys.argv[6])
 print(resolve_stall_recovery_action(
     phase,
     recovery_count,
     max_recoveries=max_recoveries,
     enable_stall_human_terminalization=enable_human_terminalization,
     max_recoveries_by_phase={"ai:done": max_done},
+    phase_attempts_count=phase_attempts_count,
 ))
 PY
 )" || true
@@ -5208,9 +5481,21 @@ normalize_stall_recovery_action() {
   local phase="$1"
   local recovery_count="$2"
   local candidate_action="${3:-}"
+  # Phase-lifetime counter — same scope as recovery_count but
+  # survives phase oscillation per update_issue_timestamps's reset
+  # rule.  Threading this through to resolve_effective_stall_recovery_action
+  # ensures the fallback path (when the judge returns a
+  # malformed/empty action) respects the same phase-attempt cap that
+  # detect_stalls uses; without it, the fallback would treat
+  # phase_attempts_count as 0 and silently bypass the cap (Copilot
+  # review, PR #2522, line 1527).  Callers that do not have the
+  # counter handy may omit it — the default 0 preserves the previous
+  # behaviour.
+  local phase_attempts_count="${4:-0}"
+  [[ "${phase_attempts_count}" =~ ^[0-9]+$ ]] || phase_attempts_count="0"
 
   local action
-  action="$(python3 - "$phase" "$recovery_count" "$candidate_action" "$MAX_STALL_RECOVERIES_PER_ISSUE" "$ENABLE_STALL_HUMAN_TERMINALIZATION" "$MAX_STALL_RECOVERIES_DONE" <<'PY'
+  action="$(python3 - "$phase" "$recovery_count" "$candidate_action" "$MAX_STALL_RECOVERIES_PER_ISSUE" "$ENABLE_STALL_HUMAN_TERMINALIZATION" "$MAX_STALL_RECOVERIES_DONE" "$phase_attempts_count" <<'PY'
 import sys
 sys.path.insert(0, 'scripts')
 from orchestrate_lib import resolve_effective_stall_recovery_action
@@ -5221,6 +5506,7 @@ candidate_action = sys.argv[3]
 max_recoveries = int(sys.argv[4])
 enable_human_terminalization = sys.argv[5].lower() == "true"
 max_done = int(sys.argv[6])
+phase_attempts_count = int(sys.argv[7])
 print(resolve_effective_stall_recovery_action(
     phase,
     recovery_count,
@@ -5228,12 +5514,17 @@ print(resolve_effective_stall_recovery_action(
     max_recoveries=max_recoveries,
     enable_stall_human_terminalization=enable_human_terminalization,
     max_recoveries_by_phase={"ai:done": max_done},
+    phase_attempts_count=phase_attempts_count,
 ))
 PY
 )" || true
 
   if [ -z "${action}" ]; then
-    action="$(recovery_action_for_phase "${phase}" "${recovery_count}")"
+    # Forward the phase-lifetime counter to the fallback helper so
+    # the phase-attempt cap fires there too — without this, an
+    # empty/invalid Python return would silently bypass the cap
+    # (claude-branch-review, PR #2522 line 5524).
+    action="$(recovery_action_for_phase "${phase}" "${recovery_count}" "${phase_attempts_count}")"
     if [ -z "${action}" ]; then
       action="retrigger_pipeline"
     fi
@@ -5462,17 +5753,27 @@ STALL_EOF
           execute_stall_recovery_action "${issue_num}" "${phase}" "resolve_merge_conflict" "${recovery_count}" "${local_id}" "${stall_minutes}" || _rtr_rc=$?
           # Q3:B — conflict override does not consume a retrigger-style
           # recovery attempt.  resolve_merge_conflict sets
-          # STALL_RECOVERY_SHOULD_INCREMENT="true" on its happy path (line
-          # ~4405); reset it here so the override is budget-neutral.
+          # STALL_RECOVERY_SHOULD_INCREMENT="true" inside
+          # execute_stall_recovery_action only when a fresh dispatch
+          # actually happened (rc=0 path); rc=2 (already dispatched
+          # this cycle or active autofix run dedupe) leaves it unset.
+          # Capture the signal here BEFORE the explicit reset below so
+          # we can gate the per-head override counter on it — without
+          # this, repeated poll ticks while the resolver is still in
+          # flight would advance the counter on every cycle and
+          # eventually consume stall budget for work that never fired
+          # (Codex P2, PR #2522, line 5565).
+          local _rtr_did_fresh_dispatch="${STALL_RECOVERY_SHOULD_INCREMENT:-false}"
+          STALL_RECOVERY_SHOULD_INCREMENT="false"
           #
           # Per-head_sha cap (Q1b): track how many overrides have fired
           # for this exact head_sha and stop being budget-neutral after
           # MAX_BUDGET_NEUTRAL_OVERRIDES so the stall ladder can advance.
           # head_sha changes on every new commit, so once the resolver
           # pushes a fix, the counter restarts for the new sha.
-          local _rtr_dispatched="${STALL_RECOVERY_SHOULD_INCREMENT:-false}"
-          STALL_RECOVERY_SHOULD_INCREMENT="false"
-          if [ "${_rtr_dispatched}" = "true" ] && [ -n "${_rtr_head_sha}" ] && [ "${_rtr_head_sha}" != "null" ] && [ -n "${STATE_FILE:-}" ] && [ -f "${STATE_FILE}" ]; then
+          if [ "${_rtr_did_fresh_dispatch}" = "true" ] \
+             && [ -n "${_rtr_head_sha}" ] && [ "${_rtr_head_sha}" != "null" ] \
+             && [ -n "${STATE_FILE:-}" ] && [ -f "${STATE_FILE}" ]; then
             local _rtr_override_count
             _rtr_override_count="$(jq -r --arg sha "${_rtr_head_sha}" '.conflict_override_count[$sha] // 0' "${STATE_FILE}" 2>/dev/null || echo "0")"
             [[ "${_rtr_override_count}" =~ ^[0-9]+$ ]] || _rtr_override_count="0"
@@ -5646,7 +5947,7 @@ REISSUE_EOF
           jq --arg lid "${local_id}" --argjson new_num "${new_num}" --argjson wave_idx "${WAVE_IDX}" \
             '.issue_number_map[$lid] = $new_num |
              (.waves[$wave_idx].issues[] | select(.id == $lid)) |=
-               (.github_issue = $new_num | .status = "pending" | .last_seen_phase = "" | .status_since_ts = (now | floor) | .stall_recovery_count = 0)' \
+               (.github_issue = $new_num | .status = "pending" | .last_seen_phase = "" | .status_since_ts = (now | floor) | .stall_recovery_count = 0 | .phase_attempts = {})' \
             "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
         fi
         tg_notify "Stall recovery: closed stalled issue #${issue_num} and re-issued as #${new_num} (phase: ${phase}, stuck ${stall_minutes}m)."$'\n'"Old issue: $(_gh_url "issues/${issue_num}")"$'\n'"New issue: $(_gh_url "issues/${new_num}")" "WARNING"
@@ -5841,8 +6142,61 @@ invoke_stall_judge() {
   local stall_minutes="$4"
   local local_id="${5:-}"
 
+  # Look up the phase-lifetime counter for this issue (managed runs
+  # only; standalone state does not carry phase_attempts).  This is
+  # used by:
+  #   * The fallback_action computation just below (so the initial
+  #     ladder pick respects the phase cap — claude-branch-review,
+  #     PR #2522 line 6143).
+  #   * The judge-failure / parse-error fallback branches (so a
+  #     flaky judge cannot bypass an exhausted phase cap — Codex
+  #     P2, PR #2522, line 1720).
+  #   * The normalize_stall_recovery_action call after a successful
+  #     judge response (Copilot review, line 1527).
+  # When phase_attempts is already at the cap, downgrade the
+  # failure-path fallback to "skip" so a transient judge crash
+  # cannot run another non-terminal recovery the cap was
+  # specifically supposed to prevent.
+  local _judge_phase_attempts_count=0
+  local _judge_phase_effective_max="${MAX_STALL_RECOVERIES_PER_ISSUE}"
+  if [ "${phase}" = "ai:done" ] \
+     && [[ "${MAX_STALL_RECOVERIES_DONE}" =~ ^[0-9]+$ ]] \
+     && [ "${MAX_STALL_RECOVERIES_DONE}" -ge 1 ]; then
+    _judge_phase_effective_max="${MAX_STALL_RECOVERIES_DONE}"
+  fi
+  if [ -n "${local_id}" ] && [ "${local_id}" != "null" ] \
+     && [ -n "${STATE_FILE:-}" ] && [ -f "${STATE_FILE}" ]; then
+    _judge_phase_attempts_count="$(jq -r --arg lid "${local_id}" --argjson wi "${WAVE_IDX:-0}" --arg p "${phase}" \
+      '((.waves[$wi].issues[] | select(.id == $lid)) // {}) | (.phase_attempts[$p] // 0)' \
+      "${STATE_FILE}" 2>/dev/null || echo "0")"
+    [[ "${_judge_phase_attempts_count}" =~ ^[0-9]+$ ]] || _judge_phase_attempts_count=0
+  fi
+
   local fallback_action
-  fallback_action="$(recovery_action_for_phase "${phase}" "${recovery_count}")"
+  # Thread the phase-lifetime counter into the fallback ladder pick
+  # so the cap fires consistently with detect_stalls' decision
+  # (claude-branch-review, PR #2522 line 6143).  This is largely
+  # belt-and-braces: the post-lookup override below explicitly
+  # forces fallback_action="skip" when the counter is at the cap,
+  # so the threaded value mostly matters when the counter is
+  # below the cap but still high enough that the Python ladder
+  # would otherwise advance one rung past it.
+  fallback_action="$(recovery_action_for_phase "${phase}" "${recovery_count}" "${_judge_phase_attempts_count}")"
+  # Derive a STABLE exhausted/not-exhausted boolean for the cache
+  # key.  Hashing the raw _judge_phase_attempts_count would otherwise
+  # invalidate the cache after every budget-consuming recovery
+  # (phase_attempts increments alongside stall_recovery_count), so a
+  # repeated bad-judge loop below the cap could never accumulate
+  # toward MAX_JUDGE_REPLAY (Codex P2, PR #2522, line 6383).  The raw
+  # count still ships in the LLM-facing diagnostics for prompt
+  # context; only the cache-key view strips it (see filter at
+  # line ~6330).
+  local _judge_phase_attempts_exhausted="false"
+  if [ "${_judge_phase_attempts_count}" -ge "${_judge_phase_effective_max}" ]; then
+    echo "  [stall-judge] phase_attempts_count=${_judge_phase_attempts_count} >= effective_max=${_judge_phase_effective_max} for phase ${phase}; the judge-failure fallback will be forced to skip so a transient judge crash cannot bypass the phase-lifetime cap."
+    fallback_action="skip"
+    _judge_phase_attempts_exhausted="true"
+  fi
 
   local comments_issue_num="${issue_num}"
   if [ -n "${local_id}" ] && [[ "${TRACKING_NUM:-}" =~ ^[0-9]+$ ]]; then
@@ -5854,14 +6208,26 @@ invoke_stall_judge() {
   local recent_comments
   # Filter out ORCHESTRATOR_STATE_V1 snapshots (they are ~57KB each and
   # are noise for the judge — it wants phase-change / recovery narrative,
-  # not state dumps) and cap each remaining body at 2000 characters. Without
-  # these two caps, 8 state snapshots produce ~260KB of argv which trips
-  # Linux MAX_ARG_STRLEN (128KB per argv entry) when passed to the final
+  # not state dumps) AND ORCHESTRATOR_STATE_V2 chunk comments (the same
+  # snapshots, just framed as multi-comment chains by post_state_comment;
+  # each chunk is the same noise and additionally churns the cache key
+  # on every poll cycle because its manifest hash changes as timestamps
+  # and counters advance — defeating MAX_JUDGE_REPLAY for orchestrator-
+  # managed stalls per Codex P2, PR #2522, line 6147) AND the
+  # standalone-state snapshot the standalone recovery loop writes via
+  # write_standalone_state_json — same noise/churn pattern as the
+  # orchestrator state, just on a per-issue tracking comment rather than
+  # the project tracking issue (Codex P2, PR #2522, line 6221 #1).  Then
+  # cap each remaining body at 2000 characters. Without these caps, 8
+  # state snapshots produce ~260KB of argv which trips Linux
+  # MAX_ARG_STRLEN (128KB per argv entry) when passed to the final
   # diagnostics jq via `--argjson recent_comments`, causing execve to
   # return E2BIG and the diagnostics blob to come out empty.
   recent_comments="$(printf '%s' "${issue_comments_json}" | jq -c '
     [.[]
       | select(((.body // "") | startswith("<!-- ORCHESTRATOR_STATE_V1")) | not)
+      | select(((.body // "") | startswith("<!-- ORCHESTRATOR_STATE_V2")) | not)
+      | select(((.body // "") | startswith("<!-- AI_STANDALONE_STALL_STATE_V1")) | not)
       | {
           author: (.user.login // ""),
           created_at: (.created_at // ""),
@@ -5910,36 +6276,34 @@ invoke_stall_judge() {
     | .[:3]
   ' 2>/dev/null || echo '[]')"
 
-  # Judge decision cache (Q1d): memoise judge output by
-  # sha256({issue_num, head_sha, phase, last_conclusion,
-  # recent_comments_hash_excluding_prior_stall_judge_comments}). When the same
-  # inputs reproduce, replay the
-  # cached action instead of burning a fresh LLM call.  After
-  # MAX_JUDGE_REPLAY consecutive replays without
-  # progress, bypass the cache and escalate so the issue isn't stuck on a
-  # bad decision forever. The cache is only consulted when STATE_FILE
-  # exists; missing-state cycles fall through to the LLM path.
-  local _judge_last_conclusion=""
-  local _judge_cacheable_comments='[]'
-  local _judge_recent_comments_hash=""
+  # Judge decision cache (Q1d): memoise judge output by sha256 of the
+  # full diagnostics blob below.  Hashing the whole prompt-input JSON
+  # — instead of a hand-picked subset like {issue_num, head_sha, phase,
+  # last_conclusion} — guarantees the cache automatically invalidates
+  # whenever a mutable input the judge actually reads changes (recent
+  # tracking comments, PR mergeability / state, head_ref / base_ref,
+  # workflow outcomes beyond the latest, prior_recovery_actions, etc.).
+  # Otherwise human guidance added between cycles could be silently
+  # ignored until MAX_JUDGE_REPLAY forces escalation on stale context.
+  # When the same diagnostics reproduce, replay the cached action
+  # instead of burning a fresh LLM call.  After MAX_JUDGE_REPLAY
+  # consecutive replays without progress, bypass the cache and
+  # escalate so the issue isn't stuck on a bad decision forever.  The
+  # cache is only consulted when STATE_FILE exists; missing-state
+  # cycles fall through to the LLM path.  Initialise the loop-state
+  # variables here so the later cache-hit branch (and the cache-write
+  # branch after the LLM call) reads sane defaults on every code path,
+  # including the missing-STATE_FILE / hashing-failed fallthroughs.
   local _judge_cache_key=""
   local _judge_cache_hit_action=""
   local _judge_cache_replay_count=0
   local _judge_force_escalate="false"
-  if [ -n "${STATE_FILE:-}" ] && [ -f "${STATE_FILE}" ]; then
-    _judge_last_conclusion="$(printf '%s' "${workflow_outcomes}" | jq -r '.[0].conclusion // ""' 2>/dev/null || echo "")"
-    _judge_cacheable_comments="$(printf '%s' "${recent_comments}" | jq -c '[.[] | select(((.body // "") | startswith("## 🧑‍⚖️ Stall Judge")) | not)]' 2>/dev/null || echo '[]')"
-    _judge_recent_comments_hash="$(printf '%s' "${_judge_cacheable_comments}" | sha256sum 2>/dev/null | awk '{print $1}')"
-    _judge_cache_key="$(printf '%s|%s|%s|%s|%s' "${issue_num}" "${head_sha:-}" "${phase}" "${_judge_last_conclusion}" "${_judge_recent_comments_hash}" | sha256sum 2>/dev/null | awk '{print $1}')"
-    if [ -n "${_judge_cache_key}" ]; then
-      _judge_cache_hit_action="$(jq -r --arg k "${_judge_cache_key}" '.judge_decision_cache[$k].action // ""' "${STATE_FILE}" 2>/dev/null || echo "")"
-      _judge_cache_replay_count="$(jq -r --arg k "${_judge_cache_key}" '.judge_decision_cache[$k].replay_count // 0' "${STATE_FILE}" 2>/dev/null || echo "0")"
-      [[ "${_judge_cache_replay_count}" =~ ^[0-9]+$ ]] || _judge_cache_replay_count=0
-      if [ -n "${_judge_cache_hit_action}" ] && [ "${_judge_cache_replay_count}" -ge "${MAX_JUDGE_REPLAY}" ]; then
-        _judge_force_escalate="true"
-      fi
-    fi
-  fi
+  local _judge_cache_force_escalate="false"
+  # Staged replay-count value when the cache-hit branch runs; the
+  # post-dispatch cache-write block decides whether to commit it
+  # based on whether a fresh budget-consuming action actually ran
+  # (Codex P2, PR #2522 line 6550).
+  local _judge_replay_next_pending=""
 
   local prior_actions='[]'
   if [ -n "${local_id}" ] && [ "${local_id}" != "null" ]; then
@@ -5960,11 +6324,14 @@ invoke_stall_judge() {
     --arg phase "${phase}" \
     --argjson stall_minutes "${stall_minutes}" \
     --argjson recovery_count "${recovery_count}" \
+    --argjson phase_attempts_count "${_judge_phase_attempts_count:-0}" \
+    --argjson phase_attempts_exhausted "${_judge_phase_attempts_exhausted:-false}" \
     --argjson recent_comments "${recent_comments}" \
     --arg target_pr "${target_pr}" \
     --arg pr_state "${pr_state}" \
     --arg pr_mergeable "${pr_mergeable}" \
     --arg head_ref "${head_ref}" \
+    --arg head_sha "${head_sha}" \
     --arg base_ref "${base_ref}" \
     --argjson workflow_outcomes "${workflow_outcomes}" \
     --argjson current_wave "${CURRENT_WAVE:-1}" \
@@ -5975,12 +6342,15 @@ invoke_stall_judge() {
       phase: $phase,
       stall_minutes: $stall_minutes,
       recovery_count: $recovery_count,
+      phase_attempts_count: $phase_attempts_count,
+      phase_attempts_exhausted: $phase_attempts_exhausted,
       recent_tracking_comments: $recent_comments,
       linked_pr: {
         number: (if $target_pr == "" then null else ($target_pr | tonumber) end),
         state: (if $pr_state == "" then null else $pr_state end),
         mergeable: (if $pr_mergeable == "" then null else ($pr_mergeable == "true") end),
         head_ref: (if $head_ref == "" then null else $head_ref end),
+        head_sha: (if $head_sha == "" then null else $head_sha end),
         base_ref: (if $base_ref == "" then null else $base_ref end)
       },
       recent_review_workflow_outcomes: $workflow_outcomes,
@@ -6001,10 +6371,13 @@ invoke_stall_judge() {
       --arg phase "${phase}" \
       --argjson stall_minutes "${stall_minutes:-0}" \
       --argjson recovery_count "${recovery_count:-0}" \
+      --argjson phase_attempts_count "${_judge_phase_attempts_count:-0}" \
+      --argjson phase_attempts_exhausted "${_judge_phase_attempts_exhausted:-false}" \
       --arg target_pr "${target_pr}" \
       --arg pr_state "${pr_state}" \
       --arg pr_mergeable "${pr_mergeable}" \
       --arg head_ref "${head_ref}" \
+      --arg head_sha "${head_sha}" \
       --arg base_ref "${base_ref}" \
       '{
         issue_number: ($issue_number | tonumber? // null),
@@ -6012,15 +6385,143 @@ invoke_stall_judge() {
         phase: (if $phase == "" then null else $phase end),
         stall_minutes: $stall_minutes,
         recovery_count: $recovery_count,
+        phase_attempts_count: $phase_attempts_count,
+        phase_attempts_exhausted: $phase_attempts_exhausted,
         linked_pr: {
           number: (if $target_pr == "" then null else ($target_pr | tonumber? // null) end),
           state: (if $pr_state == "" then null else $pr_state end),
           mergeable: (if $pr_mergeable == "" then null else ($pr_mergeable == "true") end),
           head_ref: (if $head_ref == "" then null else $head_ref end),
+          head_sha: (if $head_sha == "" then null else $head_sha end),
           base_ref: (if $base_ref == "" then null else $base_ref end)
         },
         diagnostics_build_failed: true
       }' 2>/dev/null || echo '{"diagnostics_build_failed":true}')"
+  fi
+
+  # Now that the full diagnostics blob is built (or the fallback payload
+  # has been substituted), hash it as the judge-cache key.  This is the
+  # first point at which every input that goes into the judge prompt is
+  # known, so keying on the SHA256 of the JSON guarantees that any
+  # mutable input the prompt actually carries — recent tracking
+  # comments, PR state / mergeability, head_ref / base_ref, recent
+  # workflow outcomes beyond the latest conclusion, prior_recovery_actions
+  # — automatically invalidates the cached decision.
+  #
+  # Standalone-stall caveat (Codex P2, PR #2522, lines 6411 + 6210):
+  # invoke_stall_judge is also reachable from
+  # run_standalone_stall_recovery for issues outside a tracking-project
+  # run.  Those callsites have an empty local_id, and the per-issue
+  # standalone state schema (AI_STANDALONE_STALL_STATE_V1) does not
+  # currently hold the judge decision cache.  STATE_FILE on its own
+  # is NOT a safe gate: it is a global runtime variable populated
+  # inside the tracking-issue loop, and run_standalone_stall_recovery
+  # runs afterward in the same poller invocation, so a non-empty
+  # STATE_FILE here may point at an unrelated last-processed tracking
+  # issue rather than the current standalone issue's state — writing
+  # the cache there would persist nothing useful and could pollute
+  # another project's state on the next read.  Gate the cache on a
+  # managed `local_id` and surface a single warning per standalone
+  # invocation so operators understand MAX_JUDGE_REPLAY is not
+  # enforced there.
+  local _judge_cache_eligible="false"
+  if [ -n "${local_id}" ] && [ "${local_id}" != "null" ] \
+     && [ -n "${STATE_FILE:-}" ] && [ -f "${STATE_FILE}" ]; then
+    _judge_cache_eligible="true"
+  fi
+  # Rate-limit the standalone-path warning to ONCE per poller run
+  # via a process-global flag.  Without this, every stalled
+  # standalone issue triggers the warning every cycle — spamming
+  # the workflow log and burying real warnings.  The flag lives in
+  # the parent shell across this function's invocations (no `local`,
+  # so it survives) but is reset on each fresh poller process
+  # (Copilot review, PR #2522 line 6372).
+  if [ -z "${local_id}" ] || [ "${local_id}" = "null" ]; then
+    if [ "${_STALL_JUDGE_STANDALONE_WARNED:-false}" != "true" ]; then
+      echo "::warning::Stall judge for issue #${issue_num} runs without a managed local_id (standalone path); MAX_JUDGE_REPLAY cannot enforce a replay cap on this invocation. Every identical stall will burn a fresh LLM call until the standalone state schema carries judge_decision_cache. (This warning is emitted once per poller run; subsequent standalone judge invocations will not repeat it.)" >&2
+      _STALL_JUDGE_STANDALONE_WARNED="true"
+    fi
+  fi
+  if [ "${_judge_cache_eligible}" = "true" ]; then
+    # Normalize the cache-key view of diagnostics before hashing so
+    # MAX_JUDGE_REPLAY can actually fire on repeated identical stalls.
+    # Three classes of churn used to leak the cache key:
+    #
+    # 1. Self-narration: every run posts a "## 🧑‍⚖️ Stall Judge —
+    #    Issue #N" tracking comment before returning, so the next
+    #    identical stall otherwise had a different key solely because
+    #    the previous judge's own narration was now in
+    #    recent_tracking_comments.
+    # 2. Volatile counters: stall_minutes ticks every minute, and
+    #    recovery_count / prior_recovery_actions[stall_recovery_count]
+    #    increment after every action that consumed budget.  Hashing
+    #    them meant a stuck loop's cache key always changed even when
+    #    the PR, phase, comments, and workflow state were stable — so
+    #    the lookup missed and replay_count never reached the cap.
+    # 3. (The bug Codex P2 line 6130 #1 flagged separately: head_sha
+    #    used to be ABSENT from diagnostics entirely, so a brand-new
+    #    commit on the same branch with the same mergeability could
+    #    replay a stale cached decision.  That is now fixed at the
+    #    diagnostics-build site above — head_sha is included in the
+    #    linked_pr object, so it naturally participates in the hash.)
+    #
+    # The unfiltered diagnostics blob still flows into the LLM prompt
+    # below (the judge benefits from seeing its own prior reasoning,
+    # the live stall_minutes, etc.); only the hash input is filtered.
+    # Fail-open: if jq fails, fall back to hashing the unfiltered
+    # blob (today's behaviour, no regression).
+    local _cache_diagnostics
+    # The judge-heading filter must NOT eat a human-authored comment.
+    # Earlier iterations tried (a) author-suffix matching, which broke
+    # under PAT-authenticated deployments (Codex P2, PR #2522, line
+    # 6255), and (b) author-agnostic body-shape matching (heading +
+    # both Decision lines), which over-filtered humans who quote a
+    # legacy judge report when replying (Codex P2, PR #2522, line
+    # 6330).  Switch to marker-only matching: strip a comment only
+    # if its body contains the hidden
+    # `<!-- ORCHESTRATOR_STALL_JUDGE -->` HTML-comment that the bot
+    # stamps on every judge tracking comment it posts
+    # (line ~6510 below).  Humans never include this exact byte
+    # sequence — the marker is invisible in rendered Markdown, so
+    # copy-paste quotes of the visible heading + Decision lines do
+    # not carry it.  Legacy bot comments posted before this PR lack
+    # the marker and will pollute the cache hash for the
+    # ≤8-comment window until they age out — acceptable transient
+    # behavior, vs. the alternative of permanently losing fresh
+    # human guidance every time a maintainer quotes the bot.
+    _cache_diagnostics="$(printf '%s' "${diagnostics}" | jq -c '
+      .recent_tracking_comments = (
+        (.recent_tracking_comments // [])
+        | map(select(((.body // "") | contains("<!-- ORCHESTRATOR_STALL_JUDGE -->")) | not))
+      )
+      | del(.stall_minutes)
+      | del(.recovery_count)
+      | del(.phase_attempts_count)
+      | .prior_recovery_actions = (
+          (.prior_recovery_actions // [])
+          | map(select(.key != "stall_recovery_count"))
+        )
+    ' 2>/dev/null || printf '%s' "${diagnostics}")"
+    _judge_cache_key="$(printf '%s' "${_cache_diagnostics}" | sha256sum 2>/dev/null | awk '{print $1}')"
+    if [ -n "${_judge_cache_key}" ]; then
+      _judge_cache_hit_action="$(jq -r --arg k "${_judge_cache_key}" '.judge_decision_cache[$k].action // ""' "${STATE_FILE}" 2>/dev/null || echo "")"
+      _judge_cache_replay_count="$(jq -r --arg k "${_judge_cache_key}" '.judge_decision_cache[$k].replay_count // 0' "${STATE_FILE}" 2>/dev/null || echo "0")"
+      [[ "${_judge_cache_replay_count}" =~ ^[0-9]+$ ]] || _judge_cache_replay_count=0
+      # Read the sticky synthetic-escalation marker that the
+      # force-escalate cache write below stamps onto entries derived
+      # from MAX_JUDGE_REPLAY.  Without this, the very next tick after
+      # the cap fires would replay the cached "escalate_human" but
+      # with _judge_force_escalate=false, so normalize would downgrade
+      # it back to the ladder and the terminal decision would be
+      # silently lost (Codex P2, PR #2522, line 6279).
+      _judge_cache_force_escalate="$(jq -r --arg k "${_judge_cache_key}" '.judge_decision_cache[$k].force_escalate // false' "${STATE_FILE}" 2>/dev/null || echo "false")"
+      if [ -n "${_judge_cache_hit_action}" ] && {
+           [ "${_judge_cache_replay_count}" -ge "${MAX_JUDGE_REPLAY}" ] \
+           || [ "${_judge_cache_force_escalate}" = "true" ];
+         }; then
+        _judge_force_escalate="true"
+      fi
+    fi
   fi
 
   local stall_judge_prompt_file="${RUNTIME_DIR}/stall_judge_prompt_${issue_num}.txt"
@@ -6067,12 +6568,31 @@ invoke_stall_judge() {
   local attempt
   local _judge_from_cache="false"
   if [ -n "${_judge_cache_hit_action}" ] && [ "${_judge_force_escalate}" = "true" ]; then
-    echo "  [stall-judge] Cache replay cap reached for issue #${issue_num} (key=${_judge_cache_key}, replays=${_judge_cache_replay_count} >= ${MAX_JUDGE_REPLAY}); forcing escalate_human."
+    if [ "${_judge_cache_force_escalate:-false}" = "true" ]; then
+      echo "  [stall-judge] Replaying sticky synthetic escalate_human for issue #${issue_num} (key=${_judge_cache_key}, cache marker force_escalate=true)."
+    else
+      echo "  [stall-judge] Cache replay cap reached for issue #${issue_num} (key=${_judge_cache_key}, replays=${_judge_cache_replay_count} >= ${MAX_JUDGE_REPLAY}); forcing escalate_human."
+    fi
     local _judge_escalate_justification
     _judge_escalate_justification="Cached judge decision '${_judge_cache_hit_action}' replayed ${_judge_cache_replay_count} times without progress; bypassing cache and escalating."
     jq -cn --arg a "escalate_human" --arg j "${_judge_escalate_justification}" '{action:$a, justification:$j}' > "${stall_judge_output_file}"
     judge_success="true"
     _judge_from_cache="true"
+    # Record the forced decision in the cache with the force_escalate
+    # marker so the bypass at line ~6339 (which gates on
+    # _judge_force_escalate) re-fires on the very next tick that hits
+    # this same key — without the marker, replay_count would reset to
+    # 0 here and the next cycle's normalize call would silently
+    # downgrade the synthetic escalate_human back to the ladder
+    # action, defeating MAX_JUDGE_REPLAY entirely (Codex P2,
+    # PR #2522, line 6279).  Best-effort: a jq failure is silently
+    # swallowed, matching the existing replay / write callsites
+    # below.
+    if [ -n "${_judge_cache_key}" ] && [ "${_judge_cache_eligible:-false}" = "true" ]; then
+      jq --arg k "${_judge_cache_key}" \
+        '.judge_decision_cache = ((.judge_decision_cache // {}) | .[$k] = {"action": "escalate_human", "replay_count": 0, "force_escalate": true})' \
+        "${STATE_FILE}" > "${STATE_FILE}.tmp" 2>/dev/null && mv "${STATE_FILE}.tmp" "${STATE_FILE}" || rm -f "${STATE_FILE}.tmp" 2>/dev/null || true
+    fi
   elif [ -n "${_judge_cache_hit_action}" ]; then
     echo "  [stall-judge] Cache hit for issue #${issue_num} (key=${_judge_cache_key}); replaying cached decision '${_judge_cache_hit_action}' (replay $((_judge_cache_replay_count + 1)) of max ${MAX_JUDGE_REPLAY})."
     local _judge_replay_justification
@@ -6080,10 +6600,18 @@ invoke_stall_judge() {
     jq -cn --arg a "${_judge_cache_hit_action}" --arg j "${_judge_replay_justification}" '{action:$a, justification:$j}' > "${stall_judge_output_file}"
     judge_success="true"
     _judge_from_cache="true"
-    local _judge_replay_next=$(( _judge_cache_replay_count + 1 ))
-    jq --arg k "${_judge_cache_key}" --argjson n "${_judge_replay_next}" \
-      '.judge_decision_cache = ((.judge_decision_cache // {}) | .[$k].replay_count = $n)' \
-      "${STATE_FILE}" > "${STATE_FILE}.tmp" 2>/dev/null && mv "${STATE_FILE}.tmp" "${STATE_FILE}" || rm -f "${STATE_FILE}.tmp" 2>/dev/null || true
+    # Defer the replay_count bump until AFTER the dispatch resolves
+    # below: if `execute_stall_recovery_action` reports rc=2
+    # (resolver/autofix already in flight — a dedupe path) it does
+    # no new work, so bumping replay_count here would silently age
+    # the cache against an in-flight resolver and eventually trip
+    # MAX_JUDGE_REPLAY into a forced human escalation while the
+    # original work is still running (Codex P2, PR #2522, line
+    # 6550).  Just stage the next count and let the post-dispatch
+    # cache-write block at the end of the function decide whether
+    # to commit it based on whether the dispatch was a fresh,
+    # budget-consuming action.
+    _judge_replay_next_pending=$(( _judge_cache_replay_count + 1 ))
   else
     for attempt in 1 2; do
       if [ -n "${MOCK_STALL_JUDGE_JSON:-}" ]; then
@@ -6119,11 +6647,28 @@ invoke_stall_judge() {
   local judge_justification
   judge_action="$(echo "${judge_json}" | jq -r '.action // ""')"
   judge_justification="$(echo "${judge_json}" | jq -r '.justification // "no justification provided"')"
+  # _judge_phase_attempts_count was looked up earlier (alongside
+  # fallback_action) so the judge-failure fallback branches above
+  # could downgrade to "skip" on phase-attempt exhaustion.  Reuse
+  # the same value here for the normalize call (Copilot review,
+  # PR #2522, line 1527) — no second jq read needed.
   local effective_action
-  if [ "${_judge_force_escalate}" = "true" ] && [ "${judge_action}" = "escalate_human" ]; then
+  if [ "${_judge_force_escalate:-false}" = "true" ] && [ "${judge_action}" = "escalate_human" ]; then
+    # Bypass normalize_stall_recovery_action for the synthetic
+    # MAX_JUDGE_REPLAY escalation. The operator explicitly opted into
+    # this terminalization by setting MAX_JUDGE_REPLAY, so letting the
+    # global ENABLE_STALL_HUMAN_TERMINALIZATION=false gate downgrade
+    # it back to the ladder would silently defeat the replay cap — the
+    # exact loop the cap exists to break would keep replaying / falling
+    # back instead of escalating to a human (Codex P2, PR #2522, line
+    # 6100).  The bypass is intentionally narrow: it only applies when
+    # judge_action is the synthetic "escalate_human" emitted by the
+    # force-escalate branch above.  An LLM-returned escalate_human
+    # still flows through normalize_stall_recovery_action and obeys
+    # the global gate.
     effective_action="escalate_human"
   else
-    effective_action="$(normalize_stall_recovery_action "${phase}" "${recovery_count}" "${judge_action}")"
+    effective_action="$(normalize_stall_recovery_action "${phase}" "${recovery_count}" "${judge_action}" "${_judge_phase_attempts_count}")"
   fi
   STALL_JUDGE_TARGET_PR="$(echo "${judge_json}" | jq -r '.target_pr // empty')"
   if [ -z "${STALL_JUDGE_TARGET_PR}" ] && [[ "${target_pr}" =~ ^[0-9]+$ ]]; then
@@ -6134,17 +6679,18 @@ invoke_stall_judge() {
     STALL_JUDGE_HEAD_REF="${head_ref}"
   fi
 
-  # Cache the fresh judge decision so future identical inputs replay it
-  # rather than burning another LLM call. Skip when this run was itself
-  # served from the cache (replay count was already bumped above).
-  if [ "${_judge_from_cache}" = "false" ] && [ -n "${_judge_cache_key}" ] && [ -n "${judge_action}" ] && [ -n "${STATE_FILE:-}" ] && [ -f "${STATE_FILE}" ]; then
-    jq --arg k "${_judge_cache_key}" --arg action "${judge_action}" \
-      '.judge_decision_cache = ((.judge_decision_cache // {}) | .[$k] = {"action": $action, "replay_count": 0})' \
-      "${STATE_FILE}" > "${STATE_FILE}.tmp" 2>/dev/null && mv "${STATE_FILE}.tmp" "${STATE_FILE}" || rm -f "${STATE_FILE}.tmp" 2>/dev/null || true
-  fi
-
+  # The hidden `<!-- ORCHESTRATOR_STALL_JUDGE -->` marker is placed
+  # IMMEDIATELY after the heading (not at the bottom of the comment)
+  # so the cache-key filter at line ~6330 can find it even when the
+  # diagnostics-build truncator at line ~6017+ slices the body at
+  # 2000 chars.  A typical judge comment is 3-4 KB once the
+  # diagnostics snapshot is embedded, and an end-of-body marker
+  # would be truncated out — leaving the orchestrator's own
+  # narration in recent_tracking_comments and silently churning the
+  # cache key on every cycle (Codex P2, PR #2522, line 6614).
   local judge_comment
   judge_comment="## 🧑‍⚖️ Stall Judge — Issue #${issue_num} attempt $((recovery_count + 1))
+<!-- ORCHESTRATOR_STALL_JUDGE -->
 
 **Decision (judge):** ${judge_action}
 **Decision (effective):** ${effective_action}
@@ -6167,35 +6713,110 @@ ${diagnostics}
     echo "::notice::Stall judge action '${judge_action}' normalized to '${effective_action}' for issue #${issue_num}."
   fi
 
+  # Dispatch the resolved action and track which action ACTUALLY ran
+  # so the cache write below stores an executable replay value.
+  # Previously the cache wrote effective_action BEFORE dispatch, so a
+  # resolve_merge_conflict whose dispatch later failed (network blip,
+  # no autofix worker available) would persist resolve_merge_conflict
+  # for the unchanged diagnostics key — and every subsequent
+  # identical stall would replay the same dead-end action, eventually
+  # tripping MAX_JUDGE_REPLAY into a human escalation on the back of
+  # ONE bad dispatch (Codex P2, PR #2522, line 6625).  Capture the
+  # rc from each dispatch path and the action we actually executed;
+  # cache that combination at the end.
+  #
+  # Reset STALL_RECOVERY_SHOULD_INCREMENT to "false" before the
+  # dispatch so the captured value below reflects ONLY this
+  # tick's work.  execute_stall_recovery_action sets it to "true"
+  # when a fresh budget-consuming action ran, and leaves it
+  # "false" for dedupe/no-op paths (rc=2 active-resolver, already-
+  # dispatched-this-cycle).  We use that signal below to decide
+  # whether the cache-replay path should age its replay_count
+  # (Codex P2, PR #2522, line 6550).
+  local _judge_dispatch_rc=0
+  local _judge_executed_action="${effective_action}"
+  STALL_RECOVERY_SHOULD_INCREMENT="false"
   case "${effective_action}" in
     retrigger_pipeline|auto_respond_clarify|retrigger_plan|auto_approve|retrigger_implement|retrigger_review|attempt_merge|close_and_reissue|escalate_human|skip)
-      execute_stall_recovery_action "${issue_num}" "${phase}" "${effective_action}" "${recovery_count}" "${local_id}" "${stall_minutes}"
-      return $?
+      execute_stall_recovery_action "${issue_num}" "${phase}" "${effective_action}" "${recovery_count}" "${local_id}" "${stall_minutes}" || _judge_dispatch_rc=$?
       ;;
     resolve_merge_conflict)
       if ! [[ "${STALL_JUDGE_TARGET_PR}" =~ ^[0-9]+$ ]]; then
         echo "::warning::Stall judge returned resolve_merge_conflict without target_pr; falling back to ${fallback_action}."
-        execute_stall_recovery_action "${issue_num}" "${phase}" "${fallback_action}" "${recovery_count}" "${local_id}" "${stall_minutes}"
-        return $?
-      fi
-      if [ -z "${STALL_JUDGE_HEAD_REF}" ] || [ "${STALL_JUDGE_HEAD_REF}" = "null" ]; then
+        _judge_executed_action="${fallback_action}"
+        execute_stall_recovery_action "${issue_num}" "${phase}" "${fallback_action}" "${recovery_count}" "${local_id}" "${stall_minutes}" || _judge_dispatch_rc=$?
+      elif [ -z "${STALL_JUDGE_HEAD_REF}" ] || [ "${STALL_JUDGE_HEAD_REF}" = "null" ]; then
         echo "::warning::Stall judge returned resolve_merge_conflict without head_ref; falling back to ${fallback_action}."
-        execute_stall_recovery_action "${issue_num}" "${phase}" "${fallback_action}" "${recovery_count}" "${local_id}" "${stall_minutes}"
-        return $?
-      fi
-      if ! execute_stall_recovery_action "${issue_num}" "${phase}" "resolve_merge_conflict" "${recovery_count}" "${local_id}" "${stall_minutes}"; then
+        _judge_executed_action="${fallback_action}"
+        execute_stall_recovery_action "${issue_num}" "${phase}" "${fallback_action}" "${recovery_count}" "${local_id}" "${stall_minutes}" || _judge_dispatch_rc=$?
+      elif ! execute_stall_recovery_action "${issue_num}" "${phase}" "resolve_merge_conflict" "${recovery_count}" "${local_id}" "${stall_minutes}"; then
         echo "::warning::resolve_merge_conflict dispatch failed for issue #${issue_num}; falling back to ${fallback_action}."
-        execute_stall_recovery_action "${issue_num}" "${phase}" "${fallback_action}" "${recovery_count}" "${local_id}" "${stall_minutes}"
-        return $?
+        _judge_executed_action="${fallback_action}"
+        execute_stall_recovery_action "${issue_num}" "${phase}" "${fallback_action}" "${recovery_count}" "${local_id}" "${stall_minutes}" || _judge_dispatch_rc=$?
       fi
-      return 0
       ;;
     *)
       echo "::warning::Unknown effective stall action '${effective_action}' for issue #${issue_num}; falling back to ${fallback_action}."
-      execute_stall_recovery_action "${issue_num}" "${phase}" "${fallback_action}" "${recovery_count}" "${local_id}" "${stall_minutes}"
-      return $?
+      _judge_executed_action="${fallback_action}"
+      execute_stall_recovery_action "${issue_num}" "${phase}" "${fallback_action}" "${recovery_count}" "${local_id}" "${stall_minutes}" || _judge_dispatch_rc=$?
       ;;
   esac
+
+  # Capture whether the dispatch was a FRESH budget-consuming
+  # action (as opposed to a dedupe / no-op).
+  # execute_stall_recovery_action sets STALL_RECOVERY_SHOULD_INCREMENT
+  # to "true" only on its rc=0 fresh-dispatch path; rc=2 dedupe
+  # (active autofix / resolver already in flight) leaves it
+  # "false".  Two cache decisions below depend on this:
+  #   * Fresh-LLM cache write (Codex P2 line 6625 + 6705):
+  #     skip when dispatch failed OR was a dedupe — caching a
+  #     replay that did no new work would burn MAX_JUDGE_REPLAY
+  #     on a single bad dispatch.
+  #   * Cache-replay count bump (Codex P2 line 6550): skip on
+  #     dedupe so the cache does not age while an existing
+  #     resolver is still working.
+  # IMPORTANT: do NOT clear STALL_RECOVERY_SHOULD_INCREMENT here.
+  # The outer stall-recovery loop reads it to decide whether to
+  # bump stall_recovery_count after invoke_stall_judge returns;
+  # clobbering it to "false" would silently lose every budget-
+  # consuming action this function dispatched.
+  local _judge_dispatch_was_fresh="${STALL_RECOVERY_SHOULD_INCREMENT:-false}"
+
+  # Persist the cache decision now that we know whether the
+  # dispatch actually ran fresh work.  Only writes happen when
+  # the dispatch succeeded (rc=0) AND a budget-consuming action
+  # actually ran (was_fresh=true).  Both gates together prevent:
+  #   * caching a dead-end action after a transient dispatch
+  #     failure (would replay the failure forever)
+  #   * aging the cache while a resolver is still in flight
+  #     (would trip MAX_JUDGE_REPLAY into a forced escalation
+  #     against still-active work)
+  # Cache `_judge_executed_action` rather than `effective_action`:
+  # if the judge's effective action was resolve_merge_conflict
+  # but the dispatch fell through to the ladder fallback (missing
+  # metadata OR dispatch failure), the fresh-LLM cache writes
+  # the action we actually ran — so the next identical stall
+  # replays a known-executable decision (Codex P2, PR #2522,
+  # lines 6359, 6625, 6705, 6550).
+  if [ "${_judge_dispatch_rc}" -eq 0 ] \
+     && [ "${_judge_dispatch_was_fresh}" = "true" ] \
+     && [ -n "${_judge_cache_key}" ] \
+     && [ "${_judge_cache_eligible:-false}" = "true" ]; then
+    if [ "${_judge_from_cache}" = "true" ] \
+       && [ -n "${_judge_replay_next_pending:-}" ]; then
+      # Cache-replay path: bump replay_count toward MAX_JUDGE_REPLAY.
+      jq --arg k "${_judge_cache_key}" --argjson n "${_judge_replay_next_pending}" \
+        '.judge_decision_cache = ((.judge_decision_cache // {}) | .[$k].replay_count = $n)' \
+        "${STATE_FILE}" > "${STATE_FILE}.tmp" 2>/dev/null && mv "${STATE_FILE}.tmp" "${STATE_FILE}" || rm -f "${STATE_FILE}.tmp" 2>/dev/null || true
+    elif [ "${_judge_from_cache}" = "false" ] \
+         && [ -n "${_judge_executed_action}" ]; then
+      # Fresh-LLM cache write.
+      jq --arg k "${_judge_cache_key}" --arg action "${_judge_executed_action}" \
+        '.judge_decision_cache = ((.judge_decision_cache // {}) | .[$k] = {"action": $action, "replay_count": 0})' \
+        "${STATE_FILE}" > "${STATE_FILE}.tmp" 2>/dev/null && mv "${STATE_FILE}.tmp" "${STATE_FILE}" || rm -f "${STATE_FILE}.tmp" 2>/dev/null || true
+    fi
+  fi
+  return "${_judge_dispatch_rc}"
 }
 
 # Run both standalone-stall marker searches in a single GraphQL
@@ -7052,13 +7673,18 @@ PY
       local _STD_ITER_PR_NUM_CACHED=""
       local _STD_ITER_PR_JSON_CACHED=""
       _STD_ITER_PR_NUM_CACHED="$(printf '%s' "${_std_conflict_linked}" | jq -r '.number // empty' 2>/dev/null || echo "")"
-      # API hygiene: when GraphQL already gave us PR number + head ref,
-      # seed a minimal JSON payload so retrigger_review can skip a
-      # redundant gh api pulls/{n} fetch on the non-retry fast path.
-      local _std_cached_head_ref=""
+      # API hygiene: when GraphQL already gave us PR number + head ref
+      # (and optionally headRefOid as head_sha), seed a minimal JSON
+      # payload so retrigger_review can skip a redundant gh api
+      # pulls/{n} fetch on the non-retry fast path.  Include head_sha
+      # in the seed so the standalone per-head-SHA override cap below
+      # (Codex P2, PR #2522 line 7284) can fire even when REST is
+      # skipped on a settled DIRTY/CONFLICTING state.
+      local _std_cached_head_ref="" _std_cached_head_sha=""
       _std_cached_head_ref="$(printf '%s' "${_std_conflict_linked}" | jq -r '(.head_ref // .head.ref // .headRefName // empty)' 2>/dev/null || echo "")"
+      _std_cached_head_sha="$(printf '%s' "${_std_conflict_linked}" | jq -r '(.head_sha // .head.sha // .headRefOid // empty)' 2>/dev/null || echo "")"
       if [[ "${_STD_ITER_PR_NUM_CACHED}" =~ ^[0-9]+$ ]] && [ -n "${_std_cached_head_ref}" ] && [ "${_std_cached_head_ref}" != "null" ]; then
-        _STD_ITER_PR_JSON_CACHED="$(jq -cn --argjson n "${_STD_ITER_PR_NUM_CACHED}" --arg hr "${_std_cached_head_ref}" '{number: $n, head: {ref: $hr}}' 2>/dev/null || echo "")"
+        _STD_ITER_PR_JSON_CACHED="$(jq -cn --argjson n "${_STD_ITER_PR_NUM_CACHED}" --arg hr "${_std_cached_head_ref}" --arg hs "${_std_cached_head_sha}" '{number: $n, head: {ref: $hr, sha: (if $hs == "" or $hs == "null" then null else $hs end)}}' 2>/dev/null || echo "")"
       fi
 
       # Widen the REST-fallback trigger: GitHub computes mergeability
@@ -7136,36 +7762,62 @@ PY
       fi
 
       if _check_open_pr_conflict_guard "${issue_num}" "${_std_conflict_linked}"; then
+        # Resolve head_sha for the per-head-SHA budget-neutral
+        # override cap below.  Try _std_conflict_linked first (GraphQL
+        # fast-path shape — top-level .head_sha when seeded by the
+        # graphql linked_pr transform), then _STD_ITER_PR_JSON_CACHED
+        # (REST shape — nested .head.sha).  Fail-open: if neither has
+        # it, skip the cap rather than block the dispatch (Codex P2,
+        # PR #2522, lines 1077 + 7284).
         local _std_conflict_head_sha=""
+        if [ -n "${_std_conflict_linked:-}" ] && [ "${_std_conflict_linked}" != "null" ]; then
+          _std_conflict_head_sha="$(printf '%s' "${_std_conflict_linked}" | jq -r '(.head_sha // .head.sha // empty)' 2>/dev/null || echo "")"
+        fi
+        if [ -z "${_std_conflict_head_sha}" ] && [ -n "${_STD_ITER_PR_JSON_CACHED:-}" ]; then
+          _std_conflict_head_sha="$(printf '%s' "${_STD_ITER_PR_JSON_CACHED}" | jq -r '(.head_sha // .head.sha // empty)' 2>/dev/null || echo "")"
+        fi
+        # Read the current per-head override count BEFORE dispatch so
+        # we can decide cap consumption from it, but defer the actual
+        # write (counter bump + budget consumption) to AFTER the
+        # dispatch and only apply it when the dispatch was a FRESH
+        # one (rc=0).  rc=2 means _dispatch_review_for_conflicts
+        # deduped against an in-flight autofix or an earlier dispatch
+        # this cycle — no new work happened, so neither the counter
+        # nor stall budget should advance (mirrors the managed
+        # retrigger_review fix at line 5559+ / Codex P2 line 5565).
         local _std_override_count="0"
-        local _std_next_count="0"
-        local _std_consume_budget="false"
-        _std_conflict_head_sha="$(printf '%s' "${_std_conflict_linked}" | jq -r '(.head_sha // .head.sha // .headRefOid // empty)' 2>/dev/null || echo "")"
         if [ -n "${_std_conflict_head_sha}" ] && [ "${_std_conflict_head_sha}" != "null" ]; then
-          _std_override_count="$(printf '%s' "${updated_state}" | jq -r --arg sha "${_std_conflict_head_sha}" '.conflict_override_count[$sha] // 0' 2>/dev/null || echo "0")"
+          _std_override_count="$(printf '%s' "${updated_state}" | jq -r --arg sha "${_std_conflict_head_sha}" '(.conflict_override_count[$sha] // 0)' 2>/dev/null || echo "0")"
           [[ "${_std_override_count}" =~ ^[0-9]+$ ]] || _std_override_count="0"
-          if [ "${_std_override_count}" -ge "${MAX_BUDGET_NEUTRAL_OVERRIDES}" ]; then
-            echo "  [standalone-stall] Issue #${issue_num} PR #${STALL_CONFLICT_PR_NUM} head_sha ${_std_conflict_head_sha} has hit budget-neutral override cap (${_std_override_count} >= ${MAX_BUDGET_NEUTRAL_OVERRIDES}); consuming stall budget on this attempt."
-            _std_consume_budget="true"
-          fi
-          _std_next_count=$(( _std_override_count + 1 ))
         fi
         local _std_conflict_rc=0
         _dispatch_review_for_conflicts "${STALL_CONFLICT_PR_NUM}" "${STALL_CONFLICT_HEAD_REF}" || _std_conflict_rc=$?
         case "${_std_conflict_rc}" in
           0)
+            # Fresh dispatch — bump the per-head counter and (if the
+            # cap is now hit) consume one stall-recovery attempt,
+            # mirroring the managed retrigger_review path.  Refresh
+            # status_since_ts/updated_ts on budget consumption so the
+            # issue re-enters its phase-threshold window instead of
+            # burning the rest of the ladder on the next cron tick
+            # (Codex P2, PR #2522, line 7335).  This block runs ONLY
+            # in the rc=0 branch — rc=2 (dedupe) below does not bump
+            # the counter.
             if [ -n "${_std_conflict_head_sha}" ] && [ "${_std_conflict_head_sha}" != "null" ]; then
-              updated_state="$(printf '%s' "${updated_state}" | jq -c --arg sha "${_std_conflict_head_sha}" --argjson n "${_std_next_count}" '.conflict_override_count = ((.conflict_override_count // {}) | .[$sha] = $n)' 2>/dev/null || echo "${updated_state}")"
+              if [ "${_std_override_count}" -ge "${MAX_BUDGET_NEUTRAL_OVERRIDES}" ]; then
+                echo "  [standalone-stall] Issue #${issue_num} PR #${STALL_CONFLICT_PR_NUM} head_sha ${_std_conflict_head_sha} has hit budget-neutral override cap (${_std_override_count} >= ${MAX_BUDGET_NEUTRAL_OVERRIDES}); consuming stall budget on this attempt."
+                local _std_now_ts
+                _std_now_ts="$(date -u +%s)"
+                updated_state="$(printf '%s' "${updated_state}" | jq -c --argjson now "${_std_now_ts}" \
+                  '.stall_recovery_count = ((.stall_recovery_count // 0) + 1)
+                   | .status_since_ts = $now
+                   | .updated_ts = $now' \
+                  2>/dev/null || printf '%s' "${updated_state}")"
+              fi
+              local _std_override_next=$(( _std_override_count + 1 ))
+              updated_state="$(printf '%s' "${updated_state}" | jq -c --arg sha "${_std_conflict_head_sha}" --argjson n "${_std_override_next}" \
+                '.conflict_override_count = ((.conflict_override_count // {}) | .[$sha] = $n)' 2>/dev/null || printf '%s' "${updated_state}")"
             fi
-			if [ "${_std_consume_budget}" = "true" ]; then
-			  updated_state="$(printf '%s' "${updated_state}" | jq -c --arg phase "${phase}" --argjson now "$(date +%s)" '
-				.stall_recovery_count = ((.stall_recovery_count | tonumber? // 0) + 1)
-				| .phase_attempts = (if (.phase_attempts | type) == "object" then .phase_attempts else {} end)
-				| .phase_attempts[$phase] = ((.phase_attempts[$phase] | tonumber? // 0) + 1)
-				| .status_since_ts = $now
-				| .updated_ts = $now
-			  ' 2>/dev/null || echo "${updated_state}")"
-			fi
             echo "  [standalone-stall] Issue #${issue_num} linked PR #${STALL_CONFLICT_PR_NUM} has merge conflicts — dispatched conflict resolver instead of '${action}'."
             echo "STALL_RECOVERY issue=${issue_num} reason=open_pr_merge_conflict pr=${STALL_CONFLICT_PR_NUM} phase=${phase} action=dispatch_conflict_resolver override_from=${action}"
             tg_notify_issue "${issue_num}" "Standalone stall recovery: PR #${STALL_CONFLICT_PR_NUM} has merge conflicts — dispatched conflict resolver (phase=${phase}, stuck ${elapsed_minutes}m, attempt $((recovery_count + 1)))." "WARNING"
@@ -7427,15 +8079,24 @@ REISSUE_EOF
             --add-label 'ai:closed' 2>/dev/null || true
           gh_retry gh issue close "${issue_num}" --repo "${GITHUB_REPOSITORY}" -c "Closing: standalone stall recovery. Issue was stuck in '${phase}' for ${elapsed_minutes} minutes after $((recovery_count + 1)) recovery attempt(s)." 2>/dev/null || true
           local new_state
-		  new_state="$(printf '%s' "${updated_state}" | jq -c --argjson now "$(date +%s)" '
-			.last_seen_phase = ""
-			| .status_since_ts = $now
-			| .stall_recovery_count = 0
-			| .phase_attempts = {}
-			| .updated_ts = $now
-		  ' 2>/dev/null || echo "${updated_state}")"
-		  write_standalone_state_json "${new_num}" "${new_state}" ""
-		  tg_notify_issue "${issue_num}" "Standalone stall recovery: closed and re-issued as #${new_num} (phase: ${phase}, stuck ${elapsed_minutes}m)." "WARNING"
+          new_state="$(python3 - "$updated_state" <<'PY'
+import json, sys, time
+state = json.loads(sys.argv[1])
+now = int(time.time())
+state["last_seen_phase"] = ""
+state["status_since_ts"] = now
+state["stall_recovery_count"] = 0
+# Reset the phase-lifetime counter alongside stall_recovery_count so the
+# fresh issue starts with a clean recovery ladder instead of inheriting
+# the predecessor's exhausted phase_attempts (which would route
+# detect_stalls() straight to "skip" on the first stall).
+state["phase_attempts"] = {}
+state["updated_ts"] = now
+print(json.dumps(state, separators=(",", ":")))
+PY
+)"
+          write_standalone_state_json "${new_num}" "${new_state}" ""
+          tg_notify_issue "${issue_num}" "Standalone stall recovery: closed and re-issued as #${new_num} (phase: ${phase}, stuck ${elapsed_minutes}m)." "WARNING"
 		else
 		  echo "::warning::Standalone close_and_reissue failed to create replacement issue for #${issue_num}."
 		  tg_notify_issue "${issue_num}" "Standalone stall recovery: attempted close-and-reissue but could not create replacement issue." "ERROR"
@@ -8902,7 +9563,7 @@ The poller will resume processing on the next cycle."
         "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
 
       # Update the wave entry with the github issue number
-      jq "(.waves[${WAVE_IDX}].issues[] | select(.id == \"${local_id}\")) |= (.github_issue = ${NEW_NUM} | .status = \"pending\" | .last_seen_phase = \"\" | .status_since_ts = $(date +%s) | .stall_recovery_count = 0)" \
+      jq "(.waves[${WAVE_IDX}].issues[] | select(.id == \"${local_id}\")) |= (.github_issue = ${NEW_NUM} | .status = \"pending\" | .last_seen_phase = \"\" | .status_since_ts = $(date +%s) | .stall_recovery_count = 0 | .phase_attempts = {})" \
         "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
 
       DEFERRED_STATE_CHANGED=true
@@ -10371,8 +11032,12 @@ ${RB_FIX_DESC}
             if [[ "${NEW_NUM}" =~ ^[0-9]+$ ]] && [ -n "${LOCAL_ID}" ] && [ "${LOCAL_ID}" != "null" ]; then
               jq ".issue_number_map[\"${LOCAL_ID}\"] = ${NEW_NUM}" \
                 "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
-              # Update the wave entry
-              jq "(.waves[${WAVE_IDX}].issues[] | select(.id == \"${LOCAL_ID}\")) |= (.github_issue = ${NEW_NUM} | .status = \"pending\")" \
+              # Update the wave entry.  Reset the stall counters alongside
+              # the new github_issue so the replacement issue runs the
+              # recovery ladder from scratch on its first stall instead of
+              # inheriting the predecessor's exhausted stall_recovery_count /
+              # phase_attempts and being routed straight to "skip".
+              jq "(.waves[${WAVE_IDX}].issues[] | select(.id == \"${LOCAL_ID}\")) |= (.github_issue = ${NEW_NUM} | .status = \"pending\" | .last_seen_phase = \"\" | .status_since_ts = $(date +%s) | .stall_recovery_count = 0 | .phase_attempts = {})" \
                 "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
             fi
 
@@ -10784,11 +11449,29 @@ REISSUE_EOF
       NEW_ISSUE_NUM="$(basename "${NEW_ISSUE_URL_CLEAN%%[?#]*}")"
       echo "  Created replacement issue #${NEW_ISSUE_NUM} for failed #${if_issue}."
 
-      # Update state file: replace the old issue number with the new one
-      # (impl_noop_count is preserved on the issue entry since we only
-      # change github_issue, not the issue object itself)
+      # Update state file: replace the old issue number with the new
+      # one AND reset the per-issue stall-recovery accumulators on the
+      # wave entry so the fresh replacement does not inherit an
+      # exhausted phase_attempts counter from its predecessor and get
+      # routed straight to "skip" on its first stall in that phase
+      # (Codex P2, PR #2522, orchestrate_lib.py line 1814).  Matches
+      # the reset block used by the other reissue paths (see
+      # scripts/orchestrate_poll_process.sh:5733, 9061, 10535).
+      # impl_noop_count is intentionally preserved so the
+      # ancestor-chain no-op cap can still detect a chain of no-op
+      # reissues — that counter tracks the issue lineage rather than
+      # the current attempt's progress.
       if [[ "${NEW_ISSUE_NUM}" =~ ^[0-9]+$ ]]; then
-        jq --arg if_issue "${if_issue}" --arg new_issue_num "${NEW_ISSUE_NUM}" --arg local_id "${IF_LOCAL_ID}" --argjson wave_idx "${WAVE_IDX}" '(.waves[$wave_idx].issues[] | select((.github_issue | tostring) == $if_issue)).github_issue = $new_issue_num | if ($local_id != "" and $local_id != "null") then .issue_number_map[$local_id] = $new_issue_num else . end' \
+        jq --arg if_issue "${if_issue}" --arg new_issue_num "${NEW_ISSUE_NUM}" --arg local_id "${IF_LOCAL_ID}" --argjson wave_idx "${WAVE_IDX}" \
+          '(.waves[$wave_idx].issues[] | select((.github_issue | tostring) == $if_issue)) |= (
+             .github_issue = $new_issue_num
+             | .status = "pending"
+             | .last_seen_phase = ""
+             | .status_since_ts = (now | floor)
+             | .stall_recovery_count = 0
+             | .phase_attempts = {}
+           )
+           | if ($local_id != "" and $local_id != "null") then .issue_number_map[$local_id] = $new_issue_num else . end' \
           "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
       fi
 
@@ -10871,6 +11554,28 @@ fi
     if [ -n "${PHASE_THRESHOLDS_JSON:-}" ]; then
       _stall_check_args+=(--phase-thresholds-json "${PHASE_THRESHOLDS_JSON}")
     fi
+    # Forward MAX_STALL_RECOVERIES_DONE through to detect_stalls so the
+    # ai:done per-phase override is applied to both phase_attempts and
+    # stall_recovery_count.  Without this, an ai:done issue at
+    # phase_attempts=5 (the default global cap) is hard-closed even when
+    # the operator raised MAX_STALL_RECOVERIES_DONE=99 to avoid exactly
+    # that outcome.  The shell-side ai:done helpers
+    # (recovery_action_for_phase / normalize_stall_recovery_action) already
+    # pass {"ai:done": ${MAX_STALL_RECOVERIES_DONE}} into the corresponding
+    # Python helpers; this keeps the in-process bulk path consistent.
+    # Normalize to a canonical decimal integer BEFORE formatting so a
+    # value like "09" (the regex validator at line ~882 only checks
+    # `^[0-9]+$`, which permits leading zeros) does not produce
+    # invalid JSON like `{"ai:done": 09}` and silently break
+    # check-stalls into a fall-back `{count:0}` (Copilot review,
+    # PR #2522, line 11254).  `$((10#${X}))` forces base-10
+    # interpretation, stripping leading zeros without invoking an
+    # external process.  Then build the JSON via `jq --argjson` so
+    # the result is guaranteed-valid JSON.
+    # No `local` here — this block lives in the top-level poller body
+    # (outside any function), where `local` is a syntax error.
+    _msd_canonical=$(( 10#${MAX_STALL_RECOVERIES_DONE} ))
+    _stall_check_args+=(--max-recoveries-by-phase-json "$(jq -cn --argjson n "${_msd_canonical}" '{"ai:done": $n}')")
 
     STALLS_JSON="$(python3 scripts/orchestrate_lib.py check-stalls \
       "${_stall_check_args[@]}" 2>/dev/null || echo '{"ok":false,"stalls":[],"count":0}')"

--- a/tests/test_orchestrate_lib.py
+++ b/tests/test_orchestrate_lib.py
@@ -688,6 +688,83 @@ def test_detect_stalls_max_recoveries_still_skips_with_judge_enabled():
 	assert stalls[0]["recovery_action"] == "skip"
 
 
+def test_detect_stalls_phase_attempts_respects_per_phase_cap():
+	"""An ai:done issue with phase_attempts >= global cap must NOT be skipped
+	when the operator raised the per-phase cap via max_recoveries_by_phase.
+	Without this, the new phase-lifetime counter would prematurely route
+	ai:done stalls to the destructive "skip" action even when
+	MAX_STALL_RECOVERIES_DONE was set to a higher value to keep autofix
+	cycles alive for slow review-blocked PRs (per the
+	_phase_specific_max_recoveries docstring)."""
+	state = _make_state()
+	state["waves"][0]["issues"][0]["status"] = "in_progress"
+	state["waves"][0]["issues"][0]["status_since_ts"] = 1
+	state["waves"][0]["issues"][0]["stall_recovery_count"] = 0
+	state["waves"][0]["issues"][0]["phase_attempts"] = {"ai:done": 6}
+	labels = {"10": ["ai:done"], "11": ["ai:merged"]}
+
+	stalls = orchestrate_lib.detect_stalls(
+		state=state,
+		issue_labels=labels,
+		threshold_minutes=120,
+		now_ts=8 * 60 * 60,
+		max_recoveries=5,
+		stall_judge_trigger_count=2,
+		enable_stall_judge=True,
+		max_recoveries_by_phase={"ai:done": 99},
+	)
+
+	assert len(stalls) == 1
+	# 6 phase attempts < per-phase cap of 99 → must NOT be the destructive
+	# "skip" action.
+	assert stalls[0]["recovery_action"] != "skip"
+
+
+def test_detect_stalls_phase_attempts_routes_per_phase_cap_through_judge():
+	"""When max_recoveries_by_phase is supplied and phase_attempts reaches
+	that per-phase cap, the cap still fires — but with the stall judge
+	enabled, the action routes through RUN_STALL_JUDGE_ACTION so the
+	judge gets one chance to override before destructive skip (Codex
+	P2, PR #2522, line 1705).  With the judge disabled, the original
+	silent-skip behaviour persists so the cap still terminates."""
+	def _exhausted_state():
+		state = _make_state()
+		state["waves"][0]["issues"][0]["status"] = "in_progress"
+		state["waves"][0]["issues"][0]["status_since_ts"] = 1
+		state["waves"][0]["issues"][0]["stall_recovery_count"] = 0
+		state["waves"][0]["issues"][0]["phase_attempts"] = {"ai:done": 99}
+		return state
+	labels = {"10": ["ai:done"], "11": ["ai:merged"]}
+
+	# Judge enabled: route to RUN_STALL_JUDGE_ACTION, not skip.
+	stalls = orchestrate_lib.detect_stalls(
+		state=_exhausted_state(),
+		issue_labels=labels,
+		threshold_minutes=120,
+		now_ts=8 * 60 * 60,
+		max_recoveries=5,
+		stall_judge_trigger_count=2,
+		enable_stall_judge=True,
+		max_recoveries_by_phase={"ai:done": 99},
+	)
+	assert len(stalls) == 1
+	assert stalls[0]["recovery_action"] == orchestrate_lib.RUN_STALL_JUDGE_ACTION, stalls[0]
+
+	# Judge disabled: cap still fires → silent skip (original behaviour).
+	stalls = orchestrate_lib.detect_stalls(
+		state=_exhausted_state(),
+		issue_labels=labels,
+		threshold_minutes=120,
+		now_ts=8 * 60 * 60,
+		max_recoveries=5,
+		stall_judge_trigger_count=2,
+		enable_stall_judge=False,
+		max_recoveries_by_phase={"ai:done": 99},
+	)
+	assert len(stalls) == 1
+	assert stalls[0]["recovery_action"] == "skip", stalls[0]
+
+
 def test_cmd_check_stalls_forwards_stall_judge_flags_to_detect_stalls_with_trigger_override():
 	captured: dict[str, object] = {}
 	original_detect_stalls = orchestrate_lib.detect_stalls
@@ -1869,19 +1946,26 @@ def test_phase_attempts_count_caps_recovery_action():
 	assert action == "dispatch_rb_judge"
 
 
-def test_detect_stalls_skips_when_phase_attempts_exhausted():
-	"""detect_stalls returns recovery_action='skip' when phase_attempts
-	reaches the cap, even with a fresh stall_recovery_count of 0."""
-	state = _make_state()
-	issue = state["waves"][0]["issues"][0]
-	issue["status"] = "in_progress"
-	issue["status_since_ts"] = 1
-	issue["stall_recovery_count"] = 0  # zeroed by phase oscillation
-	issue["phase_attempts"] = {"ai:review-blocked": 5}
+def test_detect_stalls_routes_exhausted_phase_attempts_through_judge():
+	"""When phase_attempts reaches the cap with a fresh
+	stall_recovery_count (e.g. zeroed by phase oscillation), the cap
+	still fires — but the action routes through RUN_STALL_JUDGE_ACTION
+	so the judge can review before a destructive skip (Codex P2,
+	PR #2522, line 1705).  With the judge disabled, the cap continues
+	to force skip."""
+	def _make_exhausted_state():
+		state = _make_state()
+		issue = state["waves"][0]["issues"][0]
+		issue["status"] = "in_progress"
+		issue["status_since_ts"] = 1
+		issue["stall_recovery_count"] = 0  # zeroed by phase oscillation
+		issue["phase_attempts"] = {"ai:review-blocked": 5}
+		return state
 	labels = {"10": ["ai:review-blocked"], "11": ["ai:merged"]}
 
+	# Judge enabled — route to judge, NOT silent skip.
 	stalls = orchestrate_lib.detect_stalls(
-		state=state,
+		state=_make_exhausted_state(),
 		issue_labels=labels,
 		threshold_minutes=120,
 		now_ts=8 * 60 * 60,
@@ -1889,9 +1973,22 @@ def test_detect_stalls_skips_when_phase_attempts_exhausted():
 		stall_judge_trigger_count=2,
 		enable_stall_judge=True,
 	)
-
 	assert len(stalls) == 1
-	assert stalls[0]["recovery_action"] == "skip"
+	assert stalls[0]["recovery_action"] == orchestrate_lib.RUN_STALL_JUDGE_ACTION, stalls[0]
+	assert stalls[0]["phase_attempts_count"] == 5
+
+	# Judge disabled — cap still binds via silent skip (backstop).
+	stalls = orchestrate_lib.detect_stalls(
+		state=_make_exhausted_state(),
+		issue_labels=labels,
+		threshold_minutes=120,
+		now_ts=8 * 60 * 60,
+		max_recoveries=5,
+		stall_judge_trigger_count=2,
+		enable_stall_judge=False,
+	)
+	assert len(stalls) == 1
+	assert stalls[0]["recovery_action"] == "skip", stalls[0]
 	assert stalls[0]["phase_attempts_count"] == 5
 
 

--- a/tests/test_stall_loop_and_churn_fixes.py
+++ b/tests/test_stall_loop_and_churn_fixes.py
@@ -2,12 +2,36 @@
 """Function-level tests for the stall-loop, integration-churn, and
 narration-noise fixes shipped together in this PR.
 
-Each test extracts the relevant bash function(s) from
-``scripts/orchestrate_poll_process.sh`` into a temp file, sources them
-into a controlled bash subprocess with a stub state file, and asserts
-on the resulting state JSON or stdout.  This mirrors the extraction
-pattern used by ``tests/test_merge_probe.py`` so we get byte-level
-coverage of the new fixes without wiring into the full poller harness.
+Each test runs a small bash subprocess via ``_run_bash`` and asserts
+on the resulting state JSON or stdout.  Three patterns are in use,
+depending on what each test needs:
+
+  * Whole-function extraction via ``_extract_function_body`` — string-
+    slices the function definition out of
+    ``scripts/orchestrate_poll_process.sh`` (relying on the project
+    convention that bash function bodies close with ``\\n}\\n`` at
+    column 0) and embeds the source directly into a heredoc-built
+    bash script.  Used when a test needs the production function's
+    full body (e.g. ``_list_integration_conflict_files``,
+    ``normalize_stall_recovery_action``).  This differs from
+    ``tests/test_merge_probe.py`` which uses an awk-based extraction
+    that writes the function into a temp file and sources it; the
+    string-slice approach here keeps the extracted body inline so
+    bash-shim functions defined alongside it in the same heredoc
+    can stub git/jq/python3 calls.
+
+  * Inline reproduction of a small jq pipeline or shell block — used
+    when the production code path is too entangled for whole-function
+    extraction (e.g. the diagnostics-build jq, the cache-key filter,
+    the override-cap counter bump).  The test rewrites the production
+    pipeline verbatim in the heredoc and asserts on its output,
+    keeping the bash bytes in sync with the production block.
+
+  * Marker-only static assertion — used when a fix is a single line
+    or comment that's hard to behaviourally exercise without spinning
+    up the full poller harness.  ``test_production_script_contains_expected_fix_markers``
+    holds the list of stable anchors so a refactor that drops a fix
+    fails fast even when the behavioural tests above might not.
 
 Covers:
   * 1b — conflict-override cap is keyed on head_sha and flips to
@@ -25,9 +49,12 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
 import textwrap
 from pathlib import Path
+
+shlex_quote = shlex.quote
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -171,52 +198,1203 @@ def test_judge_cache_replay_path_bumps_counter_then_escalates(tmp_path):
 	], lines
 
 
-def test_judge_cache_key_changes_when_head_sha_advances(tmp_path):
-	"""When the head_sha changes (e.g. resolver pushed a commit), the
-	cache key is different so the new inputs go to the LLM rather than
-	replaying a stale decision."""
+def test_judge_cache_force_escalate_marker_survives_replay(tmp_path):
+	"""When MAX_JUDGE_REPLAY synthesises an escalate_human and stamps
+	force_escalate=true on the cache entry, every subsequent identical
+	stall must continue to read force_escalate=true and re-fire the
+	bypass — otherwise the very next tick (replay_count=0,
+	_judge_force_escalate=false) would normalize escalate_human back
+	to the ladder action and the terminal decision would be silently
+	lost (Codex P2, PR #2522, line 6279)."""
+	state_file = tmp_path / "state.json"
+	# Seed: forced-escalation cache entry from a prior cap-fire.
+	state_file.write_text(json.dumps({
+		"judge_decision_cache": {
+			"abc": {"action": "escalate_human", "replay_count": 0, "force_escalate": True},
+		},
+	}))
 	script = textwrap.dedent("""
-		set -euo pipefail
-		issue_num=2870
-		phase=ai:review-blocked
-		last=failure
-		k1=$(printf '%s|%s|%s|%s' "$issue_num" "abc" "$phase" "$last" | sha256sum | awk '{print $1}')
-		k2=$(printf '%s|%s|%s|%s' "$issue_num" "def" "$phase" "$last" | sha256sum | awk '{print $1}')
-		echo "$k1"
-		echo "$k2"
-		[ "$k1" != "$k2" ] && echo distinct || echo equal
+		set -uo pipefail
+		export STATE_FILE='""" + str(state_file) + """'
+		export MAX_JUDGE_REPLAY=2
+		key=abc
+		# Reproduce the production read at line ~6220+.
+		hit_action="$(jq -r --arg k "$key" '.judge_decision_cache[$k].action // ""' "$STATE_FILE")"
+		replay_count="$(jq -r --arg k "$key" '.judge_decision_cache[$k].replay_count // 0' "$STATE_FILE")"
+		[[ "$replay_count" =~ ^[0-9]+$ ]] || replay_count=0
+		cache_force_escalate="$(jq -r --arg k "$key" '.judge_decision_cache[$k].force_escalate // false' "$STATE_FILE")"
+		force_escalate="false"
+		if [ -n "$hit_action" ] && {
+			[ "$replay_count" -ge "$MAX_JUDGE_REPLAY" ] \
+			|| [ "$cache_force_escalate" = "true" ];
+		}; then
+			force_escalate="true"
+		fi
+		echo "force_escalate=$force_escalate"
+		echo "hit_action=$hit_action"
+		echo "replay_count=$replay_count"
+		echo "cache_force_escalate=$cache_force_escalate"
 	""")
 	r = _run_bash(script, cwd=tmp_path)
-	assert r.returncode == 0, f"bash failed: {r.stderr}"
-	lines = r.stdout.strip().splitlines()
-	assert lines[-1] == "distinct"
-	# Both keys must be 64-char hex.
-	assert all(len(line) == 64 and all(c in "0123456789abcdef" for c in line) for line in lines[:2])
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	out = dict(line.split("=", 1) for line in r.stdout.strip().splitlines() if line)
+	# Even with replay_count=0 (well below MAX_JUDGE_REPLAY=2), the
+	# cache marker re-triggers force_escalate=true on EVERY replay.
+	assert out["force_escalate"] == "true", out
+	assert out["hit_action"] == "escalate_human", out
+	assert out["cache_force_escalate"] == "true", out
+	assert out["replay_count"] == "0", out
 
 
-def test_judge_cache_key_changes_when_recent_comments_change(tmp_path):
-	"""When recent_comments change, the memoization key must change so the
-	judge sees the new diagnostics instead of replaying a stale action."""
+def test_judge_cache_force_escalate_marker_stops_when_diagnostics_change(tmp_path):
+	"""The sticky escalation should ONLY fire while the stall is
+	identical (same cache key).  When diagnostics change — e.g. a
+	new commit advances head_sha — the cache key differs and the
+	old force_escalate entry no longer applies."""
+	state_file = tmp_path / "state.json"
+	state_file.write_text(json.dumps({
+		"judge_decision_cache": {
+			"abc": {"action": "escalate_human", "replay_count": 0, "force_escalate": True},
+		},
+	}))
 	script = textwrap.dedent("""
-		set -euo pipefail
-		issue_num=2870
-		phase=ai:review-blocked
-		last=failure
-		recent1='[{"body":"first"}]'
-		recent2='[{"body":"second"}]'
-		h1=$(printf '%s' "$recent1" | sha256sum | awk '{print $1}')
-		h2=$(printf '%s' "$recent2" | sha256sum | awk '{print $1}')
-		k1=$(printf '%s|%s|%s|%s|%s' "$issue_num" "abc" "$phase" "$last" "$h1" | sha256sum | awk '{print $1}')
-		k2=$(printf '%s|%s|%s|%s|%s' "$issue_num" "abc" "$phase" "$last" "$h2" | sha256sum | awk '{print $1}')
-		echo "$k1"
-		echo "$k2"
-		[ "$k1" != "$k2" ] && echo distinct || echo equal
+		set -uo pipefail
+		export STATE_FILE='""" + str(state_file) + """'
+		export MAX_JUDGE_REPLAY=2
+		# New key (e.g. head_sha advanced) — no cache entry.
+		key=xyz
+		hit_action="$(jq -r --arg k "$key" '.judge_decision_cache[$k].action // ""' "$STATE_FILE")"
+		cache_force_escalate="$(jq -r --arg k "$key" '.judge_decision_cache[$k].force_escalate // false' "$STATE_FILE")"
+		echo "hit_action=$hit_action"
+		echo "cache_force_escalate=$cache_force_escalate"
 	""")
 	r = _run_bash(script, cwd=tmp_path)
-	assert r.returncode == 0, f"bash failed: {r.stderr}"
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	out = dict(line.split("=", 1) for line in r.stdout.strip().splitlines() if line)
+	# New diagnostics → no cache hit → no sticky escalation.
+	assert out["hit_action"] == "", out
+	assert out["cache_force_escalate"] == "false", out
+
+
+def test_standalone_judge_path_warns_when_local_id_empty():
+	"""When invoke_stall_judge runs on the standalone path (empty
+	local_id), the judge cache is silently a no-op because the
+	standalone state schema does not (yet) carry
+	judge_decision_cache.  Surface a single ::warning:: so operators
+	understand MAX_JUDGE_REPLAY is not enforcing a replay cap on
+	this invocation (Codex P2, PR #2522 lines 6411 + 6210).
+
+	The earlier guard keyed on STATE_FILE existence, but STATE_FILE
+	is a global runtime variable populated inside the tracking-issue
+	loop — when the standalone loop runs afterward in the same
+	poller invocation, a non-empty STATE_FILE here may point at an
+	unrelated last-processed tracking issue.  Gate on local_id
+	emptiness instead."""
+	body = POLLER_SCRIPT.read_text(encoding="utf-8")
+	# The warning marker must be present.
+	assert "MAX_JUDGE_REPLAY cannot enforce a replay cap on this invocation" in body, (
+		"standalone-path warning is missing"
+	)
+	# The cache eligibility gate must require local_id (managed) +
+	# STATE_FILE existence — STATE_FILE alone is not safe.
+	assert "_judge_cache_eligible" in body, (
+		"cache eligibility helper must exist"
+	)
+	assert (
+		'if [ -n "${local_id}" ] && [ "${local_id}" != "null" ] \\\n'
+		'     && [ -n "${STATE_FILE:-}" ] && [ -f "${STATE_FILE}" ]; then\n'
+		'    _judge_cache_eligible="true"'
+	) in body, (
+		"cache eligibility must require BOTH non-empty local_id AND STATE_FILE"
+	)
+	# The standalone warning must trigger on empty local_id (no longer
+	# gated on STATE_FILE absence) AND be rate-limited to once per
+	# poller run via a process-global flag (Copilot review,
+	# PR #2522 line 6372).
+	assert (
+		'if [ -z "${local_id}" ] || [ "${local_id}" = "null" ]; then\n'
+		'    if [ "${_STALL_JUDGE_STANDALONE_WARNED:-false}" != "true" ]; then'
+	) in body, (
+		"standalone-path warning must trigger on empty local_id and "
+		"be guarded by _STALL_JUDGE_STANDALONE_WARNED"
+	)
+	assert "_STALL_JUDGE_STANDALONE_WARNED=" in body, (
+		"the once-per-run guard flag must be set after the first warning emit"
+	)
+
+
+def test_conflict_dispatch_cooldown_secs_canonicalises_leading_zeros(tmp_path):
+	"""CONFLICT_DISPATCH_COOLDOWN_SECS validator at line ~1017 only
+	checks `^[0-9]+$`, which permits leading-zero values like
+	"0900".  The downstream arithmetic expansion (line ~3639)
+	treats that as octal and aborts the poller with "value too
+	great for base".  Production canonicalises the value with
+	`$((10#${VAL}))` after validation; this test reproduces the
+	normalization and confirms it survives every edge case (Codex
+	P2, PR #2522 line 3603)."""
+	script = textwrap.dedent("""
+		set -euo pipefail
+		emit_for() {
+			local val="$1"
+			local canonical
+			canonical=$(( 10#${val} ))
+			# Use the canonicalised value in an arithmetic expansion
+			# the way production does (line ~3639).
+			local product
+			product=$(( canonical * 4 ))
+			echo "in=${val} canonical=${canonical} product=${product}"
+		}
+		emit_for 900
+		emit_for 0900
+		emit_for 0
+		emit_for 00900
+		emit_for 1800
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
 	lines = r.stdout.strip().splitlines()
-	assert lines[-1] == "distinct"
-	assert all(len(line) == 64 and all(c in "0123456789abcdef" for c in line) for line in lines[:2])
+	# Parse "in=X canonical=Y product=Z" rows.
+	parsed = []
+	for line in lines:
+		kvs = dict(kv.split("=", 1) for kv in line.split())
+		parsed.append((kvs["in"], int(kvs["canonical"]), int(kvs["product"])))
+	# All values canonicalise to the same integer the operator
+	# intended; arithmetic expansion produces the expected product.
+	assert parsed[0] == ("900", 900, 3600), parsed
+	assert parsed[1] == ("0900", 900, 3600), parsed
+	assert parsed[2] == ("0", 0, 0), parsed
+	assert parsed[3] == ("00900", 900, 3600), parsed
+	assert parsed[4] == ("1800", 1800, 7200), parsed
+
+
+def test_hot_file_registry_normalisation_matches_python_loader(tmp_path):
+	"""The shell hot-file probe at scripts/orchestrate_poll_process.sh:3536+
+	must normalise registry entries the same way
+	scripts/orchestrate_lib.py:_load_hot_files_seed does (lines
+	208-210): trim whitespace, replace `\\` with `/`, strip leading
+	`./`.  Otherwise consumer repos with `./scripts/foo.sh` or
+	`scripts\\foo.sh` entries silently miss the hot-file
+	short-circuit (Codex P2, PR #2522 line 3536)."""
+	registry = {
+		"hot_files": [
+			"scripts/canonical.sh",
+			"./scripts/with_leading_dot.sh",
+			"./././scripts/many_leading_dots.sh",
+			"scripts\\with_backslash.sh",
+			"  scripts/with_whitespace.sh  ",
+			"",  # empty — must be dropped
+			"./",  # only dot-slash — must be dropped after strip
+		],
+	}
+	(tmp_path / "hot_files.json").write_text(json.dumps(registry))
+	# Reproduce the production normaliser jq verbatim.
+	script = textwrap.dedent("""
+		jq -r '
+			(.hot_files // [])[]?
+			| select(type == "string")
+			| sub("^\\\\s+"; "") | sub("\\\\s+$"; "")
+			| gsub("\\\\\\\\"; "/")
+			| sub("^(\\\\./)+"; "")
+			| select(length > 0)
+		' hot_files.json
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	normalised = r.stdout.strip().splitlines()
+	expected = [
+		"scripts/canonical.sh",
+		"scripts/with_leading_dot.sh",
+		"scripts/many_leading_dots.sh",
+		"scripts/with_backslash.sh",
+		"scripts/with_whitespace.sh",
+	]
+	assert sorted(normalised) == sorted(expected), (
+		f"hot-file normaliser must match the canonical Python loader. "
+		f"Expected: {expected!r}; got: {normalised!r}"
+	)
+
+
+def test_judge_marker_survives_2000_char_truncation():
+	"""The hidden ORCHESTRATOR_STALL_JUDGE marker must appear BEFORE
+	the diagnostics snapshot so it survives the 2000-char body
+	truncation that recent_comments applies before the cache-key
+	filter inspects it (Codex P2, PR #2522 line 6614).  Production
+	judge bodies are 3-4 KB once the diagnostics JSON is embedded;
+	an end-of-body marker would otherwise be sliced out and the
+	filter would miss the bot's own comments — leaving them in the
+	hash and churning the cache key.
+
+	This test verifies the marker is positioned correctly by
+	checking the bot's comment-construction site: the marker line
+	must appear before the `**Diagnostics snapshot:**` heading.
+	"""
+	body = POLLER_SCRIPT.read_text(encoding="utf-8")
+	# Find the judge_comment heredoc.
+	heredoc_start = body.find('judge_comment="## 🧑‍⚖️ Stall Judge — Issue #')
+	assert heredoc_start >= 0, "judge_comment heredoc not found"
+	# Slice forward to the closing quote (skipping the body).
+	heredoc_end = body.find('"\n  if [ -n "${local_id}"', heredoc_start)
+	assert heredoc_end > heredoc_start, "judge_comment heredoc close not found"
+	heredoc = body[heredoc_start:heredoc_end]
+	marker_pos = heredoc.find("<!-- ORCHESTRATOR_STALL_JUDGE -->")
+	diagnostics_pos = heredoc.find("**Diagnostics snapshot:**")
+	assert marker_pos >= 0, "marker missing from judge_comment heredoc"
+	assert diagnostics_pos >= 0, "diagnostics snapshot heading missing"
+	assert marker_pos < diagnostics_pos, (
+		f"marker must come BEFORE the diagnostics snapshot so it "
+		f"survives 2000-char truncation (marker_pos={marker_pos}, "
+		f"diagnostics_pos={diagnostics_pos}, heredoc_start_in_file={heredoc_start})"
+	)
+	# Belt-and-braces: simulate the recent_comments truncation on a
+	# typical judge body and confirm the marker is preserved.  The
+	# diagnostics JSON in production is ~2-3 KB on a real stall.
+	fake_diag_blob = '{"recent_tracking_comments":[' + (',"x"' * 800) + ']}'
+	# 800*4 = 3200-char diagnostics JSON.
+	sample_body = (
+		"## 🧑‍⚖️ Stall Judge — Issue #2870 attempt 3\n"
+		"<!-- ORCHESTRATOR_STALL_JUDGE -->\n\n"
+		"**Decision (judge):** retrigger\n"
+		"**Decision (effective):** retrigger\n"
+		"**Justification:** stale check, retry\n\n"
+		"**Diagnostics snapshot:**\n\n"
+		"```json\n" + fake_diag_blob + "\n```\n"
+	)
+	assert len(sample_body) > 2000, "sample body must exceed truncation threshold"
+	# Apply the same truncation the diagnostics builder uses.
+	truncated = sample_body[:1988] + "…[truncated]" if len(sample_body) > 2000 else sample_body
+	assert "<!-- ORCHESTRATOR_STALL_JUDGE -->" in truncated, (
+		"marker must survive recent_comments 2000-char truncation"
+	)
+
+
+def test_judge_backoff_shift_uses_dispatch_count_minus_one(tmp_path):
+	"""The cooldown backoff shift must subtract 1 from dispatch_count
+	before shifting, clamped to 0, so the first retry waits the
+	documented 1× interval rather than 2× (Codex P2, PR #2522,
+	line 3640).  Reproduces the production shift computation."""
+	script = textwrap.dedent("""
+		set -euo pipefail
+		for dc in 0 1 2 3 4 5 6; do
+			shift_raw=$dc
+			shift=0
+			if [ "$shift_raw" -gt 1 ]; then
+				shift=$(( shift_raw - 1 ))
+			fi
+			if [ "$shift" -gt 4 ]; then
+				shift=4
+			fi
+			echo "dc=${dc} shift=${shift}"
+		done
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	# Parse "dc=N shift=M" rows.
+	parsed = {kv.split("=")[1]: vv.split("=")[1] for kv, vv in (line.split() for line in r.stdout.strip().splitlines())}
+	# Never dispatched (dc=0) → shift=0 (multiplier 1×; cooldown gate
+	# does not fire because last_ts=0 anyway).
+	assert parsed["0"] == "0", parsed
+	# First dispatch happened (dc=1) → NEXT retry shift=0 (1×).  This
+	# is the bug Codex flagged: the old code shifted by 1 (2×).
+	assert parsed["1"] == "0", parsed
+	# Subsequent retries: shift = dc - 1.
+	assert parsed["2"] == "1", parsed
+	assert parsed["3"] == "2", parsed
+	assert parsed["4"] == "3", parsed
+	# Capped at 4 (16× multiplier).
+	assert parsed["5"] == "4", parsed
+	assert parsed["6"] == "4", parsed
+
+
+def test_judge_diagnostics_includes_phase_attempts_count(tmp_path):
+	"""When detect_stalls routes to the judge because phase_attempts
+	hit the cap (while recovery_count is still low), the diagnostics
+	JSON must include phase_attempts_count so the judge can see the
+	real reason it was invoked, and the cache key must include it
+	so an exhausted-phase decision does not replay against an
+	earlier non-exhausted decision (Codex P2, PR #2522 line 6050)."""
+	script = textwrap.dedent("""
+		set -euo pipefail
+		# Reproduce a stripped-down version of the diagnostics jq.
+		recent_comments='[]'
+		workflow_outcomes='[]'
+		prior_actions='[]'
+		diagnostics="$(jq -cn \\
+			--arg issue_number "2870" \\
+			--arg phase "ai:review-blocked" \\
+			--argjson stall_minutes 45 \\
+			--argjson recovery_count 1 \\
+			--argjson phase_attempts_count 5 \\
+			--argjson recent_comments "${recent_comments}" \\
+			--argjson workflow_outcomes "${workflow_outcomes}" \\
+			--argjson prior_actions "${prior_actions}" \\
+			'{
+				issue_number: ($issue_number | tonumber),
+				phase: $phase,
+				stall_minutes: $stall_minutes,
+				recovery_count: $recovery_count,
+				phase_attempts_count: $phase_attempts_count,
+				recent_tracking_comments: $recent_comments,
+				recent_review_workflow_outcomes: $workflow_outcomes,
+				prior_recovery_actions: $prior_actions
+			}')"
+		printf '%s\\n' "${diagnostics}"
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	diag = json.loads(r.stdout.strip())
+	# The field is present and carries the cap-trigger count.
+	assert "phase_attempts_count" in diag, diag
+	assert diag["phase_attempts_count"] == 5, diag
+
+
+def test_judge_cache_key_stable_under_phase_attempts_count_churn(tmp_path):
+	"""Codex P2 6050 added phase_attempts_count to the diagnostics
+	JSON for the LLM, but the raw counter advances every recovery
+	(same as stall_recovery_count).  Codex P2 6383 followed up:
+	hash a stable `phase_attempts_exhausted` boolean instead, so
+	the cache key only crosses when the cap is actually reached —
+	otherwise a repeated bad-judge loop below the cap never
+	accumulates toward MAX_JUDGE_REPLAY.
+
+	This test covers both halves:
+	  - Changing raw phase_attempts_count (with the same exhausted
+	    flag) MUST NOT change the cache key.
+	  - Changing phase_attempts_exhausted from false → true MUST
+	    change the cache key.
+	"""
+	base_diag = {
+		"issue_number": 2870,
+		"phase": "ai:review-blocked",
+		"stall_minutes": 45,
+		"recovery_count": 1,
+		"phase_attempts_count": 2,
+		"phase_attempts_exhausted": False,
+		"recent_tracking_comments": [],
+		"recent_review_workflow_outcomes": [],
+		"prior_recovery_actions": [{"key": "last_seen_phase", "value": "ai:review-blocked"}],
+	}
+	low = dict(base_diag)
+	# Raw count changes within the not-exhausted band — cache must hold.
+	mid = {**base_diag, "phase_attempts_count": 4}
+	# Exhausted flips true — cache must change.
+	exhausted = {**base_diag, "phase_attempts_count": 5, "phase_attempts_exhausted": True}
+	keys = _hash_variants(tmp_path, {"low": low, "mid": mid, "exhausted": exhausted})
+	assert keys["low"] == keys["mid"], (
+		f"raw phase_attempts_count churn must NOT change the cache key "
+		f"while exhausted=false (else repeated bad-judge loops never "
+		f"accumulate toward MAX_JUDGE_REPLAY): {keys}"
+	)
+	assert keys["low"] != keys["exhausted"], (
+		f"phase_attempts_exhausted flipping true MUST change the cache key "
+		f"(else cap-exhausted escalation replays prior non-exhausted decision): {keys}"
+	)
+
+
+def test_list_integration_conflict_files_errexit_toggle_preserves_caller_state(tmp_path):
+	"""_list_integration_conflict_files toggles `set +e/-e` to capture
+	rc=$? from `git merge-tree`.  The restore must NOT
+	unconditionally re-enable errexit — if a caller had `set +e`
+	before calling the function, the function's state-restore
+	should keep errexit OFF (Copilot review, PR #2522 line 3444)."""
+	script = textwrap.dedent("""
+		# Reproduce the production state-save pattern verbatim.
+		toggle_errexit() {
+			local _had_errexit="false"
+			case "$-" in *e*) _had_errexit="true" ;; esac
+			set +e
+			# (simulated merge-tree call)
+			:
+			if [ "${_had_errexit}" = "true" ]; then
+				set -e
+			fi
+		}
+
+		# Scenario A: caller has set -e on entry → must be set -e on exit.
+		set -e
+		toggle_errexit
+		case "$-" in *e*) echo "A=errexit_on" ;; *) echo "A=errexit_off" ;; esac
+
+		# Scenario B: caller has set +e on entry → must STAY set +e on exit.
+		set +e
+		toggle_errexit
+		case "$-" in *e*) echo "B=errexit_on" ;; *) echo "B=errexit_off" ;; esac
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	out = dict(line.split("=", 1) for line in r.stdout.strip().splitlines() if line)
+	# Caller's errexit state must be preserved.
+	assert out["A"] == "errexit_on", f"set -e caller must end in set -e: {out}"
+	assert out["B"] == "errexit_off", f"set +e caller must STAY in set +e: {out}"
+
+
+def test_standalone_state_parser_early_returns_include_conflict_override_count(tmp_path):
+	"""All three early-return paths of
+	_extract_standalone_state_json_from_comments — no marker,
+	extraction empty, invalid JSON — must emit JSON that includes
+	`conflict_override_count: {}` so downstream readers/writers
+	don't need to handle multiple shapes (Copilot review,
+	PR #2522 line 5315)."""
+	func_src = _extract_function_body("_extract_standalone_state_json_from_comments")
+	script = textwrap.dedent(f"""
+		set -uo pipefail
+		export STANDALONE_STATE_MARKER_OPEN='<!-- AI_STANDALONE_STALL_STATE_V1'
+		export STANDALONE_STATE_MARKER_CLOSE='AI_STANDALONE_STALL_STATE_V1 -->'
+		{func_src}
+
+		# Path 1: empty comments list (no marker found).
+		echo "no_marker=$(_extract_standalone_state_json_from_comments '[]')"
+
+		# Path 2: marker present but extraction returns empty body.
+		# Construct a malformed comment where the open marker matches
+		# but the inner content is missing.
+		empty_body='[{{"body":"<!-- AI_STANDALONE_STALL_STATE_V1\\nAI_STANDALONE_STALL_STATE_V1 -->","created_at":"2026-01-01T00:00:00Z"}}]'
+		echo "empty_body=$(_extract_standalone_state_json_from_comments "${{empty_body}}")"
+
+		# Path 3: marker + body that is not valid JSON.
+		invalid_json='[{{"body":"<!-- AI_STANDALONE_STALL_STATE_V1\\nthis is not json\\nAI_STANDALONE_STALL_STATE_V1 -->","created_at":"2026-01-01T00:00:00Z"}}]'
+		echo "invalid_json=$(_extract_standalone_state_json_from_comments "${{invalid_json}}")"
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	out = dict(line.split("=", 1) for line in r.stdout.strip().splitlines() if line)
+	for label, json_str in out.items():
+		got = json.loads(json_str)
+		assert "conflict_override_count" in got, (
+			f"early-return path {label!r} must include conflict_override_count: got {got}"
+		)
+		assert got["conflict_override_count"] == {}, (
+			f"early-return path {label!r} must default conflict_override_count to {{}}: got {got['conflict_override_count']!r}"
+		)
+
+
+def test_judge_cache_write_gated_on_dispatch_rc_and_fresh_dispatch(tmp_path):
+	"""Reproduces the production cache-write gate to confirm:
+	  * dispatch_rc != 0 → no cache write (Codex P2 line 6705)
+	  * dispatch was a dedupe / no-op (was_fresh=false) → no
+	    cache write or replay_count bump (Codex P2 line 6550)
+	  * dispatch_rc == 0 AND was_fresh=true → write fresh-LLM
+	    OR bump replay_count, depending on cache-hit state.
+	"""
+	state_file = tmp_path / "state.json"
+	script = textwrap.dedent("""
+		set -uo pipefail
+		export STATE_FILE='""" + str(state_file) + """'
+		# Reproduce the production cache-write block verbatim.
+		try_cache_write() {
+			local _judge_dispatch_rc="$1"
+			local _judge_dispatch_was_fresh="$2"
+			local _judge_from_cache="$3"
+			local _judge_cache_key="$4"
+			local _judge_cache_eligible="$5"
+			local _judge_executed_action="$6"
+			local _judge_replay_next_pending="$7"
+			if [ "${_judge_dispatch_rc}" -eq 0 ] \
+			   && [ "${_judge_dispatch_was_fresh}" = "true" ] \
+			   && [ -n "${_judge_cache_key}" ] \
+			   && [ "${_judge_cache_eligible:-false}" = "true" ]; then
+				if [ "${_judge_from_cache}" = "true" ] && [ -n "${_judge_replay_next_pending:-}" ]; then
+					jq --arg k "${_judge_cache_key}" --argjson n "${_judge_replay_next_pending}" \
+						'.judge_decision_cache = ((.judge_decision_cache // {}) | .[$k].replay_count = $n)' \
+						"$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+					echo "did=bump"
+				elif [ "${_judge_from_cache}" = "false" ] && [ -n "${_judge_executed_action}" ]; then
+					jq --arg k "${_judge_cache_key}" --arg action "${_judge_executed_action}" \
+						'.judge_decision_cache = ((.judge_decision_cache // {}) | .[$k] = {"action": $action, "replay_count": 0})' \
+						"$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+					echo "did=fresh_write"
+				else
+					echo "did=noop"
+				fi
+			else
+				echo "did=skipped"
+			fi
+		}
+
+		# Scenario A: dispatch_rc=1 (failure) → no cache write.
+		echo '{}' > "$STATE_FILE"
+		echo "A_$(try_cache_write 1 true false k1 true retrigger_pipeline '')"
+		# Scenario B: dispatch_rc=0 but dedupe (was_fresh=false) → no write/bump.
+		echo "B_$(try_cache_write 0 false true k1 true '' 5)"
+		# Scenario C: fresh-LLM, rc=0, fresh dispatch → cache write.
+		echo "C_$(try_cache_write 0 true false k1 true retrigger_pipeline '')"
+		echo "C_state=$(jq -r '.judge_decision_cache.k1.action // \"none\"' "$STATE_FILE")"
+		# Scenario D: cache-replay, rc=0, fresh dispatch → bump replay_count.
+		# Seed the cache first.
+		echo '{"judge_decision_cache":{"k2":{"action":"retrigger_pipeline","replay_count":0}}}' > "$STATE_FILE"
+		echo "D_$(try_cache_write 0 true true k2 true retrigger_pipeline 1)"
+		echo "D_state=$(jq -r '.judge_decision_cache.k2.replay_count' "$STATE_FILE")"
+		# Scenario E: cache-replay, rc=0, but dedupe → no bump (cache stays at 0).
+		echo '{"judge_decision_cache":{"k3":{"action":"resolve_merge_conflict","replay_count":0}}}' > "$STATE_FILE"
+		echo "E_$(try_cache_write 0 false true k3 true resolve_merge_conflict 1)"
+		echo "E_state=$(jq -r '.judge_decision_cache.k3.replay_count' "$STATE_FILE")"
+		# Scenario F: cache ineligible → no write.
+		echo "F_$(try_cache_write 0 true false k4 false retrigger_pipeline '')"
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	out = dict(line.split("=", 1) for line in r.stdout.strip().splitlines() if "=" in line)
+	# Codex 6705: dispatch failed → no cache write.
+	assert out["A_did"] == "skipped", out
+	# Codex 6550 (fresh-LLM dedupe variant): no fresh-LLM write either.
+	assert out["B_did"] == "skipped", out
+	# Fresh-LLM happy path: write the executed action.
+	assert out["C_did"] == "fresh_write", out
+	assert out["C_state"] == "retrigger_pipeline", out
+	# Cache-replay happy path: bump replay_count.
+	assert out["D_did"] == "bump", out
+	assert out["D_state"] == "1", out
+	# Codex 6550 (cache-replay dedupe): replay_count stays at 0.
+	assert out["E_did"] == "skipped", out
+	assert out["E_state"] == "0", out
+	# Cache ineligible (e.g. standalone path): no write either way.
+	assert out["F_did"] == "skipped", out
+
+
+def test_mark_integration_sync_clean_resets_stale_counters_even_when_already_clean(tmp_path):
+	"""mark_integration_sync_clean must reset
+	integration_conflict_dispatch_count / dispatch_ts /
+	unresolved_ticks whenever clean state is observed — not only on
+	the non-clean → clean transition.  Legacy state files (written
+	before the post-heal reset existed) can carry stale counters
+	while `integration_sync_status` is already "clean"; without
+	this broader reset, a fresh conflict episode inherits a
+	non-zero dispatch_count and the exponential backoff caps the
+	cooldown at 16× from the very first retry (Codex P2, PR #2522
+	line 3774).
+	"""
+	state_file = tmp_path / "state.json"
+	# Seed: status already "clean" but stale per-episode counters.
+	state_file.write_text(json.dumps({
+		"integration_sync_status": "clean",
+		"integration_sync_last_error": "old error",
+		"integration_conflict_dispatch_count": 5,
+		"integration_conflict_dispatch_ts": 1700000000,
+		"integration_conflict_unresolved_ticks": 3,
+		"integration_conflict_total_dispatches": 7,
+	}))
+	# Reproduce the production reset jq.
+	script = textwrap.dedent("""
+		set -uo pipefail
+		export STATE_FILE='""" + str(state_file) + """'
+		prev_status="$(jq -r '.integration_sync_status // "clean"' "$STATE_FILE")"
+		prev_dispatch_count="$(jq -r '.integration_conflict_dispatch_count // 0' "$STATE_FILE")"
+		prev_dispatch_ts="$(jq -r '.integration_conflict_dispatch_ts // 0' "$STATE_FILE")"
+		prev_unresolved_ticks="$(jq -r '.integration_conflict_unresolved_ticks // 0' "$STATE_FILE")"
+		if [ "${prev_status}" != "clean" ] \
+		   || [ "${prev_dispatch_count}" != "0" ] \
+		   || [ "${prev_dispatch_ts}" != "0" ] \
+		   || [ "${prev_unresolved_ticks}" != "0" ]; then
+			jq '.integration_sync_status = "clean" |
+			    .integration_sync_last_error = "" |
+			    .integration_conflict_unresolved_ticks = 0 |
+			    .integration_conflict_dispatch_count = 0 |
+			    .integration_conflict_dispatch_ts = 0' \
+			  "$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+		fi
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	got = json.loads(state_file.read_text())
+	# Per-episode counters MUST all be zero after the reset.
+	assert got["integration_conflict_dispatch_count"] == 0, got
+	assert got["integration_conflict_dispatch_ts"] == 0, got
+	assert got["integration_conflict_unresolved_ticks"] == 0, got
+	# Status remains clean (idempotent) and last_error is cleared.
+	assert got["integration_sync_status"] == "clean", got
+	assert got["integration_sync_last_error"] == "", got
+	# Lifetime-cap counter is intentionally preserved.
+	assert got["integration_conflict_total_dispatches"] == 7, got
+
+
+def test_normalize_stall_recovery_action_threads_phase_attempts_count_to_fallback(tmp_path):
+	"""normalize_stall_recovery_action's fallback path (when the
+	Python helper returns empty/invalid output) must forward the
+	phase_attempts_count it already received as its 4th parameter
+	to recovery_action_for_phase.  Without this threading, an
+	empty Python return left the fallback to default
+	phase_attempts_count=0 and silently bypass the phase-lifetime
+	cap (claude-branch-review, PR #2522 line 5524).
+
+	Drive normalize_stall_recovery_action through a Python helper
+	that's stubbed to return "" so the fallback path fires.
+	Confirm that with phase_attempts_count=5 (at the cap) the
+	fallback emits "skip", not the ladder action.
+	"""
+	func_src = _extract_function_body("normalize_stall_recovery_action")
+	script = textwrap.dedent(f"""
+		set -uo pipefail
+		export MAX_STALL_RECOVERIES_PER_ISSUE=5
+		export MAX_STALL_RECOVERIES_DONE=99
+		export ENABLE_STALL_HUMAN_TERMINALIZATION=false
+
+		# Stub python3 to return empty output so the Python helper
+		# inside normalize_stall_recovery_action emits "" and the
+		# fallback path is exercised.
+		python3() {{
+			# Drain stdin (the heredoc Python script) without running it.
+			cat >/dev/null
+			# Emit empty stdout to force the bash fallback below.
+			printf ''
+		}}
+		export -f python3
+
+		{func_src}
+		# Re-define recovery_action_for_phase so we can also see what
+		# the fallback receives.  Echo the args; assert downstream.
+		recovery_action_for_phase() {{
+			echo "FALLBACK_CALLED phase=$1 recovery=$2 phase_attempts=${{3:-MISSING}}"
+		}}
+		export -f recovery_action_for_phase
+
+		# 4th arg = phase_attempts_count = 5 (at cap).
+		normalize_stall_recovery_action ai:review-blocked 1 retrigger 5
+	""")
+	r = _run_bash(script, cwd=REPO_ROOT)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	output = r.stdout.strip()
+	# The fallback must have been called WITH the threaded counter,
+	# not the default 0.
+	assert "FALLBACK_CALLED" in output, f"fallback was not invoked: {output!r}"
+	assert "phase_attempts=5" in output, (
+		f"fallback must receive the threaded phase_attempts_count=5 "
+		f"(not 0): got {output!r}"
+	)
+	assert "phase_attempts=MISSING" not in output, (
+		f"fallback must NOT call recovery_action_for_phase with only 2 args: got {output!r}"
+	)
+
+
+def test_recovery_action_for_phase_threads_phase_attempts_count_to_python(tmp_path):
+	"""recovery_action_for_phase accepts an optional 3rd argument —
+	phase_attempts_count — and forwards it to
+	resolve_stall_recovery_action so the Python helper can enforce
+	the phase-lifetime cap.  Without threading, callers that have
+	the counter handy could not propagate it through this helper
+	(claude-branch-review, PR #2522 line 5418).
+
+	Drive three scenarios:
+	  A. Counter omitted → defaults to 0, helper returns ladder action.
+	  B. Counter passed, below cap → helper returns ladder action.
+	  C. Counter passed, at cap → helper returns "skip".
+	"""
+	func_src = _extract_function_body("recovery_action_for_phase")
+	script = textwrap.dedent(f"""
+		set -uo pipefail
+		export MAX_STALL_RECOVERIES_PER_ISSUE=5
+		export MAX_STALL_RECOVERIES_DONE=99
+		export ENABLE_STALL_HUMAN_TERMINALIZATION=false
+		{func_src}
+		# A: no phase_attempts arg (legacy 2-arg caller).
+		echo "A=$(recovery_action_for_phase ai:review-blocked 1)"
+		# B: phase_attempts below cap.
+		echo "B=$(recovery_action_for_phase ai:review-blocked 1 2)"
+		# C: phase_attempts at cap → skip.
+		echo "C=$(recovery_action_for_phase ai:review-blocked 1 5)"
+	""")
+	r = _run_bash(script, cwd=REPO_ROOT)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	out = dict(line.split("=", 1) for line in r.stdout.strip().splitlines() if line)
+	# A: default 0 → Python helper returns ladder action (not skip).
+	assert out["A"] != "skip", out
+	# B: count=2 < cap=5 → ladder action.
+	assert out["B"] != "skip", out
+	# C: count=5 == cap=5 → skip (enforced).
+	assert out["C"] == "skip", out
+
+
+def test_standalone_rest_retry_reconstruction_carries_head_sha(tmp_path):
+	"""When the standalone path's REST retry loop refreshes
+	_std_conflict_linked from the full PR JSON, the jq
+	reconstruction must include head_sha so downstream code
+	(notably the per-head override cap) does not need to fall
+	through to a different cache to find it (claude-branch-review,
+	PR #2522 line 7695)."""
+	# Sample full PR JSON the REST retry would feed into the jq.
+	pr_json = {
+		"number": 9001,
+		"state": "open",
+		"head": {"ref": "feat-branch", "sha": "deadbeef0000111122223333"},
+		"mergeable": False,
+		"mergeable_state": "dirty",
+	}
+	(tmp_path / "pr.json").write_text(json.dumps(pr_json))
+	script = textwrap.dedent("""
+		# Reproduce the production reconstruction verbatim.
+		jq -c '{
+			number: (.number // null),
+			state: (.state // null),
+			head_ref: (.head.ref // null),
+			head_sha: (.head.sha // null),
+			mergeable: (if .mergeable == null then null else (.mergeable | tostring) end),
+			merge_state_status: (.mergeable_state // null)
+		}' pr.json
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	linked = json.loads(r.stdout.strip())
+	# head_sha MUST survive reconstruction so the override cap can
+	# read it from _std_conflict_linked without falling through.
+	assert linked.get("head_sha") == "deadbeef0000111122223333", linked
+	# Other fields stay intact.
+	assert linked["number"] == 9001, linked
+	assert linked["state"] == "open", linked
+	assert linked["head_ref"] == "feat-branch", linked
+	assert linked["mergeable"] == "false", linked
+	assert linked["merge_state_status"] == "dirty", linked
+
+
+def test_max_budget_neutral_overrides_and_judge_replay_canonicalisation(tmp_path):
+	"""MAX_BUDGET_NEUTRAL_OVERRIDES and MAX_JUDGE_REPLAY are validated
+	with `^[0-9]+$` which permits leading-zero values like "08" /
+	"09".  The downstream `-ge` arithmetic comparisons would then
+	abort with bash's "value too great for base" (octal
+	interpretation).  Production canonicalises both with
+	`$((10#${VAL}))` after validation; this test pins that pattern
+	(claude-branch-review on commit 5382a89)."""
+	script = textwrap.dedent("""
+		set -euo pipefail
+		emit_for() {
+			local label="$1"
+			local val="$2"
+			local canonical
+			canonical=$(( 10#${val} ))
+			# Use the canonicalised value in the actual `-ge` test
+			# the script does (line ~5724 / ~6435 / ~7666).
+			local result
+			if [ 5 -ge "${canonical}" ]; then result="5_ge_${canonical}"; else result="5_lt_${canonical}"; fi
+			echo "${label}=${canonical} ${result}"
+		}
+		emit_for default 2
+		emit_for leading_zero_8 08
+		emit_for leading_zero_9 09
+		emit_for zero 0
+		emit_for leading_zeros 007
+		emit_for large_canonical 99
+		emit_for large_with_leading 099
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	lines = r.stdout.strip().splitlines()
+	parsed = {line.split("=", 1)[0]: line.split("=", 1)[1] for line in lines}
+	# Canonicalisation must strip leading zeros and the -ge test
+	# must not abort.
+	assert parsed["default"] == "2 5_ge_2", parsed
+	assert parsed["leading_zero_8"] == "8 5_lt_8", parsed
+	assert parsed["leading_zero_9"] == "9 5_lt_9", parsed
+	assert parsed["zero"] == "0 5_ge_0", parsed
+	assert parsed["leading_zeros"] == "7 5_lt_7", parsed
+	assert parsed["large_canonical"] == "99 5_lt_99", parsed
+	assert parsed["large_with_leading"] == "99 5_lt_99", parsed
+
+
+def test_max_recoveries_done_canonicalisation_is_top_level_safe(tmp_path):
+	"""The canonical-int normalization for MAX_STALL_RECOVERIES_DONE
+	lives in the top-level poller body (outside any function), so it
+	must NOT use the `local` keyword.  `bash -n` does not catch
+	`local` at top level — it's a runtime error — so this test
+	executes the exact block in isolation under `set -euo pipefail`
+	to fail fast on regression.  Caught a real lint break on the
+	first push of this fix where `local _msd_canonical` was left at
+	top level (Copilot review, PR #2522 line 11254 follow-up).
+	"""
+	script = textwrap.dedent("""
+		set -euo pipefail
+		export MAX_STALL_RECOVERIES_DONE=99
+		_stall_check_args=()
+		# Reproduce the production canonicalisation block verbatim.
+		_msd_canonical=$(( 10#${MAX_STALL_RECOVERIES_DONE} ))
+		_stall_check_args+=(--max-recoveries-by-phase-json "$(jq -cn --argjson n "${_msd_canonical}" '{"ai:done": $n}')")
+		printf '%s\\n' "${_stall_check_args[@]}"
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"top-level block must run without `local` errors: {r.stderr}"
+	assert "local: can only be used in a function" not in r.stderr, r.stderr
+	assert "--max-recoveries-by-phase-json" in r.stdout, r.stdout
+	assert '{"ai:done":99}' in r.stdout, r.stdout
+
+
+def test_max_recoveries_done_json_is_canonical_under_leading_zero(tmp_path):
+	"""When MAX_STALL_RECOVERIES_DONE is a non-canonical decimal like
+	`09` (which the `^[0-9]+$` regex validator at line ~882 permits),
+	the --max-recoveries-by-phase-json argument must still emit
+	valid JSON.  The production fix normalizes via `$((10#${VAL}))`
+	before jq formatting (Copilot review, PR #2522 line 11254)."""
+	script = textwrap.dedent("""
+		set -uo pipefail
+		# Reproduce the production formatter for several edge cases.
+		emit_for() {
+			local val="$1"
+			local canonical
+			canonical=$(( 10#${val} ))
+			jq -cn --argjson n "${canonical}" '{"ai:done": $n}'
+		}
+		echo "canonical=$(emit_for 5)"
+		echo "leading_zero_short=$(emit_for 09)"
+		echo "leading_zero_long=$(emit_for 099)"
+		echo "leading_zeros=$(emit_for 007)"
+		echo "zero=$(emit_for 0)"
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	out = dict(line.split("=", 1) for line in r.stdout.strip().splitlines() if line)
+	# Every output must be valid JSON with the canonical integer.
+	import json as _json
+	assert _json.loads(out["canonical"]) == {"ai:done": 5}, out
+	assert _json.loads(out["leading_zero_short"]) == {"ai:done": 9}, out
+	assert _json.loads(out["leading_zero_long"]) == {"ai:done": 99}, out
+	assert _json.loads(out["leading_zeros"]) == {"ai:done": 7}, out
+	assert _json.loads(out["zero"]) == {"ai:done": 0}, out
+
+
+def test_normalize_stall_recovery_action_threads_phase_attempts_count(tmp_path):
+	"""normalize_stall_recovery_action must forward phase_attempts_count
+	to resolve_effective_stall_recovery_action so its fallback path
+	respects the phase-lifetime cap.  Without the threading,
+	malformed judge actions fell back as if phase_attempts were 0
+	and could bypass the cap entirely (Copilot review, PR #2522
+	line 1527).
+
+	Scenario: phase=ai:review-blocked, recovery_count=0 (zeroed by
+	phase oscillation), phase_attempts_count=5 (= the global cap),
+	empty candidate_action → fallback should return "skip" (cap
+	enforced), not the ladder action.
+	"""
+	func_src = _extract_function_body("normalize_stall_recovery_action")
+	script = textwrap.dedent(f"""
+		set -uo pipefail
+		export MAX_STALL_RECOVERIES_PER_ISSUE=5
+		export MAX_STALL_RECOVERIES_DONE=99
+		export ENABLE_STALL_HUMAN_TERMINALIZATION=false
+		# Stub recovery_action_for_phase to flag bugs where the fallback
+		# is reached (it should NOT be, the python path returns "skip").
+		recovery_action_for_phase() {{
+			echo "FALLBACK_BUG"
+		}}
+		{func_src}
+		# Empty candidate, recovery_count=0, phase_attempts_count=5 (cap).
+		# The expected outcome: Python helper returns "skip" because
+		# phase_attempts_count >= cap.  Without threading,
+		# phase_attempts_count would default to 0 and the python
+		# helper would return a ladder action.
+		result="$(normalize_stall_recovery_action ai:review-blocked 0 '' 5)"
+		echo "with_threading=$result"
+
+		# Negative control: same call without the count arg → defaults
+		# to 0 → python returns a ladder action (not skip).  Pins the
+		# diff so regressions in either direction are visible.
+		result_no_count="$(normalize_stall_recovery_action ai:review-blocked 0 '')"
+		echo "without_threading=$result_no_count"
+	""")
+	r = _run_bash(script, cwd=REPO_ROOT)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	out = dict(line.split("=", 1) for line in r.stdout.strip().splitlines() if "=" in line)
+	# When phase_attempts_count is threaded through as 5 (= cap),
+	# the cap fires and skip is returned.
+	assert out["with_threading"] == "skip", (
+		f"expected skip when phase_attempts_count=5; got {out}"
+	)
+	# When not threaded (default 0), the cap does NOT fire and a
+	# ladder action is returned.  This is the bug Copilot flagged —
+	# the test pins that the threading is REQUIRED to enforce the cap.
+	assert out["without_threading"] != "skip", (
+		f"control: without threading, cap must not fire; got {out}"
+	)
+	# And neither answer is FALLBACK_BUG (the python path handled it).
+	assert "FALLBACK_BUG" not in out["with_threading"], out
+	assert "FALLBACK_BUG" not in out["without_threading"], out
+
+
+def test_judge_cache_suppresses_resolve_merge_conflict_without_target_metadata(tmp_path):
+	"""When effective_action is resolve_merge_conflict but the linked
+	PR metadata (STALL_JUDGE_TARGET_PR + STALL_JUDGE_HEAD_REF) is
+	missing, the action is not executable and the downstream branch
+	falls back to retrigger_pipeline.  Caching the unexecutable
+	resolve_merge_conflict would replay the same dead-end decision
+	on every identical stall, so the cache write must be suppressed
+	when the linked-PR metadata is missing (Codex P2, PR #2522
+	line 6448)."""
+	script = textwrap.dedent("""
+		set -uo pipefail
+		# Reproduce the production gate verbatim.
+		should_cache() {
+			local effective_action="$1"
+			local target_pr="$2"
+			local head_ref="$3"
+			local _judge_should_cache="true"
+			if [ "$effective_action" = "resolve_merge_conflict" ]; then
+				if ! [[ "${target_pr:-}" =~ ^[0-9]+$ ]] || [ -z "${head_ref:-}" ]; then
+					_judge_should_cache="false"
+				fi
+			fi
+			echo "$_judge_should_cache"
+		}
+		echo "with_metadata=$(should_cache resolve_merge_conflict 1234 feat-branch)"
+		echo "missing_pr=$(should_cache resolve_merge_conflict '' feat-branch)"
+		echo "missing_ref=$(should_cache resolve_merge_conflict 1234 '')"
+		echo "missing_both=$(should_cache resolve_merge_conflict '' '')"
+		echo "non_numeric_pr=$(should_cache resolve_merge_conflict 'abc' feat-branch)"
+		# Other actions are always cacheable regardless of metadata.
+		echo "retrigger_no_meta=$(should_cache retrigger_pipeline '' '')"
+		echo "escalate_no_meta=$(should_cache escalate_human '' '')"
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	out = dict(line.split("=", 1) for line in r.stdout.strip().splitlines() if line)
+	# resolve_merge_conflict with full metadata → cache it.
+	assert out["with_metadata"] == "true", out
+	# resolve_merge_conflict missing target_pr / head_ref / both / bad target_pr → suppress cache.
+	assert out["missing_pr"] == "false", out
+	assert out["missing_ref"] == "false", out
+	assert out["missing_both"] == "false", out
+	assert out["non_numeric_pr"] == "false", out
+	# Other actions: no metadata gate.
+	assert out["retrigger_no_meta"] == "true", out
+	assert out["escalate_no_meta"] == "true", out
+
+
+def test_judge_cache_stores_executed_action_after_dispatch_fallback(tmp_path):
+	"""When the judge returns resolve_merge_conflict but the
+	resolver dispatch fails (rc=1) or the linked-PR metadata is
+	missing, invoke_stall_judge falls back to a ladder action.
+	The cache write must persist the action ACTUALLY executed —
+	otherwise next-tick replays would keep re-trying the dead-end
+	resolve_merge_conflict and trip MAX_JUDGE_REPLAY into a human
+	escalation on the back of one bad dispatch (Codex P2,
+	PR #2522 line 6625)."""
+	state_file = tmp_path / "state.json"
+	state_file.write_text(json.dumps({}))
+	script = textwrap.dedent("""
+		set -uo pipefail
+		export STATE_FILE='""" + str(state_file) + """'
+		key=cache_key_xyz
+		# Simulate the three "dispatch fell back to the ladder"
+		# scenarios from invoke_stall_judge:
+		#   A. resolve_merge_conflict + no target_pr → fallback.
+		#   B. resolve_merge_conflict + no head_ref  → fallback.
+		#   C. resolve_merge_conflict + dispatch fails → fallback.
+		# In all three, _judge_executed_action ends up as the
+		# fallback action; the cache write stores THAT, not the
+		# original effective_action.
+		cache_executed() {
+			local executed="$1"
+			jq --arg k "$key" --arg action "$executed" \
+				'.judge_decision_cache = ((.judge_decision_cache // {}) | .[$k] = {"action": $action, "replay_count": 0})' \
+				"$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+			jq -r --arg k "$key" '.judge_decision_cache[$k].action' "$STATE_FILE"
+		}
+		echo "no_target_pr=$(cache_executed retrigger_pipeline)"
+		echo "no_head_ref=$(cache_executed retrigger_pipeline)"
+		echo "dispatch_failed=$(cache_executed retrigger_pipeline)"
+		# Happy path: dispatch succeeds → cache the original action.
+		echo "happy=$(cache_executed resolve_merge_conflict)"
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	out = dict(line.split("=", 1) for line in r.stdout.strip().splitlines() if line)
+	# Every fallback path persists the LADDER action (not
+	# resolve_merge_conflict), so next-tick replays go to a known-
+	# executable decision.
+	assert out["no_target_pr"] == "retrigger_pipeline", out
+	assert out["no_head_ref"] == "retrigger_pipeline", out
+	assert out["dispatch_failed"] == "retrigger_pipeline", out
+	# Happy path: cache the original resolve_merge_conflict so
+	# subsequent identical stalls replay the (successful) dispatch.
+	assert out["happy"] == "resolve_merge_conflict", out
+
+
+def test_judge_cache_stores_effective_action_not_raw_judge_action(tmp_path):
+	"""When the judge returns an unrecognized action, the cache must
+	store the effective (post-normalize) action, not the raw invalid
+	string — otherwise every future identical stall replays the
+	invalid action, burns the normalize fallback again, and
+	eventually trips MAX_JUDGE_REPLAY based on one bad model
+	response (Codex P2, PR #2522, line 6359)."""
+	state_file = tmp_path / "state.json"
+	state_file.write_text(json.dumps({}))
+	script = textwrap.dedent("""
+		set -uo pipefail
+		export STATE_FILE='""" + str(state_file) + """'
+		key=cache_key_abc
+		# Simulate the judge returning a bogus action, normalize
+		# falling back to a safe ladder action.
+		judge_action="rerun_review"        # raw LLM output (invalid)
+		effective_action="retrigger_pipeline"  # post-normalize fallback
+		# Production now caches effective_action.
+		jq --arg k "$key" --arg action "$effective_action" \
+			'.judge_decision_cache = ((.judge_decision_cache // {}) | .[$k] = {"action": $action, "replay_count": 0})' \
+			"$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+		echo "cached_action=$(jq -r --arg k "$key" '.judge_decision_cache[$k].action' "$STATE_FILE")"
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	out = dict(line.split("=", 1) for line in r.stdout.strip().splitlines() if line)
+	# The cache MUST store the safe ladder action, not the raw invalid
+	# one — preventing the invalid-action replay loop.
+	assert out["cached_action"] == "retrigger_pipeline", out
+
+
+def test_heal_integration_conflict_rc2_does_not_refresh_dispatch_ts(tmp_path):
+	"""On an in-flight resolver (rc=2 from
+	_dispatch_review_for_conflicts), heal_integration_branch_conflict
+	must NOT advance integration_conflict_dispatch_ts.  If it did,
+	the exponential backoff calculated against (now - dispatch_ts)
+	would keep resetting to ~0 elapsed on every poll tick the
+	resolver was running, so after a long-running resolver the next
+	real retry would wait the full exponential cooldown from the
+	moment it finished — almost doubling the gap between real
+	attempts (Codex P2, PR #2522, line 3575)."""
+	state_file = tmp_path / "state.json"
+	# Seed: a real dispatch was made 10 minutes ago.
+	original_ts = 1700000000
+	state_file.write_text(json.dumps({
+		"integration_sync_status": "healing",
+		"integration_conflict_dispatch_ts": original_ts,
+		"integration_conflict_dispatch_count": 4,
+	}))
+	# Reproduce the production rc=2 branch's jq update verbatim.
+	script = textwrap.dedent("""
+		set -uo pipefail
+		export STATE_FILE='""" + str(state_file) + """'
+		# rc=2 branch (active resolver dedupe).
+		jq '.integration_sync_status = "healing"' \
+			"$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	state = json.loads(state_file.read_text())
+	# dispatch_ts MUST be unchanged from the original real dispatch.
+	assert state["integration_conflict_dispatch_ts"] == original_ts, (
+		f"rc=2 must not refresh dispatch_ts; was {original_ts}, now {state['integration_conflict_dispatch_ts']}"
+	)
+	# Status reflects healing (the only legitimate update).
+	assert state["integration_sync_status"] == "healing", state
+	# dispatch_count unchanged.
+	assert state["integration_conflict_dispatch_count"] == 4, state
+
+
+# The production cache-key filter mirrors the jq pipeline in
+# scripts/orchestrate_poll_process.sh's invoke_stall_judge (~line 6087).
+# Tests share it through this constant so the test-side filter cannot
+# silently drift from production.  When production changes, update both.
+PRODUCTION_CACHE_KEY_FILTER = (
+	'.recent_tracking_comments = '
+	'((.recent_tracking_comments // []) '
+	'| map(select(((.body // "") | contains("<!-- ORCHESTRATOR_STALL_JUDGE -->")) | not))) '
+	'| del(.stall_minutes) '
+	'| del(.recovery_count) '
+	'| del(.phase_attempts_count) '
+	'| .prior_recovery_actions = '
+	'((.prior_recovery_actions // []) '
+	'| map(select(.key != "stall_recovery_count")))'
+)
+
+
+def _diag_base() -> dict:
+	"""Diagnostics scaffold used by the cache-key tests."""
+	return {
+		"issue_number": 2870,
+		"local_id": "wave-1/issue-1",
+		"phase": "ai:review-blocked",
+		"stall_minutes": 30,
+		"recovery_count": 1,
+		"recent_tracking_comments": [],
+		"linked_pr": {
+			"number": 9001,
+			"state": "open",
+			"mergeable": False,
+			"head_ref": "feat-v1",
+			"head_sha": "abc1234567890abcdef1234567890abcdef12345",
+			"base_ref": "main",
+		},
+		"recent_review_workflow_outcomes": [{
+			"id": 111,
+			"workflow": "Review Autofix",
+			"conclusion": "failure",
+			"status": "completed",
+			"head_branch": "feat-v1",
+			"created_at": "2026-01-01T00:00:00Z",
+		}],
+		"current_wave": 1,
+		"prior_recovery_actions": [
+			{"key": "stall_recovery_count", "value": 1},
+			{"key": "last_seen_phase", "value": "ai:review-blocked"},
+			{"key": "status", "value": "review-blocked"},
+		],
+	}
+
+
+def _hash_variants(tmp_path, variants: dict) -> dict:
+	"""Run the production cache-key filter over each variant and return
+	{name: sha256_hex}."""
+	for name, diag in variants.items():
+		(tmp_path / f"{name}.json").write_text(json.dumps(diag))
+	# Build a small shell script that hashes each file.  The filter
+	# lives in a single-quoted bash assignment to keep its inner
+	# double quotes intact.
+	script = textwrap.dedent(f"""
+		set -uo pipefail
+		filter={shlex_quote(PRODUCTION_CACHE_KEY_FILTER)}
+		for f in {' '.join(variants)}; do
+			echo "${{f}}=$(jq -c "$filter" "${{f}}.json" | sha256sum | awk '{{print $1}}')"
+		done
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	return dict(line.split("=", 1) for line in r.stdout.strip().splitlines() if line)
+
+
+def test_judge_cache_key_changes_when_decision_inputs_change(tmp_path):
+	"""Decision-relevant diagnostics fields must invalidate the cache:
+	head_sha (a new commit on the same branch), mergeable flipping, the
+	head_ref changing, or a recent workflow outcome changing.  Codex
+	flagged that head_sha was missing entirely; this test pins both the
+	presence of head_sha in the hash AND the standard "any meaningful
+	field change → fresh LLM call" invariant (Codex P2, PR #2522
+	line 6130)."""
+	base = _diag_base()
+	variants = {
+		"base": base,
+		"head_sha_advanced": {**base, "linked_pr": {**base["linked_pr"], "head_sha": "def" + base["linked_pr"]["head_sha"][3:]}},
+		"head_ref_advanced": {**base, "linked_pr": {**base["linked_pr"], "head_ref": "feat-v2"}},
+		"mergeable_flipped": {**base, "linked_pr": {**base["linked_pr"], "mergeable": True}},
+		"workflow_outcome_changed": {**base, "recent_review_workflow_outcomes": [{**base["recent_review_workflow_outcomes"][0], "conclusion": "success"}]},
+	}
+	keys = _hash_variants(tmp_path, variants)
+	distinct = set(keys.values())
+	assert len(distinct) == len(keys), f"decision-relevant changes must all invalidate the key: {keys}"
+	for name, k in keys.items():
+		assert len(k) == 64 and all(c in "0123456789abcdef" for c in k), f"{name}: malformed key {k!r}"
+
+
+def test_judge_cache_key_stable_across_volatile_counters(tmp_path):
+	"""Volatile counters that change every cycle (stall_minutes ticking
+	with poll cadence, recovery_count incrementing after every action,
+	prior_recovery_actions[stall_recovery_count] mirroring the same)
+	must NOT invalidate the cache; otherwise MAX_JUDGE_REPLAY never
+	fires on the exact repeated-stall loop it exists to break (Codex
+	P2, PR #2522 line 6130, second comment)."""
+	base = _diag_base()
+	# Mutate the stall_recovery_count entry without touching the other
+	# prior_recovery_actions entries.
+	prior_bumped = [
+		{**entry, "value": 2} if entry["key"] == "stall_recovery_count" else entry
+		for entry in base["prior_recovery_actions"]
+	]
+	variants = {
+		"base": base,
+		"stall_minutes_ticked": {**base, "stall_minutes": 31},
+		"stall_minutes_jumped": {**base, "stall_minutes": 90},
+		"recovery_count_bumped": {**base, "recovery_count": 2},
+		"prior_actions_stall_count_bumped": {**base, "prior_recovery_actions": prior_bumped},
+	}
+	keys = _hash_variants(tmp_path, variants)
+	# Every variant should map to the SAME cache key as "base".
+	base_key = keys["base"]
+	for name, k in keys.items():
+		assert k == base_key, (
+			f"{name}: volatile-counter change should not change the key. "
+			f"Got {k}; base {base_key}; all {keys}"
+		)
 
 
 # ---------------------------------------------------------------------------
@@ -224,12 +1402,25 @@ def test_judge_cache_key_changes_when_recent_comments_change(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_cooldown_doubles_with_dispatch_count_capped_at_16x(tmp_path):
-	"""The effective cooldown is base × 2^min(dispatch_count, 4)."""
+	"""The effective cooldown is base × 2^min(max(dispatch_count - 1, 0), 4).
+
+	`dispatch_count` is incremented IMMEDIATELY after the first
+	successful resolver dispatch (line ~3687 in
+	heal_integration_branch_conflict), so the SECOND attempt
+	already sees `dispatch_count=1` at the cooldown gate.
+	Subtracting one before shifting makes the first retry wait the
+	documented 1× interval (Codex P2, PR #2522, line 3640).  The
+	count gets capped at 4 shift-positions (16× multiplier max).
+	"""
 	script = textwrap.dedent("""
 		set -euo pipefail
 		base=900
-		for n in 0 1 2 3 4 5 8; do
-			shift=$n
+		for n in 0 1 2 3 4 5 6 8; do
+			shift_raw=$n
+			shift=0
+			if [ "$shift_raw" -gt 1 ]; then
+				shift=$(( shift_raw - 1 ))
+			fi
 			if [ "$shift" -gt 4 ]; then
 				shift=4
 			fi
@@ -241,12 +1432,13 @@ def test_cooldown_doubles_with_dispatch_count_capped_at_16x(tmp_path):
 	r = _run_bash(script, cwd=tmp_path)
 	assert r.returncode == 0, f"bash failed: {r.stderr}"
 	expected = {
-		"0": 900,        # 1×
-		"1": 1800,       # 2×
-		"2": 3600,       # 4×
-		"3": 7200,       # 8×
-		"4": 14400,      # 16×
-		"5": 14400,      # capped
+		"0": 900,        # never dispatched: 1×
+		"1": 900,        # first dispatch happened: NEXT retry waits 1×
+		"2": 1800,       # second dispatch happened: 2×
+		"3": 3600,       # 4×
+		"4": 7200,       # 8×
+		"5": 14400,      # 16× (max)
+		"6": 14400,      # capped
 		"8": 14400,      # capped
 	}
 	got = dict(l.split("=") for l in r.stdout.strip().splitlines())
@@ -313,23 +1505,1135 @@ def test_wave_narration_posted_when_at_least_one_actual_creation(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# 1h: budget-neutral override cap is enforced for standalone PRs too,
+# not only the managed retrigger_review path (Codex P2, PR #2522,
+# line 1077).  Without the standalone path applying the cap, a stalled
+# `ai:done` issue whose PR stays dirty at the same head_sha consumed
+# zero stall budget per cycle and the resolver loop was unbounded.
+# ---------------------------------------------------------------------------
+
+def test_standalone_override_cap_increments_state_correctly(tmp_path):
+	"""Drive the standalone path's override-cap jq sequence directly:
+	  pre-cap iterations only bump conflict_override_count[sha].
+	  At the cap, the same step ALSO bumps stall_recovery_count."""
+	script = textwrap.dedent("""
+		set -uo pipefail
+		export MAX_BUDGET_NEUTRAL_OVERRIDES=2
+		sha="deadbeef"
+		updated_state='{"schema_version":1,"last_seen_phase":"ai:done","status_since_ts":0,"stall_recovery_count":0}'
+		apply_cap() {
+			local _std_override_count
+			_std_override_count="$(printf '%s' "${updated_state}" | jq -r --arg sha "${sha}" '(.conflict_override_count[$sha] // 0)')"
+			if [ "${_std_override_count}" -ge "${MAX_BUDGET_NEUTRAL_OVERRIDES}" ]; then
+				updated_state="$(printf '%s' "${updated_state}" | jq -c '.stall_recovery_count = ((.stall_recovery_count // 0) + 1)')"
+			fi
+			local _std_override_next=$(( _std_override_count + 1 ))
+			updated_state="$(printf '%s' "${updated_state}" | jq -c --arg sha "${sha}" --argjson n "${_std_override_next}" \
+				'.conflict_override_count = ((.conflict_override_count // {}) | .[$sha] = $n)')"
+			printf '%s\n' "${updated_state}"
+		}
+
+		# 3 iterations: counts 0,1,2 (last hits cap, consumes budget).
+		for i in 1 2 3; do
+			apply_cap
+		done
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	states = [json.loads(line) for line in r.stdout.strip().splitlines() if line]
+	# After iteration 1: count[sha]=1, stall_recovery_count=0.
+	assert states[0]["conflict_override_count"]["deadbeef"] == 1, states[0]
+	assert states[0]["stall_recovery_count"] == 0, states[0]
+	# After iteration 2: count[sha]=2, stall_recovery_count=0.
+	assert states[1]["conflict_override_count"]["deadbeef"] == 2, states[1]
+	assert states[1]["stall_recovery_count"] == 0, states[1]
+	# After iteration 3: count[sha]=3, stall_recovery_count=1 (cap hit).
+	assert states[2]["conflict_override_count"]["deadbeef"] == 3, states[2]
+	assert states[2]["stall_recovery_count"] == 1, states[2]
+
+
+def test_standalone_override_cap_isolated_per_head_sha(tmp_path):
+	"""Counter for a different head_sha is independent — a new push
+	(new sha) restarts the cap window."""
+	script = textwrap.dedent("""
+		set -uo pipefail
+		export MAX_BUDGET_NEUTRAL_OVERRIDES=2
+		updated_state='{"schema_version":1,"stall_recovery_count":0,"conflict_override_count":{"sha_old":5}}'
+		sha="sha_new"
+		_std_override_count="$(printf '%s' "${updated_state}" | jq -r --arg sha "${sha}" '(.conflict_override_count[$sha] // 0)')"
+		echo "count_for_new=${_std_override_count}"
+		if [ "${_std_override_count}" -ge "${MAX_BUDGET_NEUTRAL_OVERRIDES}" ]; then
+			echo "would_consume_budget=true"
+		else
+			echo "would_consume_budget=false"
+		fi
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	out = dict(line.split("=", 1) for line in r.stdout.strip().splitlines() if line)
+	# New head_sha starts at 0 — does not consume budget, regardless
+	# of how many overrides the previous sha accumulated.
+	assert out["count_for_new"] == "0", out
+	assert out["would_consume_budget"] == "false", out
+
+
+def test_standalone_head_sha_extracted_from_graphql_and_rest_shapes(tmp_path):
+	"""The standalone override cap reads head_sha from two shapes:
+	  GraphQL `_std_conflict_linked` has `.head_sha` at the top level.
+	  REST `_STD_ITER_PR_JSON_CACHED` has `.head.sha` nested.
+	The cap check must succeed in either case (Codex P2, PR #2522
+	line 7284) — otherwise the GraphQL fast path (which is the common
+	case on settled DIRTY/CONFLICTING merges) silently skips the cap."""
+	script = textwrap.dedent("""
+		set -uo pipefail
+
+		# Reproduce the production extraction logic verbatim.
+		extract_head_sha() {
+			local linked="$1"
+			local cached="$2"
+			local out=""
+			if [ -n "${linked}" ] && [ "${linked}" != "null" ]; then
+				out="$(printf '%s' "${linked}" | jq -r '(.head_sha // .head.sha // empty)' 2>/dev/null || echo "")"
+			fi
+			if [ -z "${out}" ] && [ -n "${cached}" ]; then
+				out="$(printf '%s' "${cached}" | jq -r '(.head_sha // .head.sha // empty)' 2>/dev/null || echo "")"
+			fi
+			printf '%s' "${out}"
+		}
+
+		# Case A: GraphQL shape only (REST cache is empty).
+		linked_gql='{"number":1,"head_ref":"feat","head_sha":"deadbeef0","mergeable":"FALSE","merge_state_status":"DIRTY"}'
+		echo "A=$(extract_head_sha "${linked_gql}" "")"
+
+		# Case B: REST shape only (GraphQL linked is null).
+		cached_rest='{"number":1,"head":{"ref":"feat","sha":"cafebabe1"}}'
+		echo "B=$(extract_head_sha "" "${cached_rest}")"
+
+		# Case C: Both shapes present — GraphQL wins (read first).
+		linked_gql_c='{"head_sha":"graphql_sha"}'
+		cached_rest_c='{"head":{"sha":"rest_sha"}}'
+		echo "C=$(extract_head_sha "${linked_gql_c}" "${cached_rest_c}")"
+
+		# Case D: Neither has head_sha — empty result (fail-open).
+		linked_no_sha='{"number":1,"head_ref":"feat"}'
+		cached_no_sha='{"number":1,"head":{"ref":"feat"}}'
+		echo "D=$(extract_head_sha "${linked_no_sha}" "${cached_no_sha}")"
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	out = dict(line.split("=", 1) for line in r.stdout.strip().splitlines() if line)
+	assert out["A"] == "deadbeef0", f"GraphQL shape: {out}"
+	assert out["B"] == "cafebabe1", f"REST shape: {out}"
+	assert out["C"] == "graphql_sha", f"GraphQL takes priority: {out}"
+	assert out["D"] == "", f"neither shape has sha — fail-open: {out}"
+
+
+# ---------------------------------------------------------------------------
+# 1j: _extract_standalone_state_json_from_comments must preserve the
+# conflict_override_count map across poll cycles (Codex P2, PR #2522
+# line 7339).  Without preservation, the standalone override-cap
+# counter is reset to 0 on every read, so MAX_BUDGET_NEUTRAL_OVERRIDES
+# never trips for a PR that stays conflicted at the same head_sha.
+# ---------------------------------------------------------------------------
+
+def test_standalone_state_parser_preserves_conflict_override_count(tmp_path):
+	"""Drive _extract_standalone_state_json_from_comments through the
+	full extract pipeline (marker-wrapped comment body, sed extraction,
+	jq normalize) and confirm conflict_override_count survives."""
+	# A standalone state comment matching the production marker.
+	state_payload = {
+		"schema_version": 1,
+		"last_seen_phase": "ai:done",
+		"status_since_ts": 1700000000,
+		"stall_recovery_count": 2,
+		"updated_ts": 1700000100,
+		"conflict_override_count": {"deadbeef0": 3, "cafebabe1": 1},
+	}
+	body = (
+		"<!-- AI_STANDALONE_STALL_STATE_V1\n"
+		+ json.dumps(state_payload)
+		+ "\nAI_STANDALONE_STALL_STATE_V1 -->"
+	)
+	comments_json = json.dumps([{
+		"id": 1,
+		"user": {"login": "github-actions[bot]"},
+		"created_at": "2026-01-01T00:00:00Z",
+		"body": body,
+	}])
+	(tmp_path / "comments.json").write_text(comments_json)
+
+	func_src = _extract_function_body("_extract_standalone_state_json_from_comments")
+	script = textwrap.dedent(f"""
+		set -uo pipefail
+		export STANDALONE_STATE_MARKER_OPEN='<!-- AI_STANDALONE_STALL_STATE_V1'
+		export STANDALONE_STATE_MARKER_CLOSE='AI_STANDALONE_STALL_STATE_V1 -->'
+		{func_src}
+		_extract_standalone_state_json_from_comments "$(cat comments.json)"
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}\nstdout: {r.stdout}"
+	# Parse the JSON the extractor printed.
+	got = json.loads(r.stdout.strip().splitlines()[-1])
+	# Existing whitelist fields survive.
+	assert got["stall_recovery_count"] == 2, got
+	assert got["last_seen_phase"] == "ai:done", got
+	# NEW: conflict_override_count map round-trips intact.
+	assert got["conflict_override_count"] == {"deadbeef0": 3, "cafebabe1": 1}, got
+
+
+def test_real_git_merge_tree_help_contains_write_tree():
+	"""Pin the real-git contract that the shim in
+	test_list_integration_conflict_files_rc_handling emulates.  The
+	production version probe runs `git merge-tree -h` and greps for
+	`--write-tree`; if a future git version drops or renames that
+	switch in its help text, the probe silently fails and the
+	hot-file short-circuit never fires.  A mock-only test would not
+	catch that, so this assertion runs against the actual git on the
+	test host and fails fast on contract drift (claude-branch-review
+	PR #2522)."""
+	r = subprocess.run(
+		["git", "merge-tree", "-h"],
+		capture_output=True,
+		text=True,
+	)
+	# Real git exits non-zero on `-h`; combine stdout+stderr because
+	# different git versions split the help text across streams.
+	combined = (r.stdout or "") + (r.stderr or "")
+	assert "--write-tree" in combined, (
+		"git merge-tree -h no longer documents --write-tree; the production "
+		"version probe in scripts/orchestrate_poll_process.sh:_list_integration_conflict_files "
+		"will silently disable the hot-file short-circuit. Update the probe "
+		"(and this contract test) for the new help format.\n\n"
+		f"got: {combined!r}"
+	)
+
+
+def test_standalone_state_parser_drops_malformed_conflict_override_count(tmp_path):
+	"""When a state comment contains a non-object
+	`conflict_override_count` (e.g. legacy bug, manual edit, or a
+	malformed write), the parser must default it to {} rather than
+	carrying the malformed value forward — otherwise the downstream
+	`.conflict_override_count[$sha]` jq lookup errors out and the
+	cap silently fails open (claude-branch-review PR #2522)."""
+	for label, malformed_value in [
+		("string", "not_an_object"),
+		("number", 42),
+		("array", ["a", "b"]),
+		("null", None),
+	]:
+		state_payload = {
+			"schema_version": 1,
+			"last_seen_phase": "ai:done",
+			"status_since_ts": 1700000000,
+			"stall_recovery_count": 1,
+			"updated_ts": 1700000100,
+			"conflict_override_count": malformed_value,
+		}
+		body = (
+			"<!-- AI_STANDALONE_STALL_STATE_V1\n"
+			+ json.dumps(state_payload)
+			+ "\nAI_STANDALONE_STALL_STATE_V1 -->"
+		)
+		comments_json = json.dumps([{
+			"id": 1,
+			"user": {"login": "github-actions[bot]"},
+			"created_at": "2026-01-01T00:00:00Z",
+			"body": body,
+		}])
+		(tmp_path / f"comments_{label}.json").write_text(comments_json)
+
+		func_src = _extract_function_body("_extract_standalone_state_json_from_comments")
+		script = textwrap.dedent(f"""
+			set -uo pipefail
+			export STANDALONE_STATE_MARKER_OPEN='<!-- AI_STANDALONE_STALL_STATE_V1'
+			export STANDALONE_STATE_MARKER_CLOSE='AI_STANDALONE_STALL_STATE_V1 -->'
+			{func_src}
+			_extract_standalone_state_json_from_comments "$(cat comments_{label}.json)"
+		""")
+		r = _run_bash(script, cwd=tmp_path)
+		assert r.returncode == 0, f"[{label}] shell error: {r.stderr}"
+		got = json.loads(r.stdout.strip().splitlines()[-1])
+		assert got["conflict_override_count"] == {}, (
+			f"[{label}] expected malformed value to be defaulted to {{}}; got {got['conflict_override_count']!r}"
+		)
+
+
+def test_standalone_state_parser_defaults_conflict_override_count(tmp_path):
+	"""When the source state comment has no conflict_override_count
+	(legacy V1 payload), the parser must default it to {} so
+	downstream jq writes can still bump it without exploding."""
+	state_payload = {
+		"schema_version": 1,
+		"last_seen_phase": "ai:done",
+		"status_since_ts": 1700000000,
+		"stall_recovery_count": 0,
+	}
+	body = (
+		"<!-- AI_STANDALONE_STALL_STATE_V1\n"
+		+ json.dumps(state_payload)
+		+ "\nAI_STANDALONE_STALL_STATE_V1 -->"
+	)
+	comments_json = json.dumps([{
+		"id": 1,
+		"user": {"login": "github-actions[bot]"},
+		"created_at": "2026-01-01T00:00:00Z",
+		"body": body,
+	}])
+	(tmp_path / "comments.json").write_text(comments_json)
+
+	func_src = _extract_function_body("_extract_standalone_state_json_from_comments")
+	script = textwrap.dedent(f"""
+		set -uo pipefail
+		export STANDALONE_STATE_MARKER_OPEN='<!-- AI_STANDALONE_STALL_STATE_V1'
+		export STANDALONE_STATE_MARKER_CLOSE='AI_STANDALONE_STALL_STATE_V1 -->'
+		{func_src}
+		_extract_standalone_state_json_from_comments "$(cat comments.json)"
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	got = json.loads(r.stdout.strip().splitlines()[-1])
+	assert got["conflict_override_count"] == {}, got
+
+
+# ---------------------------------------------------------------------------
+# 1k: Standalone budget-consumption must refresh status_since_ts and
+# updated_ts so the issue re-enters its phase-threshold window, instead
+# of burning through the rest of the ladder on every poll tick while
+# the resolver is still in flight (Codex P2, PR #2522, line 7335).
+# ---------------------------------------------------------------------------
+
+def test_standalone_cap_consumption_refreshes_stall_timer(tmp_path):
+	"""Reproduce the cap-consumption jq sequence and confirm that
+	status_since_ts AND updated_ts advance to the current time when
+	the cap is hit (so the standalone loop will wait the phase
+	threshold before its next attempt)."""
+	script = textwrap.dedent("""
+		set -uo pipefail
+		export MAX_BUDGET_NEUTRAL_OVERRIDES=2
+		# Pre-cap: count=2 hits the cap on this iteration.
+		updated_state='{"schema_version":1,"last_seen_phase":"ai:done","status_since_ts":100,"updated_ts":100,"stall_recovery_count":0,"conflict_override_count":{"sha_x":2}}'
+		sha="sha_x"
+		_std_override_count="$(printf '%s' "${updated_state}" | jq -r --arg sha "${sha}" '(.conflict_override_count[$sha] // 0)')"
+		# Cap is hit (count >= MAX_BUDGET_NEUTRAL_OVERRIDES) — consume
+		# budget AND refresh timestamps.
+		now_ts="$(date -u +%s)"
+		if [ "${_std_override_count}" -ge "${MAX_BUDGET_NEUTRAL_OVERRIDES}" ]; then
+			updated_state="$(printf '%s' "${updated_state}" | jq -c --argjson now "${now_ts}" \
+				'.stall_recovery_count = ((.stall_recovery_count // 0) + 1)
+				 | .status_since_ts = $now
+				 | .updated_ts = $now')"
+		fi
+		printf '%s\n' "${updated_state}"
+		echo "NOW=${now_ts}"
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	lines = r.stdout.strip().splitlines()
+	state = json.loads(lines[0])
+	now = int(lines[-1].split("=", 1)[1])
+	# Budget consumed.
+	assert state["stall_recovery_count"] == 1, state
+	# Timestamps advanced to "now" (or very close).
+	assert state["status_since_ts"] >= now - 2 and state["status_since_ts"] <= now, state
+	assert state["updated_ts"] >= now - 2 and state["updated_ts"] <= now, state
+	# And the stale 100 was overwritten.
+	assert state["status_since_ts"] != 100, state
+	assert state["updated_ts"] != 100, state
+
+
+# ---------------------------------------------------------------------------
+# 1l: Override cap must NOT bump the per-head counter on no-op
+# dispatches (rc=2 / dedupe).  The managed retrigger_review path
+# captures STALL_RECOVERY_SHOULD_INCREMENT after execute_stall_recovery_action
+# as the fresh-dispatch signal; the standalone path defers the counter
+# bump into the rc=0 case branch (Codex P2, PR #2522, line 5565).
+# ---------------------------------------------------------------------------
+
+def test_managed_override_counter_skipped_on_no_op_dispatch(tmp_path):
+	"""Reproduce the managed path's signal-capture pattern and confirm
+	the counter only bumps when STALL_RECOVERY_SHOULD_INCREMENT was
+	set to "true" by execute_stall_recovery_action."""
+	script = textwrap.dedent("""
+		set -uo pipefail
+		STATE_FILE=state.json
+		echo '{"conflict_override_count":{}}' > "$STATE_FILE"
+		export MAX_BUDGET_NEUTRAL_OVERRIDES=2
+		_rtr_head_sha="sha_x"
+
+		# Stub: simulate execute_stall_recovery_action's behaviour.
+		# fresh-dispatch path (rc=0): sets SHOULD_INCREMENT=true.
+		fake_execute_fresh() {
+			STALL_RECOVERY_SHOULD_INCREMENT="true"
+			return 0
+		}
+		# dedupe path (rc=0 but no fresh dispatch): does NOT set.
+		fake_execute_dedupe() {
+			# Note: rc=2 was mapped to 0 inside execute_stall_recovery_action.
+			# STALL_RECOVERY_SHOULD_INCREMENT stays whatever the caller initialised.
+			return 0
+		}
+
+		bump_counter_if_fresh() {
+			local _rtr_rc=0
+			"$1" || _rtr_rc=$?
+			local _rtr_did_fresh_dispatch="${STALL_RECOVERY_SHOULD_INCREMENT:-false}"
+			STALL_RECOVERY_SHOULD_INCREMENT="false"
+			if [ "${_rtr_did_fresh_dispatch}" = "true" ] \
+			   && [ -n "${_rtr_head_sha}" ] && [ "${_rtr_head_sha}" != "null" ]; then
+				local cur
+				cur="$(jq -r --arg sha "${_rtr_head_sha}" '.conflict_override_count[$sha] // 0' "$STATE_FILE")"
+				local nxt=$((cur + 1))
+				jq --arg sha "${_rtr_head_sha}" --argjson n "$nxt" \
+					'.conflict_override_count = ((.conflict_override_count // {}) | .[$sha] = $n)' \
+					"$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+			fi
+		}
+
+		# Round 1: dedupe path — counter must NOT bump.
+		STALL_RECOVERY_SHOULD_INCREMENT="false"
+		bump_counter_if_fresh fake_execute_dedupe
+		echo "after_dedupe=$(jq -r '.conflict_override_count.sha_x // 0' "$STATE_FILE")"
+
+		# Round 2: fresh dispatch — counter bumps to 1.
+		bump_counter_if_fresh fake_execute_fresh
+		echo "after_fresh1=$(jq -r '.conflict_override_count.sha_x // 0' "$STATE_FILE")"
+
+		# Round 3: another dedupe — counter stays at 1.
+		bump_counter_if_fresh fake_execute_dedupe
+		echo "after_dedupe2=$(jq -r '.conflict_override_count.sha_x // 0' "$STATE_FILE")"
+
+		# Round 4: another fresh — counter to 2.
+		bump_counter_if_fresh fake_execute_fresh
+		echo "after_fresh2=$(jq -r '.conflict_override_count.sha_x // 0' "$STATE_FILE")"
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	out = dict(line.split("=", 1) for line in r.stdout.strip().splitlines() if line)
+	# Dedupe paths must NOT advance the counter.
+	assert out["after_dedupe"] == "0", out
+	assert out["after_fresh1"] == "1", out
+	assert out["after_dedupe2"] == "1", out
+	assert out["after_fresh2"] == "2", out
+
+
+# ---------------------------------------------------------------------------
+# 1m: recent_comments builder must filter <!-- ORCHESTRATOR_STATE_V2
+# chunks alongside V1 snapshots so the judge cache key does not churn
+# every poll cycle on otherwise-identical stalls (Codex P2, PR #2522
+# line 6147).  V2 chunks have changing manifest hashes/timestamps and
+# would otherwise leak into the diagnostics blob and the cache hash.
+# ---------------------------------------------------------------------------
+
+def test_recent_comments_filter_strips_state_v1_v2_and_standalone(tmp_path):
+	"""Build a synthetic comments_json with a mix of V1, V2,
+	standalone-state, and human/orchestrator narration; apply the
+	production filter and confirm only the non-state comments
+	survive (Codex P2, PR #2522 lines 6147 + 6221 #1)."""
+	comments = [
+		{"id": 1, "user": {"login": "alice"}, "created_at": "2026-01-01T00:00:00Z",
+		 "body": "human guidance: please retry"},
+		{"id": 2, "user": {"login": "github-actions[bot]"}, "created_at": "2026-01-01T01:00:00Z",
+		 "body": "<!-- ORCHESTRATOR_STATE_V1\n{...}\nORCHESTRATOR_STATE_V1 -->"},
+		{"id": 3, "user": {"login": "github-actions[bot]"}, "created_at": "2026-01-01T02:00:00Z",
+		 "body": "<!-- ORCHESTRATOR_STATE_V2 part=1/2 manifest=" + ("a" * 64) + " -->\nchunk body\n<!-- /ORCHESTRATOR_STATE_V2 -->"},
+		{"id": 4, "user": {"login": "github-actions[bot]"}, "created_at": "2026-01-01T03:00:00Z",
+		 "body": "<!-- ORCHESTRATOR_STATE_V2 part=2/2 manifest=" + ("a" * 64) + " -->\nchunk body 2\n<!-- /ORCHESTRATOR_STATE_V2 -->"},
+		{"id": 5, "user": {"login": "bob"}, "created_at": "2026-01-01T04:00:00Z",
+		 "body": "another human comment"},
+		# Standalone state snapshot — produced by write_standalone_state_json
+		# on every poll cycle.  Codex P2 line 6221 #1: this must be
+		# filtered too or the judge cache key churns every cycle on a
+		# stalled standalone issue.
+		{"id": 6, "user": {"login": "github-actions[bot]"}, "created_at": "2026-01-01T05:00:00Z",
+		 "body": "<!-- AI_STANDALONE_STALL_STATE_V1\n{\"stall_recovery_count\":2,\"updated_ts\":1700000000}\nAI_STANDALONE_STALL_STATE_V1 -->"},
+	]
+	(tmp_path / "comments.json").write_text(json.dumps(comments))
+
+	# Reproduce the production jq filter from invoke_stall_judge.
+	script = textwrap.dedent("""
+		set -uo pipefail
+		jq -c '
+			[.[]
+				| select(((.body // "") | startswith("<!-- ORCHESTRATOR_STATE_V1")) | not)
+				| select(((.body // "") | startswith("<!-- ORCHESTRATOR_STATE_V2")) | not)
+				| select(((.body // "") | startswith("<!-- AI_STANDALONE_STALL_STATE_V1")) | not)
+				| {
+						author: (.user.login // ""),
+						created_at: (.created_at // ""),
+						body: ((.body // "") | if length > 2000 then .[:1988] + "…[truncated]" else . end)
+					}
+			] | (if length > 8 then .[-8:] else . end)
+		' comments.json
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	out = json.loads(r.stdout.strip())
+	# Only the 2 human-narration comments should survive.
+	authors = [c["author"] for c in out]
+	bodies = [c["body"] for c in out]
+	assert authors == ["alice", "bob"], f"state snapshots not filtered: {out}"
+	assert not any("ORCHESTRATOR_STATE_V1" in b for b in bodies), out
+	assert not any("ORCHESTRATOR_STATE_V2" in b for b in bodies), out
+	assert not any("AI_STANDALONE_STALL_STATE_V1" in b for b in bodies), out
+
+
+# ---------------------------------------------------------------------------
+# 1i: implementation-failed reissue must reset the per-issue stall
+# accumulators (last_seen_phase / status_since_ts / stall_recovery_count
+# / phase_attempts) on the wave entry, mirroring the other reissue
+# paths.  Without this, a fresh replacement inherits an exhausted
+# phase_attempts map and can be routed straight to "skip" on its first
+# stall in that phase (Codex P2, PR #2522, orchestrate_lib.py
+# line 1814).
+# ---------------------------------------------------------------------------
+
+def test_impl_failed_reissue_resets_stall_accumulators(tmp_path):
+	"""Exercise the jq update used by the impl-failed reissue path and
+	confirm it resets the per-issue stall counters while preserving the
+	ancestor-chain no-op tracker (impl_noop_count)."""
+	state = {
+		"schema_version": "orchestrate_state.v1",
+		"current_wave": 1,
+		"waves": [{
+			"issues": [{
+				"id": "wave-1/issue-1",
+				"github_issue": "100",
+				"status": "implementation-failed",
+				"last_seen_phase": "ai:clarification",
+				"status_since_ts": 1700000000,
+				"stall_recovery_count": 3,
+				"phase_attempts": {"ai:clarification": 5},
+				"impl_noop_count": 2,
+			}],
+		}],
+		"issue_number_map": {"wave-1/issue-1": "100"},
+	}
+	state_file = tmp_path / "state.json"
+	state_file.write_text(json.dumps(state))
+
+	script = textwrap.dedent(f"""
+		set -uo pipefail
+		if_issue=100
+		NEW_ISSUE_NUM=200
+		IF_LOCAL_ID="wave-1/issue-1"
+		WAVE_IDX=0
+		jq --arg if_issue "${{if_issue}}" --arg new_issue_num "${{NEW_ISSUE_NUM}}" --arg local_id "${{IF_LOCAL_ID}}" --argjson wave_idx "${{WAVE_IDX}}" \\
+			'(.waves[$wave_idx].issues[] | select((.github_issue | tostring) == $if_issue)) |= (
+				 .github_issue = $new_issue_num
+				 | .status = "pending"
+				 | .last_seen_phase = ""
+				 | .status_since_ts = (now | floor)
+				 | .stall_recovery_count = 0
+				 | .phase_attempts = {{}}
+			   )
+			   | if ($local_id != "" and $local_id != "null") then .issue_number_map[$local_id] = $new_issue_num else . end' \\
+			'{state_file}' > '{state_file}.tmp' && mv '{state_file}.tmp' '{state_file}'
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	updated = json.loads(state_file.read_text())
+	entry = updated["waves"][0]["issues"][0]
+	# Counters reset.
+	assert entry["github_issue"] == "200", entry
+	assert entry["status"] == "pending", entry
+	assert entry["last_seen_phase"] == "", entry
+	assert entry["stall_recovery_count"] == 0, entry
+	assert entry["phase_attempts"] == {}, entry
+	# Timestamp refreshed.
+	assert entry["status_since_ts"] > 1700000000, entry
+	# impl_noop_count preserved (ancestor-chain tracker stays alive).
+	assert entry["impl_noop_count"] == 2, entry
+	# issue_number_map remapped.
+	assert updated["issue_number_map"]["wave-1/issue-1"] == "200", updated
+
+
+# ---------------------------------------------------------------------------
+# 1g: forced escalate_human from MAX_JUDGE_REPLAY must bypass
+# normalize_stall_recovery_action so that the global
+# ENABLE_STALL_HUMAN_TERMINALIZATION=false gate cannot silently downgrade
+# the synthetic terminalization (Codex P2, PR #2522, line 6100).
+# ---------------------------------------------------------------------------
+
+def test_force_escalate_bypasses_human_terminalization_gate():
+	"""Re-create the conditional that picks effective_action and verify
+	that with _judge_force_escalate=true and judge_action=escalate_human
+	the bypass keeps escalate_human even when the normalize helper would
+	downgrade it (mimicked here with a stub that always returns the
+	ladder fallback)."""
+	# Stub normalize_stall_recovery_action to mirror its
+	# downgrade-on-disabled-terminalization behaviour, then assert the
+	# bypass branch leaves effective_action alone.
+	script = textwrap.dedent("""
+		set -uo pipefail
+		normalize_stall_recovery_action() {
+			# Mirror the production guard: escalate_human downgrades to
+			# the ladder when terminalization is disabled.
+			local _phase="$1"
+			local _rc="$2"
+			local _cand="$3"
+			if [ "$_cand" = "escalate_human" ] && [ "${ENABLE_STALL_HUMAN_TERMINALIZATION:-false}" != "true" ]; then
+				echo "retrigger_pipeline"
+				return
+			fi
+			echo "$_cand"
+		}
+
+		export ENABLE_STALL_HUMAN_TERMINALIZATION=false
+
+		# Case A: forced-escalate path. Bypass keeps escalate_human.
+		_judge_force_escalate="true"
+		judge_action="escalate_human"
+		phase="ai:review-blocked"
+		recovery_count=3
+		if [ "${_judge_force_escalate:-false}" = "true" ] && [ "${judge_action}" = "escalate_human" ]; then
+			effective_action_a="escalate_human"
+		else
+			effective_action_a="$(normalize_stall_recovery_action "${phase}" "${recovery_count}" "${judge_action}")"
+		fi
+		echo "A=${effective_action_a}"
+
+		# Case B: LLM-returned escalate_human (no force flag) is normalized.
+		_judge_force_escalate="false"
+		judge_action="escalate_human"
+		if [ "${_judge_force_escalate:-false}" = "true" ] && [ "${judge_action}" = "escalate_human" ]; then
+			effective_action_b="escalate_human"
+		else
+			effective_action_b="$(normalize_stall_recovery_action "${phase}" "${recovery_count}" "${judge_action}")"
+		fi
+		echo "B=${effective_action_b}"
+
+		# Case C: forced-escalate flag set but action is something else
+		# (defensive — shouldn't happen, but the bypass must not catch it).
+		_judge_force_escalate="true"
+		judge_action="retrigger_pipeline"
+		if [ "${_judge_force_escalate:-false}" = "true" ] && [ "${judge_action}" = "escalate_human" ]; then
+			effective_action_c="escalate_human"
+		else
+			effective_action_c="$(normalize_stall_recovery_action "${phase}" "${recovery_count}" "${judge_action}")"
+		fi
+		echo "C=${effective_action_c}"
+	""")
+	r = _run_bash(script, cwd=REPO_ROOT)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	out = dict(line.split("=", 1) for line in r.stdout.strip().splitlines())
+	assert out["A"] == "escalate_human", f"forced bypass failed: {out}"
+	assert out["B"] == "retrigger_pipeline", f"non-forced LLM escalate_human should normalize: {out}"
+	assert out["C"] == "retrigger_pipeline", f"forced-but-other-action must not bypass: {out}"
+
+
+# ---------------------------------------------------------------------------
+# 1f: `recovery_action_for_phase` shell precheck must mirror the Python
+# helper's per-phase cap (Codex P2, PR #2522, line 10907).  When the
+# judge bails on a transient failure, `invoke_stall_judge` falls back to
+# this helper; if the shell precheck short-circuits at the global cap
+# before the Python helper sees the ai:done override, a recoverable
+# ai:done stall can be hard-closed via `close_and_reissue` despite
+# MAX_STALL_RECOVERIES_DONE permitting more recoveries.
+# ---------------------------------------------------------------------------
+
+def test_recovery_action_for_phase_respects_ai_done_phase_cap():
+	"""For phase==ai:done with recovery_count above the global cap but
+	below MAX_STALL_RECOVERIES_DONE, the precheck must NOT short-
+	circuit to "skip"; for any other phase the global cap still applies."""
+	func_src = _extract_function_body("recovery_action_for_phase")
+	# Case A: ai:done above global (5) but below per-phase (99) → not skip.
+	script_a = textwrap.dedent(f"""
+		set -uo pipefail
+		export MAX_STALL_RECOVERIES_PER_ISSUE=5
+		export MAX_STALL_RECOVERIES_DONE=99
+		export ENABLE_STALL_HUMAN_TERMINALIZATION=false
+		{func_src}
+		recovery_action_for_phase "ai:done" 10
+	""")
+	r_a = _run_bash(script_a, cwd=REPO_ROOT)
+	assert r_a.returncode == 0, f"[ai:done@10] shell error: {r_a.stderr}"
+	action_a = r_a.stdout.strip()
+	assert action_a != "skip", (
+		f"[ai:done@10, cap=99] expected non-skip, got: {action_a!r}; stderr={r_a.stderr}"
+	)
+	# Case B: ai:implementing above global cap → skip (unchanged behaviour).
+	script_b = textwrap.dedent(f"""
+		set -uo pipefail
+		export MAX_STALL_RECOVERIES_PER_ISSUE=5
+		export MAX_STALL_RECOVERIES_DONE=99
+		export ENABLE_STALL_HUMAN_TERMINALIZATION=false
+		{func_src}
+		recovery_action_for_phase "ai:implementing" 10
+	""")
+	r_b = _run_bash(script_b, cwd=REPO_ROOT)
+	assert r_b.returncode == 0, f"[ai:implementing@10] shell error: {r_b.stderr}"
+	action_b = r_b.stdout.strip()
+	assert action_b == "skip", (
+		f"[ai:implementing@10, cap=5] expected skip, got: {action_b!r}"
+	)
+	# Case C: ai:done above the per-phase cap → skip (cap still binds).
+	script_c = textwrap.dedent(f"""
+		set -uo pipefail
+		export MAX_STALL_RECOVERIES_PER_ISSUE=5
+		export MAX_STALL_RECOVERIES_DONE=99
+		export ENABLE_STALL_HUMAN_TERMINALIZATION=false
+		{func_src}
+		recovery_action_for_phase "ai:done" 99
+	""")
+	r_c = _run_bash(script_c, cwd=REPO_ROOT)
+	assert r_c.returncode == 0, f"[ai:done@99] shell error: {r_c.stderr}"
+	action_c = r_c.stdout.strip()
+	assert action_c == "skip", f"[ai:done@99, cap=99] expected skip, got: {action_c!r}"
+
+
+# ---------------------------------------------------------------------------
+# 1e: judge cache key must be stable across the orchestrator's own
+# self-narration ("## 🧑‍⚖️ Stall Judge" tracking comments).  Every fresh
+# judge run posts one of these comments before returning; without the
+# filter, the next identical stall has a different key solely because the
+# previous judge run is now in recent_tracking_comments, which defeats
+# MAX_JUDGE_REPLAY entirely (Codex P2, PR #2522, line 6042).
+# ---------------------------------------------------------------------------
+
+def test_judge_cache_key_stable_across_self_judge_narration(tmp_path):
+	"""Two consecutive stalls with the only difference being a fresh
+	"## 🧑‍⚖️ Stall Judge — Issue #N" tracking comment must yield the
+	same cache key after the filter is applied."""
+	base = {
+		"issue_number": 2870,
+		"local_id": "wave-1/issue-1",
+		"phase": "ai:review-blocked",
+		"stall_minutes": 45,
+		"recovery_count": 2,
+		"linked_pr": {"number": 9001, "state": "open", "mergeable": False, "head_ref": "feat", "base_ref": "main"},
+		"recent_review_workflow_outcomes": [{"id": 111, "workflow": "Review Autofix", "conclusion": "failure", "status": "completed", "head_branch": "feat", "created_at": "2026-01-01T00:00:00Z"}],
+		"current_wave": 1,
+		"prior_recovery_actions": [{"key": "stall_recovery_count", "value": 2}],
+	}
+	diag_t1 = dict(base)
+	diag_t1["recent_tracking_comments"] = [
+		{"author": "alice", "body": "human guidance comment", "created_at": "2026-01-01T00:00:00Z"},
+	]
+	diag_t2 = dict(base)
+	diag_t2["recent_tracking_comments"] = [
+		{"author": "alice", "body": "human guidance comment", "created_at": "2026-01-01T00:00:00Z"},
+		{
+			"author": "github-actions[bot]",
+			"body": (
+				"## 🧑‍⚖️ Stall Judge — Issue #2870 attempt 3\n\n"
+				"**Decision (judge):** retrigger_review\n"
+				"**Decision (effective):** retrigger_review\n"
+				"**Justification:** stale check, retry\n\n"
+				"<!-- ORCHESTRATOR_STALL_JUDGE -->"
+			),
+			"created_at": "2026-01-01T01:00:00Z",
+		},
+	]
+	# Different judge narration on tick 3 (different attempt number).
+	diag_t3 = dict(base)
+	diag_t3["recent_tracking_comments"] = [
+		{"author": "alice", "body": "human guidance comment", "created_at": "2026-01-01T00:00:00Z"},
+		{
+			"author": "github-actions[bot]",
+			"body": (
+				"## 🧑‍⚖️ Stall Judge — Issue #2870 attempt 4\n\n"
+				"**Decision (judge):** retrigger_review\n"
+				"**Decision (effective):** retrigger_review\n"
+				"**Justification:** stale check, retry\n\n"
+				"<!-- ORCHESTRATOR_STALL_JUDGE -->"
+			),
+			"created_at": "2026-01-01T02:00:00Z",
+		},
+	]
+
+	for name, diag in [("t1", diag_t1), ("t2", diag_t2), ("t3", diag_t3)]:
+		(tmp_path / f"{name}.json").write_text(json.dumps(diag))
+
+	# Use the shared PRODUCTION_CACHE_KEY_FILTER so this test cannot
+	# silently drift from production when the filter evolves.
+	script = textwrap.dedent(f"""
+		set -uo pipefail
+		filter={shlex_quote(PRODUCTION_CACHE_KEY_FILTER)}
+		hash_filtered() {{
+			jq -c "$filter" "$1" | sha256sum | awk '{{print $1}}'
+		}}
+		hash_unfiltered() {{
+			jq -c '.' "$1" | sha256sum | awk '{{print $1}}'
+		}}
+		echo "filtered_t1=$(hash_filtered t1.json)"
+		echo "filtered_t2=$(hash_filtered t2.json)"
+		echo "filtered_t3=$(hash_filtered t3.json)"
+		echo "unfiltered_t1=$(hash_unfiltered t1.json)"
+		echo "unfiltered_t2=$(hash_unfiltered t2.json)"
+		echo "unfiltered_t3=$(hash_unfiltered t3.json)"
+	""")
+	r = _run_bash(script, cwd=tmp_path)
+	assert r.returncode == 0, f"shell error: {r.stderr}"
+	keys = dict(line.split("=", 1) for line in r.stdout.strip().splitlines())
+	# Post-filter: all three keys equal (self-narration stripped).
+	assert keys["filtered_t1"] == keys["filtered_t2"] == keys["filtered_t3"], (
+		f"filtered keys not stable: {keys}"
+	)
+	# Sanity check: without the filter, t1/t2/t3 differ (so the filter
+	# really is the thing making them equal).
+	assert keys["unfiltered_t1"] != keys["unfiltered_t2"], "unfiltered control diverges"
+	assert keys["unfiltered_t2"] != keys["unfiltered_t3"], "unfiltered control diverges"
+
+
+def test_judge_cache_filter_preserves_human_comments_referencing_judge_heading(tmp_path):
+	"""The cache-key filter must drop ONLY the bot's own judge
+	tracking comments — i.e., comments that match the full bot body
+	shape (heading + both Decision lines, OR the hidden
+	ORCHESTRATOR_STALL_JUDGE marker).  Human comments that quote the
+	heading inline, or that start with a heading-like phrase but
+	lack the Decision lines, must remain in the hash (Codex P2,
+	PR #2522 lines 6200 + 6221 #4 + 6255).
+
+	The author-suffix check (`endswith("[bot]")`) was dropped because
+	deployments using a PAT author the bot's comments as the PAT
+	user, not `*[bot]`, which silently broke filtering — replaced
+	with body-shape matching."""
+	base = _diag_base()
+	# Production judge body has the heading + both Decision lines
+	# + the hidden ORCHESTRATOR_STALL_JUDGE HTML-comment marker.
+	JUDGE_BODY = (
+		"## 🧑‍⚖️ Stall Judge — Issue #2870 attempt 3\n\n"
+		"**Decision (judge):** retrigger\n"
+		"**Decision (effective):** retrigger\n"
+		"**Justification:** test\n\n"
+		"<!-- ORCHESTRATOR_STALL_JUDGE -->"
+	)
+	# t1: inline human reference, no bot heading at start.
+	diag_human_ref = {**base, "recent_tracking_comments": [
+		{"author": "alice", "body": "Regarding Stall Judge — Issue #2870, please choose close_and_reissue.", "created_at": "2026-01-01T00:00:00Z"},
+	]}
+	# t2: inline human reference PLUS the bot's actual judge body
+	# (carrying the marker).
+	diag_human_ref_with_judge = {**base, "recent_tracking_comments": [
+		{"author": "alice", "body": "Regarding Stall Judge — Issue #2870, please choose close_and_reissue.", "created_at": "2026-01-01T00:00:00Z"},
+		{"author": "github-actions[bot]", "body": JUDGE_BODY, "created_at": "2026-01-01T01:00:00Z"},
+	]}
+	# t3: only the bot's body (human reference absent).
+	diag_only_judge = {**base, "recent_tracking_comments": [
+		{"author": "github-actions[bot]", "body": JUDGE_BODY, "created_at": "2026-01-01T01:00:00Z"},
+	]}
+	# t4: no comments.
+	diag_no_comments = {**base, "recent_tracking_comments": []}
+	# t5: a human whose body STARTS with the bot heading verbatim
+	# but lacks the Decision lines and the hidden marker (e.g.
+	# someone tried to draft a judge-style reply by hand).  Must
+	# stay in the hash because the body-shape filter requires
+	# heading + BOTH Decision lines + marker — heading alone is not
+	# enough.
+	diag_human_heading_only = {**base, "recent_tracking_comments": [
+		{"author": "bob",
+		 "body": "## 🧑‍⚖️ Stall Judge — Issue #2870 attempt 99\n\nbob: please pick close_and_reissue.",
+		 "created_at": "2026-01-01T01:00:00Z"},
+	]}
+	# t6: a deployment where the bot is authenticated as a PAT user
+	# (the comment is NOT authored by `*[bot]`).  The new body-shape
+	# filter MUST still strip it; the earlier author-suffix filter
+	# would have left it in.
+	diag_pat_authored_judge = {**base, "recent_tracking_comments": [
+		{"author": "automation-pat-user", "body": JUDGE_BODY, "created_at": "2026-01-01T01:00:00Z"},
+	]}
+
+	keys = _hash_variants(tmp_path, {
+		"human_ref": diag_human_ref,
+		"human_ref_with_judge": diag_human_ref_with_judge,
+		"only_judge": diag_only_judge,
+		"no_comments": diag_no_comments,
+		"human_heading_only": diag_human_heading_only,
+		"pat_authored_judge": diag_pat_authored_judge,
+	})
+	# An inline human reference is NOT filtered (changes hash vs no_comments).
+	assert keys["human_ref"] != keys["no_comments"], (
+		f"inline human reference must remain in the hash: {keys}"
+	)
+	# Adding the bot judge body on top of the human reference must
+	# NOT change the hash (bot body filtered).
+	assert keys["human_ref"] == keys["human_ref_with_judge"], (
+		f"bot judge body must be stripped, leaving the human reference: {keys}"
+	)
+	# Bot-only variant filters down to empty == no_comments.
+	assert keys["only_judge"] == keys["no_comments"], (
+		f"bot body + no other comments must filter down to empty: {keys}"
+	)
+	# Human with heading-only (no Decision lines, no marker) must
+	# stay in the hash — heading alone is not enough to filter.
+	assert keys["human_heading_only"] != keys["no_comments"], (
+		f"human-heading-only must remain in the hash (no Decision lines, "
+		f"no marker → must not match the bot-body filter): {keys}"
+	)
+	# PAT-authored bot body MUST be filtered (the whole point of the
+	# Codex P2 6255 fix — author-suffix check was unreliable).
+	assert keys["pat_authored_judge"] == keys["no_comments"], (
+		f"PAT-authored bot body must be filtered like a bot comment "
+		f"(body-shape match, not author-suffix): {keys}"
+	)
+
+
+# ---------------------------------------------------------------------------
+# 2c: _list_integration_conflict_files exit-code handling.
+#
+# The function header contracts: rc==0 when conflicts are detected, rc==1
+# otherwise (clean merge OR probe failure — fail-open).  A previous
+# version branched only on `if out=$(git merge-tree ...)`, so any
+# non-zero exit from git merge-tree was treated as "conflict detected",
+# which meant a fatal probe error (rc>=128, e.g. malformed ref, OOM,
+# unsupported subcommand) leaked through with empty output instead of
+# being mapped to fail-open.  This test pins the corrected case-on-rc
+# behavior so the contract cannot regress.
+# ---------------------------------------------------------------------------
+
+def _extract_function_body(name: str) -> str:
+	"""Slice ``name() { ... }`` out of the poller script.
+
+	Relies on the project convention that top-level bash function bodies
+	close with ``\\n}\\n`` at column 0 (no nested closing braces at
+	column 0 inside the function)."""
+	body = POLLER_SCRIPT.read_text(encoding="utf-8")
+	head = f"\n{name}() {{\n"
+	start = body.index(head) + 1  # skip the leading newline
+	end = body.index("\n}\n", start) + 3
+	return body[start:end]
+
+
+def test_list_integration_conflict_files_rc_handling(tmp_path):
+	"""Validate the documented exit-code branches and the SHA-strip
+	multi-line gate:
+	  rc==0 (clean merge)                       → return 1, no stdout
+	  rc==1 with OID + paths                    → return 0, paths echoed
+	  rc==1 with a single SHA-shaped path       → return 0, path preserved
+	    (the multi-line gate keeps the strip from dropping a real
+	    conflict file whose name happens to be 40/64 hex chars)
+	  rc==1 with empty output                   → return 1 (fail-open)
+	  rc>=128 (fatal probe error)               → return 1 (fail-open)
+
+	Also exercises the pipefail-safe version probe — the shim simulates
+	real git's `git merge-tree -h` behaviour (help to stderr, exit 129).
+	"""
+	func_src = _extract_function_body("_list_integration_conflict_files")
+	# Each scenario: (label, mock_rc, mock_stdout, expected_rc, expected_paths).
+	scenarios = [
+		("clean_merge",                  0,   "",                                                  1, []),
+		("conflict_oid_plus_paths",      1,   ("d" * 40) + "\nsrc/foo.txt\nsrc/bar.txt",           0, ["src/foo.txt", "src/bar.txt"]),
+		("conflict_sha_shaped_filename", 1,   "d" * 40,                                            0, ["d" * 40]),
+		("conflict_empty_output",        1,   "",                                                  1, []),
+		("fatal_error_128",              128, "",                                                  1, []),
+	]
+	for label, mock_rc, mock_stdout, expected_rc, expected_paths in scenarios:
+		expects_paths = bool(expected_paths)
+		# Use a tempfile for the mock stdout so embedded newlines round-trip
+		# cleanly — bash env vars do not interpret `\n` escapes inside
+		# double quotes, so passing multi-line content via `export VAR=...`
+		# would collapse to a single literal-`\n` line.
+		mock_out_file = tmp_path / f"mock_out_{label}.txt"
+		mock_out_file.write_text(mock_stdout)
+		script = textwrap.dedent(f"""
+			# Mirror the production script's strict mode exactly so
+			# this test catches errexit-related regressions — without
+			# `-e`, a future caller pattern like
+			# `out=$(git merge-tree ...); rc=$?` outside an `if VAR=$(...)`
+			# wrapper would silently exit the script on rc==1 instead
+			# of falling through to the case handler.  Copilot
+			# review, PR #2522 line 1128.
+			set -euo pipefail
+			export MOCK_MERGE_TREE_RC={mock_rc}
+			export MOCK_MERGE_TREE_OUT_FILE='{mock_out_file}'
+			git() {{
+				case "$1" in
+					merge-tree)
+						if [ "$#" -ge 2 ] && [ "$2" = "--write-tree" ]; then
+							[ -s "$MOCK_MERGE_TREE_OUT_FILE" ] && cat "$MOCK_MERGE_TREE_OUT_FILE"
+							return "$MOCK_MERGE_TREE_RC"
+						fi
+						# `git merge-tree -h` on modern git prints help to
+						# stderr and exits 129 — emulate that so the
+						# pipefail-safe probe is actually under test.
+						if [ "$#" -ge 2 ] && [ "$2" = "-h" ]; then
+							echo "usage: git merge-tree [<options>] --write-tree <branch1> <branch2>" >&2
+							return 129
+						fi
+						return 0
+						;;
+					*)
+						return 0
+						;;
+				esac
+			}}
+			{func_src}
+			# Capture rc with `|| rc=$?` so this test exercises
+			# `set -euo pipefail` end-to-end without prematurely
+			# exiting when the function returns 1 (clean-merge / probe
+			# failure / fail-open).  Production callers use
+			# `if VAR=$(...)` which has the same errexit-suppressing
+			# effect; we use the explicit-capture form here so we can
+			# also assert on the function's stdout.
+			rc=0
+			_list_integration_conflict_files int-branch main || rc=$?
+			echo "RC=${{rc}}"
+		""")
+		r = _run_bash(script, cwd=tmp_path)
+		assert r.returncode == 0, f"[{label}] shell error: {r.stderr}\nstdout: {r.stdout}"
+		# Stderr must be free of bash arithmetic / integer-parse errors
+		# — those indicate a regression like the `grep -c . || echo 0`
+		# count-duplication bug (Copilot PR #2522 line 3396) where the
+		# function still returns the right rc but emits spurious
+		# stderr noise that would mask real failures in production
+		# logs.
+		assert "integer expression expected" not in r.stderr, (
+			f"[{label}] bash integer-parse error leaked to stderr "
+			f"(likely line_count computation regressed):\n{r.stderr}"
+		)
+		lines = r.stdout.strip().splitlines()
+		assert lines, f"[{label}] no output: stderr={r.stderr}"
+		rc_line = lines[-1]
+		assert rc_line == f"RC={expected_rc}", (
+			f"[{label}] got '{rc_line}', expected RC={expected_rc}; full stdout: {r.stdout!r}"
+		)
+		path_lines = [l for l in lines[:-1] if l]
+		if expects_paths:
+			assert sorted(path_lines) == sorted(expected_paths), (
+				f"[{label}] path mismatch: expected {expected_paths}, got {path_lines}"
+			)
+		else:
+			assert path_lines == [], f"[{label}] expected no stdout paths; got: {path_lines}"
+
+
+# ---------------------------------------------------------------------------
 # Production-script contract: every fix is wired into the real script.
 # ---------------------------------------------------------------------------
 
 def test_production_script_contains_expected_fix_markers():
 	"""Smoke check that the live orchestrate_poll_process.sh still has
 	the per-fix anchors so future refactors that drop them are caught."""
-	assert POLLER_SCRIPT.exists(), f"Script not found: {POLLER_SCRIPT}"
 	body = POLLER_SCRIPT.read_text(encoding="utf-8")
 	assert "MAX_BUDGET_NEUTRAL_OVERRIDES" in body
 	assert "MAX_JUDGE_REPLAY" in body
 	assert "judge_decision_cache" in body
 	assert "conflict_override_count" in body
-	assert "_judge_recent_comments_hash" in body
 	assert "_list_integration_conflict_files" in body
 	assert "ACTUALLY_CREATED_COUNT" in body
 	assert "effective_cooldown" in body
 	assert 'post_tracking_comment "${WAVE_COMMENT}"' in body
+	# Codex P2 fixes (PR #2522).
+	# - 6042: cache key strips self-narration before hashing.
+	assert "Stall Judge — Issue #" in body, (
+		"cache-key filter for self-judge narration is missing"
+	)
+	# - 10907: shell precheck respects per-phase MAX_STALL_RECOVERIES_DONE.
+	assert "_phase_effective_max" in body, (
+		"recovery_action_for_phase per-phase cap variable is missing"
+	)
+	# - 6100: forced escalate_human bypasses normalize_stall_recovery_action.
+	assert "_judge_force_escalate" in body and "Bypass normalize_stall_recovery_action" in body, (
+		"force-escalate normalization bypass is missing"
+	)
+	# - 1077: standalone path applies the same per-head-SHA override cap.
+	assert "_std_override_count" in body, (
+		"standalone override-cap counter is missing"
+	)
+	# 3322: pipefail-safe merge-tree feature probe.
+	assert "git merge-tree -h 2>&1 || true" in body, (
+		"pipefail-safe merge-tree -h probe is missing"
+	)
+	# Codex P2 6130 #1: head_sha included in diagnostics (main + fallback build).
+	assert 'head_sha: (if $head_sha == ""' in body, (
+		"head_sha missing from diagnostics build (cache key cannot invalidate on new commits)"
+	)
+	# Codex P2 6130 #2: cache-key filter strips volatile counters.
+	assert "del(.stall_minutes)" in body and "del(.recovery_count)" in body, (
+		"cache-key filter must strip volatile counters"
+	)
+	# Codex P2 7284: GraphQL headRefOid plumbed so head_sha is available in the GraphQL fast path.
+	assert "headRefOid" in body, (
+		"GraphQL must select headRefOid so the standalone override cap can fire"
+	)
+	# Codex P2 1814 (orchestrate_lib.py reference): impl-failed reissue resets stall accumulators.
+	assert "orchestrate_lib.py line 1814" in body, (
+		"impl-failed reissue reset comment marker is missing"
+	)
+	# Codex P2 7339: standalone state parser carries conflict_override_count forward.
+	assert "conflict_override_count" in body and '.conflict_override_count // null) | type) == "object"' in body, (
+		"standalone state parser must preserve conflict_override_count with a type check"
+	)
+	# Codex P2 7335: standalone cap consumption refreshes status_since_ts/updated_ts.
+	assert "status_since_ts = $now" in body and "updated_ts = $now" in body, (
+		"standalone cap consumption must refresh stall timestamps"
+	)
+	# Codex P2 5565: override counter only bumps on fresh dispatches (managed path).
+	assert "_rtr_did_fresh_dispatch" in body, (
+		"managed retrigger_review must capture the fresh-dispatch signal"
+	)
+	# Codex P2 6147: recent_comments filter strips V2 chunks too.
+	assert 'startswith("<!-- ORCHESTRATOR_STATE_V2")) | not' in body, (
+		"recent_comments filter must strip ORCHESTRATOR_STATE_V2 chunks"
+	)
+	# Codex P2 6200 + 6255 + 6330: cache-key filter is marker-only
+	# (hidden ORCHESTRATOR_STALL_JUDGE).  Author-suffix was tried
+	# first and broke under PATs; author-agnostic body-shape was
+	# tried second and over-filtered humans who quote the bot.  The
+	# hidden marker is invisible in rendered Markdown so humans
+	# almost never carry it.
+	assert "<!-- ORCHESTRATOR_STALL_JUDGE -->" in body, (
+		"bot judge tracking comment must include the hidden ORCHESTRATOR_STALL_JUDGE marker"
+	)
+	assert 'contains("<!-- ORCHESTRATOR_STALL_JUDGE -->")' in body, (
+		"cache-key filter must match the hidden ORCHESTRATOR_STALL_JUDGE marker"
+	)
+	# The legacy heading+Decision shape fallback has been DROPPED to
+	# avoid over-filtering humans who quote a legacy judge report;
+	# this anchor pins that the fallback is not reintroduced.
+	assert 'contains("**Decision (effective):**")' not in body, (
+		"legacy heading+Decision body-shape fallback must not be reintroduced "
+		"(over-filters human quotes of bot reports)"
+	)
+	# Codex P2 6221 #1: standalone state marker filtered from recent_comments.
+	assert 'startswith("<!-- AI_STANDALONE_STALL_STATE_V1")) | not' in body, (
+		"recent_comments filter must strip AI_STANDALONE_STALL_STATE_V1 snapshots"
+	)
+	# Codex P2 3352 + 3363: conflict-probe fetch uses explicit
+	# refspecs WITH the `+` force-prefix so rewritten branches still
+	# update remote-tracking refs (otherwise stale refs pass
+	# rev-parse and the merge-tree probe judges the wrong tip).
+	assert "+refs/heads/${integration_branch}:refs/remotes/origin/${integration_branch}" in body, (
+		"conflict probe must use forced refspecs (+refs/heads/...) so rewritten branches refresh"
+	)
+	# Codex P2 6448 + 6625: the judge cache now stores
+	# _judge_executed_action (the action that ACTUALLY ran) rather
+	# than effective_action.  When resolve_merge_conflict's
+	# dispatch falls back to the ladder action (missing metadata
+	# OR dispatch failure), the cache stores the executed
+	# fallback so the next identical stall does not replay a dead-
+	# end action.
+	assert "_judge_executed_action" in body, (
+		"judge cache must track the actually-executed action, not the LLM's effective_action"
+	)
+	assert '--arg action "${_judge_executed_action}"' in body, (
+		"cache jq write must reference _judge_executed_action"
+	)
+	# Codex P2 1720: judge-failure fallback honors phase-attempt cap.
+	assert "the judge-failure fallback will be forced to skip so a transient judge crash cannot bypass the phase-lifetime cap" in body, (
+		"judge-failure fallback must downgrade to skip when phase_attempts is exhausted"
+	)
+	# Codex P2 6279: synthetic forced escalations stamp force_escalate=true in cache.
+	assert '"force_escalate": true' in body, (
+		"force-escalate cache write must stamp the marker so the bypass survives replay"
+	)
+	assert "_judge_cache_force_escalate" in body, (
+		"cache read must propagate force_escalate to _judge_force_escalate"
+	)
+	# Codex P2 6359 + 6625: cache the actually-executed action
+	# (post-normalize AND post-dispatch-fallback), not the raw
+	# judge_action.  An invalid LLM action gets normalized; a
+	# resolve_merge_conflict whose dispatch fails gets the ladder
+	# fallback — both replayed safely on identical stalls.
+	# The marker assertion is the explicit `_judge_executed_action`
+	# check above (and the absence of `--arg action "${judge_action}"`).
+	assert '--arg action "${judge_action}"' not in body, (
+		"fresh-LLM cache write must NOT store the raw judge_action "
+		"(invalid actions would loop) — it must store _judge_executed_action"
+	)
+	# Codex P2 3575: rc=2 active-resolver dedupe does NOT refresh dispatch_ts.
+	assert "cooldown timer unchanged" in body, (
+		"heal_integration_branch_conflict rc=2 path must not refresh dispatch_ts"
+	)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- Merge `origin/main` into the PR branch and resolve conflicts so the orchestrator stall-recovery, judge, and standalone-state fixes from both branches are reconciled.  
- Ensure phase-lifetime counters (`phase_attempts`) and per-phase caps are threaded through detection, normalization and judge code to avoid silent destructive skips.  
- Harden the poller shell paths (merge-tree probe, numeric canonicalisation, conflict-probe fetch) and make the judge decision cache robust to self-narration and replay-edge cases.

### Description

- Resolved merge conflicts across `scripts/orchestrate_lib.py`, `scripts/orchestrate_poll_process.sh` and related tests, preserving both PR #2522 behavior and main fixes; threaded `phase_attempts_count` into `detect_stalls`, `normalize_stall_recovery_action`, `invoke_stall_judge`, and the shell helpers.  
- Updated standalone state handling to preserve and default `phase_attempts` and `conflict_override_count` in the standalone state parser so the per-head override cap works for standalone PRs.  
- Improved judge cache/key logic: normalize diagnostics before hashing, strip the orchestrator's own judge comments and volatile counters, use a sticky `force_escalate` marker for MAX_JUDGE_REPLAY forced escalations, and store the actually-executed action in the cache (not the raw LLM action).  
- Hardened shell helpers: made `git merge-tree` probe pipefail-safe and robust to git versions, canonicalised numeric env vars via `10#` to avoid octal errors, ensured conflict-probe fetch uses forced refspecs and blob filtering, and adjusted cooldown backoff shift logic (subtract one then clamp).  
- Kept main's safer wave narration path by routing wave comments through `post_tracking_comment` instead of direct `gh api` calls.  
- Adjusted and expanded tests to reflect the merged behavior and to assert the new anchors and invariants (many `tests/*` updated to assert cache/key, standalone state, numeric canonicalisation, override cap, and judge-bypass behaviors).

### Testing

- Ran `python -m pytest tests/test_orchestrate_lib.py tests/test_stall_loop_and_churn_fixes.py` and the suite completed successfully (`138 passed`).  
- Ran `git diff --check` and `git diff --cached --check` to ensure no whitespace/conflict markers remain (no issues).  
- Attempted `python -m pytest tests/test_orchestrate_poll_process.py` in this environment; it made partial progress but the long-running full poller test timed out under the environment constraints (timed out during extended execution).  
- Verified staged diff/stat shows conflict markers removed and merged changes committed; created merge commit integrating `origin/main` into the PR branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a025474a3c483309595cb9ae0749d57)