### PR TITLE
fix(review_autofix_sweep): stop using `gh api --slurp` with `--jq`

### DIFF
--- a/.github/workflows/review_autofix_sweep.yml
+++ b/.github/workflows/review_autofix_sweep.yml
@@ -75,12 +75,14 @@ jobs:
           set -euo pipefail
 
           # Fetch all open PRs, then filter to non-draft client-side.
-          # `gh api --paginate --slurp` returns an array of page arrays for
-          # /pulls, so `add // []` merges every page into one snapshot while
-          # preserving the single logical lookup path for this sweep.
-          prs_json="$(gh api --paginate --slurp -X GET "repos/${REPOSITORY}/pulls" \
+          # `gh` rejects `--slurp` combined with `--jq`, so pipe the
+          # per-page arrays from `gh api --paginate` through a separate
+          # `jq -s 'add // []'` to merge them into one snapshot before
+          # filtering. Mirrors the established repo pattern (e.g.
+          # implement.yml:786, gh_helpers.sh:916).
+          prs_json="$(gh api --paginate -X GET "repos/${REPOSITORY}/pulls" \
             -f state=open -f per_page=100 \
-            --jq '(add // []) | map(select(.draft == false) | {
+            | jq -s '(add // []) | map(select(.draft == false) | {
               number,
               head_ref: .head.ref,
               title: (.title // ""),


### PR DESCRIPTION
## Summary

The `Internal: AI Review Autofix Sweep` job has been failing every cron tick with exit code 1 before enumerating any PRs, so the sweep dispatched nothing.

Root cause: the only `gh api` call in the job combined `--slurp` with `--jq`, which `gh` explicitly rejects:

```
the `--slurp` option is not supported with `--jq` or `--template`
```

Fix: drop `--slurp`/`--jq` from the `gh api` call and pipe through a separate `jq -s '(add // []) | …'` to merge the per-page arrays into one snapshot before filtering. Same end result the original `--slurp --jq` combination intended, and mirrors the established repo pattern at `implement.yml:786`, `gh_helpers.sh:916`, and several places in `scripts/orchestrate_poll_process.sh`.

## Evidence

- Log: `the '--slurp' option is not supported with '--jq' or '--template'` followed by `##[error]Process completed with exit code 1.`
- Failing call: `.github/workflows/review_autofix_sweep.yml:81` (pre-fix)
- `gh api --paginate` for JSON-array endpoints (like `/pulls`) emits each page's array as a separate top-level JSON value, so `jq -s 'add // []'` is the correct merge step.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` parses the workflow OK
- [x] `jq -s '(add // []) | map(select(.draft == false) | { … })'` returns the expected merged+filtered list on simulated 2-page input
- [x] Same filter returns `[]` on empty stdin (no PRs)
- [ ] Next scheduled `*/30 * * * *` tick should emit `AUTOFIX_SWEEP_START` / `AUTOFIX_SWEEP_END` instead of exit-1ing

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6df1b37MUCYzkmKBeqKam)_