### PR TITLE
fix(workflows): persist+restore Codex platform binary in cache path

### DIFF
--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -102,13 +102,15 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install Codex CLI and core tools
+      - name: Install Codex CLI
+        uses: shubhodeep1/coding-workflows/.github/actions/install-codex@stable
+        with:
+          codex_version: ${{ vars.CODEX_VERSION || 'v0.114.0' }}
+
+      - name: Install OS-level core tools
         shell: bash
         run: |
           set -euo pipefail
-
-          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
-          npm install -g "@openai/codex@${CODEX_VERSION}" --include=optional --no-audit --no-fund
 
           missing_tools=()
           for tool in jq curl gh; do

--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -103,6 +103,8 @@ jobs:
           python-version: "3.12"
 
       - name: Install Codex CLI
+        # Intentionally use the released action ref as the rollout boundary.
+        # Consumers pick this up when test-and-mark-stable retags @stable.
         uses: shubhodeep1/coding-workflows/.github/actions/install-codex@stable
         with:
           codex_version: ${{ vars.CODEX_VERSION || 'v0.114.0' }}

--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -179,6 +179,8 @@ jobs:
 
       - name: Install Codex CLI
         if: steps.find_tracking.outputs.has_work == 'true'
+        # Intentionally use the released action ref as the rollout boundary.
+        # Consumers pick this up when test-and-mark-stable retags @stable.
         uses: shubhodeep1/coding-workflows/.github/actions/install-codex@stable
         with:
           codex_version: ${{ vars.CODEX_VERSION || 'v0.114.0' }}

--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -177,14 +177,17 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install Codex CLI and core tools
+      - name: Install Codex CLI
+        if: steps.find_tracking.outputs.has_work == 'true'
+        uses: shubhodeep1/coding-workflows/.github/actions/install-codex@stable
+        with:
+          codex_version: ${{ vars.CODEX_VERSION || 'v0.114.0' }}
+
+      - name: Install OS-level core tools
         if: steps.find_tracking.outputs.has_work == 'true'
         shell: bash
         run: |
           set -euo pipefail
-
-          CODEX_VERSION="${{ vars.CODEX_VERSION || 'v0.114.0' }}"
-          npm install -g "@openai/codex@${CODEX_VERSION}" --include=optional --no-audit --no-fund
 
           missing_tools=()
           for tool in jq curl gh; do

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -61,7 +61,12 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ runner.tool_cache }}/codex
-          key: codex-${{ vars.CODEX_VERSION || 'v0.114.0' }}
+          # -v2: previous cache only stored @openai/codex (no platform binary),
+          # so cache hits restored a stub-only install and Codex crashed at
+          # startup with "Missing optional dependency @openai/codex-linux-x64".
+          # Bump invalidates the broken entries; persist+restore below now
+          # handle both packages symmetrically.
+          key: codex-${{ vars.CODEX_VERSION || 'v0.114.0' }}-v2
 
       - name: Install Codex CLI
         if: steps.cache-codex.outputs.cache-hit != 'true'
@@ -75,14 +80,23 @@ jobs:
           set -euo pipefail
           CODEX_BIN="$(which codex)"
           mkdir -p "${{ runner.tool_cache }}/codex"
-          cp -r "$(npm root -g)/@openai/codex" "${{ runner.tool_cache }}/codex/package"
+          cp -r "$(npm root -g)/@openai/codex"           "${{ runner.tool_cache }}/codex/package"
+          cp -r "$(npm root -g)/@openai/codex-linux-x64" "${{ runner.tool_cache }}/codex/codex-linux-x64"
           cp "${CODEX_BIN}" "${{ runner.tool_cache }}/codex/codex"
 
       - name: Restore Codex CLI from cache
         if: steps.cache-codex.outputs.cache-hit == 'true'
         run: |
           set -euo pipefail
-          npm install -g "${{ runner.tool_cache }}/codex/package" --include=optional --no-audit --no-fund
+          # Install BOTH packages from the cached local paths so the platform
+          # binary is restored deterministically. --include=optional is
+          # unreliable for global installs (npm/cli#4828) and cannot resolve
+          # the npm alias from a local path anyway.
+          npm install -g \
+            "${{ runner.tool_cache }}/codex/package" \
+            "${{ runner.tool_cache }}/codex/codex-linux-x64" \
+            --no-audit --no-fund
+          codex --version
 
       - name: Resolve integration ref
         id: refctx

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -78,7 +78,6 @@ jobs:
         if: steps.cache-codex.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          CODEX_BIN="$(which codex)"
           NPM_GLOBAL_ROOT="$(npm root -g)"
           mkdir -p "${{ runner.tool_cache }}/codex"
           [ -d "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64" ] || {
@@ -87,7 +86,6 @@ jobs:
           }
           cp -r "${NPM_GLOBAL_ROOT}/@openai/codex"           "${{ runner.tool_cache }}/codex/package"
           cp -r "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64" "${{ runner.tool_cache }}/codex/codex-linux-x64"
-          cp "${CODEX_BIN}" "${{ runner.tool_cache }}/codex/codex"
 
       - name: Restore Codex CLI from cache
         if: steps.cache-codex.outputs.cache-hit == 'true'

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -79,23 +79,31 @@ jobs:
         run: |
           set -euo pipefail
           CODEX_BIN="$(which codex)"
+          NPM_GLOBAL_ROOT="$(npm root -g)"
           mkdir -p "${{ runner.tool_cache }}/codex"
-          cp -r "$(npm root -g)/@openai/codex"           "${{ runner.tool_cache }}/codex/package"
-          cp -r "$(npm root -g)/@openai/codex-linux-x64" "${{ runner.tool_cache }}/codex/codex-linux-x64"
+          [ -d "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64" ] || {
+            echo "::error::Codex platform package @openai/codex-linux-x64 missing after install"
+            exit 1
+          }
+          cp -r "${NPM_GLOBAL_ROOT}/@openai/codex"           "${{ runner.tool_cache }}/codex/package"
+          cp -r "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64" "${{ runner.tool_cache }}/codex/codex-linux-x64"
           cp "${CODEX_BIN}" "${{ runner.tool_cache }}/codex/codex"
 
       - name: Restore Codex CLI from cache
         if: steps.cache-codex.outputs.cache-hit == 'true'
         run: |
           set -euo pipefail
-          # Install BOTH packages from the cached local paths so the platform
-          # binary is restored deterministically. --include=optional is
-          # unreliable for global installs (npm/cli#4828) and cannot resolve
-          # the npm alias from a local path anyway.
-          npm install -g \
-            "${{ runner.tool_cache }}/codex/package" \
-            "${{ runner.tool_cache }}/codex/codex-linux-x64" \
-            --no-audit --no-fund
+          NPM_GLOBAL_ROOT="$(npm root -g)"
+          NPM_GLOBAL_PREFIX="$(npm prefix -g)"
+          # Restore the cached directories directly into the global npm tree so
+          # the @openai/codex-linux-x64 alias name is preserved. npm install -g
+          # on the local paths re-reads package.json, and both cached
+          # directories report "name": "@openai/codex".
+          mkdir -p "${NPM_GLOBAL_ROOT}/@openai" "${NPM_GLOBAL_PREFIX}/bin"
+          rm -rf "${NPM_GLOBAL_ROOT}/@openai/codex" "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64"
+          cp -r "${{ runner.tool_cache }}/codex/package" "${NPM_GLOBAL_ROOT}/@openai/codex"
+          cp -r "${{ runner.tool_cache }}/codex/codex-linux-x64" "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64"
+          ln -sf "${NPM_GLOBAL_ROOT}/@openai/codex/bin/codex.js" "${NPM_GLOBAL_PREFIX}/bin/codex"
           codex --version
 
       - name: Resolve integration ref

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -226,7 +226,12 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ runner.tool_cache }}/codex
-          key: codex-${{ vars.CODEX_VERSION || 'v0.114.0' }}
+          # -v2: previous cache only stored @openai/codex (no platform binary),
+          # so cache hits restored a stub-only install and Codex crashed at
+          # startup with "Missing optional dependency @openai/codex-linux-x64".
+          # Bump invalidates the broken entries; persist+restore below now
+          # handle both packages symmetrically.
+          key: codex-${{ vars.CODEX_VERSION || 'v0.114.0' }}-v2
 
       - name: Install Codex CLI
         if: steps.cache-codex.outputs.cache-hit != 'true'
@@ -240,14 +245,23 @@ jobs:
           set -euo pipefail
           CODEX_BIN="$(which codex)"
           mkdir -p "${{ runner.tool_cache }}/codex"
-          cp -r "$(npm root -g)/@openai/codex" "${{ runner.tool_cache }}/codex/package"
+          cp -r "$(npm root -g)/@openai/codex"           "${{ runner.tool_cache }}/codex/package"
+          cp -r "$(npm root -g)/@openai/codex-linux-x64" "${{ runner.tool_cache }}/codex/codex-linux-x64"
           cp "${CODEX_BIN}" "${{ runner.tool_cache }}/codex/codex"
 
       - name: Restore Codex CLI from cache
         if: steps.cache-codex.outputs.cache-hit == 'true'
         run: |
           set -euo pipefail
-          npm install -g "${{ runner.tool_cache }}/codex/package" --include=optional --no-audit --no-fund
+          # Install BOTH packages from the cached local paths so the platform
+          # binary is restored deterministically. --include=optional is
+          # unreliable for global installs (npm/cli#4828) and cannot resolve
+          # the npm alias from a local path anyway.
+          npm install -g \
+            "${{ runner.tool_cache }}/codex/package" \
+            "${{ runner.tool_cache }}/codex/codex-linux-x64" \
+            --no-audit --no-fund
+          codex --version
 
       - name: Create Codex config
         env:
@@ -830,7 +844,12 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ runner.tool_cache }}/codex
-          key: codex-${{ vars.CODEX_VERSION || 'v0.114.0' }}
+          # -v2: previous cache only stored @openai/codex (no platform binary),
+          # so cache hits restored a stub-only install and Codex crashed at
+          # startup with "Missing optional dependency @openai/codex-linux-x64".
+          # Bump invalidates the broken entries; persist+restore below now
+          # handle both packages symmetrically.
+          key: codex-${{ vars.CODEX_VERSION || 'v0.114.0' }}-v2
 
       - name: Install Codex CLI
         if: steps.cache-codex.outputs.cache-hit != 'true'
@@ -844,14 +863,23 @@ jobs:
           set -euo pipefail
           CODEX_BIN="$(which codex)"
           mkdir -p "${{ runner.tool_cache }}/codex"
-          cp -r "$(npm root -g)/@openai/codex" "${{ runner.tool_cache }}/codex/package"
+          cp -r "$(npm root -g)/@openai/codex"           "${{ runner.tool_cache }}/codex/package"
+          cp -r "$(npm root -g)/@openai/codex-linux-x64" "${{ runner.tool_cache }}/codex/codex-linux-x64"
           cp "${CODEX_BIN}" "${{ runner.tool_cache }}/codex/codex"
 
       - name: Restore Codex CLI from cache
         if: steps.cache-codex.outputs.cache-hit == 'true'
         run: |
           set -euo pipefail
-          npm install -g "${{ runner.tool_cache }}/codex/package" --include=optional --no-audit --no-fund
+          # Install BOTH packages from the cached local paths so the platform
+          # binary is restored deterministically. --include=optional is
+          # unreliable for global installs (npm/cli#4828) and cannot resolve
+          # the npm alias from a local path anyway.
+          npm install -g \
+            "${{ runner.tool_cache }}/codex/package" \
+            "${{ runner.tool_cache }}/codex/codex-linux-x64" \
+            --no-audit --no-fund
+          codex --version
 
       - name: Create Codex config
         env:
@@ -1275,7 +1303,12 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ runner.tool_cache }}/codex
-          key: codex-${{ vars.CODEX_VERSION || 'v0.114.0' }}
+          # -v2: previous cache only stored @openai/codex (no platform binary),
+          # so cache hits restored a stub-only install and Codex crashed at
+          # startup with "Missing optional dependency @openai/codex-linux-x64".
+          # Bump invalidates the broken entries; persist+restore below now
+          # handle both packages symmetrically.
+          key: codex-${{ vars.CODEX_VERSION || 'v0.114.0' }}-v2
 
       - name: Install Codex CLI
         if: steps.cache-codex.outputs.cache-hit != 'true'
@@ -1289,14 +1322,23 @@ jobs:
           set -euo pipefail
           CODEX_BIN="$(which codex)"
           mkdir -p "${{ runner.tool_cache }}/codex"
-          cp -r "$(npm root -g)/@openai/codex" "${{ runner.tool_cache }}/codex/package"
+          cp -r "$(npm root -g)/@openai/codex"           "${{ runner.tool_cache }}/codex/package"
+          cp -r "$(npm root -g)/@openai/codex-linux-x64" "${{ runner.tool_cache }}/codex/codex-linux-x64"
           cp "${CODEX_BIN}" "${{ runner.tool_cache }}/codex/codex"
 
       - name: Restore Codex CLI from cache
         if: steps.cache-codex.outputs.cache-hit == 'true'
         run: |
           set -euo pipefail
-          npm install -g "${{ runner.tool_cache }}/codex/package" --include=optional --no-audit --no-fund
+          # Install BOTH packages from the cached local paths so the platform
+          # binary is restored deterministically. --include=optional is
+          # unreliable for global installs (npm/cli#4828) and cannot resolve
+          # the npm alias from a local path anyway.
+          npm install -g \
+            "${{ runner.tool_cache }}/codex/package" \
+            "${{ runner.tool_cache }}/codex/codex-linux-x64" \
+            --no-audit --no-fund
+          codex --version
 
       - name: Create Codex config
         env:

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -243,7 +243,6 @@ jobs:
         if: steps.cache-codex.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          CODEX_BIN="$(which codex)"
           NPM_GLOBAL_ROOT="$(npm root -g)"
           mkdir -p "${{ runner.tool_cache }}/codex"
           [ -d "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64" ] || {
@@ -252,7 +251,6 @@ jobs:
           }
           cp -r "${NPM_GLOBAL_ROOT}/@openai/codex"           "${{ runner.tool_cache }}/codex/package"
           cp -r "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64" "${{ runner.tool_cache }}/codex/codex-linux-x64"
-          cp "${CODEX_BIN}" "${{ runner.tool_cache }}/codex/codex"
 
       - name: Restore Codex CLI from cache
         if: steps.cache-codex.outputs.cache-hit == 'true'
@@ -869,7 +867,6 @@ jobs:
         if: steps.cache-codex.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          CODEX_BIN="$(which codex)"
           NPM_GLOBAL_ROOT="$(npm root -g)"
           mkdir -p "${{ runner.tool_cache }}/codex"
           [ -d "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64" ] || {
@@ -878,7 +875,6 @@ jobs:
           }
           cp -r "${NPM_GLOBAL_ROOT}/@openai/codex"           "${{ runner.tool_cache }}/codex/package"
           cp -r "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64" "${{ runner.tool_cache }}/codex/codex-linux-x64"
-          cp "${CODEX_BIN}" "${{ runner.tool_cache }}/codex/codex"
 
       - name: Restore Codex CLI from cache
         if: steps.cache-codex.outputs.cache-hit == 'true'
@@ -1336,7 +1332,6 @@ jobs:
         if: steps.cache-codex.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          CODEX_BIN="$(which codex)"
           NPM_GLOBAL_ROOT="$(npm root -g)"
           mkdir -p "${{ runner.tool_cache }}/codex"
           [ -d "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64" ] || {
@@ -1345,7 +1340,6 @@ jobs:
           }
           cp -r "${NPM_GLOBAL_ROOT}/@openai/codex"           "${{ runner.tool_cache }}/codex/package"
           cp -r "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64" "${{ runner.tool_cache }}/codex/codex-linux-x64"
-          cp "${CODEX_BIN}" "${{ runner.tool_cache }}/codex/codex"
 
       - name: Restore Codex CLI from cache
         if: steps.cache-codex.outputs.cache-hit == 'true'

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -244,23 +244,31 @@ jobs:
         run: |
           set -euo pipefail
           CODEX_BIN="$(which codex)"
+          NPM_GLOBAL_ROOT="$(npm root -g)"
           mkdir -p "${{ runner.tool_cache }}/codex"
-          cp -r "$(npm root -g)/@openai/codex"           "${{ runner.tool_cache }}/codex/package"
-          cp -r "$(npm root -g)/@openai/codex-linux-x64" "${{ runner.tool_cache }}/codex/codex-linux-x64"
+          [ -d "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64" ] || {
+            echo "::error::Codex platform package @openai/codex-linux-x64 missing after install"
+            exit 1
+          }
+          cp -r "${NPM_GLOBAL_ROOT}/@openai/codex"           "${{ runner.tool_cache }}/codex/package"
+          cp -r "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64" "${{ runner.tool_cache }}/codex/codex-linux-x64"
           cp "${CODEX_BIN}" "${{ runner.tool_cache }}/codex/codex"
 
       - name: Restore Codex CLI from cache
         if: steps.cache-codex.outputs.cache-hit == 'true'
         run: |
           set -euo pipefail
-          # Install BOTH packages from the cached local paths so the platform
-          # binary is restored deterministically. --include=optional is
-          # unreliable for global installs (npm/cli#4828) and cannot resolve
-          # the npm alias from a local path anyway.
-          npm install -g \
-            "${{ runner.tool_cache }}/codex/package" \
-            "${{ runner.tool_cache }}/codex/codex-linux-x64" \
-            --no-audit --no-fund
+          NPM_GLOBAL_ROOT="$(npm root -g)"
+          NPM_GLOBAL_PREFIX="$(npm prefix -g)"
+          # Restore the cached directories directly into the global npm tree so
+          # the @openai/codex-linux-x64 alias name is preserved. npm install -g
+          # on the local paths re-reads package.json, and both cached
+          # directories report "name": "@openai/codex".
+          mkdir -p "${NPM_GLOBAL_ROOT}/@openai" "${NPM_GLOBAL_PREFIX}/bin"
+          rm -rf "${NPM_GLOBAL_ROOT}/@openai/codex" "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64"
+          cp -r "${{ runner.tool_cache }}/codex/package" "${NPM_GLOBAL_ROOT}/@openai/codex"
+          cp -r "${{ runner.tool_cache }}/codex/codex-linux-x64" "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64"
+          ln -sf "${NPM_GLOBAL_ROOT}/@openai/codex/bin/codex.js" "${NPM_GLOBAL_PREFIX}/bin/codex"
           codex --version
 
       - name: Create Codex config
@@ -862,23 +870,31 @@ jobs:
         run: |
           set -euo pipefail
           CODEX_BIN="$(which codex)"
+          NPM_GLOBAL_ROOT="$(npm root -g)"
           mkdir -p "${{ runner.tool_cache }}/codex"
-          cp -r "$(npm root -g)/@openai/codex"           "${{ runner.tool_cache }}/codex/package"
-          cp -r "$(npm root -g)/@openai/codex-linux-x64" "${{ runner.tool_cache }}/codex/codex-linux-x64"
+          [ -d "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64" ] || {
+            echo "::error::Codex platform package @openai/codex-linux-x64 missing after install"
+            exit 1
+          }
+          cp -r "${NPM_GLOBAL_ROOT}/@openai/codex"           "${{ runner.tool_cache }}/codex/package"
+          cp -r "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64" "${{ runner.tool_cache }}/codex/codex-linux-x64"
           cp "${CODEX_BIN}" "${{ runner.tool_cache }}/codex/codex"
 
       - name: Restore Codex CLI from cache
         if: steps.cache-codex.outputs.cache-hit == 'true'
         run: |
           set -euo pipefail
-          # Install BOTH packages from the cached local paths so the platform
-          # binary is restored deterministically. --include=optional is
-          # unreliable for global installs (npm/cli#4828) and cannot resolve
-          # the npm alias from a local path anyway.
-          npm install -g \
-            "${{ runner.tool_cache }}/codex/package" \
-            "${{ runner.tool_cache }}/codex/codex-linux-x64" \
-            --no-audit --no-fund
+          NPM_GLOBAL_ROOT="$(npm root -g)"
+          NPM_GLOBAL_PREFIX="$(npm prefix -g)"
+          # Restore the cached directories directly into the global npm tree so
+          # the @openai/codex-linux-x64 alias name is preserved. npm install -g
+          # on the local paths re-reads package.json, and both cached
+          # directories report "name": "@openai/codex".
+          mkdir -p "${NPM_GLOBAL_ROOT}/@openai" "${NPM_GLOBAL_PREFIX}/bin"
+          rm -rf "${NPM_GLOBAL_ROOT}/@openai/codex" "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64"
+          cp -r "${{ runner.tool_cache }}/codex/package" "${NPM_GLOBAL_ROOT}/@openai/codex"
+          cp -r "${{ runner.tool_cache }}/codex/codex-linux-x64" "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64"
+          ln -sf "${NPM_GLOBAL_ROOT}/@openai/codex/bin/codex.js" "${NPM_GLOBAL_PREFIX}/bin/codex"
           codex --version
 
       - name: Create Codex config
@@ -1321,23 +1337,31 @@ jobs:
         run: |
           set -euo pipefail
           CODEX_BIN="$(which codex)"
+          NPM_GLOBAL_ROOT="$(npm root -g)"
           mkdir -p "${{ runner.tool_cache }}/codex"
-          cp -r "$(npm root -g)/@openai/codex"           "${{ runner.tool_cache }}/codex/package"
-          cp -r "$(npm root -g)/@openai/codex-linux-x64" "${{ runner.tool_cache }}/codex/codex-linux-x64"
+          [ -d "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64" ] || {
+            echo "::error::Codex platform package @openai/codex-linux-x64 missing after install"
+            exit 1
+          }
+          cp -r "${NPM_GLOBAL_ROOT}/@openai/codex"           "${{ runner.tool_cache }}/codex/package"
+          cp -r "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64" "${{ runner.tool_cache }}/codex/codex-linux-x64"
           cp "${CODEX_BIN}" "${{ runner.tool_cache }}/codex/codex"
 
       - name: Restore Codex CLI from cache
         if: steps.cache-codex.outputs.cache-hit == 'true'
         run: |
           set -euo pipefail
-          # Install BOTH packages from the cached local paths so the platform
-          # binary is restored deterministically. --include=optional is
-          # unreliable for global installs (npm/cli#4828) and cannot resolve
-          # the npm alias from a local path anyway.
-          npm install -g \
-            "${{ runner.tool_cache }}/codex/package" \
-            "${{ runner.tool_cache }}/codex/codex-linux-x64" \
-            --no-audit --no-fund
+          NPM_GLOBAL_ROOT="$(npm root -g)"
+          NPM_GLOBAL_PREFIX="$(npm prefix -g)"
+          # Restore the cached directories directly into the global npm tree so
+          # the @openai/codex-linux-x64 alias name is preserved. npm install -g
+          # on the local paths re-reads package.json, and both cached
+          # directories report "name": "@openai/codex".
+          mkdir -p "${NPM_GLOBAL_ROOT}/@openai" "${NPM_GLOBAL_PREFIX}/bin"
+          rm -rf "${NPM_GLOBAL_ROOT}/@openai/codex" "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64"
+          cp -r "${{ runner.tool_cache }}/codex/package" "${NPM_GLOBAL_ROOT}/@openai/codex"
+          cp -r "${{ runner.tool_cache }}/codex/codex-linux-x64" "${NPM_GLOBAL_ROOT}/@openai/codex-linux-x64"
+          ln -sf "${NPM_GLOBAL_ROOT}/@openai/codex/bin/codex.js" "${NPM_GLOBAL_PREFIX}/bin/codex"
           codex --version
 
       - name: Create Codex config


### PR DESCRIPTION
## Summary

Eliminates every remaining `npm install ... @openai/codex` invocation outside the canonical `install-codex` composite action. After this PR the only place that directly installs the Codex npm package is `.github/actions/install-codex/action.yml`, which uses the correct two-package alias pattern (entry + `@openai/codex-linux-x64` under its alias name).

Two distinct but related defects share the same root cause (npm/cli#4828 makes `--include=optional` unreliable for global installs, so the platform binary `@openai/codex-linux-x64` can silently fail to install).

### Defect 1 — broken cache-restore (was actually failing in production)

`plan.yml` and `workflow-log-analysis.yml` cached only `@openai/codex`, never `@openai/codex-linux-x64`. After the first cache miss persisted the stub, every subsequent cache hit restored a stub-only install and the Codex CLI crashed at startup with `Missing optional dependency @openai/codex-linux-x64`. This is the residual risk explicitly acknowledged in `ba7290e` (PR #2185).

Consumer evidence: `shubhodeep1/multi-user-ai-agent` AI Plan runs `25965325901` (issue #23) and `25965326266` (issue #22) both hit cache `codex-v0.114.0` (restored size 5420 B — just the JS shim) and failed at `/opt/hostedtoolcache/codex/package/bin/codex.js:100` three retries each.

Only `multi-user-ai-agent` has tripped this so far because GitHub Actions cache is scoped per repository and the bug needs ≥2 runs to bite. Other consumers in `.github/ai/consumer_repos.json` are latently affected — they either haven't run these workflows enough, or had the entry evicted (7-day inactivity).

### Defect 2 — residual inline installs (latent, not yet failing)

`orchestrate.yml:111` and `orchestrate_poll.yml:187` were added in a forward-merge after PR #2185 and copied the legacy `npm install -g "@openai/codex@${CODEX_VERSION}" --include=optional` pattern instead of using the shared composite action. Different failure mode from Defect 1 (registry install, not local-path), but identical npm/cli#4828 root cause — the failure that motivated `install-codex`'s existence in the first place (run 25441973385 cited in `ba7290e`).

## Fix

### Commit 1 — `fix(workflows): persist+restore Codex platform binary in cache path`

Mirrors the `install-codex` action's two-package pattern:

- **Persist both** `@openai/codex` **and** `@openai/codex-linux-x64` to the tool cache.
- **Restore** by `npm install -g`-ing both cached paths together. Drop the misleading `--include=optional` (cannot resolve npm aliases from a local path anyway). Add a `codex --version` smoke check so a broken restore fails fast.
- **Bump the cache key to `-v2`** so the existing broken `codex-v0.114.0` cache entries in every consumer repo are bypassed in one shot.

Touched: `.github/workflows/plan.yml` (1 block) + `.github/workflows/workflow-log-analysis.yml` (3 blocks — the consumer-side analysis said 2, it's actually 3).

### Commit 2 — `fix(workflows): migrate residual codex installs to install-codex@stable`

- Replace the inline `npm install -g "@openai/codex@${CODEX_VERSION}" --include=optional` line with `uses: ./.github/actions/install-codex@stable`.
- Split the original "Install Codex CLI and core tools" step into two: a `uses:` step for Codex, plus a remaining `run:` step for OS-level core tools (jq/curl/gh apt-install + `PYTHONDONTWRITEBYTECODE`).
- Preserves the `if: steps.find_tracking.outputs.has_work == 'true'` gate on `orchestrate_poll.yml` across both new steps.

Touched: `.github/workflows/orchestrate.yml` + `.github/workflows/orchestrate_poll.yml`.

## Backward compatibility

- **Codex CLI version is unchanged** — still pinned to `vars.CODEX_VERSION || 'v0.114.0'`. The `install-codex@stable` ref is the composite-action wrapper, not the Codex binary; consumers cannot accidentally ride a Codex CLI upgrade.
- **One-shot cache miss** on the first run after merge in every consumer repo (~30s of `install-codex` work), then cache hits normally. By design — without the `-v2` bump the live broken cache for `codex-v0.114.0` would keep masking the fix.
- No public-contract changes (no env vars, flags, outputs, log keys, or downstream fields renamed). §6 (naming immutability) clean. §10 (MongoDB contracts) untouched.

## Base branch

Targeting `stable` so `test-and-mark-stable.yml` can cut a patch release (v1.11.1) and re-tag `@stable` for consumers. Landing on `main` would leave the fix invisible to consumers until the next minor-bump promote.

## Test plan

- [ ] CI on `stable` passes.
- [ ] Manual: dispatch `test-and-mark-stable.yml --ref stable --dry_run true` and confirm the gate runs Codex successfully.
- [ ] After merge + release: confirm next AI Plan run on `shubhodeep1/multi-user-ai-agent` issues #22/#23 reaches the planning phase without the `Missing optional dependency` error.
- [ ] After merge + release: confirm the orchestrate workflows still install Codex correctly on a fresh run (look for the new "Install Codex CLI" step succeeding).
- [ ] Optional: inspect persisted cache contents — `${runner.tool_cache}/codex/` should contain both `package/` and `codex-linux-x64/`.