### PR TITLE
fix(review-autofix): unblock conflict resolver when autofix iterations exhausted

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -4168,11 +4168,13 @@ jobs:
         # is deferred — both autofix and conflict resolution are pushed together.
         #
         # The EDITOR_NOOP_SUSPICIOUS != 'true' clause mirrors the gate on
-        # "Detect merge conflicts" above: if the editor never produced a
-        # validated commit, MERGE_CONFLICT cannot legitimately be true here
-        # (the prior step is skipped and leaves the env var unset), but we
-        # repeat the guard for defence-in-depth in case future code paths set
-        # MERGE_CONFLICT outside that step.
+        # "Detect merge conflicts" above: on ordinary editor-tail runs, if the
+        # editor never produced a validated commit, that step was also skipped
+        # and left MERGE_CONFLICT unset. We repeat the guard for defence-in-
+        # depth in case future code paths set MERGE_CONFLICT outside that
+        # step. On max_iterations_reached runs, EDITOR_NOOP_SUSPICIOUS stays
+        # unset, so this guard is a no-op and MERGE_CONFLICT can legitimately
+        # come from the detect step above.
         if: success() && env.CAN_PUSH == 'true' && env.MERGE_CONFLICT == 'true' && env.PR_CLOSED != 'true' && env.AUTOFIX_STALE_BASE_SKIP != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true' && env.EDITOR_NOOP_SUSPICIOUS != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3786,7 +3786,27 @@ jobs:
         # here: the ledger is bookkeeping and does not count as a productive
         # editor change, so the no-op disposition still needs validation
         # before downstream clean-review gates fire. See PR #1472.
-        if: "!cancelled() && (steps.commit_changes.outputs.did_commit != 'true' || env.LEDGER_ONLY_COMMIT == 'true') && env.EDITOR_CHANGES_LOST != 'true' && env.PR_CLOSED != 'true' && env.AUTOFIX_STALE_BASE_SKIP != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true'"
+        #
+        # Skip on max_iterations_reached runs (autofix cap hit, or
+        # force_rb_judge=true short-circuit): in those modes the editor
+        # is intentionally not invoked, so `EDITOR_SUMMARY_FILE` is
+        # legitimately empty and there is no editor claim to validate.
+        # Running this step would set EDITOR_NOOP_SUSPICIOUS=true off
+        # the empty-summary branch (line below), which then gates off
+        # the "Detect merge conflicts" and "Resolve merge conflicts"
+        # steps (their `if:` filters on `EDITOR_NOOP_SUSPICIOUS != 'true'`
+        # for defence-in-depth against a leaked MERGE_CONFLICT). The
+        # net effect was a deadlock: an exhausted PR with merge
+        # conflicts could never reach the Codex conflict resolver, and
+        # the orchestrator-poll's `_dispatch_review_for_conflicts`
+        # (scripts/orchestrate_poll_process.sh) kept re-dispatching the
+        # same futile run every cycle. See PR #2667 / runs 25968901129+
+        # for the original deadlock. Downstream auto-merge / mark-ready
+        # gates that also consume `EDITOR_NOOP_SUSPICIOUS` already
+        # short-circuit independently on `max_iterations_reached != 'true'`,
+        # so leaving the env var unset on these runs does not relax any
+        # auto-merge safety.
+        if: "!cancelled() && steps.retrigger_guard.outputs.max_iterations_reached != 'true' && (steps.commit_changes.outputs.did_commit != 'true' || env.LEDGER_ONLY_COMMIT == 'true') && env.EDITOR_CHANGES_LOST != 'true' && env.PR_CLOSED != 'true' && env.AUTOFIX_STALE_BASE_SKIP != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true'"
         run: |
           set -euo pipefail
 

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3888,15 +3888,17 @@ jobs:
         # Actual
         # resolution is gated separately below.
         #
-        # Skip when EDITOR_NOOP_SUSPICIOUS=true: the editor never produced a
-        # validated commit, so even a successful conflict resolver run would
-        # have nothing fix-related to push. Running merge detection here
-        # otherwise wastes ~30s and — if the defensive fallback at the
-        # end of this step trips on an unrelated git issue — sets
-        # MERGE_CONFLICT=true, which in turn fires the (futile) Codex
-        # resolver and produces a `FAILED_STEPS=1` cascade that the e2e
-        # poller treats as the proximate failure (analysis: e2e-smoke-
-        # failure-25126757724.md §B/D).
+        # Skip when EDITOR_NOOP_SUSPICIOUS=true on ordinary editor-tail runs:
+        # the editor never produced a validated commit, so even a successful
+        # conflict resolver run would have nothing fix-related to push. This
+        # does not apply when max_iterations_reached=true, because the
+        # disposition step is skipped in that mode and conflict resolution is
+        # independent of the editor cycle. Running merge detection here
+        # otherwise wastes ~30s and — if the defensive fallback at the end of
+        # this step trips on an unrelated git issue — sets MERGE_CONFLICT=true,
+        # which in turn fires the (futile) Codex resolver and produces a
+        # `FAILED_STEPS=1` cascade that the e2e poller treats as the proximate
+        # failure (analysis: e2e-smoke-failure-25126757724.md §B/D).
         if: success() && env.CAN_PUSH == 'true' && env.PR_CLOSED != 'true' && env.AUTOFIX_STALE_BASE_SKIP != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true' && env.EDITOR_NOOP_SUSPICIOUS != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Summary

PRs that hit `MAX_AUTOFIX_ITERATIONS` (3 consecutive `[ai-autofix]` commits) **and** have a real base-branch merge conflict were getting stuck: the orchestrator-poll dispatched the conflict resolver every cycle, but each run silently short-circuited and produced nothing.

Root cause: when `max_iterations_reached=true`, the editor is intentionally skipped (`.github/workflows/review_autofix.yml`, `retrigger_guard` step). The downstream **"Validate editor no-op disposition"** step (`:3768`) does not honour `max_iterations_reached`, so it ran anyway, saw the empty `EDITOR_SUMMARY_FILE`, emitted `::warning::Editor summary file is missing or empty — editor never produced output.`, and exported `EDITOR_NOOP_SUSPICIOUS=true`. That env var is part of the `if:` gate on:

- **Detect merge conflicts** (`:3880`)
- **Prepare merge-conflict resolver prompt and pre-snapshot** (`:4154`)
- **Run Codex resolver, validate, stage, commit** (`:4188`)

All three short-circuited. `MERGE_CONFLICT` stayed unset, Codex never ran, and `scripts/orchestrate_poll_process.sh:_dispatch_review_for_conflicts` happily kept dispatching new runs that did the same thing.

Observed on PR #2667 (issue #2665, tracking #2627): 5 follow-up dispatches (runs `25975007509`, `25975462692`, `25975915057`, `25976391937`, `25977759050`) over ~4h, every one with the same annotation, zero `[ai-merge-resolve]` commits on the branch. `git merge-tree origin/orchestrator/project-2627 origin/ai/issue-2665` confirms a real content conflict in `.github/workflows/review_autofix.yml`.

## Fix

Add `steps.retrigger_guard.outputs.max_iterations_reached != 'true'` to the `if:` of "Validate editor no-op disposition". The step's whole purpose is to verify an editor *claim*; when the editor was deliberately skipped there is no claim and no validation is needed. The conflict resolver and detect-merge-conflicts steps then see `EDITOR_NOOP_SUSPICIOUS` unset (treated as `!= 'true'`) and run on exhausted PRs with conflicts, as the comment block at `:4143-4146` already states is intended.

Auto-merge / mark-ready gates that also consume `EDITOR_NOOP_SUSPICIOUS` already short-circuit independently on `max_iterations_reached != 'true'`, so this does not relax any auto-merge safety.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/review_autofix.yml'))"` passes after the edit
- [ ] After merge, watch the next orchestrator-poll tick re-dispatch `internal-review.yml` on `ai/issue-2665`; expect the codex-agent job to now reach "Detect merge conflicts" → `MERGE_CONFLICT=true` → "Run Codex resolver" → `[ai-merge-resolve]` commit pushed
- [ ] Confirm PR #2667 transitions from `mergeable_state=dirty` back to `clean`/`unstable` and the `ai:review-blocked` label clears

## Investigation references

- Critical alert: autofix exhausted (3 iterations) on PR #2667
- Original exhaustion run: https://github.com/shubhodeep1/coding-workflows/actions/runs/25968901129 (job 76337234486)
- Pre-judge dispatch from poller: https://github.com/shubhodeep1/coding-workflows/actions/runs/25969319666 (job 76338350622, log line `[review-blocked] Pre-judge dispatch for PR #2667: merge conflicts (mergeable=false, mergeable_state=dirty)`)
- Workflow line refs: gate at `.github/workflows/review_autofix.yml:3789`; downstream blocked gates at `:3880`, `:4154`, `:4188`; poller dispatcher at `scripts/orchestrate_poll_process.sh:8071`, called from `:9647`

https://claude.ai/code/session_01KRbngemtaTZ9yCW7JH55Zz

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRbngemtaTZ9yCW7JH55Zz)_