### PR TITLE
fix(forward-merge,promote): warn against squash-merge that strips stable→main ancestry

### DIFF
--- a/.github/workflows/forward-merge-stable-to-main.yml
+++ b/.github/workflows/forward-merge-stable-to-main.yml
@@ -244,6 +244,21 @@ jobs:
           # and abort before the PR is opened.
           BRANCH="auto/forward-merge-stable-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
+          # The merge-strategy warning is identical on both paths and
+          # MUST appear at the top of the PR body. Squash-merging or
+          # rebase-merging this PR drops `stable`'s commits from `main`'s
+          # ancestry — the content lands but `git merge-base
+          # --is-ancestor stable origin/main` returns false, which is
+          # exactly what promote-main-to-stable.yml's pre-flight check
+          # refuses on. The fix is to merge with "Create a merge
+          # commit" so the 2-parent merge commit preserves ancestry.
+          MERGE_STRATEGY_WARNING="> [!CAUTION]
+          > **DO NOT use \"Squash and merge\" or \"Rebase and merge\" on this PR.**
+          > Use **\"Create a merge commit\"** so \`stable\`'s commits remain in \`main\`'s ancestry.
+          > Squashing strips ancestry — \`promote-main-to-stable.yml\`'s pre-flight
+          > \`git merge-base --is-ancestor HEAD origin/main\` check will then refuse
+          > the next promote run, even though the file content has been forwarded."
+
           if [ "${MERGE_STATUS}" = "conflict" ]; then
             # Conflict path: HEAD is back at origin/main after `merge
             # --abort`, so push a branch rooted at origin/stable. With
@@ -252,7 +267,9 @@ jobs:
             # commits from stable.
             git push origin "refs/remotes/origin/stable:refs/heads/${BRANCH}"
             CONFLICT_LIST="${CONFLICT_FILES:-(none captured)}"
-            BODY="Automated forward-merge of \`stable\` into \`main\` failed due to merge conflicts. Resolve the conflicts and merge this PR so the bug fix on \`stable\` is also present on \`main\`.
+            BODY="${MERGE_STRATEGY_WARNING}
+
+          Automated forward-merge of \`stable\` into \`main\` failed due to merge conflicts. Resolve the conflicts and merge this PR so the bug fix on \`stable\` is also present on \`main\`.
 
           Conflicting files (from the aborted merge attempt): \`${CONFLICT_LIST}\`
 
@@ -264,7 +281,9 @@ jobs:
             # so the PR contains the merge that branch protection
             # rejected on `main`.
             git push origin "HEAD:refs/heads/${BRANCH}"
-            BODY="Automated forward-merge of \`stable\` into \`main\` could not push directly (branch protection). Merge this PR so the bug fix on \`stable\` is also present on \`main\`.
+            BODY="${MERGE_STRATEGY_WARNING}
+
+          Automated forward-merge of \`stable\` into \`main\` could not push directly (branch protection). Merge this PR so the bug fix on \`stable\` is also present on \`main\`.
 
           Source SHA: \`${GITHUB_SHA}\`
           Triggered by: forward-merge-stable-to-main.yml"

--- a/.github/workflows/promote-main-to-stable.yml
+++ b/.github/workflows/promote-main-to-stable.yml
@@ -103,14 +103,25 @@ jobs:
           set -euo pipefail
           # `stable` must be an ancestor of `origin/main` (or equal). If
           # it isn't, stable has commits not present on main — most
-          # likely a forward-merge PR that wasn't merged, or a direct
-          # push to stable that bypassed the forward-merge workflow.
-          # Refuse rather than silently force-pushing or merging — the
-          # operator should investigate first.
+          # likely a forward-merge PR that wasn't merged, a direct push
+          # to stable that bypassed the forward-merge workflow, or — by
+          # far the most common cause in this repo's history — a
+          # forward-merge PR that WAS merged but via "Squash and merge"
+          # / "Rebase and merge" instead of "Create a merge commit",
+          # which copies the file content into a new single-parent
+          # commit on main and silently strips stable's commits from
+          # main's ancestry. Refuse rather than silently force-pushing
+          # or merging — the operator should investigate first.
           if ! git merge-base --is-ancestor HEAD origin/main; then
             ahead=$(git rev-list --count origin/main..HEAD)
+            mb=$(git merge-base HEAD origin/main 2>/dev/null || echo "")
             echo "::error::stable has ${ahead} commit(s) not present on main — refusing to promote."
-            echo "::error::Forward-merge those commits via forward-merge-stable-to-main.yml first, then re-run."
+            if [ -z "${mb}" ]; then
+              echo "::error::stable and main have NO common ancestor (unrelated histories) — every recent forward-merge PR was likely squash-merged. Recovery: cherry-pick any genuinely unforwarded stable patches onto main, then force-reset stable to origin/main (\`git push --force-with-lease origin <main-sha>:refs/heads/stable\`)."
+            else
+              echo "::error::Most likely cause: a forward-merge PR was merged via \"Squash and merge\" or \"Rebase and merge\" instead of \"Create a merge commit\". Squash/rebase strips stable's commits from main's ancestry even though the file content was forwarded. Inspect with: \`git log --oneline origin/main..HEAD\` and verify the corresponding squash commits on main."
+            fi
+            echo "::error::Forward-merge those commits via forward-merge-stable-to-main.yml first (and use \"Create a merge commit\" when merging the fallback PR), then re-run."
             exit 1
           fi
 


### PR DESCRIPTION
## Why

A `promote-main-to-stable` run failed with:

```
##[error]stable has 17 commit(s) not present on main — refusing to promote.
##[error]Forward-merge those commits via forward-merge-stable-to-main.yml first, then re-run.
```

The user had **already** merged the conflict-resolution forward-merge PRs (#2561 + #2562), expected promote to pass, and was confused why it didn't.

## Root cause

Every recent "forward-merge stable into main" PR was merged via **"Squash and merge"** (and PR #2561's merge commit `82ec752` has parent count = 1, confirming this). Squash-merging copies file content into a brand-new single-parent commit on main with a different SHA — so the original commits on `stable` never enter `main`'s ancestry. The validation step at `.github/workflows/promote-main-to-stable.yml:110` runs `git merge-base --is-ancestor HEAD origin/main` and refuses on the mismatch, even though the *content* has been forwarded.

This pattern repeats across #2561, #2562, #2542, #2532, #2521, #2506, #2481, #2439, #2444 — all 1-parent (squash) merges. Over time, `main` and `stable` have drifted into completely **unrelated histories** (no merge-base at all). The branch state at the time of investigation:

- 65 commits on `stable` not ancestors of `main`
- 743 lines on `stable` not in `main` (verified to be older/superseded code — `main` has refactored beyond it; no porting was needed)
- 51 commits on `main` not in `stable` (legitimate post-promote development)

The forward-merge workflow's *direct-push* path uses `git merge --no-ff` which preserves ancestry. But when conflicts force the fallback PR path, neither the PR body nor the promote error told the operator that "Create a merge commit" is required.

## What this PR changes

**1. `forward-merge-stable-to-main.yml`** — Prepend a prominent `> [!CAUTION]` banner to the fallback PR body on both the conflict and push_rejected paths, telling reviewers to use **"Create a merge commit"** (not Squash, not Rebase). The warning string is built once via `$MERGE_STRATEGY_WARNING` so both paths stay in sync.

**2. `promote-main-to-stable.yml`** — Extend the validation step's error block so the diagnostic is actionable:
- Check if `main` and `stable` share *any* merge-base; if not, surface the "unrelated histories" tell-tale of repeated squash-merging.
- Surface the most-likely squash/rebase root cause with the inspection command (`git log --oneline origin/main..HEAD`) and the "use Create a merge commit" recovery guidance.

The validation predicate itself is unchanged — promote still refuses iff stable HEAD is not an ancestor of origin/main. The point is purely to make the diagnostic actionable for the next operator who hits this.

## Out-of-band recovery (not in this PR)

The currently-stranded state of `stable` (65 commits, unrelated histories) cannot be fixed by a workflow change. A separate force-reset of `refs/heads/stable` to `origin/main`'s HEAD is required to unstick promote. That force-push is being performed out-of-band — `@stable` git tag (which consumers pin to) is unaffected since only the branch ref is touched.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(f))'` on both modified YAML files — passes
- [ ] Next forward-merge workflow run hits the fallback PR path — verify the PR body renders the CAUTION banner at the top
- [ ] Next promote workflow run on stable-not-ancestor-of-main state — verify the new diagnostic surfaces the squash-merge guidance and (if applicable) the unrelated-histories message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWLQfHFAkm7fZ1BfUeoNX9)_