### PR TITLE
fix: UTF-8 sanitisation for floor_rules truncation + all codex stdin pipes

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -653,6 +653,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Source sanitize_codex_prompt_file (best-effort) so invalid
+          # UTF-8 in the prompt cannot deterministically kill every
+          # clarify retry.
+          # shellcheck source=/dev/null
+          source scripts/gh_helpers.sh 2>/dev/null || true
+
           PROMPT_TEMPLATE_FILE="${RUNTIME_DIR}/mode-clarify-inline.txt"
           cat > "${PROMPT_TEMPLATE_FILE}" <<'PROMPT'
           === CLARIFICATION TASK ===
@@ -815,6 +821,10 @@ jobs:
             echo "=== ISSUE CONTEXT ==="
             cat "${ISSUE_CONTEXT_FILE}"
           } > "${CODEX_PROMPT_FILE}"
+
+          if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+            sanitize_codex_prompt_file "${CODEX_PROMPT_FILE}"
+          fi
 
           # Pass prompt via stdin to avoid ARG_MAX limits with large context files
           max_attempts=3

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1292,6 +1292,14 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Source sanitize_codex_prompt_file (best-effort). Codex
+          # CLI's stdin reader strictly validates UTF-8; any invalid
+          # byte that leaked into the prompt would abort the
+          # implementer immediately. Stripping invalid bytes before
+          # piping is the cheapest insurance.
+          # shellcheck source=/dev/null
+          source scripts/gh_helpers.sh 2>/dev/null || true
+
           PROMPT_TEMPLATE_FILE="${RUNTIME_DIR}/mode-implement-inline.txt"
           cat > "${PROMPT_TEMPLATE_FILE}" <<'EOF'
           === IMPLEMENTATION TASK ===
@@ -1761,6 +1769,9 @@ jobs:
             # the cumulative log by line offset.
             attempt_log_file="${RUNTIME_DIR}/codex_log_attempt_${attempt}.txt"
             : > "${attempt_log_file}"
+            if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+              sanitize_codex_prompt_file "${PROMPT_FILE_TO_USE}"
+            fi
             (
               exec codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${PROMPT_FILE_TO_USE}"
             ) > "${CODEX_OUTPUT_FILE}" 2> >(
@@ -2375,6 +2386,11 @@ jobs:
           set -euo pipefail
           echo "repaired=false" >> "$GITHUB_OUTPUT"
 
+          # Source sanitize_codex_prompt_file (best-effort) so the
+          # repair-prompt pipe to codex strips invalid UTF-8 first.
+          # shellcheck source=/dev/null
+          source scripts/gh_helpers.sh 2>/dev/null || true
+
           REPAIR_PROMPT_TEMPLATE="prompts/mode-implement-repair.txt"
           REPAIR_VALIDATOR_SCRIPT="scripts/validate_changed_files_syntax.sh"
           CAPTURE_FILE="${RUNTIME_DIR}/post_codex_validation_errors.txt"
@@ -2689,6 +2705,9 @@ jobs:
 
             REPAIR_OUTPUT_FILE="${RUNTIME_DIR}/post_codex_repair_output_attempt_${attempt}.txt"
             REPAIR_LOG_FILE="${RUNTIME_DIR}/post_codex_repair_log_attempt_${attempt}.txt"
+            if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+              sanitize_codex_prompt_file "${REPAIR_PROMPT_FILE}"
+            fi
             if ! codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${REPAIR_PROMPT_FILE}" > "${REPAIR_OUTPUT_FILE}" 2> >(tee -a "${REPAIR_LOG_FILE}" >&2); then
               echo "::warning::Post-Codex repair attempt ${attempt} failed while invoking Codex."
               continue
@@ -3951,6 +3970,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Source sanitize_codex_prompt_file (best-effort) so the
+          # concatenated prompt is UTF-8-clean before piping to codex.
+          # shellcheck source=/dev/null
+          source scripts/gh_helpers.sh 2>/dev/null || true
+
           cat > "${ISSUE_SUMMARY_PROMPT_FILE}" <<EOF
           Generate a concise issue summary for a pull request comment.
 
@@ -3976,8 +4000,15 @@ jobs:
           trap 'rm -f "${RUNTIME_DIR}/issue_context_for_summary.txt"' EXIT
 
           for _summary_attempt in 1 2 3; do
-            cat "${ISSUE_SUMMARY_PROMPT_FILE}" "${RUNTIME_DIR}/issue_context_for_summary.txt" \
-              | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${ISSUE_SUMMARY_FILE}" || true
+            # Materialise the concatenation into a temp file so we
+            # can sanitize invalid UTF-8 before piping to codex
+            # (codex's stdin reader strictly validates UTF-8).
+            _summary_combined_prompt="${RUNTIME_DIR}/issue_summary_combined_prompt.txt"
+            cat "${ISSUE_SUMMARY_PROMPT_FILE}" "${RUNTIME_DIR}/issue_context_for_summary.txt" > "${_summary_combined_prompt}"
+            if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+              sanitize_codex_prompt_file "${_summary_combined_prompt}"
+            fi
+            codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${_summary_combined_prompt}" > "${ISSUE_SUMMARY_FILE}" || true
             if [ -s "${ISSUE_SUMMARY_FILE}" ] && grep -q '^### AI Issue Summary' "${ISSUE_SUMMARY_FILE}"; then
               echo "Summary generated on attempt ${_summary_attempt}."
               break

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -3997,13 +3997,13 @@ jobs:
             cat "${PLAN_FILE}"
           } > "${RUNTIME_DIR}/issue_context_for_summary.txt"
 
-          trap 'rm -f "${RUNTIME_DIR}/issue_context_for_summary.txt"' EXIT
+          _summary_combined_prompt="${RUNTIME_DIR}/issue_summary_combined_prompt.txt"
+          trap 'rm -f "${RUNTIME_DIR}/issue_context_for_summary.txt" "${_summary_combined_prompt}"' EXIT
 
           for _summary_attempt in 1 2 3; do
             # Materialise the concatenation into a temp file so we
             # can sanitize invalid UTF-8 before piping to codex
             # (codex's stdin reader strictly validates UTF-8).
-            _summary_combined_prompt="${RUNTIME_DIR}/issue_summary_combined_prompt.txt"
             cat "${ISSUE_SUMMARY_PROMPT_FILE}" "${RUNTIME_DIR}/issue_context_for_summary.txt" > "${_summary_combined_prompt}"
             if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
               sanitize_codex_prompt_file "${_summary_combined_prompt}"

--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -573,6 +573,15 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Source sanitize_codex_prompt_file (best-effort). Codex
+          # CLI's stdin reader strictly validates UTF-8; any invalid
+          # byte that leaked into the prompt (e.g. via a byte-based
+          # truncation in an upstream awk script) would abort the
+          # decomposer immediately. Stripping invalid bytes before
+          # piping is the cheapest insurance.
+          # shellcheck source=/dev/null
+          source scripts/gh_helpers.sh 2>/dev/null || true
+
           # Author-enumeration enforcement.
           #
           # When the project description explicitly enumerates sub-issues
@@ -657,6 +666,9 @@ jobs:
             attempt_ok=0
             attempt_started_at="$(date +%s)"
             attempt_worktree_before="$(git status --porcelain=v1 --untracked-files=all)"
+            if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+              sanitize_codex_prompt_file "${CODEX_PROMPT_FILE}"
+            fi
             # `--` terminates `timeout`'s option parsing so a leading
             # '-' in DURATION cannot be mistaken for an option (defence
             # in depth on top of the regex check above). stdin

--- a/.github/workflows/orchestrate_clarify_respond.yml
+++ b/.github/workflows/orchestrate_clarify_respond.yml
@@ -631,6 +631,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Source sanitize_codex_prompt_file (best-effort) so the
+          # clarify-respond prompt is UTF-8-clean before piping.
+          # shellcheck source=/dev/null
+          source scripts/gh_helpers.sh 2>/dev/null || true
+
           # Keep static context first for cache reuse, then append run-specific
           # data so issue/comment changes do not invalidate the cached prefix.
           {
@@ -675,6 +680,9 @@ jobs:
           max_attempts=3
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "Codex clarify-respond attempt ${attempt}/${max_attempts}..."
+            if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+              sanitize_codex_prompt_file "${CODEX_PROMPT_FILE}"
+            fi
             if cat "${CODEX_PROMPT_FILE}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
               if grep -q '[^[:space:]]' "${CODEX_OUTPUT_FILE}"; then
                 echo "Codex clarify-respond succeeded on attempt ${attempt}."
@@ -701,6 +709,11 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
           set -euo pipefail
+
+          # Source sanitize_codex_prompt_file (best-effort) so the
+          # critic + revised prompts are UTF-8-clean before piping.
+          # shellcheck source=/dev/null
+          source scripts/gh_helpers.sh 2>/dev/null || true
 
           # Self-critique pass for non-letter decisions
           HAS_NON_LETTER="false"
@@ -735,6 +748,9 @@ jobs:
             } > "${RUNTIME_DIR}/critic_prompt.txt"
 
             CRITIC_MODEL="${MODEL_EDITOR}"
+            if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+              sanitize_codex_prompt_file "${RUNTIME_DIR}/critic_prompt.txt"
+            fi
             if cat "${RUNTIME_DIR}/critic_prompt.txt" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec \
               --model "${CRITIC_MODEL}" --sandbox danger-full-access > "${RUNTIME_DIR}/critic_output.txt" 2>/dev/null; then
               if grep -q 'VERDICT: REJECT' "${RUNTIME_DIR}/critic_output.txt"; then
@@ -748,6 +764,9 @@ jobs:
                   echo "Revise your decisions to address this feedback."
                 } > "${CODEX_PROMPT_FILE}.v2"
 
+                if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+                  sanitize_codex_prompt_file "${CODEX_PROMPT_FILE}.v2"
+                fi
                 if cat "${CODEX_PROMPT_FILE}.v2" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec \
                   --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2>/dev/null; then
                   echo "Revised decision produced after self-critique."

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -1002,6 +1002,10 @@ jobs:
               >/dev/null 2>&1 || true
           fi
 
+          if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+            sanitize_codex_prompt_file "${CODEX_PROMPT_FILE}"
+          fi
+
           max_attempts=3
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "Codex planning attempt ${attempt}/${max_attempts}..."

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -405,6 +405,13 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Source sanitize_codex_prompt_file (best-effort) so the
+          # log-analysis prompt is UTF-8-clean before piping. Log
+          # excerpts pulled from CI can carry control bytes from
+          # downstream tool output that may include invalid UTF-8.
+          # shellcheck source=/dev/null
+          source scripts/gh_helpers.sh 2>/dev/null || true
+
           TRACKING_ISSUE_RAW="${TRACKING_ISSUE:-0}"
           TRACKING_ISSUE_NUM=""
           if [[ "${TRACKING_ISSUE_RAW}" =~ ^[0-9]+$ ]] && [ "${TRACKING_ISSUE_RAW}" -gt 0 ]; then
@@ -582,6 +589,9 @@ jobs:
           analyze_attempts_used=0
           for attempt in $(seq 1 "${max_attempts}"); do
             analyze_attempts_used="${attempt}"
+            if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+              sanitize_codex_prompt_file "${CODEX_PROMPT_FILE}"
+            fi
             set +e
             codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${WORKFLOW_EDITOR_MODEL}" --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" > "${REPORT_FILE}" 2> >(tee -a /tmp/workflow-analysis-codex.log >&2)
             ANALYZE_EXIT=$?
@@ -990,6 +1000,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Source sanitize_codex_prompt_file (best-effort) so the
+          # deep-audit prompt is UTF-8-clean before piping.
+          # shellcheck source=/dev/null
+          source scripts/gh_helpers.sh 2>/dev/null || true
+
           TRACKING_ISSUE_RAW="${TRACKING_ISSUE:-0}"
           TRACKING_ISSUE_NUM=""
           if [[ "${TRACKING_ISSUE_RAW}" =~ ^[0-9]+$ ]] && [ "${TRACKING_ISSUE_RAW}" -gt 0 ]; then
@@ -1099,6 +1114,9 @@ jobs:
 
           AUDIT_EXIT=0
           for attempt in $(seq 1 "${max_attempts}"); do
+            if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+              sanitize_codex_prompt_file "${CODEX_PROMPT_FILE}"
+            fi
             set +e
             codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${WORKFLOW_EDITOR_MODEL}" --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" > "${SECTION_FILE}" 2> >(tee -a /tmp/workflow-audit-codex.log >&2)
             AUDIT_EXIT=$?
@@ -1448,6 +1466,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Source sanitize_codex_prompt_file (best-effort) so the
+          # API-redundancy prompt is UTF-8-clean before piping.
+          # shellcheck source=/dev/null
+          source scripts/gh_helpers.sh 2>/dev/null || true
+
           TRACKING_ISSUE_RAW="${TRACKING_ISSUE:-0}"
           TRACKING_ISSUE_NUM=""
           if [[ "${TRACKING_ISSUE_RAW}" =~ ^[0-9]+$ ]] && [ "${TRACKING_ISSUE_RAW}" -gt 0 ]; then
@@ -1556,6 +1579,9 @@ jobs:
 
           API_EXIT=0
           for attempt in $(seq 1 "${max_attempts}"); do
+            if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+              sanitize_codex_prompt_file "${CODEX_PROMPT_FILE}"
+            fi
             set +e
             codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${WORKFLOW_EDITOR_MODEL}" --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" > "${SECTION_FILE}" 2> >(tee -a /tmp/workflow-api-redundancy-codex.log >&2)
             API_EXIT=$?

--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -1410,12 +1410,16 @@ _embed_input_file()
 # stdin boundary.
 #
 # Behaviour notes:
-#   • Best-effort. No-op if <path> is missing/empty, if `iconv` is
-#     not installed, or if the temp file write fails.
-#   • Uses `iconv -f UTF-8 -t UTF-8//IGNORE`, which drops invalid
-#     sequences. GNU iconv exits non-zero whenever it discards
-#     bytes even though the rewritten output is correct, so we
-#     accept any non-empty output regardless of exit status.
+#   • Best-effort. No-op if <path> is missing/empty or if the temp
+#     file write fails.
+#   • Prefers `iconv -f UTF-8 -t UTF-8//IGNORE` when available.
+#     GNU iconv exits non-zero whenever it discards bytes even though
+#     the rewritten output is correct, so we accept any non-empty
+#     output regardless of exit status.
+#   • Falls back to `python3` UTF-8 decode/encode with
+#     `errors="ignore"` when iconv is missing, unsupported (musl),
+#     or discards the entire file. That preserves the documented
+#     "last line of defence" behaviour even for all-invalid inputs.
 #   • Idempotent. Running on already-valid UTF-8 leaves the file
 #     byte-identical (modulo the mv/rename, which the caller's
 #     downstream `wc -c` / `sha256sum` instrumentation will reflect).
@@ -1429,18 +1433,32 @@ sanitize_codex_prompt_file()
 	if [ -z "${_path}" ] || [ ! -f "${_path}" ]; then
 		return 0
 	fi
-	if ! command -v iconv >/dev/null 2>&1; then
-		return 0
-	fi
 	local _tmp
 	_tmp="$(mktemp "${_path}.utf8XXXXXX" 2>/dev/null)" || return 0
-	# //IGNORE discards invalid sequences. iconv exits non-zero
-	# whenever it skips any, but the output IS correct, so don't
-	# gate the rewrite on $? — gate on whether output was produced.
-	iconv -f UTF-8 -t UTF-8//IGNORE < "${_path}" > "${_tmp}" 2>/dev/null || true
-	if [ -s "${_tmp}" ] || [ ! -s "${_path}" ]; then
-		mv "${_tmp}" "${_path}"
-	else
-		rm -f "${_tmp}"
+	if command -v iconv >/dev/null 2>&1; then
+		# //IGNORE discards invalid sequences. iconv exits non-zero
+		# whenever it skips any, but the output IS correct, so don't
+		# gate the rewrite on $? — gate on whether output was produced.
+		iconv -f UTF-8 -t UTF-8//IGNORE < "${_path}" > "${_tmp}" 2>/dev/null || true
+		if [ -s "${_tmp}" ] || [ ! -s "${_path}" ]; then
+			mv "${_tmp}" "${_path}" 2>/dev/null || rm -f "${_tmp}"
+			return 0
+		fi
+		: > "${_tmp}" 2>/dev/null || { rm -f "${_tmp}"; return 0; }
 	fi
+	if command -v python3 >/dev/null 2>&1; then
+		if python3 - "${_path}" "${_tmp}" <<'PY' 2>/dev/null
+from pathlib import Path
+import sys
+
+src = Path(sys.argv[1])
+dst = Path(sys.argv[2])
+dst.write_bytes(src.read_bytes().decode("utf-8", "ignore").encode("utf-8"))
+PY
+		then
+			mv "${_tmp}" "${_path}" 2>/dev/null || rm -f "${_tmp}"
+			return 0
+		fi
+	fi
+	rm -f "${_tmp}"
 }

--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -1387,3 +1387,60 @@ _embed_input_file()
 		printf '%s\n' "$(( _used + _emit_bytes ))" > "${_state}" 2>/dev/null || true
 	fi
 }
+
+# ---------------------------------------------------------------
+# sanitize_codex_prompt_file <path>
+#
+# Rewrite <path> in place with any invalid UTF-8 byte sequences
+# stripped, so the Codex CLI's strict UTF-8 stdin reader never
+# rejects the prompt on the first invalid byte. This is the
+# last-line-of-defence sanitisation for prompt files that get piped
+# to `codex … exec … < "${path}"`.
+#
+# Background: Codex CLI reads its prompt from stdin as a UTF-8
+# string and aborts on the first invalid byte with
+#   `Failed to read prompt from stdin: input is not valid UTF-8
+#    (invalid byte at offset N). Convert it to UTF-8 and retry`
+# Any upstream byte-based truncation that lands mid-codepoint
+# (e.g. mawk's byte-oriented `substr` on a 3-byte em-dash) — or any
+# other corruption that leaks invalid bytes into an embedded input
+# file — deterministically kills the editor, and the retry loop is
+# impotent because the same bad bytes survive into the regenerated
+# prompt. This helper makes that failure mode impossible at the
+# stdin boundary.
+#
+# Behaviour notes:
+#   • Best-effort. No-op if <path> is missing/empty, if `iconv` is
+#     not installed, or if the temp file write fails.
+#   • Uses `iconv -f UTF-8 -t UTF-8//IGNORE`, which drops invalid
+#     sequences. GNU iconv exits non-zero whenever it discards
+#     bytes even though the rewritten output is correct, so we
+#     accept any non-empty output regardless of exit status.
+#   • Idempotent. Running on already-valid UTF-8 leaves the file
+#     byte-identical (modulo the mv/rename, which the caller's
+#     downstream `wc -c` / `sha256sum` instrumentation will reflect).
+#   • Silent on success. The caller's existing `wc -c` / `sha256sum`
+#     echo lines around the codex pipe will surface any byte-count
+#     delta after sanitisation, so we don't add log noise here.
+# ---------------------------------------------------------------
+sanitize_codex_prompt_file()
+{
+	local _path="${1:-}"
+	if [ -z "${_path}" ] || [ ! -f "${_path}" ]; then
+		return 0
+	fi
+	if ! command -v iconv >/dev/null 2>&1; then
+		return 0
+	fi
+	local _tmp
+	_tmp="$(mktemp "${_path}.utf8XXXXXX" 2>/dev/null)" || return 0
+	# //IGNORE discards invalid sequences. iconv exits non-zero
+	# whenever it skips any, but the output IS correct, so don't
+	# gate the rewrite on $? — gate on whether output was produced.
+	iconv -f UTF-8 -t UTF-8//IGNORE < "${_path}" > "${_tmp}" 2>/dev/null || true
+	if [ -s "${_tmp}" ] || [ ! -s "${_path}" ]; then
+		mv "${_tmp}" "${_path}"
+	else
+		rm -f "${_tmp}"
+	fi
+}

--- a/scripts/implement_diagnose_post_codex_failure.sh
+++ b/scripts/implement_diagnose_post_codex_failure.sh
@@ -599,6 +599,9 @@ PY
 }
 
 DIAGNOSE_SUCCESS=false
+if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+  sanitize_codex_prompt_file "${IMPLEMENT_DIAGNOSE_PROMPT_FILE}"
+fi
 if timeout "${IMPLEMENT_DIAGNOSE_TIMEOUT_SEC}"s codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${DIAGNOSE_MODEL}" --sandbox danger-full-access \
   < "${IMPLEMENT_DIAGNOSE_PROMPT_FILE}" > "${IMPLEMENT_DIAGNOSE_OUTPUT_FILE}" \
   2> >(tee -a "${IMPLEMENT_DIAGNOSE_LOG_FILE}" >&2); then

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -3115,6 +3115,7 @@ invoke_judge_for_integration_conflict() {
     echo "   short diagnosis in the commit message."
   } > "${prompt_file}"
 
+  sanitize_codex_prompt_file "${prompt_file}"
   if cat "${prompt_file}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR:-openai/gpt-5.4}" --sandbox danger-full-access > "${output_file}" 2>> "${RUNTIME_DIR}/integration_judge.log"; then
     echo "  [integration-heal] Judge exec completed for PR #${final_pr}."
     rm -f "${prompt_file}" "${output_file}" "${judge_static_file}" "${judge_semble_query_file}"
@@ -6193,6 +6194,7 @@ invoke_stall_judge() {
       if [ -n "${MOCK_STALL_JUDGE_JSON:-}" ]; then
         printf '%s\n' "${MOCK_STALL_JUDGE_JSON}" > "${stall_judge_output_file}"
       else
+        sanitize_codex_prompt_file "${stall_judge_prompt_file}"
         codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${stall_judge_prompt_file}" > "${stall_judge_output_file}" 2>> "${RUNTIME_DIR}/stall_judge.log" || true
       fi
       if grep -q '[^[:space:]]' "${stall_judge_output_file}"; then
@@ -9983,6 +9985,7 @@ ${FOLLOWUP_BLOCK_REASON}"
       RB_JUDGE_SUCCESS=false
       for attempt in 1 2; do
         echo "  Review-blocked judge attempt ${attempt}/2..."
+        sanitize_codex_prompt_file "${RB_JUDGE_PROMPT_FILE}"
         cat "${RB_JUDGE_PROMPT_FILE}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${RB_JUDGE_OUTPUT_FILE}" 2>/dev/null || true
         if grep -q '[^[:space:]]' "${RB_JUDGE_OUTPUT_FILE}"; then
           RB_JUDGE_SUCCESS=true
@@ -11582,6 +11585,7 @@ ${PR_DIFF}
   max_attempts=2
   for attempt in $(seq 1 "${max_attempts}"); do
     echo "Judge attempt ${attempt}/${max_attempts}..."
+    sanitize_codex_prompt_file "${JUDGE_PROMPT_FILE}"
     # The pipeline may return 141 (SIGPIPE) when the prompt is larger
     # than the OS pipe buffer and codex closes stdin before cat finishes.
     # This is harmless — check the output file regardless of exit code.

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -122,6 +122,9 @@ tg_notify_issue() {
 if ! type gh_retry >/dev/null 2>&1; then
   gh_retry() { "$@"; }
 fi
+if ! command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+  sanitize_codex_prompt_file() { :; }
+fi
 
 append_judge_semble_query_text() {
   local label="$1"

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -942,6 +942,15 @@ prompt_tmp="$(mktemp)"
 } > "${prompt_tmp}"
 mv "${prompt_tmp}" "${EDITOR_PROMPT_FILE}"
 
+# Last-line-of-defence UTF-8 sanitisation: Codex CLI's stdin reader
+# strictly validates UTF-8 and aborts on the first invalid byte. Any
+# embedded input that leaks invalid bytes (e.g. floor_tags.txt with a
+# mid-codepoint truncation from scripts/review_floor_rules.sh — the
+# bug from multi-user-ai-agent PR #33) would otherwise kill the
+# editor across every retry. See `sanitize_codex_prompt_file` in
+# scripts/gh_helpers.sh for the design.
+sanitize_codex_prompt_file "${EDITOR_PROMPT_FILE}"
+
 echo "Editor prompt bytes: $(wc -c < "${EDITOR_PROMPT_FILE}")"
 echo "Editor prompt sha256: $(sha256sum "${EDITOR_PROMPT_FILE}" | awk '{print $1}')"
 

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -31,6 +31,9 @@ if ! command -v _embed_input_file >/dev/null 2>&1; then
     cat "${_p}"
   }
 fi
+if ! command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+  sanitize_codex_prompt_file() { :; }
+fi
 
 # Filter workflow-generated Serena runtime artifacts from the editor
 # no-op detector only when the repo did not already own the Serena

--- a/scripts/review_conflict_resolve.sh
+++ b/scripts/review_conflict_resolve.sh
@@ -41,6 +41,15 @@
 
 set -euo pipefail
 
+# Source gh_helpers.sh for sanitize_codex_prompt_file (and the broader
+# gh_retry / rate-limit helpers if they are needed later in this
+# script). Best-effort: a missing helpers file leaves the helper
+# undefined, and the caller block below guards against that.
+if [ -f "${SUPPORT_SCRIPTS_DIR:-scripts}/gh_helpers.sh" ]; then
+  # shellcheck source=gh_helpers.sh
+  source "${SUPPORT_SCRIPTS_DIR:-scripts}/gh_helpers.sh" 2>/dev/null || true
+fi
+
 if [ -f "${SUPPORT_SCRIPTS_DIR:-scripts}/semble_helpers.sh" ]; then
   # shellcheck source=/dev/null
   source "${SUPPORT_SCRIPTS_DIR:-scripts}/semble_helpers.sh"
@@ -908,6 +917,12 @@ while [ "${attempt}" -le "${INTEGRATION_SYNC_RESOLVER_MAX_ATTEMPTS}" ]; do
   # _build_retry_prompt and the retry-log line for every iteration.
   _codex_exit=0
   _attempt_started_at=$(date +%s)
+  # Strip any invalid UTF-8 bytes that may have leaked into the
+  # retry-prompt (rebuilt inside the loop, so we sanitise each
+  # iteration). See sanitize_codex_prompt_file in scripts/gh_helpers.sh.
+  if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+    sanitize_codex_prompt_file "${_effective_prompt_file}"
+  fi
   timeout --signal=TERM --kill-after=30s -- "${CONFLICT_RESOLVER_PER_ATTEMPT_TIMEOUT_SECS}" \
     codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${_effective_prompt_file}" > "${tmp_output}" \
     || _codex_exit=$?

--- a/scripts/review_consolidate.sh
+++ b/scripts/review_consolidate.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Source gh_helpers.sh for sanitize_codex_prompt_file. Best-effort: a
+# missing helpers file leaves the function undefined and the caller
+# below guards via `command -v`.
+if [ -f "${SUPPORT_SCRIPTS_DIR:-scripts}/gh_helpers.sh" ]; then
+	# shellcheck source=gh_helpers.sh
+	source "${SUPPORT_SCRIPTS_DIR:-scripts}/gh_helpers.sh" 2>/dev/null || true
+fi
+
 review_log()
 {
 	printf 'stage=consolidator %s\n' "$*" >&2
@@ -138,6 +146,12 @@ fi
 
 cmd_rc=0
 
+# Strip any invalid UTF-8 from the consolidator prompt before piping
+# to codex (whose stdin reader strictly validates UTF-8). See
+# sanitize_codex_prompt_file in scripts/gh_helpers.sh for the design.
+if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+	sanitize_codex_prompt_file "${CONSOLIDATOR_PROMPT_FILE}"
+fi
 if ! CODEX_HOME="${consolidator_codex_home}" \
 	timeout "${REVIEW_CONSOLIDATOR_TIMEOUT_SECS}" \
 	"${codex_bin}" --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${REVIEW_CONSOLIDATOR_MODEL}" --sandbox danger-full-access \

--- a/scripts/review_floor_rules.sh
+++ b/scripts/review_floor_rules.sh
@@ -6,6 +6,16 @@ BUNDLE_FILE="${1:-reviewer_bundle.txt}"
 OUT_FILE="${2:-floor_tags.txt}"
 TOLERANCE_LINES=3
 
+# Source the shared UTF-8 sanitiser from the same directory when
+# available so floor_tags.txt gets the same mktemp + python fallback
+# behaviour as the other Codex prompt-entrypoint sanitisation paths.
+_floor_rules_script_dir="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "${_floor_rules_script_dir}/gh_helpers.sh" ]; then
+	# shellcheck source=gh_helpers.sh
+	# shellcheck disable=SC1091
+	source "${_floor_rules_script_dir}/gh_helpers.sh" 2>/dev/null || true
+fi
+
 warn() {
 	local event="$1"
 	shift || true
@@ -597,24 +607,11 @@ fi
 # mawk's `substr` (and gawk's, under LC_ALL=C/POSIX) is byte-based, so
 # the cap can land mid-codepoint inside a multi-byte character (e.g.
 # the 3-byte em-dash U+2014 = \xe2\x80\x94) and leave an orphaned
-# lead-byte sequence in OUT_FILE. Codex CLI's stdin reader strictly
-# validates UTF-8 and aborts on the first invalid byte, so a single
-# truncated em-dash here was enough to kill the editor across all
-# retries on multi-user-ai-agent PR #33. iconv -t UTF-8//IGNORE
-# silently drops the orphaned bytes; on already-valid input it leaves
-# OUT_FILE byte-identical. Best-effort: skip if iconv is missing.
-if [ -s "${OUT_FILE}" ] && command -v iconv >/dev/null 2>&1; then
-	_floor_tags_utf8_tmp="${OUT_FILE}.utf8tmp"
-	# iconv exits non-zero whenever //IGNORE skips any bytes, even
-	# though the output IS correct; gate on whether output was
-	# produced, not on $?.
-	iconv -f UTF-8 -t UTF-8//IGNORE < "${OUT_FILE}" > "${_floor_tags_utf8_tmp}" 2>/dev/null || true
-	if [ -s "${_floor_tags_utf8_tmp}" ]; then
-		mv "${_floor_tags_utf8_tmp}" "${OUT_FILE}"
-	else
-		rm -f "${_floor_tags_utf8_tmp}"
-	fi
-	unset _floor_tags_utf8_tmp
+# lead-byte sequence in OUT_FILE. Reuse the shared helper so this path
+# gets the same mktemp collision-avoidance and all-invalid-input
+# fallback as every other prompt sanitisation call site.
+if [ -s "${OUT_FILE}" ] && command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+	sanitize_codex_prompt_file "${OUT_FILE}"
 fi
 
 anchors_scanned=0

--- a/scripts/review_floor_rules.sh
+++ b/scripts/review_floor_rules.sh
@@ -592,6 +592,31 @@ else
 	: > "${OUT_FILE}"
 fi
 
+# Strip any invalid UTF-8 bytes from the rendered rows. The excerpt
+# truncation above uses `substr(out, 1, 240)` inside an awk script;
+# mawk's `substr` (and gawk's, under LC_ALL=C/POSIX) is byte-based, so
+# the cap can land mid-codepoint inside a multi-byte character (e.g.
+# the 3-byte em-dash U+2014 = \xe2\x80\x94) and leave an orphaned
+# lead-byte sequence in OUT_FILE. Codex CLI's stdin reader strictly
+# validates UTF-8 and aborts on the first invalid byte, so a single
+# truncated em-dash here was enough to kill the editor across all
+# retries on multi-user-ai-agent PR #33. iconv -t UTF-8//IGNORE
+# silently drops the orphaned bytes; on already-valid input it leaves
+# OUT_FILE byte-identical. Best-effort: skip if iconv is missing.
+if [ -s "${OUT_FILE}" ] && command -v iconv >/dev/null 2>&1; then
+	_floor_tags_utf8_tmp="${OUT_FILE}.utf8tmp"
+	# iconv exits non-zero whenever //IGNORE skips any bytes, even
+	# though the output IS correct; gate on whether output was
+	# produced, not on $?.
+	iconv -f UTF-8 -t UTF-8//IGNORE < "${OUT_FILE}" > "${_floor_tags_utf8_tmp}" 2>/dev/null || true
+	if [ -s "${_floor_tags_utf8_tmp}" ]; then
+		mv "${_floor_tags_utf8_tmp}" "${OUT_FILE}"
+	else
+		rm -f "${_floor_tags_utf8_tmp}"
+	fi
+	unset _floor_tags_utf8_tmp
+fi
+
 anchors_scanned=0
 multi_reviewer_hits=0
 keyword_hits=0

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -34,6 +34,9 @@ source "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh" 2>/dev/null || true
 if ! command -v gh_retry >/dev/null 2>&1; then
   gh_retry() { "$@"; }
 fi
+if ! command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+  sanitize_codex_prompt_file() { :; }
+fi
 REVIEW_RB_SEMBLE_HELPERS_AVAILABLE="false"
 REVIEW_RB_SEMBLE_MAX_CHUNKS="4"
 REVIEW_RB_SEMBLE_QUERY_MAX_BYTES="12000"

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -502,6 +502,7 @@ for attempt_idx in "${!JUDGE_ATTEMPT_LEVELS[@]}"; do
   if [ -f "${HOME}/.codex/config.toml" ]; then
     sed -i "s/model_reasoning_effort = \".*\"/model_reasoning_effort = \"${level}\"/" "${HOME}/.codex/config.toml"
   fi
+  sanitize_codex_prompt_file "${RB_JUDGE_PROMPT}"
   if codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox read-only < "${RB_JUDGE_PROMPT}" > "${RB_JUDGE_OUTPUT}" 2>"${JUDGE_STDERR_FILE}"; then
     if grep -q '[^[:space:]]' "${RB_JUDGE_OUTPUT}"; then
       JUDGE_EFFECTIVE_REASONING_EFFORT="${level}"
@@ -836,6 +837,7 @@ __EDIT_DISCIPLINE__
         sed -i "s/model_reasoning_effort = \".*\"/model_reasoning_effort = \"${JUDGE_EFFECTIVE_REASONING_EFFORT}\"/" "${HOME}/.codex/config.toml"
       fi
 
+      sanitize_codex_prompt_file "${RB_FIX_PROMPT}"
       if codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${RB_FIX_PROMPT}" > "${RB_FIX_OUTPUT}" 2>/dev/null; then
         echo "Fix codex completed."
       else

--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -28,6 +28,9 @@ if ! command -v _embed_input_file >/dev/null 2>&1; then
     cat "${_p}"
   }
 fi
+if ! command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+  sanitize_codex_prompt_file() { :; }
+fi
 
 if [ -f "${SUPPORT_SCRIPTS_DIR:-scripts}/semble_helpers.sh" ]; then
   # shellcheck source=/dev/null

--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -1442,6 +1442,10 @@ run_reviewer() {
         sed -i "s/^[[:space:]]*model_reasoning_effort[[:space:]]*=[[:space:]]*\".*\"/model_reasoning_effort = \"${reasoning_level}\"/" "${reviewer_codex_home}/.codex/config.toml" 2>/dev/null || true
       fi
     fi
+    # Strip any invalid UTF-8 from the reviewer prompt before piping
+    # to codex (whose stdin reader strictly validates UTF-8). See
+    # sanitize_codex_prompt_file in scripts/gh_helpers.sh.
+    sanitize_codex_prompt_file "${prompt_file}"
     (
       # Reviewers must not mutate the workspace: writes here pollute the pre-editor
       # snapshot used by review_autofix.yml's touched-file detector (comm -13 safety

--- a/scripts/self_heal_validation.sh
+++ b/scripts/self_heal_validation.sh
@@ -43,6 +43,14 @@ set -euo pipefail
 command -v jq >/dev/null 2>&1 || { echo "self-heal: jq is required" >&2; exit 2; }
 command -v patch >/dev/null 2>&1 || { echo "self-heal: patch is required" >&2; exit 2; }
 
+# Source gh_helpers.sh for sanitize_codex_prompt_file (best-effort —
+# the call site below guards via `command -v`).
+if [ -f "scripts/gh_helpers.sh" ]; then
+	# shellcheck source=gh_helpers.sh
+	# shellcheck disable=SC1091
+	source scripts/gh_helpers.sh 2>/dev/null || true
+fi
+
 SEMBLE_HELPERS_AVAILABLE="false"
 # shellcheck source=semble_helpers.sh
 if [ -f "scripts/semble_helpers.sh" ]; then
@@ -283,6 +291,9 @@ self_heal_serena_tool_hints="$(build_self_heal_serena_tool_hints || true)"
 SELF_HEAL_LLM_SUCCESS=false
 for _llm_attempt in 1 2; do
 	echo "self-heal: LLM call attempt ${_llm_attempt}/2" >> "${SELF_HEAL_LOG_FILE}"
+	if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+		sanitize_codex_prompt_file "${SELF_HEAL_PROMPT_FILE}"
+	fi
 	if cat "${SELF_HEAL_PROMPT_FILE}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${SELF_HEAL_OUTPUT_FILE}" 2>> "${SELF_HEAL_LOG_FILE}"; then
 		# Extract the last JSON object that contains a "target_prompt" key.
 		# Use json.JSONDecoder.raw_decode() which is string/escape-aware

--- a/scripts/summarize_reviewer_consensus.sh
+++ b/scripts/summarize_reviewer_consensus.sh
@@ -59,6 +59,13 @@ fi
 : "${PREVIOUS_REVIEWS_DIR:?PREVIOUS_REVIEWS_DIR must be set}"
 : "${RUNTIME_DIR:?RUNTIME_DIR must be set}"
 
+# Source gh_helpers.sh for sanitize_codex_prompt_file (best-effort).
+if [ -f "${SUPPORT_SCRIPTS_DIR:-scripts}/gh_helpers.sh" ]; then
+	# shellcheck source=gh_helpers.sh
+	# shellcheck disable=SC1091
+	source "${SUPPORT_SCRIPTS_DIR:-scripts}/gh_helpers.sh" 2>/dev/null || true
+fi
+
 SUMMARISER_MODEL="${XPOLL_SUMMARISER_MODEL:-openai/gpt-5.4-mini}"
 SUMMARISER_REASONING="${XPOLL_SUMMARISER_REASONING:-medium}"
 SUMMARISER_TARGET_PER_REVIEWER="${XPOLL_SUMMARISER_LINES_PER_REVIEWER:-160}"
@@ -302,6 +309,9 @@ while [ "${attempt}" -le "${SUMMARISER_MAX_ATTEMPTS}" ]; do
 	echo "summariser (${PREFIX}): attempt ${attempt}/${SUMMARISER_MAX_ATTEMPTS} — model=${SUMMARISER_MODEL} reasoning=${SUMMARISER_REASONING}" | tee -a "${log_file}"
 
 	last_rc=0
+	if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+		sanitize_codex_prompt_file "${prompt_file}"
+	fi
 	CODEX_HOME="${summariser_codex_home}" \
 		timeout --signal=KILL "${SUMMARISER_CALL_TIMEOUT}" \
 		"${codex_bin}" --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${SUMMARISER_MODEL}" --sandbox read-only < "${prompt_file}" \

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -2512,6 +2512,7 @@ else
   for attempt in $(seq 1 "${MAX_CODEX_ATTEMPTS}"); do
     DISCOVER_ATTEMPTS_USED="${attempt}"
     echo "Validation hint discovery attempt ${attempt}/${MAX_CODEX_ATTEMPTS}"
+    sanitize_codex_prompt_file "${DISCOVER_PROMPT_FILE}"
     set +e
     cat "${DISCOVER_PROMPT_FILE}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${DISCOVER_OUTPUT_FILE}" 2> >(tee -a "${DISCOVER_LOG_FILE}" >&2)
     DISCOVER_EXIT=$?
@@ -3203,6 +3204,7 @@ DIAGNOSE_ATTEMPTS_USED=0
 for attempt in $(seq 1 "${MAX_CODEX_ATTEMPTS}"); do
   DIAGNOSE_ATTEMPTS_USED="${attempt}"
   echo "Validation diagnosis attempt ${attempt}/${MAX_CODEX_ATTEMPTS}"
+  sanitize_codex_prompt_file "${DIAGNOSE_PROMPT_FILE}"
   set +e
   cat "${DIAGNOSE_PROMPT_FILE}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${DIAGNOSE_OUTPUT_FILE}" 2> >(tee -a "${DIAGNOSE_LOG_FILE}" >&2)
   DIAGNOSE_EXIT=$?

--- a/scripts/validate_process.sh
+++ b/scripts/validate_process.sh
@@ -243,6 +243,9 @@ tg_notify()
 if ! type gh_retry >/dev/null 2>&1; then
   gh_retry() { "$@"; }
 fi
+if ! command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
+  sanitize_codex_prompt_file() { :; }
+fi
 
 write_github_env_value()
 {

--- a/tests/fixtures/review_pipeline/reviewer_bundle_utf8_boundary_excerpt.txt
+++ b/tests/fixtures/review_pipeline/reviewer_bundle_utf8_boundary_excerpt.txt
@@ -1,0 +1,9 @@
+FILE_PATH: /tmp/review_excerpt_utf8.txt
+BYTES: 100
+SHA256: utf8boundary
+CONTENT_START
+File: src/utf8_boundary.py
+Line or code reference: 7
+Problem: This excerpt is engineered so xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx—Z and trailing text after the cut.
+ISSUE_CONFIDENCE: 5/5
+CONTENT_END

--- a/tests/test_review_floor_rules.py
+++ b/tests/test_review_floor_rules.py
@@ -170,6 +170,34 @@ def test_excerpt_truncation_caps_at_240_chars(tmp_path: Path) -> None:
 	assert len(excerpt) == 240
 
 
+def test_excerpt_truncation_at_240_bytes_does_not_emit_invalid_utf8(tmp_path: Path) -> None:
+	"""Regression guard for multi-user-ai-agent PR #33: mawk's byte-based
+	`substr(out, 1, 240)` at scripts/review_floor_rules.sh:303 could land
+	mid-codepoint inside a 3-byte em-dash and leak invalid UTF-8 into
+	floor_tags.txt, which Codex CLI's stdin reader then rejected with
+	"input is not valid UTF-8", killing the editor across every retry.
+	The fix post-processes OUT_FILE through iconv -f UTF-8 -t UTF-8//IGNORE
+	so any orphaned partial-codepoint bytes are dropped before downstream
+	consumers see the file. The fixture places the em-dash so the 240-byte
+	cut lands inside it.
+	"""
+	out_file = tmp_path / "floor_tags.txt"
+	_run_floor_rules(FIXTURES / "reviewer_bundle_utf8_boundary_excerpt.txt", out_file)
+
+	# The whole rendered file must be valid UTF-8 end-to-end. Strict
+	# decode raises UnicodeDecodeError on the first invalid byte —
+	# exactly what Codex CLI's stdin reader does.
+	out_file.read_bytes().decode("utf-8")
+
+	rows = _parse_floor_tags(out_file)
+	assert len(rows) == 1
+	_, _, _, excerpt = rows[0]
+	assert excerpt, "excerpt was empty after sanitisation"
+	assert excerpt.startswith("This excerpt is engineered so"), (
+		f"excerpt prefix corrupted by sanitisation: {excerpt[:80]!r}"
+	)
+
+
 def test_fail_open_unhandled_error_emits_empty_valid_output(tmp_path: Path) -> None:
 	bundle = tmp_path / "bundle.txt"
 	bundle.write_text(

--- a/tests/test_review_floor_rules.py
+++ b/tests/test_review_floor_rules.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = REPO_ROOT / "scripts" / "review_floor_rules.sh"
+GH_HELPERS = REPO_ROOT / "scripts" / "gh_helpers.sh"
 FIXTURES = REPO_ROOT / "tests" / "fixtures" / "review_pipeline"
 
 
@@ -196,6 +197,26 @@ def test_excerpt_truncation_at_240_bytes_does_not_emit_invalid_utf8(tmp_path: Pa
 	assert excerpt.startswith("This excerpt is engineered so"), (
 		f"excerpt prefix corrupted by sanitisation: {excerpt[:80]!r}"
 	)
+
+
+def test_sanitize_codex_prompt_file_rewrites_all_invalid_utf8(tmp_path: Path) -> None:
+	prompt_file = tmp_path / "invalid_prompt.txt"
+	prompt_file.write_bytes(b"\xff\xfe\xfa")
+
+	subprocess.run(
+		[
+			"bash",
+			"-lc",
+			f"source {GH_HELPERS!s}; sanitize_codex_prompt_file {prompt_file!s}",
+		],
+		cwd=REPO_ROOT,
+		env={"PATH": f"{Path('/usr/bin')}:{Path('/bin')}", "PYTHONDONTWRITEBYTECODE": "1"},
+		check=True,
+		capture_output=True,
+		text=True,
+	)
+
+	assert prompt_file.read_bytes() == b""
 
 
 def test_fail_open_unhandled_error_emits_empty_valid_output(tmp_path: Path) -> None:

--- a/tests/test_review_floor_rules.py
+++ b/tests/test_review_floor_rules.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import inspect
+import shlex
 import subprocess
 import tempfile
 from pathlib import Path
@@ -207,7 +208,7 @@ def test_sanitize_codex_prompt_file_rewrites_all_invalid_utf8(tmp_path: Path) ->
 		[
 			"bash",
 			"-lc",
-			f"source {GH_HELPERS!s}; sanitize_codex_prompt_file {prompt_file!s}",
+			f"source {shlex.quote(str(GH_HELPERS))}; sanitize_codex_prompt_file {shlex.quote(str(prompt_file))}",
 		],
 		cwd=REPO_ROOT,
 		env={"PATH": f"{Path('/usr/bin')}:{Path('/bin')}", "PYTHONDONTWRITEBYTECODE": "1"},


### PR DESCRIPTION
## Summary

Fixes the editor no-op suspicious failure observed on
multi-user-ai-agent PR #33 / run 25989742180. Root cause was
mid-codepoint UTF-8 truncation in `scripts/review_floor_rules.sh:303`
that leaked invalid bytes into `floor_tags.txt`, which then poisoned
the editor prompt and was rejected by Codex CLI's strict UTF-8 stdin
reader on every retry.

- **Commit 1 — root cause.** Post-process `OUT_FILE` in
  `review_floor_rules.sh` through `iconv -f UTF-8 -t UTF-8//IGNORE`
  so any orphaned partial-codepoint bytes left by mawk's byte-based
  `substr(out, 1, 240)` are dropped before downstream consumers see
  the file. Adds a regression test + fixture pinning the boundary case.
- **Commit 2 — defense in depth.** Adds
  `sanitize_codex_prompt_file` to `scripts/gh_helpers.sh` and calls it
  right before every `codex … exec … < "${PROMPT_FILE}"` in the repo
  (editor, judge, conflict-resolver, reviewer, consolidator,
  summariser, validator, self-heal, implement, orchestrate,
  workflow-log-analysis). Any future invalid-UTF-8 leak from any
  input source — not just floor_tags — is now caught at the stdin
  boundary instead of killing Codex.

## Failure mode reproduced

```
$ awk 'BEGIN { s = "..."; if (length(s)>240) s = substr(s,1,240); printf "%s", s }' \
    | tail -c 6 | od -c
0000000   x   x   x   x 342 200
```

`\xe2\x80` is the first two bytes of the 3-byte em-dash `U+2014`.
On run 25989742180 the orphaned bytes landed at offset 59598 of
`editor_prompt.txt`; Codex CLI's stdin reader aborted with
`Failed to read prompt from stdin: input is not valid UTF-8 (invalid
byte at offset 59598)` across all 6 retries, the editor fell back to
its synthetic stub, and the validator correctly flagged
`EDITOR_NOOP_SUSPICIOUS=true`.

The new pytest case `test_excerpt_truncation_at_240_bytes_does_not_emit_invalid_utf8`
pins the boundary: without the iconv step it fails with
`UnicodeDecodeError`; with the step it produces a valid 240-char excerpt.

## Why a single PR

Per CLAUDE.md §12.A the single-PR rule applies. Commit 1 is the
in-scope root cause; commit 2 is the proactive defense-in-depth fix
covering the latent exposure at every other codex stdin pipe (CLAUDE.md
§12.B "latent bugs in adjacent code"). Splitting commit 2 into its own
PR would have left ~25 other codex invocations vulnerable to the same
failure mode for as long as that follow-up sat in review.

## Files changed

```
.github/workflows/implement.yml                    | 35 +++++++++++++-
.github/workflows/orchestrate.yml                  | 12 +++++
.github/workflows/orchestrate_clarify_respond.yml  | 19 ++++++++
.github/workflows/workflow-log-analysis.yml        | 26 +++++++++++
scripts/gh_helpers.sh                              | 57 +++++++++++++++++++++++
scripts/implement_diagnose_post_codex_failure.sh   |  3 ++
scripts/orchestrate_poll_process.sh                |  4 ++
scripts/review_apply_fixes.sh                      |  9 ++++
scripts/review_conflict_resolve.sh                 | 15 ++++++
scripts/review_consolidate.sh                      | 14 ++++++
scripts/review_floor_rules.sh                      | 25 ++++++++++
scripts/review_rb_judge.sh                         |  2 +
scripts/review_run_reviewers.sh                    |  4 ++
scripts/self_heal_validation.sh                    | 11 +++++
scripts/summarize_reviewer_consensus.sh            | 10 ++++
scripts/validate_process.sh                        |  2 +
tests/test_review_floor_rules.py                   | 28 +++++++++++
tests/fixtures/review_pipeline/reviewer_bundle_utf8_boundary_excerpt.txt  (new)
```

Targets `stable` per the request to land the fix on the release
branch (consumer wrappers pin `@stable`).

## Test plan

- [x] `pytest tests/test_review_floor_rules.py` — 12/12 pass
  (includes the new UTF-8 boundary regression test).
- [x] `bash -n` syntax-check on every modified shell script.
- [x] `yaml.safe_load` parse-check on every modified workflow YAML.
- [x] Local reproduction: `awk … substr(s,1,240)` on mawk 1.3.4 with
  `LC_ALL=C.UTF-8` produces `\xe2\x80` (matches run 25989742180
  exactly); after `iconv -f UTF-8 -t UTF-8//IGNORE` the same input
  decodes cleanly.
- [ ] First real `review_autofix` run on a consumer PR after this
  lands — the editor should no longer fall through to the synthetic
  no-op when reviewer excerpts contain multi-byte characters near the
  240-byte boundary.

https://claude.ai/code/session_01WfwduR5yacEKGwgqNRm3D2

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfwduR5yacEKGwgqNRm3D2)_