### PR TITLE
fix(review_autofix): use STRICT ledger-only flag in clean-review-tail gates

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -4137,7 +4137,17 @@ jobs:
           tg_send_tracked "${PR_NUMBER}" "${MSG}" "DEBUG"
 
       - name: Mark linked issues ready to merge
-        if: "success() && (steps.retrigger_guard.outputs.max_iterations_reached != 'true' || steps.retrigger_guard.outputs.skip_judge == 'true') && (steps.commit_changes.outputs.did_commit != 'true' || env.LEDGER_ONLY_COMMIT == 'true') && env.MERGE_CONFLICT != 'true' && env.PR_CLOSED != 'true' && env.EDITOR_CHANGES_LOST != 'true' && env.EDITOR_NOOP_SUSPICIOUS != 'true' && env.AUTOFIX_STALE_BASE_SKIP != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true'"
+        # Clean-review-tail gate: did_commit=false OR LEDGER_ONLY_COMMIT_STRICT=true.
+        # We deliberately read the STRICT flag (not LEDGER_ONLY_COMMIT) because
+        # the non-strict flag is also set by the audit-convergence branch in
+        # scripts/review_commit_changes.sh, which can fire on commits that DID
+        # land real source-file edits. Reading the loose flag here would mark
+        # the linked issue ai:ready-to-merge for a run whose committed edits
+        # have not yet been re-reviewed. See PR #2542 (mergedAt 12:36:08Z on
+        # head f11d6dc while editor commit 005824e was still local) and the
+        # docstring at scripts/review_commit_changes.sh:32-41 for the same
+        # rationale that already governs EDITOR_CHANGES_LOST at :3315-3326.
+        if: "success() && (steps.retrigger_guard.outputs.max_iterations_reached != 'true' || steps.retrigger_guard.outputs.skip_judge == 'true') && (steps.commit_changes.outputs.did_commit != 'true' || env.LEDGER_ONLY_COMMIT_STRICT == 'true') && env.MERGE_CONFLICT != 'true' && env.PR_CLOSED != 'true' && env.EDITOR_CHANGES_LOST != 'true' && env.EDITOR_NOOP_SUSPICIOUS != 'true' && env.AUTOFIX_STALE_BASE_SKIP != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true'"
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           REPOSITORY: ${{ github.repository }}
@@ -4363,7 +4373,24 @@ jobs:
           fi
 
       - name: Enable auto-merge on PR
-        if: "success() && (steps.retrigger_guard.outputs.max_iterations_reached != 'true' || steps.retrigger_guard.outputs.skip_judge == 'true') && (steps.commit_changes.outputs.did_commit != 'true' || env.LEDGER_ONLY_COMMIT == 'true') && env.MERGE_CONFLICT != 'true' && env.PR_CLOSED != 'true' && env.EDITOR_CHANGES_LOST != 'true' && env.EDITOR_NOOP_SUSPICIOUS != 'true' && env.AUTOFIX_STALE_BASE_SKIP != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true'"
+        # Clean-review-tail gate: did_commit=false OR LEDGER_ONLY_COMMIT_STRICT=true.
+        # The STRICT flag means "only the review-issue ledger was committed";
+        # the non-strict LEDGER_ONLY_COMMIT also fires on the audit-convergence
+        # branch in scripts/review_commit_changes.sh, which can be true on a
+        # commit that DID land real source-file edits. Reading the loose flag
+        # here caused PR #2542 to auto-merge at the pre-edit head SHA f11d6dc
+        # while the editor's productive commit 005824e (real edits to
+        # review_autofix.yml + README.md) was still local: the auto-merge step
+        # fires before "Push all pending commits" by design (see :4436-4440
+        # comment), and GitHub squashed the old head before the new commit
+        # reached the remote. With STRICT, an audit-converged commit that
+        # contains real edits blocks auto-merge here; the synchronize event
+        # from the deferred push then triggers a fresh review_autofix
+        # iteration on the new tip (the gate-job AUTOFIX_SKIP_SELF_TRIGGERED
+        # default is `false`, so the [ai-autofix] synchronize is NOT
+        # skipped — see :327). The autofix loop now actually "keeps going
+        # until there are no edits" instead of converging on a stale head.
+        if: "success() && (steps.retrigger_guard.outputs.max_iterations_reached != 'true' || steps.retrigger_guard.outputs.skip_judge == 'true') && (steps.commit_changes.outputs.did_commit != 'true' || env.LEDGER_ONLY_COMMIT_STRICT == 'true') && env.MERGE_CONFLICT != 'true' && env.PR_CLOSED != 'true' && env.EDITOR_CHANGES_LOST != 'true' && env.EDITOR_NOOP_SUSPICIOUS != 'true' && env.AUTOFIX_STALE_BASE_SKIP != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true'"
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           ENABLE_AUTO_MERGE: ${{ vars.ENABLE_AUTO_MERGE || 'true' }}
@@ -4755,7 +4782,11 @@ jobs:
           fi
 
       - name: Telegram success
-        if: "success() && (steps.retrigger_guard.outputs.max_iterations_reached != 'true' || steps.retrigger_guard.outputs.skip_judge == 'true') && (steps.commit_changes.outputs.did_commit != 'true' || env.LEDGER_ONLY_COMMIT == 'true') && env.MERGE_CONFLICT != 'true' && env.PR_CLOSED != 'true' && env.EDITOR_CHANGES_LOST != 'true' && env.EDITOR_NOOP_SUSPICIOUS != 'true' && env.AUTOFIX_STALE_BASE_SKIP != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true'"
+        # Clean-review-tail gate: matches the auto-merge / mark-ready siblings
+        # above so the success notification only fires on a truly converged
+        # iteration. See the comment block on "Enable auto-merge on PR" for
+        # the LEDGER_ONLY_COMMIT_STRICT rationale.
+        if: "success() && (steps.retrigger_guard.outputs.max_iterations_reached != 'true' || steps.retrigger_guard.outputs.skip_judge == 'true') && (steps.commit_changes.outputs.did_commit != 'true' || env.LEDGER_ONLY_COMMIT_STRICT == 'true') && env.MERGE_CONFLICT != 'true' && env.PR_CLOSED != 'true' && env.EDITOR_CHANGES_LOST != 'true' && env.EDITOR_NOOP_SUSPICIOUS != 'true' && env.AUTOFIX_STALE_BASE_SKIP != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true'"
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -4386,9 +4386,9 @@ jobs:
         # reached the remote. With STRICT, an audit-converged commit that
         # contains real edits blocks auto-merge here; the synchronize event
         # from the deferred push then triggers a fresh review_autofix
-        # iteration on the new tip (the gate-job AUTOFIX_SKIP_SELF_TRIGGERED
-        # default is `false`, so the [ai-autofix] synchronize is NOT
-        # skipped — see :327). The autofix loop now actually "keeps going
+        # iteration on the new tip (the gate job checks
+        # `${AUTOFIX_SKIP_SELF_TRIGGERED:-false}`, so the default is `false`
+        # and the [ai-autofix] synchronize is NOT skipped). The autofix loop now actually "keeps going
         # until there are no edits" instead of converging on a stale head.
         if: "success() && (steps.retrigger_guard.outputs.max_iterations_reached != 'true' || steps.retrigger_guard.outputs.skip_judge == 'true') && (steps.commit_changes.outputs.did_commit != 'true' || env.LEDGER_ONLY_COMMIT_STRICT == 'true') && env.MERGE_CONFLICT != 'true' && env.PR_CLOSED != 'true' && env.EDITOR_CHANGES_LOST != 'true' && env.EDITOR_NOOP_SUSPICIOUS != 'true' && env.AUTOFIX_STALE_BASE_SKIP != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true'"
         env:


### PR DESCRIPTION
## Summary

- PR #2542 auto-merged at the pre-edit head SHA `f11d6dc` while the latest review_autofix run's editor commit `005824e` (real edits to `.github/workflows/review_autofix.yml` + `README.md`) was still local and unpushed; the new commit reached the remote ~3s after GitHub squash-merged the PR, so the autofix edits never made it into `main`.
- Root cause: the clean-review-tail `if:` gate on the auto-merge step (and two siblings) reads the loose `LEDGER_ONLY_COMMIT` env var, which `scripts/review_commit_changes.sh` also sets via the audit-convergence branch (`:574-585`) when the editor's per-file audit counters report `applied=0, already_applied>=1` — even on commits that DID land real source edits. The script docstring (`:32-41`) and the EDITOR_CHANGES_LOST detector at workflow `:3315-3326` already document why callers in this position must read the STRICT flag.
- Fix: switch the three sibling clean-review-tail gates (`Mark linked issues ready to merge` :4150, `Enable auto-merge on PR` :4393, `Telegram success` :4789) from `env.LEDGER_ONLY_COMMIT` to `env.LEDGER_ONLY_COMMIT_STRICT`. The deferred-push ordering at `:4438-4440` is preserved, so the original concurrency self-cancel race the deferred-push design was added to avoid stays avoided. When audit convergence fires on a commit with real edits, auto-merge is now blocked; the synchronize event from the deferred push then triggers a fresh review_autofix iteration on the new tip (gate-job `AUTOFIX_SKIP_SELF_TRIGGERED` default is `false` — `:327` — so the `[ai-autofix]` synchronize is NOT gate-skipped). The autofix loop now actually keeps going until there are no edits.

## Proactive fixes included

Per CLAUDE.md §12.B (latent bugs in adjacent code in the same flow), the two sibling steps that share the identical `if:` condition with the auto-merge gate were fixed alongside it:

- `:4150` Mark linked issues ready to merge — without the fix, the linked issue is labelled `ai:ready-to-merge` for a run whose committed edits have not been re-reviewed.
- `:4789` Telegram success — without the fix, a "success" notification fires for a run whose edits got merged-over.

## Out of scope (deliberately not touched)

- `:3545` "Validate editor no-op disposition" — its `:3541-3544` comment explicitly justifies the loose flag (fallback-marker validation must run on audit-converged runs).
- `:4656` continuation-dispatch skip (`is_ledger_only_commit`) — documented in `README.md` under `AUTOFIX_CONTINUATION_ENABLED`; changing its semantics needs a coordinated README update. The synchronize path already keeps the loop going, so this isn't blocking the user's expectation.
- The underlying audit-counter under-reporting in the editor (why it said `applied=0` for productive edits) is a deeper bug in `scripts/review_apply_fixes.sh` / model prompt, separate from this race.

## Evidence

- PR #2542 mergedAt `2026-05-12T12:36:08Z` on head `f11d6dc`; merge commit `6dddbfe`.
- Codex PR Self-Healing Semantic Agent run [25732488531](https://github.com/shubhodeep1/coding-workflows/actions/runs/25732488531):
  - `Apply fixes with editor model` 12:08:37 -> 12:36:01.
  - `Commit changes` 12:36:03 -> `[auto/forward-merge-stable-25725182354-1 005824e] [ai-autofix] apply PR fixes` (2 files changed, 41 insertions, 26 deletions).
  - `Audit convergence detected: 6 reviewer file(s), applied=0, already_applied=2.` -> `DID_COMMIT=true, LEDGER_ONLY_COMMIT=true, LEDGER_ONLY_COMMIT_STRICT=false`.
  - `Enabling auto-merge (squash) on PR #2542...` 12:36:05.85; `Auto-merge enabled.` 12:36:09.42.
  - `Push all pending commits` finished 12:36:11.07: `f11d6dc..005824e  HEAD -> auto/forward-merge-stable-25725182354-1` — 3s after the merge already fired.
- `git log origin/main | grep 005824e` -> empty; commit is on the (closed) PR branch but never made it into `main`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/review_autofix.yml'))"` — parses cleanly.
- [x] `PYTHONDONTWRITEBYTECODE=1 python3 tests/test_detect_editor_changes_lost.py` — 18 passed, 0 failed (covers the sibling EDITOR_CHANGES_LOST gate that already uses STRICT).
- [ ] Reviewer trace: on a synthetic audit-converged-with-real-edits scenario, confirm the three sibling gates evaluate to `false` (`did_commit=true && STRICT=false`) and that the synchronize event from the deferred push reliably kicks the next iteration.
- [ ] Reviewer trace: confirm the legitimate ledger-only case (`STRICT=true`) still passes the gates so genuine convergence still auto-merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AEkTQ3C2RTMcHdendoRhLo)_