### PR TITLE
fix(validation-refresh): isolate smoke-test dispatches in concurrency group

### DIFF
--- a/.github/workflows/validation-refresh.yml
+++ b/.github/workflows/validation-refresh.yml
@@ -34,7 +34,17 @@ permissions:
   contents: read
 
 concurrency:
-  group: validation-refresh-${{ github.repository }}
+  # Include `branch_name` in the group key so smoke-test dispatches from
+  # `test-and-mark-stable.yml` (which pass a per-run branch name like
+  # `ai/validation-refresh-smoke-<run_id>`) cannot be cancelled by the
+  # daily cron or by a parallel default-branch manual dispatch, which
+  # would otherwise share the same group and surface as
+  # `orphan-workflows-test` failing with `concluded cancelled`.
+  # Schedule events and dispatches without an override both resolve to
+  # `ai/validation-refresh` (the workflow's documented default), so they
+  # still share one group and the cancel-in-progress semantics for
+  # production runs are preserved.
+  group: validation-refresh-${{ github.repository }}-${{ github.event.inputs.branch_name || 'ai/validation-refresh' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Release v1.11.1 failed because `orphan-workflows-test` reported
`validation-refresh run #25980248328 concluded cancelled`
([run 25980238302](https://github.com/shubhodeep1/coding-workflows/actions/runs/25980238302)).

Root cause: `validation-refresh.yml` declared

```yaml
concurrency:
  group: validation-refresh-${{ github.repository }}
  cancel-in-progress: true
```

The `orphan-workflows-test` smoke gate in `test-and-mark-stable.yml`
dispatches `validation-refresh.yml` with a per-run branch name
(`ai/validation-refresh-smoke-<run_id>`) and waits for the run to
complete. Because the concurrency group was static, the daily
`schedule` cron — or any concurrent default-branch manual dispatch —
that fires during the smoke window shares the same group, and with
`cancel-in-progress: true` the smoke run is cancelled and the gate
fails. The v1.11.1 timing:

- `25980248328` workflow_dispatch (smoke): `2026-05-17T03:28:24Z`
- `25980272205` schedule (cron `17 2 * * *`, delayed by Actions): `2026-05-17T03:29:46Z`

The cron fired 82s into the smoke run and cancelled it
(`Canceling since a higher priority waiting request for
validation-refresh-shubhodeep1/coding-workflows exists`).

## Fix

Extend the concurrency group key with the `branch_name` input
(`github.event.inputs.branch_name || 'ai/validation-refresh'`). The
smoke dispatch's per-run branch name now resolves to a unique group
per `GITHUB_RUN_ID`, so cron / production manual dispatches can no
longer cancel a smoke run. Schedule events and dispatches that omit
`branch_name` both resolve to the workflow's documented default
`ai/validation-refresh`, so production runs still share one group and
the existing `cancel-in-progress` semantics are preserved unchanged.

## Files changed

- `.github/workflows/validation-refresh.yml` (lines 36–48) — extend
  concurrency group key with `branch_name` input; comment block
  explaining the smoke-vs-production isolation.

## Test plan

- [ ] Re-run `Test & Mark Stable Release` and confirm
      `orphan-workflows-test` passes when the daily cron is not active.
- [ ] (Optional) Verify a smoke dispatch is no longer cancelled by a
      concurrent scheduled run by triggering both within the same
      window.
- [ ] Confirm scheduled `validation-refresh` runs (cron `17 2 * * *`)
      continue to cancel-in-progress against each other and against
      default-input manual dispatches (group
      `validation-refresh-<repo>-ai/validation-refresh`).

Targeted at `stable` per the investigation request — the failure
surfaced on the stable release pipeline and the workflow change needs
to land there directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZEB8MbfafQXXnrHYxUHuG)_