### PR TITLE
feat(update_workflows): sync top-level CLAUDE.md to consumer repos

### DIFF
--- a/.github/workflows/update_workflows.yml
+++ b/.github/workflows/update_workflows.yml
@@ -70,10 +70,11 @@ jobs:
             "https://x-access-token:${GH_TOKEN}@github.com/${TEMPLATES_REPO}.git" \
             "${TMPDIR}/upstream"
           cd "${TMPDIR}/upstream"
-          # CLAUDE.md is included so the workflow-templates/CLAUDE.md
-          # symlink (→ ../CLAUDE.md) resolves under sparse-checkout when
-          # the claude_md_sync step copies it via cp -L.
-          git sparse-checkout set "${TEMPLATES_DIR}" "${SCRIPTS_DIR}" "CLAUDE.md"
+          # In cone mode, repo-root files remain present alongside these
+          # directory patterns, which keeps workflow-templates/CLAUDE.md
+          # (a symlink to ../CLAUDE.md) readable without passing a bare
+          # root-file argument here; modern git rejects that form.
+          git sparse-checkout set "${TEMPLATES_DIR}" "${SCRIPTS_DIR}"
           cd -
 
           echo "upstream_dir=${TMPDIR}/upstream/${TEMPLATES_DIR}" >> "$GITHUB_OUTPUT"
@@ -223,7 +224,7 @@ jobs:
           # sparse-checkout this will fail loudly rather than silently
           # writing a broken file.
           if ! cat -- "${UPSTREAM_CLAUDE_MD}" >/dev/null 2>&1; then
-            echo "::error::workflow-templates/CLAUDE.md is unreadable (dangling symlink or missing target)."
+            echo "::error::Root CLAUDE.md is unreadable via workflow-templates/CLAUDE.md (dangling symlink or missing sparse-checkout target)."
             exit 1
           fi
 

--- a/.github/workflows/update_workflows.yml
+++ b/.github/workflows/update_workflows.yml
@@ -213,7 +213,7 @@ jobs:
           LOCAL_CLAUDE_MD="CLAUDE.md"
 
           echo "claude_md_changed=false" >> "$GITHUB_OUTPUT"
-          : > /tmp/claude_md_changed_file.txt
+          rm -f /tmp/claude_md_changed_file.txt
 
           if [ ! -e "${UPSTREAM_CLAUDE_MD}" ] && [ ! -L "${UPSTREAM_CLAUDE_MD}" ]; then
             echo "Upstream has no workflow-templates/CLAUDE.md at this ref — nothing to sync."

--- a/.github/workflows/update_workflows.yml
+++ b/.github/workflows/update_workflows.yml
@@ -76,7 +76,6 @@ jobs:
           git sparse-checkout set "${TEMPLATES_DIR}" "${SCRIPTS_DIR}" "CLAUDE.md"
           cd -
 
-          echo "upstream_root=${TMPDIR}/upstream" >> "$GITHUB_OUTPUT"
           echo "upstream_dir=${TMPDIR}/upstream/${TEMPLATES_DIR}" >> "$GITHUB_OUTPUT"
 
       - name: Apply canonical audit-gate assets
@@ -215,7 +214,7 @@ jobs:
           echo "claude_md_changed=false" >> "$GITHUB_OUTPUT"
           : > /tmp/claude_md_changed_file.txt
 
-          if [ ! -e "${UPSTREAM_CLAUDE_MD}" ]; then
+          if [ ! -e "${UPSTREAM_CLAUDE_MD}" ] && [ ! -L "${UPSTREAM_CLAUDE_MD}" ]; then
             echo "Upstream has no workflow-templates/CLAUDE.md at this ref — nothing to sync."
             exit 0
           fi

--- a/.github/workflows/update_workflows.yml
+++ b/.github/workflows/update_workflows.yml
@@ -70,9 +70,13 @@ jobs:
             "https://x-access-token:${GH_TOKEN}@github.com/${TEMPLATES_REPO}.git" \
             "${TMPDIR}/upstream"
           cd "${TMPDIR}/upstream"
-          git sparse-checkout set "${TEMPLATES_DIR}" "${SCRIPTS_DIR}"
+          # CLAUDE.md is included so the workflow-templates/CLAUDE.md
+          # symlink (→ ../CLAUDE.md) resolves under sparse-checkout when
+          # the claude_md_sync step copies it via cp -L.
+          git sparse-checkout set "${TEMPLATES_DIR}" "${SCRIPTS_DIR}" "CLAUDE.md"
           cd -
 
+          echo "upstream_root=${TMPDIR}/upstream" >> "$GITHUB_OUTPUT"
           echo "upstream_dir=${TMPDIR}/upstream/${TEMPLATES_DIR}" >> "$GITHUB_OUTPUT"
 
       - name: Apply canonical audit-gate assets
@@ -188,6 +192,49 @@ jobs:
             echo ".claude/ assets synced: ${CHANGED_COUNT} file(s) changed."
           else
             echo ".claude/ assets already up to date."
+          fi
+
+      - name: Sync top-level CLAUDE.md from upstream
+        id: claude_md_sync
+        run: |
+          set -euo pipefail
+
+          # Mirror upstream's root CLAUDE.md → consumer's root CLAUDE.md.
+          # Semantics match the .claude/ sync above and the wrapper
+          # update: upstream is source of truth, hand-edits are
+          # overwritten on every sync. The upstream copy reached here
+          # via the workflow-templates/CLAUDE.md symlink (→ ../CLAUDE.md);
+          # cp -L dereferences it so the consumer gets a regular file
+          # at its repo root, not a symlink. If upstream has no
+          # CLAUDE.md at this stable ref the sync is a no-op.
+
+          UPSTREAM_DIR="${{ steps.fetch.outputs.upstream_dir }}"
+          UPSTREAM_CLAUDE_MD="${UPSTREAM_DIR}/CLAUDE.md"
+          LOCAL_CLAUDE_MD="CLAUDE.md"
+
+          echo "claude_md_changed=false" >> "$GITHUB_OUTPUT"
+          : > /tmp/claude_md_changed_file.txt
+
+          if [ ! -e "${UPSTREAM_CLAUDE_MD}" ]; then
+            echo "Upstream has no workflow-templates/CLAUDE.md at this ref — nothing to sync."
+            exit 0
+          fi
+
+          # Dereferenced read — if the symlink target wasn't pulled by
+          # sparse-checkout this will fail loudly rather than silently
+          # writing a broken file.
+          if ! cat -- "${UPSTREAM_CLAUDE_MD}" >/dev/null 2>&1; then
+            echo "::error::workflow-templates/CLAUDE.md is unreadable (dangling symlink or missing target)."
+            exit 1
+          fi
+
+          if [ ! -f "${LOCAL_CLAUDE_MD}" ] || ! diff -q --strip-trailing-cr --ignore-space-at-eol "${UPSTREAM_CLAUDE_MD}" "${LOCAL_CLAUDE_MD}" >/dev/null 2>&1; then
+            cp -L "${UPSTREAM_CLAUDE_MD}" "${LOCAL_CLAUDE_MD}"
+            echo "claude_md_changed=true" >> "$GITHUB_OUTPUT"
+            printf '%s\n' "${LOCAL_CLAUDE_MD}" > /tmp/claude_md_changed_file.txt
+            echo "Top-level CLAUDE.md synced from upstream."
+          else
+            echo "Top-level CLAUDE.md already up to date."
           fi
 
       - name: Compare and update workflow wrappers
@@ -315,7 +362,7 @@ jobs:
           fi
 
       - name: Commit and push updates
-        if: steps.update.outputs.has_updates == 'true' || steps.audit_gate.outputs.status == 'applied' || steps.claude_sync.outputs.claude_has_changes == 'true'
+        if: steps.update.outputs.has_updates == 'true' || steps.audit_gate.outputs.status == 'applied' || steps.claude_sync.outputs.claude_has_changes == 'true' || steps.claude_md_sync.outputs.claude_md_changed == 'true'
         run: |
           set -euo pipefail
 
@@ -334,6 +381,12 @@ jobs:
               [ -n "$changed_path" ] || continue
               git add -- "$changed_path"
             done < /tmp/claude_changed_files.txt
+          fi
+          if [ -f /tmp/claude_md_changed_file.txt ] && [ -s /tmp/claude_md_changed_file.txt ]; then
+            while IFS= read -r changed_path; do
+              [ -n "$changed_path" ] || continue
+              git add -- "$changed_path"
+            done < /tmp/claude_md_changed_file.txt
           fi
 
           COMMIT_BODY=""
@@ -365,6 +418,16 @@ jobs:
           if [ -n "$CLAUDE_CHANGED_LIST" ]; then
             COMMIT_BODY="${COMMIT_BODY}.claude/ assets:\n${CLAUDE_CHANGED_LIST}\n"
           fi
+          CLAUDE_MD_CHANGED_LIST=""
+          if [ -f /tmp/claude_md_changed_file.txt ] && [ -s /tmp/claude_md_changed_file.txt ]; then
+            while IFS= read -r changed_path; do
+              [ -n "$changed_path" ] || continue
+              CLAUDE_MD_CHANGED_LIST="${CLAUDE_MD_CHANGED_LIST}• ${changed_path}\n"
+            done < /tmp/claude_md_changed_file.txt
+          fi
+          if [ -n "$CLAUDE_MD_CHANGED_LIST" ]; then
+            COMMIT_BODY="${COMMIT_BODY}Top-level CLAUDE.md:\n${CLAUDE_MD_CHANGED_LIST}\n"
+          fi
 
           if git diff --cached --quiet; then
             echo "No staged changes detected after update step; skipping commit."
@@ -376,7 +439,7 @@ jobs:
           git push
 
       - name: Send Telegram notification
-        if: steps.update.outputs.has_updates == 'true' || steps.audit_gate.outputs.status == 'applied' || steps.claude_sync.outputs.claude_has_changes == 'true'
+        if: steps.update.outputs.has_updates == 'true' || steps.audit_gate.outputs.status == 'applied' || steps.claude_sync.outputs.claude_has_changes == 'true' || steps.claude_md_sync.outputs.claude_md_changed == 'true'
         env:
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}
@@ -425,6 +488,11 @@ jobs:
           if [ -f /tmp/claude_changed_files.txt ] && [ -s /tmp/claude_changed_files.txt ]; then
             CLAUDE_CHANGED_LIST=$(cat /tmp/claude_changed_files.txt)
           fi
+          CLAUDE_MD_CHANGED="${{ steps.claude_md_sync.outputs.claude_md_changed }}"
+          CLAUDE_MD_CHANGED_LIST=""
+          if [ -f /tmp/claude_md_changed_file.txt ] && [ -s /tmp/claude_md_changed_file.txt ]; then
+            CLAUDE_MD_CHANGED_LIST=$(cat /tmp/claude_md_changed_file.txt)
+          fi
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           MSG="Workflow wrappers updated in ${REPO}
@@ -448,6 +516,11 @@ jobs:
             MSG="${MSG}
           ${CLAUDE_CHANGED_COUNT} .claude/ asset(s) synced:
           ${CLAUDE_CHANGED_LIST}"
+          fi
+          if [ "${CLAUDE_MD_CHANGED}" = "true" ] && [ -n "$CLAUDE_MD_CHANGED_LIST" ]; then
+            MSG="${MSG}
+          Top-level CLAUDE.md synced:
+          ${CLAUDE_MD_CHANGED_LIST}"
           fi
           MSG="${MSG}
           Source: coding-workflows@stable
@@ -537,6 +610,8 @@ jobs:
           fi
           CLAUDE_CHANGED_COUNT="${{ steps.claude_sync.outputs.claude_changed }}"
           echo "- **.claude/ assets synced:** ${CLAUDE_CHANGED_COUNT:-0}" >> "$GITHUB_STEP_SUMMARY"
+          CLAUDE_MD_CHANGED="${{ steps.claude_md_sync.outputs.claude_md_changed }}"
+          echo "- **Top-level CLAUDE.md synced:** ${CLAUDE_MD_CHANGED:-false}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
           if [ "${HAS_UPDATES}" = "true" ]; then
@@ -576,5 +651,12 @@ jobs:
             echo "**.claude/ files:**" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
             cat /tmp/claude_changed_files.txt >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ -s /tmp/claude_md_changed_file.txt ]; then
+            echo "**Top-level CLAUDE.md:**" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            cat /tmp/claude_md_changed_file.txt >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/workflow-templates/CLAUDE.md
+++ b/workflow-templates/CLAUDE.md
@@ -1,0 +1,1 @@
+../CLAUDE.md


### PR DESCRIPTION
## Summary

- Adds `workflow-templates/CLAUDE.md` as a symlink → `../CLAUDE.md` so the canonical interactive-session instructions stay at the repo root while riding the same `@stable` propagation pipe as workflow wrappers, audit-gate assets, and `.claude/` assets.
- Extends `update_workflows.yml`'s sparse-checkout to include the root `CLAUDE.md` (so the symlink target resolves), adds a new `claude_md_sync` step that mirrors the file via `cp -L` to the consumer's repo root, and wires the result into the commit gate, commit body, Telegram notification, and step summary.
- No changes to `mark-stable.yml` or `consumer_repos.json` — the existing `repository_dispatch` fan-out and consumer registry already cover this path.

## Semantics

Matches every other synced asset in this pipeline: upstream is source of truth and the consumer's `CLAUDE.md` is overwritten on each sync. Consumers opt out by setting the `ALLOW_WORKFLOW_EDITS` repo variable to `false` (existing kill-switch — covers every sync step in `update_workflows.yml`, including this one).

The symlink is committed at git mode `120000`; `cp -L` dereferences it so the consumer receives a regular file at its repo root, not a symlink.

## Test plan

- [ ] Tag a `@stable` release (or `workflow_dispatch` `update_workflows.yml` against a test consumer) and confirm the new step:
  - copies `CLAUDE.md` into the consumer's repo root,
  - lists the change in the commit body, Telegram alert, and step summary,
  - is a no-op on a second run (no spurious churn from CRLF / trailing whitespace).
- [ ] Verify the consumer's `CLAUDE.md` is a regular file (`file CLAUDE.md`), not a symlink.
- [ ] Verify a consumer with `ALLOW_WORKFLOW_EDITS=false` skips the sync.
- [ ] Verify the dangling-symlink guard in `claude_md_sync` fails loudly if sparse-checkout ever drops the root `CLAUDE.md`.

https://claude.ai/code/session_01NMjm7nwoVzDFqaJ7rz3L4X

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMjm7nwoVzDFqaJ7rz3L4X)_