### PR TITLE
fix(review_apply_fixes): escape markdown backticks in editor heredoc

### DIFF
--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -819,7 +819,7 @@ message; an empty diff is treated as no-actionable-output and the loop
 bails after 3 attempts without a commit. Try apply_patch first; if it
 does not land cleanly on a hunk, switch tools (alternate apply_patch
 shape, printf/heredoc for plain-text targets, or any other write tool)
-and verify with `git diff --stat`. Avoid `sed -i` / `perl -i` / `awk`
+and verify with \`git diff --stat\`. Avoid \`sed -i\` / \`perl -i\` / \`awk\`
 regex substitutions on multi-line source — they exit 0 even when the
 regex misses, leaving the file unchanged.
 </completeness_contract>
@@ -851,7 +851,7 @@ Under PR comment audit: include one bullet per bot PR review/review_comment entr
 - path and line (if available)
 - disposition: applied / already satisfied / ignored
 - short reason for the disposition
-Under Ignored suggestions (with short reason): when you intentionally override parsed consolidator guidance, include a bullet with the exact grep-friendly prefix `CONSOLIDATOR_OVERRIDDEN:` and the format `- CONSOLIDATOR_OVERRIDDEN: <issue_id> — <reason>` (use `no-issue-id` when the advisory issue lacks a parsed issue_id).
+Under Ignored suggestions (with short reason): when you intentionally override parsed consolidator guidance, include a bullet with the exact grep-friendly prefix \`CONSOLIDATOR_OVERRIDDEN:\` and the format \`- CONSOLIDATOR_OVERRIDDEN: <issue_id> — <reason>\` (use \`no-issue-id\` when the advisory issue lacks a parsed issue_id).
 Under Change status: emit exactly one bullet whose value is one of:
 - edited
 - not-edited


### PR DESCRIPTION
## Summary

Release v1.11.0 ([run 25956662404](https://github.com/shubhodeep1/coding-workflows/actions/runs/25956662404)) failed at the `validate-scripts` job, step `ShellCheck static analysis`, with:

```
In scripts/review_apply_fixes.sh line 854:
...                              ^-- SC1073 (error): Couldn't parse this redirection. Fix to allow more checks.
...                               ^-- SC1072 (error):  Fix any mentioned problems and try again.
FAIL: scripts/review_apply_fixes.sh
##[error]Process completed with exit code 1.
```

## Root cause

The editor-prompt heredoc at `scripts/review_apply_fixes.sh:433` is intentionally unquoted (`cat <<__EDITOR_PROMPT__`, not `<<'__EDITOR_PROMPT__'`) so that the embedded `${VAR}` references and `$(_embed_input_file ...)` substitutions are expanded into the prompt body. The trade-off is that any backticks inside the heredoc body are parsed as command substitution.

PR #2626 (82fd939) added a new schema bullet on line 854 that wraps `CONSOLIDATOR_OVERRIDDEN:` and `- CONSOLIDATOR_OVERRIDDEN: <issue_id> — <reason>` in backticks as markdown-style code spans. Inside the unquoted heredoc those backticks open a command substitution whose body contains `<issue_id>` and `<reason>` — tokens ShellCheck cannot parse as valid redirections, producing SC1072/SC1073 and breaking the release gate.

The same shape also fails at runtime: the soft-error summary from the same release already shows `scripts/review_apply_fixes.sh: line 433: CONSOLIDATOR_OVERRIDDEN:: command not found` — bash had been evaluating the substitution every time the editor prompt was assembled.

## Fix

Escape the backticks with `\\\`` so they render as literal markdown markers in the prompt body without triggering command substitution. Variable expansion elsewhere in the heredoc is preserved.

## Proactive fixes included

- `scripts/review_apply_fixes.sh:822` — an older latent instance with the same shape (`` `git diff --stat` ``, `` `sed -i` ``, `` `perl -i` ``, `` `awk` ``). Those substitutions were silently executing every time the editor prompt was assembled, contaminating the prompt body with command output / stderr. ShellCheck happened to accept them only because each substituted command name parses cleanly on its own — but the runtime bug was already in production. Per CLAUDE.md §12.B (latent bugs in adjacent code exercised by the same flow), escaped under this PR.

## Test plan

- [x] `shellcheck --severity=error scripts/review_apply_fixes.sh` → exit 0
- [x] Full CI loop reproduction: `for f in scripts/*.sh; do shellcheck --severity=error "$f"; done` → all `OK`, exit 0
- [x] Heredoc smoke test confirms escaped backticks render literally and intentional `${VAR}` expansion still works
- [ ] Re-run the release workflow on this branch and confirm `validate-scripts` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCiTxM4Puz54v6576HiUWx)_