### PR TITLE
fix(validation-harness): install git in python-repo-checks container

### DIFF
--- a/tests/fixtures/validation_harness/python_repo_checks/Dockerfile.app
+++ b/tests/fixtures/validation_harness/python_repo_checks/Dockerfile.app
@@ -6,7 +6,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /workspace
 
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends bash jq coreutils \
+	&& apt-get install -y --no-install-recommends bash jq coreutils git \
 	&& rm -rf /var/lib/apt/lists/*
 
 COPY . /workspace

--- a/workflow-templates/validation-harness/python-repo-checks/Dockerfile.app.j2
+++ b/workflow-templates/validation-harness/python-repo-checks/Dockerfile.app.j2
@@ -6,7 +6,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /workspace
 
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends bash jq coreutils \
+	&& apt-get install -y --no-install-recommends bash jq coreutils git \
 	&& rm -rf /var/lib/apt/lists/*
 
 COPY . /workspace


### PR DESCRIPTION
## Summary

Fixes the `Validation Refresh` workflow failure (run [25711543536](https://github.com/shubhodeep1/coding-workflows/actions/runs/25711543536)) where `shubhodeep1/coding-workflows` reported `outcome: error` with `pipeline_failed_without_changes` while every other consumer repo stayed green.

### Root cause

Commit d43d7d57a added two new tests to `tests/test_validate_process_template_mode.py`:
- `test_serena_runtime_filter_hides_only_unchanged_bootstrap_tree`
- `test_clear_stale_serena_codex_config_removes_only_serena_block`

The first one seeds a temporary repo via `_bootstrap_git_repo`, which shells out to `git init`/`config`/`add`/`commit`, and the inline bash payload pipes `git status --porcelain -uall` through `validate_process.sh`'s `filter_runtime_status_noise`.

The `python-repo-checks` validation-harness Dockerfile (used by all consumer repos rendered with `type: python-repo-checks`, including this repo itself per `.ai/validate.yml`) installs only `bash jq coreutils` on top of `python:3.12-slim`. **`git` is not in the container.** When `40_repo_checks.sh` runs `python3 tests/test_validate_process_template_mode.py` inside the container, the new test raises `FileNotFoundError: [Errno 2] No such file or directory: 'git'`, the test file's `main()` exits non-zero, and the driver fails with exit 1.

The reason the diagnostic looked like a canary failure (`1..3 | ok 1 - bash | ok 2 - python3`) is that `validation_refresh_runner.py:_format_command_failure` truncates the child stdout to the **first 3 lines**, which happen to be the canary's plan + first two oks regardless of which later test actually failed.

Reproduced locally by stripping git from PATH while keeping bash/python3/jq/sh, and observing:

```
test_serena_runtime_filter_hides_only_unchanged_bootstrap_tree()
  _bootstrap_git_repo(repo_dir)
    _git(["git", "init"], cwd=repo_dir)
FileNotFoundError: [Errno 2] No such file or directory: 'git'
exit_code=1
```

Only `coding-workflows` hits this in production — every other consumer ends up with the bootstrapped `scripts/run_validation_repo_checks.sh` placeholder, which is a no-op `exit 0`. Only this repo ships the real entry script with the four python-checks that exercise git.

### Fix

Add `git` to the `apt-get install` line in `workflow-templates/validation-harness/python-repo-checks/Dockerfile.app.j2` and refresh the matching golden fixture at `tests/fixtures/validation_harness/python_repo_checks/Dockerfile.app` so `test_python_repo_checks_golden_output_matches_fixture_tree` keeps passing.

The sibling `node-hardhat-solidity` family Dockerfile already installs git for the same reason; this brings python-repo-checks in line. Image size delta is small (~10 MB).

## Test plan

- [x] `python3 tests/test_family_python_repo_checks.py` — golden fixture + invariant guards pass
- [x] `python3 tests/test_render_validation_templates.py` — renderer tests pass
- [x] Reproduce: run `tests/test_validate_process_template_mode.py` with git stripped from PATH → fails with the exact `FileNotFoundError` the harness saw
- [x] Re-run same test with git available → passes
- [ ] Trigger `workflow_dispatch` on `validation-refresh.yml` after merge and confirm `shubhodeep1/coding-workflows` flips from `outcome: error` back to `outcome: skipped`

https://claude.ai/code/session_014SBxKCv6rKGwCk71Qooi4y

---
_Generated by [Claude Code](https://claude.ai/code/session_014SBxKCv6rKGwCk71Qooi4y)_