### PR TITLE
docs: plan for gsd-inspired improvements

### DIFF
--- a/docs/gsd-future-improvements.md
+++ b/docs/gsd-future-improvements.md
@@ -1,0 +1,731 @@
+# Future Improvements from GSD (Deferred / Contentious Items)
+
+## Purpose
+
+This is a **backlog / consideration doc**, not an action plan. It enumerates
+the items surfaced by the research into
+[`gsd-build/get-shit-done`](https://github.com/gsd-build/get-shit-done) that
+the companion implementation plan
+(`docs/plans/gsd-inspired-improvements-plan.md`) deliberately did NOT adopt.
+
+Each item lists what it would do, the source mechanism in gsd-build, pro /
+con, estimated cost, the open decisions that have to be made before a real
+implementation plan can be drafted, and any identified conflicts with this
+repo's existing conventions (CLAUDE.md §6 naming immutability, §10 MongoDB,
+§14 consumer repos, §15 GitHub API hygiene).
+
+The list is ordered roughly by structural cost (smallest first). Items
+**S1–S5** are "structural / scope refactor" candidates excluded from the
+adopted-now plan because they touch the interactive Claude Code surface or
+require a renderer / installer / packaging refactor. Items **C1–C5** are
+"contentious" candidates flagged because they conflict with — or materially
+reinterpret — an existing rule or convention.
+
+This doc is shipped alongside the implementation plan so reviewers can see
+what was considered and consciously deferred. When a future PR decides to
+adopt any of these items, the corresponding section here should be moved
+to a new `docs/plans/<slug>-plan.md` with the open decisions resolved.
+
+The naming and structure of this doc mirror `docs/ai-tools-future-improvements.md`
+verbatim so reviewers familiar with that file can navigate this one without
+re-learning the layout.
+
+---
+
+## S1. Interactive `.claude/commands/` surface mirroring gsd's user-loop
+
+### What it would do
+
+Add a slash-command surface to `.claude/commands/` that mirrors the
+six-step gsd-build loop adapted to our org-scale model:
+
+- `/discuss-issue` (mirrors `/gsd-discuss-phase`) — gather phase-specific
+  implementation decisions (layouts, API shapes, error handling) for an
+  open issue before triggering `/clarify` or `/plan`.
+- `/verify-pr` (mirrors `/gsd-verify-work`) — walk a human reviewer
+  through a merged PR with an auto-diagnosis sub-agent attached.
+- `/map-repo` (mirrors `/gsd-map-codebase`) — produce a structured
+  one-shot codebase analysis for a consumer repo before its first
+  pipeline run.
+
+Today we have three interactive commands (`/analyze-log`,
+`/investigate-issue`, `/write-plan`). gsd-build ships 67 plus six
+namespace meta-skills. The proposed three are the minimum-viable subset
+that fills genuine gaps in our pipeline.
+
+### Source
+
+- gsd-build `commands/gsd/discuss-phase.md`,
+  `commands/gsd/verify-work.md`, `commands/gsd/map-codebase.md`.
+- gsd-build README §"How It Works" — the loop diagram.
+- gsd-build `docs/INVENTORY.md` §"Commands (67 shipped)".
+
+### Pro
+
+- **Closes a real gap.** Our `/clarify` is binary
+  (Q&A-or-clear); `/discuss-issue` would let a human walk the issue
+  through "here's how I want this built" *before* clarify runs, so
+  clarify becomes a sanity check on a richer input. This is exactly
+  the niche `/gsd-discuss-phase` fills.
+- **Reusable across consumer repos.** Slash commands in
+  `.claude/commands/` propagate via the `update_workflows.yml` flow
+  (after extending it to copy `.claude/commands/` alongside
+  `.github/workflows/`).
+- **Low-blast-radius.** Slash commands are opt-in user surface; no
+  unattended pipeline behaviour changes.
+
+### Con
+
+- **User scoped this doc to NOT adopt the interactive surface.** The
+  clarification round explicitly excluded "Interactive Claude Code
+  surface" from the target areas. This item is in the companion doc
+  precisely because the user wants it surfaced but not shipped now.
+- **Parallel-surface risk.** A `/discuss-issue` command competes
+  with the existing `/clarify` phase. Operators may not know which
+  to run first. Needs explicit precedence rules.
+- **Propagation lift.** `.claude/commands/` is not in
+  `update_workflows.yml`'s copy set today; adding it touches the
+  consumer-repo propagation contract (§14).
+
+### Estimated cost
+
+- 3–4 hours to draft each of the three command files.
+- 2 hours to extend `update_workflows.yml` for `.claude/commands/`
+  propagation.
+- 1 hour to document precedence vs `/clarify` in `agents.md`.
+- Total: ~10–15 hours.
+
+### Open decisions before this becomes a real plan
+
+- **Precedence vs `/clarify`.** Does `/discuss-issue` always run
+  before `/clarify`? Is it gated by an issue label? Operator-triggered
+  only?
+- **Output artefact.** gsd-build writes per-phase `CONTEXT.md` and
+  `DISCUSSION-LOG.md`. We don't have an analogous filesystem state
+  store; do we (a) write into a new `.ai/discussion/` directory,
+  (b) post structured comments on the GitHub issue, or (c) persist
+  into the existing `ai-memory` branch as a new schema?
+- **Scope of `/verify-pr`.** Read-only check, or wired into the
+  review_autofix loop?
+- **Map-repo timing.** First time a consumer repo onboards, or on
+  every `update_workflows.yml` dispatch?
+
+### Known conflicts
+
+- **§14 consumer repos.** `.claude/commands/` propagation is new;
+  every repo in `.github/ai/consumer_repos.json` would receive the
+  new commands by default. Either gate the copy behind
+  `vars.WORKFLOW_PROFILE` (interacts with the adopted-now plan's
+  item 9) or document the new propagation surface explicitly.
+- **§6 naming.** Once a slash command is documented in a consumer
+  repo's README, renaming `/discuss-issue` becomes a breaking
+  change. Commit to vocabulary up front.
+
+---
+
+## S2. Two-stage hierarchical routing for slash commands (namespace meta-skills)
+
+### What it would do
+
+If S1 lands and our slash-command surface grows past ~10 commands,
+adopt gsd-build's namespace meta-skill pattern: six top-level
+"router" skills (`coding-workflow`, `coding-quality`,
+`coding-ops`, …) each containing a routing table that points at
+concrete sub-commands. The model sees ~120 tokens of router
+descriptors per turn instead of a flat 50-command listing.
+
+### Source
+
+- gsd-build `commands/gsd/ns-workflow.md`, `commands/gsd/ns-project.md`,
+  `commands/gsd/ns-quality.md`, `commands/gsd/ns-context.md`,
+  `commands/gsd/ns-manage.md`, `commands/gsd/ns-ideate.md`.
+- gsd-build [#2792](https://github.com/gsd-build/get-shit-done/issues/2792) —
+  rationale: eager skill listing scales as O(N tokens) per turn.
+- gsd-build `docs/ARCHITECTURE.md` §"Two-stage hierarchical routing".
+
+### Pro
+
+- **Bounds per-turn token cost** as the surface grows. gsd-build
+  reports 2150 tokens → 120 tokens (~94 % saving).
+- **Future-proof for surface growth.** If we adopt S1's three
+  commands plus expand over time, routing scales linearly.
+- **Tool Attention research backed.** gsd-build cites
+  "keyword-dense tags outperform prose for routing at ~40 % the
+  token cost."
+
+### Con
+
+- **Premature at current surface size.** We have three commands. The
+  break-even point is somewhere around 15–20 commands.
+- **Indirection cost.** New contributors must learn the namespace
+  layer before finding the concrete command.
+
+### Estimated cost
+
+- 2 hours per namespace router skill × 4–6 routers = 8–12 hours.
+- Migration of existing slash-command users to the namespace form is
+  silent (commands remain directly invocable).
+
+### Open decisions
+
+- **Trigger threshold.** At what surface size do we adopt? Propose
+  ≥15 commands.
+- **Namespace vocabulary.** Borrow gsd's six (`workflow`, `project`,
+  `quality`, `context`, `manage`, `ideate`) or invent our own?
+
+### Known conflicts
+
+- **§6 naming.** Namespace skill names become identifiers and
+  cannot be renamed without an alias migration once consumer repos
+  reference them.
+
+---
+
+## S3. Filesystem-native persistent per-issue workspace (`.planning/`-style)
+
+### What it would do
+
+Mirror gsd-build's `.planning/` state model: a per-issue (or
+per-tracking-issue) filesystem-native directory containing
+`PROJECT.md`, `REQUIREMENTS.md`, `ROADMAP.md`, `STATE.md`,
+`CONTEXT.md` that survives context resets and is human-inspectable.
+
+Today we have the `ai-memory` git branch with structured candidate
+records, which is conceptually similar but git-branch-shaped rather
+than working-tree-shaped. The trade-off is inspectability vs
+portability.
+
+### Source
+
+- gsd-build `docs/ARCHITECTURE.md` §"File-Based State" — design
+  principles.
+- gsd-build `docs/STATE-MD-LIFECYCLE.md` — state document
+  lifecycle.
+- gsd-build hooks `gsd-phase-boundary.sh` and
+  `gsd-validate-commit.sh` — runtime hooks that detect
+  `.planning/` writes and emit reminders.
+
+### Pro
+
+- **Inspectability.** A human checking out a consumer-repo branch
+  sees the current issue state in `.planning/STATE.md` directly,
+  without `gh api` or a memory branch checkout.
+- **Survives context resets.** Today our `ai-memory` records do
+  survive but require a separate branch checkout to inspect.
+- **Hook-friendly.** The runtime hooks in gsd-build
+  (`gsd-phase-boundary.sh`, `gsd-validate-commit.sh`) wire neatly
+  into a filesystem state store.
+
+### Con
+
+- **Working-tree pollution.** Every consumer repo would gain a
+  `.planning/` directory in its working tree. Some operators will
+  see this as noise.
+- **Race conditions.** Concurrent workflow runs writing into the
+  same `.planning/` directory on the same branch race; our existing
+  `ai-memory` branch model serialises via git push retries.
+- **Duplicates `ai-memory`.** We'd have two state systems
+  (filesystem `.planning/` + memory branch) unless one is retired.
+
+### Estimated cost
+
+- ~30 hours to design the schema (and reconcile with `ai-memory`).
+- ~20 hours to wire writes from each phase.
+- ~10 hours to migrate downstream consumers.
+- Total: ~60 hours.
+
+### Open decisions
+
+- **Coexist with `ai-memory` or replace it?** Replace requires
+  migrating every existing schema; coexist doubles maintenance.
+- **`.gitignore` posture.** Commit `.planning/` to the consumer
+  branch, or `.gitignore` it and rely on workflow-artefact upload?
+- **Multi-issue isolation.** Per-issue subdirectory
+  (`.planning/issue-<N>/`) vs single shared.
+
+### Known conflicts
+
+- **§10 MongoDB.** Our memory subsystem is documented as memory-branch
+  backed (`README.md` §"Memory System"). Adding a filesystem store
+  alongside is an architectural shift that requires a new contract
+  document, even though there's no MongoDB collection involved.
+- **§14 consumer repos.** Every consumer repo would gain
+  `.planning/` directories; operators must opt-in or have the
+  directory `.gitignore`d.
+
+---
+
+## S4. Active runtime hooks for interactive Claude Code sessions
+
+### What it would do
+
+Port the gsd-build hook surface into `.claude/hooks/` so interactive
+Claude Code sessions in this repo (and propagated to consumer repos)
+gain:
+
+- **Context-rot warning hook** (`gsd-context-monitor.js`) —
+  PostToolUse hook that injects WARNING at 35 % context remaining,
+  CRITICAL at 25 %. Debounce 5 tool uses between warnings.
+- **Statusline metrics writer** (`gsd-statusline.js`) — writes
+  `/tmp/claude-ctx-{session_id}.json` consumed by the context
+  monitor.
+- **Phase-boundary reminder** (`gsd-phase-boundary.sh`) —
+  PostToolUse hook that emits a `STATE.md` update reminder when a
+  planning file is modified.
+- **Prompt-injection PreToolUse guard** (`gsd-prompt-guard.js`) —
+  scans content being written into a designated state directory
+  (`.ai/` or `.planning/`) for 14 injection patterns. Advisory
+  warning, does not block.
+- **Read-injection scanner** (`gsd-read-injection-scanner.js`) —
+  scans content being read INTO context for injection patterns.
+
+This is the interactive-session counterpart to the adopted-now
+**Item 5** (memory-write injection guard for the unattended
+pipeline).
+
+### Source
+
+- gsd-build `hooks/gsd-context-monitor.js` (8.1 KB).
+- gsd-build `hooks/gsd-statusline.js` (22.6 KB — the largest hook).
+- gsd-build `hooks/gsd-phase-boundary.sh` (1.9 KB, opt-in via
+  `hooks.community: true`).
+- gsd-build `hooks/gsd-prompt-guard.js` (3.5 KB).
+- gsd-build `hooks/gsd-read-injection-scanner.js` (5.5 KB).
+
+### Pro
+
+- **Genuinely novel.** Context-rot warning to the *agent* (not just
+  the user via the statusline) is a clever pattern — gsd-build
+  literally comments "the statusline only shows the user; this
+  hook makes the AGENT aware." We have no analogue.
+- **Defence in depth on injection.** Item 5 covers memory writes;
+  these hooks would cover Claude Code-side reads and writes too.
+- **Opt-in per hook.** gsd-build's phase-boundary hook is opt-in via
+  `.planning/config.json` `hooks.community: true`. Adoptable as
+  `vars.CC_HOOKS_ENABLED`.
+
+### Con
+
+- **Out of scope per user's clarification.** Interactive Claude Code
+  surface was explicitly excluded from the adopted-now plan.
+- **`.claude/hooks/` propagation contract.** Today our `.claude/hooks/`
+  contains only `session-start.sh`. Adding multi-hook surface
+  changes the propagation footprint.
+- **Node.js dependency.** Several hooks are `node` scripts. Today
+  our `.claude/hooks/session-start.sh` is bash-only.
+
+### Estimated cost
+
+- ~4 hours per hook × 5 hooks = 20 hours.
+- ~2 hours to wire propagation through `update_workflows.yml`.
+- ~3 hours to document opt-in toggles.
+- Total: ~25 hours.
+
+### Open decisions
+
+- **Which hooks to port first?** Context-monitor is the highest-leverage
+  candidate (genuinely novel, immediately useful).
+- **Node.js or bash port?** gsd-build's hooks are mostly Node. A
+  bash port is feasible for the simpler hooks but loses gsd's
+  structured-JSON output contract.
+- **Statusline integration.** Claude Code's statusline mechanism
+  is partially documented; depending on platform, the
+  `/tmp/claude-ctx-*` bridge file pattern may or may not work
+  unmodified.
+
+### Known conflicts
+
+- **§6 naming.** Hook filenames in `.claude/hooks/` are referenced
+  by the Claude Code harness via `settings.json`; renames break
+  the harness. Commit to filenames up front.
+- **§14 consumer repos.** Adding hooks to the propagation set
+  changes what every consumer repo gets on the next
+  `update_workflows.yml` run.
+
+---
+
+## S5. Filesystem-native `@-reference` syntax in prompts
+
+### What it would do
+
+Replace the `{{REFERENCE_*}}` placeholder mechanism (the adopted-now
+plan's item 2) with gsd-build's filesystem-native `@-reference`
+syntax: phase prompts contain literal
+`@~/.claude/get-shit-done/references/verification-loop.md`
+references that the runtime resolves at load time.
+
+### Source
+
+- gsd-build `agents/gsd-planner.md` line:
+  `@~/.claude/get-shit-done/references/mandatory-initial-read.md`.
+- gsd-build `docs/ARCHITECTURE.md` §"References" — shared knowledge
+  documents.
+
+### Pro
+
+- **Renderer-free.** No `scripts/render_prompt.sh` placeholder
+  resolution step; the agent runtime handles the include.
+- **Standard convention.** Matches Claude Code's documented
+  `@-reference` syntax for skills.
+
+### Con
+
+- **Runtime-dependent.** codex-cli does not currently resolve
+  `@-references` in mode prompts; only the Claude Code harness
+  does. Adopting this would require either (a) a renderer-side
+  expansion that *implements* `@-reference` resolution, defeating
+  the purpose, or (b) an upstream codex-cli feature request.
+- **`{{...}}` mechanism already works.** The adopted-now plan's
+  item 2 reuses existing renderer behaviour.
+
+### Estimated cost
+
+- ~10 hours to design the resolution mechanism.
+- ~15 hours to migrate every reference from `{{...}}` to `@-ref`.
+- Total: ~25 hours.
+
+### Open decisions
+
+- **Runtime support.** Wait for codex-cli `@-reference` support,
+  or layer a Claude-Code-only path that uses native `@-refs` and a
+  codex-cli-only path that uses `{{...}}`?
+
+### Known conflicts
+
+- **§5 minimal change set.** Two mechanisms for the same purpose
+  competes; we should converge before adopting.
+
+---
+
+## C1. CONTEXT.md predicate-only format replacing prose in `agents.md`
+
+### What it would do
+
+Refactor `agents.md` from its current prose-and-tables format to
+gsd-build's machine-greppable single-line predicate format:
+
+```
+LOG_PREFIX.LABEL_REPAIR=present
+PHASE.clarify.default_model=openai/gpt-5.4
+PHASE.implement.editor_idle_timeout=1200
+```
+
+Today `agents.md` mixes prose, tables, and code-fence blocks. The
+gsd-build pattern is one fact per line, no prose.
+
+### Source
+
+- gsd-build `CONTEXT.md` header rule:
+  > "Format: this document is machine-greppable. Each operational
+  > fact is a single-line predicate (`CLASS.subkey=value`). Agent
+  > briefs cite predicates by ID verbatim — never paraphrase from
+  > this file."
+
+### Pro
+
+- **Grep-friendly.** `grep '^PHASE\.implement\.' agents.md` would
+  return every implement-phase fact in one shot.
+- **Drift-resistant.** Predicate format is parseable; we could
+  layer a test that asserts every predicate corresponds to a real
+  config knob.
+
+### Con
+
+- **Human readability.** Predicate format is hard to read at scale.
+  gsd-build mitigates with a glossary at the top; ours would need
+  the same.
+- **Conflicts with the adopted-now item 6.** That item adds
+  predicates *alongside* prose. C1 is the wholesale replacement.
+
+### Estimated cost
+
+- ~8 hours to refactor every existing prose section into predicates.
+- ~3 hours to add a glossary header.
+- ~4 hours to add a drift-test that asserts predicate ↔ config
+  parity.
+- Total: ~15 hours.
+
+### Open decisions
+
+- **Prose alongside or instead?** The adopted-now item 6 picks
+  "alongside"; C1 is "instead."
+- **Predicate vocabulary commitment.** Once committed, predicate
+  names are §6-protected identifiers.
+
+### Known conflicts
+
+- **§6 naming.** Predicate names (`LOG_PREFIX.LABEL_REPAIR`,
+  `PHASE.implement.editor_idle_timeout`) become stable identifiers.
+- **Existing prose consumers.** Some prompts grep for prose strings
+  in `agents.md` today (e.g.
+  `unattended_system_instructions.md` references "Stable log
+  prefixes" by string). Removing the prose breaks those.
+
+---
+
+## C2. Default flip to gsd's "absent = enabled" feature-flag pattern
+
+### What it would do
+
+Switch our feature-flag defaults from explicit-true (today every
+env-var has an explicit default) to gsd-build's pattern: absent
+key in `vars.*` defaults to `true`. Users explicitly disable
+features they don't want.
+
+### Source
+
+- gsd-build `docs/ARCHITECTURE.md` §"Absent = Enabled":
+  > "Workflow feature flags follow the absent = enabled pattern.
+  > If a key is missing from `config.json`, it defaults to `true`.
+  > Users explicitly disable features; they don't need to enable
+  > defaults."
+
+### Pro
+
+- **Onboarding simplicity.** Consumer repos start with every
+  feature on by default; operators turn things off if they don't
+  want them.
+- **Aligns with our existing `OPENROUTER_PROMPT_CACHE_DISABLED`
+  pattern** (kill-switch model) — the inverse of an enable-flag.
+
+### Con
+
+- **Conflicts with §0 prime directive.** "If you are not 100 %
+  certain the outcome matches the user's expectations: STOP."
+  Defaulting absent to enabled means the system silently does
+  more than the operator may have configured.
+- **Bad for unattended pipelines.** Our pipelines run on cron;
+  silent feature activation that the operator missed in the
+  release notes is a real risk.
+- **Explicit-default discipline is already in CLAUDE.md §4** —
+  "Always provide defaults for new env vars unless explicitly
+  told otherwise. Preserve all existing env var names."
+
+### Estimated cost
+
+- ~5 hours to refactor every default-true env-var (~30 such vars).
+- ~2 hours to document the migration.
+- Total: ~7 hours.
+
+### Open decisions
+
+- **Scope.** All vars, only new vars, or only a designated
+  subset?
+- **Migration.** Existing consumer repos with `vars.X=false`
+  continue to work, but absent → true means an operator who
+  *expected* `vars.X` to mean "off by default" gets surprised.
+
+### Known conflicts
+
+- **CLAUDE.md §0 / §4.** This is a deliberate inversion of our
+  current explicit-default discipline.
+- **§14 consumer repos.** Existing consumer repos have implicit
+  contracts with the explicit-default model; switching is a
+  documented breaking change.
+
+---
+
+## C3. Adversarial / FORCE-stance language in judge and reviewer prompts
+
+### What it would do
+
+Add gsd-build's `<adversarial_stance>` block — verbatim:
+> "FORCE stance: Assume every plan set is flawed until evidence
+> proves otherwise. Your starting hypothesis: these plans will not
+> deliver the phase goal. Surface what disqualifies them."
+
+— to:
+
+- `prompts/mode-judge.txt`
+- `prompts/mode-judge-review-blocked.txt`
+- `prompts/review-reviewer-checklist.txt`
+
+The adopted-now plan's item 4 already requires explicit severity
+classification (a milder form of the same discipline). C3 is the
+stronger language.
+
+### Source
+
+- gsd-build `agents/gsd-plan-checker.md` `<adversarial_stance>`
+  block.
+
+### Pro
+
+- **Reduces "looks-good rubber-stamp" risk** on long-running
+  autofix loops where a tired judge approves a PR that subtly
+  drifts from the issue.
+- **Forces evidence-backed verdicts.** Pairs naturally with the
+  reviewer-fabrication ban already adopted in
+  `apply-ai-tools-learnings-plan.md` goal 13.
+
+### Con
+
+- **Over-rejection risk.** A reviewer that "assumes flawed until
+  proven" can wedge a benign PR. Today's reviewer floor
+  (`scripts/review_floor_rules.sh`) already promotes 2-reviewer-
+  agreed nearby findings; layering adversarial stance on top
+  could push the panel to manufacture findings to satisfy the
+  framing.
+- **Cost.** Adversarial-stance language tends to expand reviewer
+  output (defending the rejection becomes part of the loop). Our
+  consensus summariser already truncates at
+  `XPOLL_SUMMARISER_LINES_PER_REVIEWER=160`; bigger reviewer
+  outputs mean more aggressive truncation.
+
+### Estimated cost
+
+- ~2 hours per prompt × 3 prompts = 6 hours.
+- ~4 hours of bake on a smoke consumer repo to measure rejection-
+  rate impact.
+- Total: ~10 hours.
+
+### Open decisions
+
+- **Calibration.** "Assume flawed" or softer "verify before
+  accepting"? The adopted-now item 4 picks the softer form;
+  this is the explicit-flag version.
+- **Per-pass calibration.** Apply only to pass 2 reviewers (after
+  pass 1 cross-pollination) so pass 1 stays broad?
+
+### Known conflicts
+
+- **None per §6/§10/§14/§15.** This is purely prompt language.
+- **Existing reviewer two-pass discipline.** `ENABLE_REVIEWER_TWO_PASS`
+  changes panel behaviour; adversarial stance would interact with
+  that and may need per-pass scoping.
+
+---
+
+## C4. Forced per-phase prompt size shrink to <500 lines
+
+### What it would do
+
+Push every `prompts/mode-*.txt` and `prompts/review-*.txt` under
+the gsd-build DEFAULT tier (1000 lines for workflows, but gsd's
+*agent* prompts target <500 lines after the v1.39+ progressive
+disclosure refactor). The adopted-now item 1 commits to soft
+tiers (250 / 500 / 800 lines) with budget enforcement; C4 is the
+forced shrink to a single sub-500 ceiling.
+
+### Source
+
+- gsd-build `docs/ARCHITECTURE.md` §"Progressive disclosure for
+  workflows" — the v1.39 budget regime.
+- gsd-build `workflows/discuss-phase/` decomposition pattern
+  (parent dispatches to `modes/<mode>.md` + `templates/*.md`).
+
+### Pro
+
+- **Smaller prompts cache better.** Reduces per-turn token cost
+  across every phase.
+- **Forces decomposition.** Long prompts decay; smaller ones
+  stay focused.
+
+### Con
+
+- **Aggressive.** `mode-validate-generate.txt` is 809 lines and
+  has 22 self-referential sections; forcing <500 needs a real
+  decomposition into `prompts/mode-validate-generate/` subdir.
+- **Conflicts with existing prompt-evolution patterns.** Our
+  prompts grow organically as fix-up discoveries land
+  (`apply-ai-tools-learnings-plan.md` added ~10 items to several
+  prompts).
+
+### Estimated cost
+
+- ~6 hours per prompt that exceeds the new ceiling × 4 prompts
+  (validate-generate, validate-fix-harness, validate-diagnose,
+  judge-review-blocked) = 24 hours.
+- ~4 hours of regression smoke.
+- Total: ~30 hours.
+
+### Open decisions
+
+- **One ceiling or tiered?** The adopted-now item 1 picks tiered;
+  C4 is single-ceiling.
+- **Decomposition target.** Subdirectories (gsd's pattern) or
+  `{{...}}` reference blocks (our pattern)?
+
+### Known conflicts
+
+- **§5 minimal change set.** Decomposition is a structural
+  refactor.
+
+---
+
+## C5. NPM-installable consumer-repo bootstrap (replace `update_workflows.yml`)
+
+### What it would do
+
+Replace the `update_workflows.yml` `repository_dispatch`-based
+propagation model with an npm CLI: `npx coding-workflows-cc@latest`
+installs the wrappers into a consumer repo, à la
+`npx get-shit-done-cc@latest`.
+
+### Source
+
+- gsd-build `package.json` + the
+  `npx get-shit-done-cc@latest` install path.
+- gsd-build `docs/USER-GUIDE.md` install profiles.
+
+### Pro
+
+- **Operator UX.** A single `npx` command vs four GitHub
+  Secrets + repo-vars setup.
+- **Versioned releases.** npm tags map naturally to our
+  `@stable` ref scheme.
+- **Cross-runtime.** Same installer can target multiple AI
+  runtimes (Claude Code, codex-cli, Cursor, Windsurf).
+
+### Con
+
+- **Loses our `@stable` dispatch model.** The current model
+  pushes updates to consumer repos automatically when
+  `coding-workflows@stable` is tagged; an npm installer is
+  pull-based and operators must re-run.
+- **New surface to maintain.** A Node CLI is a new package,
+  release pipeline, npm credentials, etc.
+- **Conflicts with our §14 consumer registry.** The dispatch
+  model is built around the registry; an npm pull model
+  doesn't need a registry at all.
+
+### Estimated cost
+
+- ~40 hours to design the CLI.
+- ~30 hours to implement (Node code, install routines,
+  permission rewrites).
+- ~10 hours of consumer-repo migration documentation.
+- Total: ~80 hours.
+
+### Open decisions
+
+- **Coexist or replace?** Coexist means double-maintenance.
+- **Auto-update.** If npm, do consumer repos get a stale
+  install warning? gsd-build runs `gsd-check-update-worker.js`
+  for this.
+- **`@stable` semantics.** Map npm tags to `@stable` /
+  `@beta` / `@canary`?
+
+### Known conflicts
+
+- **§14 consumer repos.** Replaces the dispatch-driven
+  propagation model entirely. Every repo in
+  `.github/ai/consumer_repos.json` would need a migration.
+- **§5 minimal change set.** This is a structural rewrite of
+  the propagation contract.
+
+---
+
+## Index
+
+- **S1** — Interactive `.claude/commands/` surface mirroring gsd's
+  user-loop. ~15 h.
+- **S2** — Two-stage hierarchical routing for slash commands. ~12 h.
+- **S3** — Filesystem-native persistent per-issue workspace. ~60 h.
+- **S4** — Active runtime hooks for interactive Claude Code. ~25 h.
+- **S5** — Filesystem-native `@-reference` syntax in prompts. ~25 h.
+- **C1** — CONTEXT.md predicate-only format. ~15 h.
+- **C2** — Default flip to "absent = enabled". ~7 h.
+- **C3** — Adversarial / FORCE-stance language. ~10 h.
+- **C4** — Forced per-phase prompt size shrink. ~30 h.
+- **C5** — NPM-installable consumer-repo bootstrap. ~80 h.

--- a/docs/plans/gsd-inspired-improvements-plan.md
+++ b/docs/plans/gsd-inspired-improvements-plan.md
@@ -1,0 +1,620 @@
+# GSD-Inspired Improvements (Unattended Pipeline + Scripts + Operator Surface)
+
+## Summary
+
+Adopt ten additive improvements distilled from
+[`gsd-build/get-shit-done`](https://github.com/gsd-build/get-shit-done)
+(`v1.42.x`, npm-installable Claude Code meta-prompting / spec-driven dev
+system, 67 commands / 33 agents / 13 hooks) into our **unattended pipeline
+prompts**, **workflow orchestration scripts**, and **operator / consumer-repo
+experience**. Each item names a gsd-build source file or mechanism, an
+explicit target in this repo, and the proposed wording or wiring. No
+interactive `.claude/commands` are added in this plan — that surface is
+deliberately out of scope per the clarification round and goes in the
+companion `docs/gsd-future-improvements.md`.
+
+## Context
+
+The trigger is the user's question "go through
+https://github.com/gsd-build/get-shit-done and tell me what learnings and
+improvements we can get from it to apply to our repo." A research pass
+through the gsd-build root, `docs/ARCHITECTURE.md`, `docs/INVENTORY.md`,
+`CONTEXT.md`, `CLAUDE.md`, every `agents/gsd-*.md` agent name, every
+`hooks/gsd-*.{js,sh}` hook, and the README produced four buckets:
+
+1. **Directly portable mechanisms** — prompt-size budgets, reference-block
+   extraction, severity classification, pre-execution plan checks,
+   injection guards, machine-greppable predicate format, inventory
+   drift-tests, atomic per-task commits, install profiles, INVENTORY roster.
+   Adopted in this plan.
+2. **Interactive-Claude-Code-only items** — slash-command surface, context
+   monitor hooks, statusline metrics, prompt-injection PreToolUse hook.
+   Surfaced in the companion doc as **S1–S4 deferred (interactive scope)**.
+3. **Contentious mechanism conflicts** — `absent=enabled` flag default,
+   adversarial FORCE-stance language, forced per-prompt line shrink,
+   predicate-only docs, npm bootstrap installer. Surfaced in the companion
+   doc as **C1–C5**.
+4. **Out of scope, will not adopt** — gsd's solo-developer milestone
+   framework (`/gsd-complete-milestone` / `/gsd-new-milestone`), gsd's
+   `--dangerously-skip-permissions` install ergonomics, gsd's
+   roadmap/milestone state graph. We are an org-scale unattended pipeline,
+   not a solo loop.
+
+The closest precedents in this repo are
+[`docs/plans/apply-ai-tools-learnings-plan.md`](./apply-ai-tools-learnings-plan.md)
+and
+[`docs/symphony-inspired-improvements.md`](../symphony-inspired-improvements.md).
+This plan reuses their template — each adopted item names a source file, a
+target file in this repo, the wording or wiring, and any §6/§10/§14/§15
+constraints it triggers.
+
+CLAUDE.md sections that bind this work:
+
+- **§5 Minimal Change Set** — "Extend existing mechanisms — never compete
+  with them." Items 1–6, 8, 10 extend existing files (`prompts/`,
+  `scripts/`, `tests/`, `agents.md`, `README.md`); item 7 adds a single new
+  test file; item 9 adds a single new `workflow-templates/` profile manifest.
+- **§6 Backward Compatibility / Naming Immutability** — No identifier is
+  renamed. Item 2 introduces new `prompts/references/*.txt` shared blocks
+  but keeps every existing `prompts/mode-*.txt` filename intact and
+  references the new blocks via `{{...}}` placeholders rather than
+  filesystem `@-references` (we'd need a renderer change for `@-refs`; out
+  of scope).
+- **§14 Consumer Repo Registry** — Item 9 (install profiles) changes the
+  shape of `workflow-templates/` consumption. Every repo in
+  `.github/ai/consumer_repos.json` (11 repos) keeps working under the
+  "full" profile by default; profile selection is opt-in via a new
+  `vars.WORKFLOW_PROFILE` repo-var.
+- **§15 GitHub API Call Hygiene** — None of the adopted items add new
+  `gh api` callsites. Item 5 (injection guard) operates entirely on local
+  text; item 7 (drift test) reads only the filesystem.
+
+## Goals
+
+Each goal is falsifiable by re-reading the named file after the corresponding
+item lands.
+
+1. **Phase-prompt size budgets** — every `prompts/mode-*.txt` carries a
+   declared tier and a CI test (`tests/prompt_size_budget.py` or
+   equivalent) fails the build when the file exceeds its tier. Source:
+   gsd-build `tests/workflow-size-budget.test.cjs`,
+   `docs/ARCHITECTURE.md#progressive-disclosure-for-workflows`.
+2. **Reference blocks** — at least three reusable prompt blocks
+   (`verification-loop.txt`, `output-contract.txt`, `severity-classification.txt`)
+   live in `prompts/references/` and are referenced from at least two
+   phase prompts each. Source: gsd-build `get-shit-done/references/*.md`,
+   `gsd-planner.md`'s `@~/.claude/get-shit-done/references/mandatory-initial-read.md`.
+3. **Pre-execution plan check** — `prompts/mode-plan.txt` ends with a
+   self-check sub-pass that requires BLOCKER/WARNING classification of any
+   gaps before `STATUS: CLEAR` can be emitted. Source: gsd-build
+   `agents/gsd-plan-checker.md` adversarial FORCE-stance.
+4. **Severity classification required** — reviewer + judge outputs MUST
+   carry `SEVERITY: BLOCKER|MAJOR|NIT`; outputs missing severity are
+   invalid. Source: gsd-build `gsd-plan-checker.md` Required Finding
+   Classification block.
+5. **Memory-write injection guard** — every candidate record committed to
+   the `ai-memory` branch via `scripts/ai_memory.py` or
+   `scripts/memory_helpers.sh` is scanned for the 14 gsd-build injection
+   patterns; matches log a `MEMORY_INJECTION_DETECTED` warning to stderr
+   and tag the record with `injection_suspected: true` but do not block
+   the write (advisory-only, mirroring gsd-build's policy). Source:
+   gsd-build `hooks/gsd-prompt-guard.js` regex set.
+6. **Predicate-format facts in `agents.md`** — the "Stable log prefixes"
+   and "Repo-specific batching helpers" sections gain
+   machine-greppable `PREDICATE.subkey=value` lines alongside existing
+   prose. Source: gsd-build `CONTEXT.md` header rule "Each operational
+   fact is a single-line predicate (`CLASS.subkey=value`)."
+7. **Inventory drift-control test** — a new `tests/inventory_parity.py`
+   verifies every `prompts/mode-*.txt`, every `.github/workflows/*.yml`,
+   and every `scripts/*` file appears in the README and `agents.md`
+   roster (or is on a documented exemption list). Source: gsd-build
+   `tests/inventory-counts.test.cjs`, `tests/commands-doc-parity.test.cjs`.
+8. **Per-task atomic commit discipline** — `prompts/mode-implement.txt`
+   gains an explicit "one logical change = one commit" rule, with a
+   commit-message format that names the plan task it satisfies. Source:
+   gsd-build `agents/gsd-executor.md` atomic-commit pattern (35 KB agent).
+9. **Operator install profiles** — `workflow-templates/profiles/{core,standard,full}.txt`
+   list which wrappers ship under each profile; `update_workflows.yml`
+   reads `vars.WORKFLOW_PROFILE` and installs only the listed wrappers.
+   Default profile = `full` (no behaviour change for existing consumer
+   repos). Source: gsd-build README `--profile=core,standard,full`,
+   `/gsd:surface` runtime toggle.
+10. **Authoritative INVENTORY.md** — `docs/INVENTORY.md` enumerates every
+    phase prompt, every workflow, every script with a one-line role, and
+    is anchored by the drift-control test from goal 7. Source: gsd-build
+    `docs/INVENTORY.md` v1.36.0 pin.
+
+## Non-goals
+
+- **No interactive `.claude/commands` additions.** The user excluded the
+  interactive Claude Code surface from this plan. Deferred items go in
+  `docs/gsd-future-improvements.md`.
+- **No new agents / subagents.** gsd-build has 33 agents; we are not
+  adopting any. Our codex-cli model invocations are phase-shaped, not
+  agent-shaped, and the existing precedent
+  (`docs/plans/apply-ai-tools-learnings-plan.md` §7) bounds the
+  subagent-related rules we already adopted.
+- **No `@-reference` filesystem syntax.** Reference blocks are wired via
+  `{{...}}` placeholders resolved by the existing `scripts/render_prompt.sh`
+  expansion path. Filesystem-native `@-references` would require a renderer
+  refactor; goes in the companion doc as **S5**.
+- **No npm / installer bootstrap.** We have a workflow-dispatch–driven
+  propagation model (`update_workflows.yml` against
+  `.github/ai/consumer_repos.json`). Replacing it with an npm CLI is a
+  separate project; goes in the companion doc as **C5**.
+- **No milestone / roadmap state graph.** gsd-build is built around a
+  solo developer's project lifecycle; we are issue-driven and orchestrator-
+  managed. Not adopting.
+- **No `--dangerously-skip-permissions` ergonomics or runtime hot-reload.**
+  Out of scope for unattended pipelines.
+- **No mass rename of stable log prefixes** listed in `agents.md` —
+  forbidden by §6.
+
+## Constraints
+
+- **§5** — every item below extends, not replaces. Reviewer / judge
+  prompts that already carry partial severity language (`prompts/review-consolidator.txt`
+  has `SEVERITY: blocker | high | med | low`) are tightened, not rewritten.
+- **§6** — no identifier rename. Item 4 aligns reviewer-side severity
+  vocabulary with consolidator-side vocabulary via additive aliases
+  (`high == MAJOR`, `med | low == NIT` translation table) rather than
+  forcing a one-shot rename.
+- **§10** — none of the adopted items touch a MongoDB collection or index.
+  No `/db/contracts/*` updates required.
+- **§14** — item 9 is propagation-relevant. The default `WORKFLOW_PROFILE`
+  is `full`, so no consumer repo sees a behaviour change unless its
+  operator explicitly opts down to `core` or `standard`. Every repo in
+  `.github/ai/consumer_repos.json` keeps its current wrapper set.
+- **§15** — items 1, 2, 3, 4, 5, 6, 8, 10 are prose-only (no API calls).
+  Item 7 (drift test) and item 9 (profile manifest) read only local files
+  in CI. No new `gh api` calls anywhere.
+- **Security** — item 5 (memory-write injection guard) is the only
+  security-relevant change. It is advisory-only by design (matches
+  gsd-build's policy) — blocking false-positives would break the
+  fail-open invariant that every `ai-memory` write must satisfy
+  (`README.md` §"Memory System": "a memory error never fails the
+  workflow").
+- **Performance** — items 1, 7 add CI checks that run on push; combined
+  expected runtime <5 s on the repo's current size. Item 5 adds a
+  ~14-regex scan per candidate-record write; per-record cost <1 ms.
+
+## Approach
+
+Each item is a **prose-only or single-file additive change** to a named
+existing file or a new single file in a documented location. Items are
+ordered roughly by blast radius (smallest first) so a partial roll-out
+still produces a working pipeline; items 1–8 ship as one PR, items 9–10
+as a separate follow-up PR if reviewer load is a concern.
+
+Three design decisions worth surfacing:
+
+- **`{{...}}` placeholders, not `@-references`.** gsd-build's
+  `@~/.claude/get-shit-done/references/foo.md` syntax requires a Claude
+  Code-side resolver. Our `render_prompt.sh` already supports
+  `{{SERENA_EFFICIENCY_BLOCK_READ_ONLY}}`–style placeholders; extending
+  that mechanism to `{{REFERENCE_VERIFICATION_LOOP}}` is a 10-line
+  script change. Going to filesystem `@-refs` would mean teaching every
+  codex-cli phase about a new include syntax — deferred to **S5**.
+- **Advisory-only injection guard.** gsd-build's
+  `hooks/gsd-prompt-guard.js` is also advisory ("Why advisory-only:
+  Blocking would prevent legitimate workflow operations"). Adopting the
+  same posture preserves our existing fail-open memory contract; the
+  alternative (blocking) would create a new failure mode where a
+  legitimately written rule like "ignore previous instructions for this
+  field" would deadlock memory writes.
+- **Default profile = `full`.** gsd-build's installer is profile-default
+  (user picks `core` interactively). We default to `full` so existing
+  consumer repos see no change. Profile selection is opt-in via
+  `vars.WORKFLOW_PROFILE`. This matches §5's "extend existing
+  mechanisms" principle: `update_workflows.yml` still installs every
+  wrapper by default; profiles are a *narrowing* override, not a
+  replacement.
+
+Alternatives considered and rejected:
+
+- **Wholesale slash-command adoption.** gsd-build is fundamentally
+  designed around 67 interactive slash commands. Mirroring even a subset
+  (e.g. `/discuss-phase`, `/verify-work`) in `.claude/commands/` would
+  add a parallel surface that competes with our existing unattended
+  pipeline (clarify, plan, implement, review, validate). Per the
+  clarification round, this is deferred to **S1** in the companion doc.
+- **Replacing prose `agents.md` with predicate-only format.** Conflicts
+  with §6 — `agents.md` is consumed by both our orchestrator-poller
+  loop and downstream consumer-repo prompts that grep for specific
+  prose strings. Going predicate-only would break those greps. Item 6
+  adds predicates *alongside* existing prose instead.
+
+## Implementation Steps
+
+Each step lists files, change in one sentence, and any preconditions.
+
+### Item 1 — Phase-prompt size budgets
+
+1. **New `tests/prompt_size_budget.py`** — read every `prompts/mode-*.txt`
+   and `prompts/review-*.txt`, derive each file's tier from a new
+   frontmatter line `# tier: DEFAULT|LARGE|XL` (default `DEFAULT` if
+   missing), assert `wc -l <= {250 | 500 | 800}`, exit nonzero on
+   violation. Hook into `.github/workflows/ci.yml`.
+2. **Add tier frontmatter to every `prompts/mode-*.txt` and `prompts/review-*.txt`** —
+   one comment line per file. Current sizes (from `wc -l`):
+   - DEFAULT (≤250): every prompt except the four below.
+   - LARGE (≤500): `mode-validate-diagnose.txt` (198 — comfortably under
+     but pre-flagged as LARGE for headroom), `mode-validate-fix-harness.txt`
+     (276 — exceeds DEFAULT, marks LARGE).
+   - XL (≤800): `mode-validate-generate.txt` (809 — exceeds XL by 9 lines;
+     extract the ≥10-line `### Validation harness output contract` block
+     into `prompts/references/validate-output-contract.txt` in step 2 of
+     item 2, bringing the parent under 800).
+3. **Preconditions:** item 2 step 1 lands first so the extracted reference
+   block exists.
+
+### Item 2 — Reference blocks
+
+1. **New `prompts/references/verification-loop.txt`** (~30 lines) — the
+   typecheck → lint → tests → build → smoke gate-order rule already
+   adopted in `apply-ai-tools-learnings-plan.md` goal 5; extracted into
+   a single reusable block. Referenced from `prompts/mode-implement.txt`,
+   `prompts/mode-validate-generate.txt`, `prompts/mode-validate-fix-harness.txt`.
+2. **New `prompts/references/output-contract.txt`** (~20 lines) — the
+   `<preamble>` / `<checkpoint>` / `<final_summary>` status-update
+   cadence rules from `apply-ai-tools-learnings-plan.md` goal 4;
+   extracted. Referenced from every `prompts/mode-*.txt`.
+3. **New `prompts/references/severity-classification.txt`** (~25 lines) —
+   the BLOCKER / MAJOR / NIT vocabulary + the "issues without severity
+   are invalid output" rule. Referenced from
+   `prompts/review-reviewer-checklist.txt`,
+   `prompts/review-consolidator.txt`,
+   `prompts/mode-judge-review-blocked.txt`, `prompts/mode-judge.txt`.
+4. **Extend `scripts/render_prompt.sh`** — add three new placeholder
+   substitutions: `{{REFERENCE_VERIFICATION_LOOP}}`,
+   `{{REFERENCE_OUTPUT_CONTRACT}}`, `{{REFERENCE_SEVERITY_CLASSIFICATION}}`.
+   Mechanism mirrors existing `{{SERENA_EFFICIENCY_BLOCK_READ_ONLY}}`
+   handling (single sed/awk substitution from a known file). Renderer
+   fails if a placeholder is unresolved (matches existing contract).
+5. **Edit phase prompts** to reference the blocks via the placeholders.
+   No existing rule text is deleted; the placeholder is inserted at the
+   appropriate section and the existing prose is replaced *only if* the
+   reference block fully captures the rule (otherwise the placeholder
+   sits *alongside* the prose). Preserves §5 minimum-change discipline.
+
+### Item 3 — Pre-execution plan check
+
+1. **Edit `prompts/mode-plan.txt`** — append a new terminal section
+   `## Pre-execution self-check` (≤40 lines) that requires the model to
+   emit either `STATUS: CLEAR` plus a single line `PLAN_SELF_CHECK: PASS`
+   or a list of `PLAN_SELF_CHECK: BLOCKER: <one-line>` /
+   `PLAN_SELF_CHECK: WARNING: <one-line>` findings before exiting. If
+   any `BLOCKER` is emitted, the plan is `STATUS: NOT_CLEAR` and goes
+   back to clarification. This is a single-prompt analogue of gsd's
+   external `gsd-plan-checker` agent — we don't need a separate model
+   call because the plan model is already at `xhigh` reasoning and the
+   self-check is ~50 extra tokens.
+2. **Edit `scripts/plan_process.sh`** (or the plan-workflow consumer)
+   to parse `PLAN_SELF_CHECK: BLOCKER:` lines and propagate them as a
+   plan-reopened signal — fail the plan workflow with a structured
+   error if any BLOCKER is present. **Preconditions:** verify the
+   plan-workflow consumer name (`scripts/render_prompt.sh` and
+   `.github/workflows/plan.yml` show `prompts/mode-plan.txt` is read by
+   `plan.yml`; the parsing change goes in the workflow step that
+   currently consumes the plan output).
+
+### Item 4 — Severity classification required
+
+1. **Edit `prompts/review-reviewer-checklist.txt`** — add a "Severity is
+   mandatory" subsection citing `prompts/references/severity-classification.txt`
+   via `{{REFERENCE_SEVERITY_CLASSIFICATION}}` (after item 2). Replaces
+   the existing implicit-severity convention with explicit.
+2. **Edit `prompts/review-consolidator.txt`** — clarify the existing
+   `SEVERITY: blocker | high | med | low` line to: "Reviewer-side
+   `BLOCKER` maps to `blocker`; `MAJOR` maps to `high`; `NIT` maps to
+   `med`. `low` is reserved for advisory-only consolidator-internal
+   downgrades and is never emitted by reviewers." This is an alias
+   convention; nothing renames.
+3. **Edit `prompts/mode-judge.txt` and `prompts/mode-judge-review-blocked.txt`** —
+   require judges to surface the same vocabulary when summarising
+   reviewer output. Reuse `{{REFERENCE_SEVERITY_CLASSIFICATION}}`.
+4. **Add to `prompts/references/severity-classification.txt`** the rule:
+   "Issues without an explicit severity classification are not valid
+   output and MUST be re-emitted with severity." (Source: gsd-build
+   `gsd-plan-checker.md` `<adversarial_stance>`.)
+
+### Item 5 — Memory-write injection guard
+
+1. **New `scripts/memory_injection_patterns.py`** — a single-module file
+   exposing `INJECTION_PATTERNS` (list of 14 regexes from gsd-build
+   `hooks/gsd-prompt-guard.js` lines 17–32) and a function
+   `scan(text) -> list[str]` returning matched pattern names.
+2. **Edit `scripts/ai_memory.py`** — at every `write_candidate`–shaped
+   entrypoint (search `def write_` and `def _write_` in
+   `scripts/ai_memory_lib.py` and `scripts/ai_memory.py`; the exact
+   function names need to be verified during implementation, not
+   guessed here), call `scan(record_body)` before commit; on any match,
+   emit `AI_MEMORY_TELEMETRY: {op: 'injection_scan', ok: true,
+   matches: [...]}` to stderr (matches existing telemetry conventions
+   per README §"Telemetry") and add a top-level field
+   `injection_suspected: true` to the record JSON. Never block.
+3. **Edit `scripts/memory_helpers.sh`** — pass the new flag through any
+   shell-side write wrappers so the telemetry surface is consistent.
+4. **No change to `AI_MEMORY_ENABLED` kill-switch behaviour.** The guard
+   is purely additive.
+
+### Item 6 — Predicate-format facts in `agents.md`
+
+1. **Edit `agents.md`** — under "Stable log prefixes (contractual)", add
+   a single new subsection `### Predicate roster (machine-greppable)`
+   with one line per stable prefix in the form
+   `LOG_PREFIX.name=<prefix>` (e.g. `LOG_PREFIX.name=LABEL_REPAIR`).
+   Add a similar subsection under "Repo-specific batching helpers":
+   `BATCH_HELPER.name=_fetch_candidate_issue_details_graphql`,
+   `BATCH_HELPER.module=scripts/orchestrate_poll_process.sh`. The
+   existing prose is preserved verbatim above; predicates are
+   *alongside*, not *instead of*.
+2. **Edit `unattended_system_instructions.md`** — extend the existing
+   "Repo-specific batching helpers" callout there to mirror the new
+   predicate format (if the consumer pipeline ever wants to grep for
+   these without parsing prose).
+
+### Item 7 — Inventory drift-control test
+
+1. **New `docs/INVENTORY.md`** — one section per surface (phase prompts,
+   workflows, scripts, prompt references, audit-gate assets) with a
+   one-line role per file. Source the role from existing per-file
+   header comments or README mentions (no new prose where the README
+   already documents the file).
+2. **New `tests/inventory_parity.py`** — for each surface, glob the
+   filesystem, glob the README plus `agents.md` plus
+   `docs/INVENTORY.md`, assert one-to-one correspondence (or named
+   exemption). Pull exemption list from a new
+   `tests/inventory_exemptions.txt` (initially empty; entries land
+   with a one-line justification).
+3. **Hook into `.github/workflows/ci.yml`** — run `tests/inventory_parity.py`
+   on push/PR. Failure mode: print the drifted file(s); operator must
+   either document the new file or add it to the exemption list.
+
+### Item 8 — Per-task atomic commit discipline
+
+1. **Edit `prompts/mode-implement.txt`** — append a `## Commit
+   discipline` section (≤20 lines):
+   - One logical change = one commit.
+   - Commit message format: `<verb>: <change> (plan task <N.M>)`
+     where `<N.M>` is the task ID from `PLAN.md` if present, else
+     omit the parenthetical.
+   - Bulk style edits or auto-format passes go in a separate trailing
+     commit titled `chore: auto-format pass`.
+   - Failed test fix-ups roll into the commit that introduced the
+     failure (use `--amend` only on commits from the current `implement`
+     run that have not yet been pushed).
+2. **Verify alignment with existing review_autofix behaviour** — the
+   `[ai-autofix]` commit-prefix convention in `review_autofix.yml`
+   continues to apply; the atomic-commit rule is a *plan-execution*
+   discipline, not an autofix discipline.
+
+### Item 9 — Operator install profiles
+
+1. **New `workflow-templates/profiles/core.txt`** — one-wrapper-per-line
+   list:
+   ```
+   ai-clarify.yml
+   ai-plan.yml
+   ai-implement.yml
+   ai-review.yml
+   ai-issue-pr-status.yml
+   ai-cancel-on-pr-close.yml
+   ```
+2. **New `workflow-templates/profiles/standard.txt`** — core + orchestrator
+   + validation:
+   ```
+   <every line in core.txt>
+   ai-orchestrate.yml
+   ai-orchestrate-poll.yml
+   ai-orchestrate-clarify-respond.yml
+   ai-validate.yml
+   review_rb_judge_dispatch.yml
+   ```
+3. **New `workflow-templates/profiles/full.txt`** — every wrapper in
+   `workflow-templates/`. Default.
+4. **Edit `.github/workflows/update_workflows.yml`** — read
+   `vars.WORKFLOW_PROFILE` (default `full`), read the matching
+   `workflow-templates/profiles/<profile>.txt`, install only the listed
+   wrappers. Wrappers already present in the consumer repo that are
+   *not* listed in the profile are LEFT IN PLACE (no removals) —
+   profile downgrade does not delete files, only stops creating new
+   ones. This preserves §6 / §14 contracts.
+5. **Edit `README.md`** — add a "Install profiles" subsection under
+   "Quickstart" documenting `vars.WORKFLOW_PROFILE` and the three
+   manifest files.
+6. **Document in `agents.md`** — add a one-line predicate
+   `PROFILE.default=full` and one line per defined profile.
+
+### Item 10 — Authoritative INVENTORY.md
+
+See item 7. The `docs/INVENTORY.md` file added there is the authoritative
+roster; this item is the *act of writing the prose* (the test only
+enforces drift-control parity). One-line role per file, sourced from
+existing per-file headers where they exist.
+
+## Files & Modules
+
+- `[new]` `docs/plans/gsd-inspired-improvements-plan.md` — this file.
+- `[new]` `docs/gsd-future-improvements.md` — companion deferred /
+  contentious items (separate ship-alongside doc).
+- `[new]` `docs/INVENTORY.md` — authoritative roster.
+- `[new]` `prompts/references/verification-loop.txt`.
+- `[new]` `prompts/references/output-contract.txt`.
+- `[new]` `prompts/references/severity-classification.txt`.
+- `[new]` `prompts/references/validate-output-contract.txt` — extracted
+  to bring `mode-validate-generate.txt` under XL tier.
+- `[new]` `tests/prompt_size_budget.py`.
+- `[new]` `tests/inventory_parity.py`.
+- `[new]` `tests/inventory_exemptions.txt`.
+- `[new]` `scripts/memory_injection_patterns.py`.
+- `[new]` `workflow-templates/profiles/core.txt`.
+- `[new]` `workflow-templates/profiles/standard.txt`.
+- `[new]` `workflow-templates/profiles/full.txt`.
+- `[edit]` `prompts/mode-plan.txt` — append pre-execution self-check.
+- `[edit]` `prompts/mode-implement.txt` — append commit discipline +
+  reference placeholders.
+- `[edit]` `prompts/mode-validate-generate.txt` — extract output contract;
+  insert reference placeholder.
+- `[edit]` `prompts/mode-validate-fix-harness.txt` — insert reference
+  placeholders.
+- `[edit]` `prompts/mode-validate-diagnose.txt` — insert reference
+  placeholders.
+- `[edit]` `prompts/review-reviewer-checklist.txt` — severity-required
+  placeholder + alias rule.
+- `[edit]` `prompts/review-consolidator.txt` — severity vocabulary
+  alignment.
+- `[edit]` `prompts/mode-judge.txt` and `prompts/mode-judge-review-blocked.txt` —
+  severity placeholder.
+- `[edit]` `scripts/render_prompt.sh` — add three placeholder
+  substitutions.
+- `[edit]` `scripts/ai_memory.py`, `scripts/ai_memory_lib.py`,
+  `scripts/memory_helpers.sh` — wire injection guard.
+- `[edit]` `agents.md` — predicate roster subsections.
+- `[edit]` `unattended_system_instructions.md` — predicate-format batch
+  helpers callout.
+- `[edit]` `.github/workflows/update_workflows.yml` — read
+  `vars.WORKFLOW_PROFILE`.
+- `[edit]` `.github/workflows/ci.yml` — add prompt-size + inventory-parity
+  test steps.
+- `[edit]` `README.md` — Install profiles subsection.
+
+## Data Model / Index Changes
+
+None. No MongoDB collection touched. `/db/contracts/*` updates not
+required.
+
+## Tests
+
+- **Unit** — `tests/prompt_size_budget.py` and `tests/inventory_parity.py`
+  are themselves the new test coverage; both run in CI on push/PR.
+- **Integration** — re-run the existing smoke test for clarify / plan /
+  implement / review on a single consumer repo (e.g.
+  `shubhodeep1/digital_pa`) to verify the new `{{REFERENCE_*}}`
+  placeholders resolve correctly via `render_prompt.sh`. Acceptance:
+  every smoke phase emits its expected `STATUS: …` line.
+- **Manual** — operator-side, set `vars.WORKFLOW_PROFILE=core` on one
+  test consumer repo, run `update_workflows.yml`, verify only the
+  six core wrappers are touched and no other wrappers are removed.
+  Acceptance: `git diff --stat` on the consumer repo shows only the
+  intended wrapper edits.
+- **Smoke** — the `nightly-validation-selftest.yml` workflow re-runs
+  the validate phase end-to-end; verify the size-budget test passes
+  in that nightly bake.
+
+## Risks & Mitigations
+
+- **Risk:** Item 2's `{{REFERENCE_*}}` placeholder mechanism breaks
+  silently if `render_prompt.sh` is invoked from a code path that does
+  not source the reference files.
+  - **Mitigation:** The existing renderer contract already fails on
+    unresolved placeholders. Item 2 step 4 explicitly preserves that
+    behaviour; CI catches any regression.
+- **Risk:** Item 3 (`PLAN_SELF_CHECK`) over-rejects benign plans
+  because the plan model is asked to find blockers in its own output.
+  - **Mitigation:** Treat the self-check as a *signal*, not a *gate* —
+    the plan workflow can continue to `ai:awaiting-approval` even on a
+    WARNING-only self-check. Only BLOCKER fails the plan. Operators
+    can disable the self-check via a new `vars.PLAN_SELF_CHECK_ENABLED`
+    repo-var (default `true`).
+- **Risk:** Item 4 (severity required) breaks existing reviewer outputs
+  that omit severity.
+  - **Mitigation:** Add a parser fallback in `scripts/review_parse.sh`
+    (or equivalent) that defaults missing severity to `MAJOR` and
+    emits a `REVIEWER_SEVERITY_DEFAULT` warning; this is the same
+    fail-open posture as `REVIEW_PARSER_FAILOPEN` (default `1`).
+- **Risk:** Item 5 (injection guard) false-positives on legitimate
+  text that contains a flagged phrase (e.g. a plan note that quotes
+  "ignore previous instructions" as the example of an injection).
+  - **Mitigation:** Advisory-only by design — the record is still
+    written; only the `injection_suspected: true` flag is set.
+    Downstream reads can choose to filter or not.
+- **Risk:** Item 9 (profile manifest) misaligned with `update_workflows.yml`
+  results in a consumer repo missing a wrapper after an upstream change.
+  - **Mitigation:** Default profile is `full` so existing consumer
+    repos see no behaviour change. Profile downgrade explicitly does
+    NOT remove already-installed wrappers (item 9 step 4); operators
+    must remove manually.
+- **Risk:** Item 7 (inventory drift-control test) creates churn on
+  every new prompt / script addition.
+  - **Mitigation:** The exemption file (`tests/inventory_exemptions.txt`)
+    is the escape hatch — adding a one-line entry with a justification
+    is the lightest possible workflow when documentation is genuinely
+    deferred.
+- **Risk:** Per-task atomic commits (item 8) conflict with codex-cli's
+  current commit-batching behaviour.
+  - **Mitigation:** The rule is a prompt-level guideline, not a
+    process enforced by a hook. codex-cli will still batch where it
+    cannot decompose; we accept that and verify on smoke runs that
+    median commits-per-implement-run goes from 1 to 2–4 (target).
+
+## Rollout
+
+- **Phase A (PR 1, this PR):** Ship `docs/plans/gsd-inspired-improvements-plan.md`
+  (this file) and `docs/gsd-future-improvements.md` (companion).
+- **Phase B (PR 2):** Items 1, 2, 6, 7, 10 — prose-only / file-additive
+  changes with zero behavioural impact on existing runs. Ships behind
+  no flag; CI gates the size-budget and inventory-parity tests.
+- **Phase C (PR 3):** Items 3, 4, 8 — prompt edits affecting plan,
+  reviewer, judge, implement. Gate item 3 behind
+  `vars.PLAN_SELF_CHECK_ENABLED` (default `true`); items 4 and 8 are
+  prose changes with fail-open parsers.
+- **Phase D (PR 4):** Item 5 — memory injection guard, advisory-only.
+  Gate behind `vars.MEMORY_INJECTION_SCAN_ENABLED` (default `true`).
+  Telemetry surface verified in the next workflow-log-analysis pass.
+- **Phase E (PR 5):** Item 9 — install profiles. Default `full`, opt-in
+  for `core` / `standard` via a single repo-var. Document in README.
+  Consumer-repo propagation per `.github/ai/consumer_repos.json` (§14)
+  is automatic — no per-repo migration needed.
+- **Rollback path:** every phase is reverted independently by removing
+  the new file(s) and reverting the placeholder insertions or the
+  `vars.*` repo-var. Phase D rollback additionally requires flipping
+  `MEMORY_INJECTION_SCAN_ENABLED` to `false`. No rollback requires
+  rewriting history or amending merged commits.
+- **Consumer-repo propagation (§14):** when Phase E lands, the next
+  `update_workflows.yml` dispatch tagged `@stable` reaches all 11
+  repos in `.github/ai/consumer_repos.json`. Default-`full` means no
+  behaviour change unless an operator opts down.
+
+## Open Questions
+
+- **OQ1:** Should the `PLAN_SELF_CHECK` (item 3) actually be a *second
+  LLM call* (a dedicated plan-checker phase, mirroring gsd-build's
+  separate `gsd-plan-checker` agent), or remain a self-emitted block
+  from the plan model? The current proposal is the single-prompt
+  variant for cost reasons. If we observe the plan model rarely
+  self-flags real BLOCKERs in smoke runs, a separate phase becomes
+  the right design. Defer to a later iteration based on smoke evidence.
+- **OQ2:** Should the injection-guard pattern set (item 5) include
+  domain-specific patterns beyond gsd-build's 14? Candidates: codex-cli
+  tool-name leaks (`apply_patch`, `multi_tool_use.parallel`) from
+  `apply-ai-tools-learnings-plan.md` goal 1, GitHub-flavoured
+  injection (`@stable`, `@codex change` redirect attempts). The
+  initial PR ships gsd-build's 14 verbatim; domain patterns can layer
+  in via a follow-up.
+- **OQ3:** Should item 9's default profile flip to `standard` (drop
+  the `workflow-log-analysis.yml` and `memory_maintenance.yml`
+  wrappers from the default install) once the profile mechanism is
+  proven? Not for this PR — default is `full`.
+
+## References
+
+- gsd-build/get-shit-done: <https://github.com/gsd-build/get-shit-done>
+  (default branch `main`, sampled at this plan's write time).
+- gsd-build `docs/ARCHITECTURE.md` — workflow-tier budgets,
+  reference-block pattern, two-stage routing.
+- gsd-build `docs/INVENTORY.md` — drift-control test surface.
+- gsd-build `agents/gsd-planner.md`, `agents/gsd-plan-checker.md` —
+  adversarial FORCE-stance, severity-required rule.
+- gsd-build `hooks/gsd-prompt-guard.js` — 14-pattern injection regex set.
+- gsd-build `hooks/gsd-context-monitor.js`,
+  `hooks/gsd-phase-boundary.sh` — runtime hooks (deferred to companion
+  doc as **S4**).
+- gsd-build README `--profile=core|standard|full` —
+  `npx get-shit-done-cc@latest`.
+- This repo: `docs/plans/apply-ai-tools-learnings-plan.md`,
+  `docs/ai-tools-future-improvements.md`,
+  `docs/symphony-inspired-improvements.md` — template precedents.
+- This repo: `CLAUDE.md` §§ 5, 6, 10, 14, 15 — binding constraints.
+- This repo: `README.md` §"Memory System", §"Telemetry" — memory
+  contract that item 5 must preserve.


### PR DESCRIPTION
## Summary

Adopt ten additive improvements distilled from
[`gsd-build/get-shit-done`](https://github.com/gsd-build/get-shit-done) (v1.42.x,
npm-installable Claude Code meta-prompting / spec-driven dev system, 67 commands
/ 33 agents / 13 hooks) into our **unattended pipeline prompts**, **workflow
orchestration scripts**, and **operator / consumer-repo experience**. Each item
names a gsd-build source file or mechanism, an explicit target in this repo,
and the proposed wording or wiring. No interactive `.claude/commands` are added
in this plan — that surface is deferred to the companion doc.

## What this plan covers

- **Goals** — phase-prompt size budgets, reference blocks, pre-execution plan
  check, severity classification, memory-write injection guard, predicate
  facts in `agents.md`, inventory drift-control test, per-task atomic commits,
  operator install profiles, authoritative INVENTORY.md.
- **Approach** — additive, `{{...}}`-placeholder reference mechanism (reuses
  existing `scripts/render_prompt.sh` contract), advisory-only injection guard
  (preserves fail-open memory contract), default install profile = `full` (no
  consumer-repo behaviour change).
- **Implementation steps** — 10 items, ordered roughly by blast radius.
  Phased rollout: Phase A (this PR — docs only), Phase B (prose/file-additive),
  Phase C (prompt edits), Phase D (memory injection guard), Phase E (install
  profiles).
- **Tests** — new `tests/prompt_size_budget.py` and `tests/inventory_parity.py`
  hooked into CI; manual smoke per consumer repo for the profile flow.
- **Rollout** — Phase A only in this PR. Subsequent phases ship as separate
  PRs (B–E) under `claude/...` branches, each independently revertable.

## Companion doc

A companion `docs/gsd-future-improvements.md` enumerates ten **deferred /
contentious** items (**S1–S5** structural, **C1–C5** contentious) that were
surfaced by the research but consciously excluded from the adopted-now plan.
Naming and structure mirror `docs/ai-tools-future-improvements.md`.

## Open questions

- **OQ1**: Should `PLAN_SELF_CHECK` (item 3) be a separate LLM call (mirroring
  gsd's `gsd-plan-checker` agent) instead of a self-emitted block from the plan
  model? Defer to smoke evidence.
- **OQ2**: Should the injection-guard pattern set (item 5) include
  domain-specific patterns beyond gsd-build's 14? Initial PR ships 14 verbatim;
  domain patterns layer in via a follow-up.
- **OQ3**: Should item 9's default profile flip to `standard` once the profile
  mechanism is proven? Not for this PR — default stays `full`.

## Plan files

- [`docs/plans/gsd-inspired-improvements-plan.md`](./docs/plans/gsd-inspired-improvements-plan.md)
- [`docs/gsd-future-improvements.md`](./docs/gsd-future-improvements.md)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ap7vj5XKYoZegushd4QP9)_