### PR TITLE
docs(CLAUDE.md): add §16 Task Delegation and §17 Preferred Tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -450,6 +450,29 @@ you audited and why they were insufficient.
 
 ---
 
+## §16. Task Delegation
+
+When spawning subagents, use the cheapest model that can handle the task:
+- Haiku: bulk mechanical tasks - no judgment needed
+- Sonnet: scoped research, code exploration, synthesis
+- Opus: only for real planning or tradeoff decisions
+
+Spawn rules:
+- Haiku cannot spawn subagents. If it needs to, return to parent.
+- Max spawn depth: 2
+- Subagents escalate to parent, never self-escalate model tier
+
+---
+
+## §17. Preferred Tools
+
+- Public pages → WebFetch (free, text-only)
+- Dynamic pages / auth walls → agent-browser CLI
+- PDFs → pdftotext (not Read tool)
+- Repeated fetch patterns → wrap as reusable tool
+
+---
+
 ## FINAL REMINDER
 
 If uncertainty exists: **ASK (multiple-choice). DO NOT EXECUTE.**


### PR DESCRIPTION
## Summary

Append two new sections to the interactive `CLAUDE.md`:

- **§16. Task Delegation** — codifies the subagent model-tier policy (Haiku for bulk mechanical work, Sonnet for scoped research, Opus only for real planning/tradeoffs) and the spawn rules (Haiku cannot spawn; max depth 2; subagents escalate to parent rather than self-escalating tier).
- **§17. Preferred Tools** — codifies tool preferences: WebFetch for public pages, agent-browser CLI for dynamic/auth-walled pages, `pdftotext` for PDFs, and wrapping repeated fetch patterns into reusable tools.

Sections are numbered §16/§17 to match the existing convention and to preserve the §6 naming-immutability guarantee (no existing section renumbered). Inserted before the `FINAL REMINDER` block.

## Test plan

- [ ] Verify the new sections render correctly on GitHub.
- [ ] Verify no other section numbers changed (`git diff` shows only additions in `CLAUDE.md`).
- [ ] Confirm `FINAL REMINDER` remains the last section.

https://claude.ai/code/session_015aZic1Dioh2aWmu8nAChHq

---
_Generated by [Claude Code](https://claude.ai/code/session_015aZic1Dioh2aWmu8nAChHq)_