### PR TITLE
fix(node-hardhat-harness): decouple ANVIL_PORT from manifest.port and keep anvil flags through sh -c entrypoint

### DIFF
--- a/tests/test_render_validation_templates_node_hardhat_regressions.py
+++ b/tests/test_render_validation_templates_node_hardhat_regressions.py
@@ -149,10 +149,80 @@ def test_log9_validate_env_values_are_double_quoted() -> None:
         custom_result = _run_renderer(manifest_path, output_root)
         assert custom_result.returncode == 0, custom_result.stderr
         custom_env_text = (output_root / "validate.env").read_text(encoding="utf-8")
-        assert 'ANVIL_PORT="9555"' in custom_env_text
+        # `manifest.port` is the app HTTP listener port, not the chain RPC port;
+        # it must NOT propagate into ANVIL_PORT. The chain RPC port stays at
+        # Anvil's default 8545 unless `env_overrides.ANVIL_PORT` is set.
+        assert 'ANVIL_PORT="8545"' in custom_env_text
+        assert 'ANVIL_PORT="9555"' not in custom_env_text
         assert 'CANARY_TOOLS="curl jq node"' in custom_env_text
         assert 'RPC_URL=""' in env_text
         assert 'RPC_URL=""' in custom_env_text
+
+
+def test_anvil_port_overridable_via_env_overrides_not_manifest_port() -> None:
+    """`env_overrides.ANVIL_PORT` is the supported knob for a non-default chain RPC port.
+
+    Setting `manifest.port` to a value other than 8545 used to leak the app
+    HTTP port into ANVIL_PORT, which broke the rendered compose healthcheck
+    and RPC routing for any consumer whose app HTTP port differed from
+    Anvil's default. The fix decouples the two: keep ANVIL_PORT at 8545 by
+    default and let consumers override it via `env_overrides.ANVIL_PORT`.
+    """
+    with tempfile.TemporaryDirectory(prefix="render-validation-node-hardhat-") as td:
+        temp_root = Path(td)
+        manifest_path = temp_root / "validate.yml"
+        output_root = temp_root / "out"
+        payload = _manifest_payload()
+        # App-HTTP-port-like value that must NOT spill into ANVIL_PORT.
+        payload["port"] = 8080
+        payload["env_overrides"] = {"ANVIL_PORT": "9555"}
+        _write_yaml(manifest_path, payload)
+
+        result = _run_renderer(manifest_path, output_root)
+        assert result.returncode == 0, result.stderr
+
+        env_text = (output_root / "validate.env").read_text(encoding="utf-8")
+        # The default ANVIL_PORT="8545" line appears first, but env_overrides
+        # emits ANVIL_PORT="9555" afterwards, and `set -a; . validate.env`
+        # last-write-wins so the override takes effect at source time.
+        assert 'ANVIL_PORT="8545"' in env_text, env_text
+        assert 'ANVIL_PORT="9555"' in env_text, env_text
+        override_pos = env_text.find('ANVIL_PORT="9555"')
+        default_pos = env_text.find('ANVIL_PORT="8545"')
+        assert override_pos > default_pos, env_text
+
+
+def test_anvil_compose_command_is_single_element_list_so_sh_c_keeps_flags() -> None:
+    """foundry's ENTRYPOINT is ["/bin/sh", "-c"]: command must be a 1-elem list.
+
+    The foundry image's ENTRYPOINT is ["/bin/sh", "-c"]; if compose's
+    `command:` is a string, compose tokenizes it into multiple argv elements
+    and the resulting exec is `/bin/sh -c anvil --host 0.0.0.0 --port 8545`,
+    where sh -c uses only the FIRST non-option arg as the script (anvil)
+    and the rest become positional parameters $0, $1, ... — anvil runs
+    without flags and binds to its default 127.0.0.1:8545. Rendering the
+    command as a single-element list keeps the whole command line in argv[0]
+    so sh -c runs the intended script.
+    """
+    with tempfile.TemporaryDirectory(prefix="render-validation-node-hardhat-") as td:
+        temp_root = Path(td)
+        manifest_path = temp_root / "validate.yml"
+        output_root = temp_root / "out"
+        _write_yaml(manifest_path, _manifest_payload())
+
+        result = _run_renderer(manifest_path, output_root)
+        assert result.returncode == 0, result.stderr
+
+        compose_text = (output_root / "docker-compose.test.yml").read_text(encoding="utf-8")
+        parsed = yaml.safe_load(compose_text)
+        anvil_command = parsed["services"]["anvil"]["command"]
+        assert isinstance(anvil_command, list), f"command must be a list, got {type(anvil_command).__name__}: {anvil_command!r}"
+        assert len(anvil_command) == 1, f"command must be single-element, got {anvil_command!r}"
+        assert anvil_command[0] == "anvil --host 0.0.0.0 --port ${ANVIL_PORT:-8545}", anvil_command[0]
+        # Guard against accidental regression to the folded-scalar / string form
+        # that compose would tokenize back into a multi-arg argv.
+        assert "command: >-" not in compose_text, compose_text
+        assert "command: anvil --host" not in compose_text, compose_text
 
 
 def test_shutdown_helper_is_rendered_and_invoked() -> None:

--- a/workflow-templates/validation-harness/node-hardhat-solidity/docker-compose.test.yml.j2
+++ b/workflow-templates/validation-harness/node-hardhat-solidity/docker-compose.test.yml.j2
@@ -8,8 +8,15 @@ services:
   anvil:
     image: ghcr.io/foundry-rs/foundry:v1.3.1
     init: true
-    command: >-
-      anvil --host 0.0.0.0 --port ${ANVIL_PORT:-8545}
+    # The foundry image's ENTRYPOINT is ["/bin/sh", "-c"], so the command must
+    # arrive as a SINGLE argv element (the full script for sh -c). Compose
+    # tokenizes a string-form `command:` into a list of separate args, which
+    # would make sh -c run only the first token ("anvil") and silently drop
+    # --host/--port (anvil would then bind to its default 127.0.0.1:8545,
+    # failing the healthcheck below when ANVIL_PORT != 8545). Use a
+    # single-element list to keep the whole command line intact.
+    command:
+      - "anvil --host 0.0.0.0 --port ${ANVIL_PORT:-8545}"
     healthcheck:
       test:
         - "CMD-SHELL"

--- a/workflow-templates/validation-harness/node-hardhat-solidity/validate.env.j2
+++ b/workflow-templates/validation-harness/node-hardhat-solidity/validate.env.j2
@@ -1,7 +1,10 @@
 {%- set env_overrides = manifest.get('env_overrides', {}) or {} -%}
 APP_SERVICE="app"
 APP_URL=""
-ANVIL_PORT="{{ manifest.get('port', 8545) }}"
+# ANVIL_PORT is the chain RPC port (anvil --port); `manifest.port` is the app
+# HTTP listener and a different concept, so do not derive ANVIL_PORT from it.
+# Override via `env_overrides.ANVIL_PORT` if a non-default chain port is needed.
+ANVIL_PORT="8545"
 RPC_URL=""
 CANARY_TOOLS="{{ slots.canary_tools | join(' ') }}"
 HEALTH_TIMEOUT_SECONDS="120"


### PR DESCRIPTION
## Summary

The `node-hardhat-solidity` validation harness was rendering a compose stack that never reached a healthy `anvil` container when the consumer's `.ai/validate.yml` had `port:` set to anything other than `8545` (e.g. an app HTTP port like `8080`). Validation failed at preflight with `dependency failed to start: container validation-anvil-1 is unhealthy`, even though the anvil container log showed `Listening on 127.0.0.1:8545`.

## Root cause — two related template defects

1. **Wrong-port semantics.** `validate.env.j2:4` derived `ANVIL_PORT` from `manifest.get('port', 8545)`, but `manifest.port` is the **app HTTP listener** — not the chain RPC port. Any consumer whose app port differed from `8545` had the wrong value baked into ANVIL_PORT, and the compose healthcheck + RPC routing then probed the wrong port.
2. **`sh -c` argv loss.** `docker-compose.test.yml.j2:11-12` rendered the anvil `command:` as a YAML folded block scalar string. Compose tokenizes string-form commands into separate argv elements; combined with the foundry image's `Entrypoint=["/bin/sh","-c"]`, the exec became `/bin/sh -c anvil --host 0.0.0.0 --port <port>`, where `sh -c` only treats the first non-option arg as the script. The `--host` / `--port` flags became positional parameters `$0`, `$1`, … and anvil silently bound to its default `127.0.0.1:8545`, failing every healthcheck that probed a non-default port.

The failing run's diagnosis quoted `docker inspect` directly: `Entrypoint=["/bin/sh","-c"]` and `Cmd=["anvil","--host","0.0.0.0","--port","8080"]` — proof that the flags were sitting in argv but never reaching anvil.

## Fix

- `workflow-templates/validation-harness/node-hardhat-solidity/validate.env.j2:4` — stop deriving `ANVIL_PORT` from `manifest.port`; default to literal `"8545"`. Consumers that need a non-default chain RPC port can set `env_overrides.ANVIL_PORT`; the env_overrides loop emits the override after the default, so `set -a; . validate.env` last-write-wins carries the override through.
- `workflow-templates/validation-harness/node-hardhat-solidity/docker-compose.test.yml.j2:11-12` — render the anvil `command:` as a single-element list (`- "anvil --host 0.0.0.0 --port ${ANVIL_PORT:-8545}"`) so the entire command line stays in argv[0] and reaches `sh -c` as one script, preserving the flags.

## Tests

- `tests/test_render_validation_templates_node_hardhat_regressions.py::test_log9_validate_env_values_are_double_quoted` — updated to assert `manifest.port=9555` does NOT leak into `ANVIL_PORT` (it was previously asserting the buggy behavior).
- `test_anvil_port_overridable_via_env_overrides_not_manifest_port` *(new)* — `env_overrides.ANVIL_PORT` is the supported override knob; with `manifest.port=8080` + `env_overrides.ANVIL_PORT="9555"`, the override appears after the default so last-write-wins gives 9555.
- `test_anvil_compose_command_is_single_element_list_so_sh_c_keeps_flags` *(new)* — parses the rendered compose YAML and asserts the anvil `command:` is a 1-element list whose single string contains the full anvil flag line; guards against regression to the folded-scalar / multi-arg-list forms.

Also verified end-to-end that with `validate.env` sourced into the host shell (matching `validate_driver.sh`'s `load_env_file()` path), `docker compose config` produces `command: [- anvil --host 0.0.0.0 --port 9555]` for the override case and `[- anvil --host 0.0.0.0 --port 8545]` for the default case — flags intact, port correct.

## Test plan

- [x] All 25 tests in `tests/test_render_validation_templates_node_hardhat_regressions.py` pass.
- [x] Sibling renderer tests (`test_render_validation_templates.py`, `test_render_validation_templates_repo_checks.py`) still pass.
- [x] `python3 scripts/validation_lint.py <rendered-output>` returns `validation-lint: OK` on the selftest fixture render.
- [x] `docker compose config` on the rendered compose file parses the anvil `command:` as `[- anvil --host 0.0.0.0 --port <ANVIL_PORT>]` with the env-override path interpolating correctly (9555 when overridden, 8545 by default).
- [ ] Re-run the failing validation workflow (issue #226) against the new `@stable` once tagged, to confirm the anvil container reaches healthy and the harness proceeds past preflight.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HyqTzZGZpzxDMwwKpYw7ct)_