### PR TITLE
fix(review_rb_judge): exclude self-run from check-runs gate to unblock merge_with_followup

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -5341,23 +5341,23 @@ jobs:
               not_writable)
                 MSG="$(printf 'PR review blocked — autofix exhausted (%s iterations), branch not writable\nNeeds human intervention' "${MAX_AUTOFIX_ITERATIONS}")" ;;
               missing_followup_details)
-                MSG="PR review blocked — judge selected merge_with_followup but omitted follow-up details\nNeeds judge retry or manual follow-up issue creation" ;;
+                MSG="$(printf 'PR review blocked — judge selected merge_with_followup but omitted follow-up details\nNeeds judge retry or manual follow-up issue creation')" ;;
               unresolved_head_sha)
-                MSG="PR review blocked — judge could not resolve PR head SHA\nStall recovery will retry automatically" ;;
+                MSG="$(printf 'PR review blocked — judge could not resolve PR head SHA\nStall recovery will retry automatically')" ;;
               check_runs_query_failed)
-                MSG="PR review blocked — judge could not query head check-runs\nStall recovery will retry automatically" ;;
+                MSG="$(printf 'PR review blocked — judge could not query head check-runs\nStall recovery will retry automatically')" ;;
               blocking_check_runs)
-                MSG="PR review blocked — merge_with_followup approved but check-runs are still in flight\nStall recovery will retry automatically" ;;
+                MSG="$(printf 'PR review blocked — merge_with_followup approved but check-runs are still in flight\nStall recovery will retry automatically')" ;;
               sync_merge_failed)
-                MSG="PR review blocked — merge_with_followup approved but gh pr merge failed\nNeeds retry or manual merge investigation" ;;
+                MSG="$(printf 'PR review blocked — merge_with_followup approved but gh pr merge failed\nNeeds retry or manual merge investigation')" ;;
               auto_merge_disabled)
-                MSG="PR review blocked — merge_with_followup approved but ENABLE_AUTO_MERGE=false\nManual merge required before follow-up creation" ;;
+                MSG="$(printf 'PR review blocked — merge_with_followup approved but ENABLE_AUTO_MERGE=false\nManual merge required before follow-up creation')" ;;
               merge_conflict)
-                MSG="PR review blocked — PR has merge conflicts\nNeeds rebase or conflict resolution" ;;
+                MSG="$(printf 'PR review blocked — PR has merge conflicts\nNeeds rebase or conflict resolution')" ;;
               mergeability_pending)
-                MSG="PR review blocked — GitHub mergeability still computing\nStall recovery will retry automatically" ;;
+                MSG="$(printf 'PR review blocked — GitHub mergeability still computing\nStall recovery will retry automatically')" ;;
               followup_issue_create_failed)
-                MSG="PR review blocked — PR merged but follow-up issue creation failed\nNeeds follow-up issue creation or retry" ;;
+                MSG="$(printf 'PR review blocked — PR merged but follow-up issue creation failed\nNeeds follow-up issue creation or retry')" ;;
               llm_failed_critical_issues|json_parse_failed_critical_issues)
                 MSG="$(printf 'PR review blocked — autofix exhausted (%s iterations), judge LLM failed, deterministic fallback found critical issues\nNeeds human intervention' "${MAX_AUTOFIX_ITERATIONS}")" ;;
               llm_failed*|json_parse_failed*)

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -4665,7 +4665,7 @@ jobs:
               ;;
             merge_conflict)
               BODY_HEADING="AI review/autofix — PR has merge conflicts"
-              BODY_DETAIL="The review-blocked judge could not act because the PR has merge conflicts against its base branch (mergeable=false). Please resolve the conflicts (rebase or merge in main) and push; the autofix loop will re-run."
+              BODY_DETAIL="The review-blocked judge could not act because the PR has merge conflicts against its base branch (mergeable=false). Please resolve the conflicts (rebase or merge the base branch) and push; the autofix loop will re-run."
               ;;
             mergeability_pending)
               BODY_HEADING="AI review/autofix — mergeability still computing"

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -4639,6 +4639,10 @@ jobs:
           # actually happened. Empty reason = legacy / pre-fix script,
           # falls through to the original body.
           case "${JUDGE_SKIP_REASON:-}" in
+            missing_followup_details)
+              BODY_HEADING="AI review/autofix — judge omitted follow-up issue details"
+              BODY_DETAIL="The review-blocked judge chose \`merge_with_followup\` but returned an empty \`followup_issue.title\` and/or \`.body\`, so the workflow refused the action rather than merge code without durable tracking for the deferred gap. Stall recovery will re-fire the judge; if this repeats, inspect the judge output in the workflow log."
+              ;;
             blocking_check_runs)
               BODY_HEADING="AI review/autofix — merge gated by in-flight check-runs"
               BODY_DETAIL="The review-blocked judge approved this PR but other CI check-runs on the head commit had not yet completed when the merge was attempted. Stall recovery will re-fire the judge after the remaining check-runs settle; no action is required unless the blocking checks themselves are stuck. Linked issues remain labelled \`ai:review-blocked\` so the recovery ladder will retry."
@@ -4666,6 +4670,10 @@ jobs:
             mergeability_pending)
               BODY_HEADING="AI review/autofix — mergeability still computing"
               BODY_DETAIL="The review-blocked judge could not act because GitHub was still computing the PR's mergeability state when the gate ran. Stall recovery will re-fire the judge shortly; no action is required unless the state remains unknown for an extended period."
+              ;;
+            followup_issue_create_failed)
+              BODY_HEADING="AI review/autofix — merge landed but follow-up issue creation failed"
+              BODY_DETAIL="The review-blocked judge approved \`merge_with_followup\` and the PR merge succeeded, but GitHub failed while creating the follow-up issue. The deferred gap is not yet tracked; please create the follow-up manually if needed, or let stall recovery / a subsequent judge run retry issue creation."
               ;;
             *)
               BODY_HEADING="AI review/autofix blocked — needs human intervention"
@@ -5332,6 +5340,24 @@ jobs:
                 MSG="$(printf 'PR review blocked — autofix exhausted (%s iterations), judge disabled\nNeeds human intervention' "${MAX_AUTOFIX_ITERATIONS}")" ;;
               not_writable)
                 MSG="$(printf 'PR review blocked — autofix exhausted (%s iterations), branch not writable\nNeeds human intervention' "${MAX_AUTOFIX_ITERATIONS}")" ;;
+              missing_followup_details)
+                MSG="PR review blocked — judge selected merge_with_followup but omitted follow-up details\nNeeds judge retry or manual follow-up issue creation" ;;
+              unresolved_head_sha)
+                MSG="PR review blocked — judge could not resolve PR head SHA\nStall recovery will retry automatically" ;;
+              check_runs_query_failed)
+                MSG="PR review blocked — judge could not query head check-runs\nStall recovery will retry automatically" ;;
+              blocking_check_runs)
+                MSG="PR review blocked — merge_with_followup approved but check-runs are still in flight\nStall recovery will retry automatically" ;;
+              sync_merge_failed)
+                MSG="PR review blocked — merge_with_followup approved but gh pr merge failed\nNeeds retry or manual merge investigation" ;;
+              auto_merge_disabled)
+                MSG="PR review blocked — merge_with_followup approved but ENABLE_AUTO_MERGE=false\nManual merge required before follow-up creation" ;;
+              merge_conflict)
+                MSG="PR review blocked — PR has merge conflicts\nNeeds rebase or conflict resolution" ;;
+              mergeability_pending)
+                MSG="PR review blocked — GitHub mergeability still computing\nStall recovery will retry automatically" ;;
+              followup_issue_create_failed)
+                MSG="PR review blocked — PR merged but follow-up issue creation failed\nNeeds follow-up issue creation or retry" ;;
               llm_failed_critical_issues|json_parse_failed_critical_issues)
                 MSG="$(printf 'PR review blocked — autofix exhausted (%s iterations), judge LLM failed, deterministic fallback found critical issues\nNeeds human intervention' "${MAX_AUTOFIX_ITERATIONS}")" ;;
               llm_failed*|json_parse_failed*)

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -4620,20 +4620,68 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           MAX_AUTOFIX_ITERATIONS: ${{ vars.MAX_AUTOFIX_ITERATIONS || '5' }}
+          JUDGE_SKIP_REASON: ${{ steps.rb_judge.outputs.judge_skip_reason }}
         run: |
           set -euo pipefail
           source "${SUPPORT_SCRIPTS_DIR}/gh_helpers.sh" 2>/dev/null || true
 
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          BODY="$(cat <<EOF
-          **AI review/autofix blocked — needs human intervention**
 
-          This PR has reached the maximum number of autofix iterations (${MAX_AUTOFIX_ITERATIONS}) without resolving all review issues. The remaining problems could not be auto-fixed and require manual attention.
+          # Reason-specific body. The generic "max autofix iterations"
+          # body posted unconditionally (pre-fix) confused operators
+          # when the actual refusal was a transient gate — e.g. the
+          # merge_with_followup self-deadlock observed on tele-funtoken-
+          # msg-scoring PR #2989, where the judge approved the merge but
+          # the check-runs gate refused it because the rb_judge's own
+          # host job (review / codex-agent) was still in_progress.
+          # judge_skip_reason now carries the proximate cause from
+          # scripts/review_rb_judge.sh so the comment can explain what
+          # actually happened. Empty reason = legacy / pre-fix script,
+          # falls through to the original body.
+          case "${JUDGE_SKIP_REASON:-}" in
+            blocking_check_runs)
+              BODY_HEADING="AI review/autofix — merge gated by in-flight check-runs"
+              BODY_DETAIL="The review-blocked judge approved this PR but other CI check-runs on the head commit had not yet completed when the merge was attempted. Stall recovery will re-fire the judge after the remaining check-runs settle; no action is required unless the blocking checks themselves are stuck. Linked issues remain labelled \`ai:review-blocked\` so the recovery ladder will retry."
+              ;;
+            check_runs_query_failed)
+              BODY_HEADING="AI review/autofix — judge could not query check-runs"
+              BODY_DETAIL="The review-blocked judge could not fetch the check-runs API for the PR head commit and refused the merge rather than land code against unvalidated CI state. This is usually transient; stall recovery will re-fire the judge. If it persists, check the workflow run log for the GitHub API error."
+              ;;
+            unresolved_head_sha)
+              BODY_HEADING="AI review/autofix — judge could not resolve PR head SHA"
+              BODY_DETAIL="The review-blocked judge could not resolve the PR head SHA from the GitHub PR JSON and refused the merge to avoid landing unjudged code. Stall recovery will re-fire the judge. If this recurs, the GitHub PR API may be returning a partial payload — check the workflow run log."
+              ;;
+            sync_merge_failed)
+              BODY_HEADING="AI review/autofix — judge approved merge but \`gh pr merge\` failed"
+              BODY_DETAIL="The review-blocked judge approved this PR and all check-runs had settled, but the synchronous \`gh pr merge --squash\` call failed. Typical causes: branch-protection rules, a merge queue requirement, missing permissions on the GH token, GitHub returning 422, or a concurrent push that changed HEAD. Stall recovery will re-fire the judge; the operator may need to merge manually if the underlying cause is permission/policy."
+              ;;
+            auto_merge_disabled)
+              BODY_HEADING="AI review/autofix — judge approved merge but auto-merge is disabled"
+              BODY_DETAIL="The review-blocked judge approved this PR but \`ENABLE_AUTO_MERGE\` is false in repo configuration, so the judge cannot land the merge itself. Please merge this PR manually; the follow-up tracking issue will be created on the next judge run after the merge lands."
+              ;;
+            merge_conflict)
+              BODY_HEADING="AI review/autofix — PR has merge conflicts"
+              BODY_DETAIL="The review-blocked judge could not act because the PR has merge conflicts against its base branch (mergeable=false). Please resolve the conflicts (rebase or merge in main) and push; the autofix loop will re-run."
+              ;;
+            mergeability_pending)
+              BODY_HEADING="AI review/autofix — mergeability still computing"
+              BODY_DETAIL="The review-blocked judge could not act because GitHub was still computing the PR's mergeability state when the gate ran. Stall recovery will re-fire the judge shortly; no action is required unless the state remains unknown for an extended period."
+              ;;
+            *)
+              BODY_HEADING="AI review/autofix blocked — needs human intervention"
+              BODY_DETAIL="This PR has reached the maximum number of autofix iterations (${MAX_AUTOFIX_ITERATIONS}) without resolving all review issues. The remaining problems could not be auto-fixed and require manual attention."
+              ;;
+          esac
+
+          BODY="$(cat <<EOF
+          **${BODY_HEADING}**
+
+          ${BODY_DETAIL}
 
           **What to do:**
           - Review the editor summary comments above for details on what was fixed and what was not
-          - Address the remaining issues manually
-          - Push a new commit to re-trigger the review workflow
+          - Address the remaining issues manually if needed
+          - Push a new commit to re-trigger the review workflow if you have made changes
 
           Linked issues have been labeled \`ai:review-blocked\`.
 

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -1066,6 +1066,7 @@ Leaving the PR's linked issues in ai:review-blocked. The workflow's review-block
         # scripts/orchestrate_poll_process.sh:232).
         if [ -z "${PR_HEAD_SHA}" ]; then
           echo "::warning::PR #${PR_NUMBER} head SHA could not be resolved from the PR JSON — refusing merge_with_followup. Without a known SHA the merge cannot be bound via --match-head-commit (a concurrent push could land unjudged code). Leaving linked issues in ai:review-blocked."
+          echo "judge_skip_reason=unresolved_head_sha" >> "$GITHUB_OUTPUT"
         else
           # Fallback to '{}' (NOT '[]') on API failure — same fail-
           # closed rationale as orchestrate_poll_process.sh's
@@ -1075,29 +1076,54 @@ Leaving the PR's linked issues in ai:review-blocked. The workflow's review-block
           # neither branch and trips the numeric guard below for the
           # "could not query" refusal path.
           _check_runs_json="$(gh_retry _safe_gh_jq --paginate --slurp "repos/${REPOSITORY}/commits/${PR_HEAD_SHA}/check-runs?per_page=100" 2>/dev/null || echo '{}')"
+          # Self-run exclusion: this script runs inside the
+          # `review / codex-agent` job hosted by review_autofix.yml
+          # (or its dispatch wrapper). That job IS itself a check-run
+          # on PR_HEAD_SHA with status=in_progress while this gate
+          # executes, so a naive "any incomplete check-run blocks"
+          # filter self-deadlocks the merge_with_followup path —
+          # observed end-to-end in shubhodeep1/tele-funtoken-msg-scoring
+          # PR #2989 (run 25993440211): judge decided merge_with_followup
+          # at 14:32:30Z, gate at 14:32:32Z counted the still-in_progress
+          # codex-agent job (which completed at 14:33:01Z), refused the
+          # merge, and the workflow then posted the misleading
+          # "max autofix iterations" fallback comment. The orchestrator's
+          # `_pr_checks_completed` helper does NOT need this exclusion
+          # because it runs from a separate workflow (ai-orchestrate-
+          # poll.yml) whose host job is never on the polled SHA's
+          # check-run list. Match Actions-emitted check-runs by their
+          # `details_url` which always carries `/actions/runs/<run_id>/
+          # job/<job_id>`. Empty $self_run preserves the original
+          # behavior for non-Actions / test callers (no exclusion).
+          _self_run_id="${GITHUB_RUN_ID:-}"
           # jq filter: --paginate --slurp emits an array of page
           # response objects; the elif branch handles legacy single-
           # object shape from tests / older callers. Either way we
           # flatten every page check_runs and count items that have
-          # not yet completed with an acceptable conclusion. Without
-          # pagination, commits with >100 check-runs would hide
-          # pending/failing runs on later pages and let the gate
+          # not yet completed with an acceptable conclusion AND are
+          # not the current GitHub Actions run hosting this script.
+          # Without pagination, commits with >100 check-runs would
+          # hide pending/failing runs on later pages and let the gate
           # incorrectly report success. (Note: comments stay outside
           # the jq script — apostrophes inside the heredoc-style
           # single-quoted jq expression would terminate it early.)
-          _incomplete_checks="$(printf '%s' "${_check_runs_json}" | jq -r '
+          _incomplete_checks="$(printf '%s' "${_check_runs_json}" | jq -r --arg self_run "${_self_run_id}" '
+            def _is_self_check_run: ($self_run != "") and ((.details_url // "") | test("/actions/runs/" + $self_run + "(/|$)"));
+            def _is_pending: .status != "completed" or (.conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped" and .conclusion != "cancelled");
             if (type == "array") then
-              [.[]? | (.check_runs // [])[] | select(.status != "completed" or (.conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped" and .conclusion != "cancelled"))] | length
+              [.[]? | (.check_runs // [])[] | select(_is_pending and (_is_self_check_run | not))] | length
             elif (type == "object" and (.check_runs | type == "array")) then
-              [.check_runs[] | select(.status != "completed" or (.conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped" and .conclusion != "cancelled"))] | length
+              [.check_runs[] | select(_is_pending and (_is_self_check_run | not))] | length
             else
               empty
             end
           ' 2>/dev/null | tail -n1)"
           if ! [[ "${_incomplete_checks}" =~ ^[0-9]+$ ]]; then
             echo "::warning::PR #${PR_NUMBER} could not query check-runs for SHA ${PR_HEAD_SHA:0:7} — refusing merge_with_followup to avoid creating a follow-up against unvalidated code. Leaving linked issues in ai:review-blocked."
+            echo "judge_skip_reason=check_runs_query_failed" >> "$GITHUB_OUTPUT"
           elif [ "${_incomplete_checks}" -gt 0 ]; then
             echo "::warning::PR #${PR_NUMBER} has ${_incomplete_checks} blocking check-run(s) for SHA ${PR_HEAD_SHA:0:7} — refusing merge_with_followup until all checks complete with success/neutral/skipped/cancelled. Leaving linked issues in ai:review-blocked; stall recovery will re-fire the judge after checks settle."
+            echo "judge_skip_reason=blocking_check_runs" >> "$GITHUB_OUTPUT"
           elif [ "${ENABLE_AUTO_MERGE}" = "true" ]; then
             # Sync merge only — NEVER --auto enrollment. The whole point
             # of the conservative ladder is to ensure follow-up creation
@@ -1125,15 +1151,19 @@ Leaving the PR's linked issues in ai:review-blocked. The workflow's review-block
               MERGE_CONFIRMED="true"
             else
               echo "::warning::PR #${PR_NUMBER} sync merge failed despite passing check-runs (typically: branch protection rules / merge queue / permissions / 422 / concurrent push changing HEAD). Leaving linked issues in ai:review-blocked — stall recovery will re-fire the judge."
+              echo "judge_skip_reason=sync_merge_failed" >> "$GITHUB_OUTPUT"
             fi
           else
             echo "::warning::PR #${PR_NUMBER} is mergeable but ENABLE_AUTO_MERGE=false — manual merge required. Leaving linked issues in ai:review-blocked so the follow-up is not opened against unmerged code; operator should merge manually and the judge can run again to create the follow-up."
+            echo "judge_skip_reason=auto_merge_disabled" >> "$GITHUB_OUTPUT"
           fi
         fi
       elif [ "${PR_STATE}" = "open" ] && [ "${PR_MERGEABLE}" = "false" ]; then
         echo "::warning::PR #${PR_NUMBER} has merge conflicts (mergeable=false); judge cannot merge as-is. Leaving linked issues in ai:review-blocked so the follow-up is not opened against unmerged code."
+        echo "judge_skip_reason=merge_conflict" >> "$GITHUB_OUTPUT"
       else
         echo "::warning::PR #${PR_NUMBER} state=${PR_STATE} mergeable=${PR_MERGEABLE:-null} merged=${PR_MERGED:-false}, cannot confirm merge (mergeability still computing or PR not open). Leaving linked issues in ai:review-blocked."
+        echo "judge_skip_reason=mergeability_pending" >> "$GITHUB_OUTPUT"
       fi
 
       if [ "${MERGE_CONFIRMED}" = "true" ]; then

--- a/tests/test_implement_semble_contract.py
+++ b/tests/test_implement_semble_contract.py
@@ -226,6 +226,31 @@ def test_review_rb_judge_reissue_baseline_module_runs_clean() -> None:
 	)
 
 
+def test_review_rb_judge_self_run_exclusion_module_runs_clean() -> None:
+	self_run_test = REPO_ROOT / "tests" / "test_review_rb_judge_self_run_exclusion.py"
+	env = os.environ.copy()
+	env["PYTHONDONTWRITEBYTECODE"] = "1"
+	result = subprocess.run(
+		["python3", str(self_run_test)],
+		cwd=str(REPO_ROOT),
+		env=env,
+		capture_output=True,
+		text=True,
+		timeout=120,
+	)
+	assert result.returncode == 0, (
+		"review-blocked self-run exclusion regression test failed\n"
+		f"stdout:\n{result.stdout}\n"
+		f"stderr:\n{result.stderr}"
+	)
+	assert "passed" in result.stdout and "total" in result.stdout, (
+		"review-blocked self-run exclusion regression test did not execute "
+		"its direct-entrypoint harness\n"
+		f"stdout:\n{result.stdout}\n"
+		f"stderr:\n{result.stderr}"
+	)
+
+
 def main() -> int:
 	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
 	passed = 0

--- a/tests/test_review_rb_judge_self_run_exclusion.py
+++ b/tests/test_review_rb_judge_self_run_exclusion.py
@@ -55,6 +55,7 @@ import json
 import re
 import subprocess
 import shutil
+import unittest
 from pathlib import Path
 
 
@@ -290,6 +291,19 @@ def test_workflow_preserves_max_iterations_fallback() -> None:
 	)
 
 
+def test_workflow_merge_conflict_comment_is_branch_agnostic() -> None:
+	"""The merge-conflict remediation text must not hardcode `main`
+	because review_autofix runs on arbitrary base branches."""
+	wf = _review_autofix_text()
+	step_anchor = "- name: Post review-blocked comment on PR (autofix exhaustion)"
+	idx = wf.find(step_anchor)
+	assert idx >= 0
+	next_step = wf.find("\n      - name:", idx + len(step_anchor))
+	step_body = wf[idx:next_step if next_step > 0 else len(wf)]
+	assert "merge the base branch" in step_body
+	assert "merge in main" not in step_body
+
+
 # ---------------------------------------------------------------------------
 # Runtime: actually invoke jq on synthetic fixtures and verify the count.
 # ---------------------------------------------------------------------------
@@ -313,8 +327,7 @@ end
 
 def _run_jq(payload: object, self_run: str) -> str:
 	if shutil.which("jq") is None:
-		import pytest
-		pytest.skip("jq binary not available in test environment")
+		raise unittest.SkipTest("jq binary not available in test environment")
 	result = subprocess.run(
 		["jq", "-r", "--arg", "self_run", self_run, JQ_FILTER],
 		input=json.dumps(payload),
@@ -323,6 +336,20 @@ def _run_jq(payload: object, self_run: str) -> str:
 		check=True,
 	)
 	return result.stdout.strip()
+
+
+def test_run_jq_missing_binary_raises_skiptest() -> None:
+	original_which = shutil.which
+	try:
+		shutil.which = lambda _binary: None
+		try:
+			_run_jq([], "")
+		except unittest.SkipTest as exc:
+			assert "jq binary not available" in str(exc)
+		else:
+			raise AssertionError("_run_jq() must raise SkipTest when jq is unavailable")
+	finally:
+		shutil.which = original_which
 
 
 def test_jq_filter_excludes_self_run_only_blocker() -> None:
@@ -447,6 +474,7 @@ def main() -> int:
 	# invoke them directly to ensure the assertions actually execute.
 	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
 	passed = 0
+	skipped = 0
 	failed = 0
 	for func in test_funcs:
 		name = func.__name__
@@ -454,10 +482,13 @@ def main() -> int:
 			func()
 			print(f"  PASS  {name}")
 			passed += 1
+		except unittest.SkipTest as exc:
+			print(f"  SKIP  {name}: {exc}")
+			skipped += 1
 		except Exception as exc:
 			print(f"  FAIL  {name}: {exc}")
 			failed += 1
-	print(f"\n{passed} passed, {failed} failed, {passed + failed} total")
+	print(f"\n{passed} passed, {skipped} skipped, {failed} failed, {passed + skipped + failed} total")
 	return 1 if failed > 0 else 0
 
 

--- a/tests/test_review_rb_judge_self_run_exclusion.py
+++ b/tests/test_review_rb_judge_self_run_exclusion.py
@@ -255,6 +255,27 @@ def test_workflow_branches_telegram_message_on_each_reason() -> None:
 		)
 
 
+def test_workflow_telegram_reason_messages_use_printf_for_newlines() -> None:
+	"""Reason-specific Telegram branches must use printf so the embedded
+	`\n` becomes a real newline before tg_send_msg URL-encodes the body."""
+	wf = _review_autofix_text()
+	step_anchor = "- name: Telegram review-blocked judge decision"
+	idx = wf.find(step_anchor)
+	assert idx >= 0
+	next_step = wf.find("\n      - name:", idx + len(step_anchor))
+	step_body = wf[idx:next_step if next_step > 0 else len(wf)]
+
+	for reason in EXPECTED_MERGE_WITH_FOLLOWUP_SKIP_REASONS:
+		assert re.search(
+			rf'\n\s*{re.escape(reason)}\)\n\s+MSG="\$\(printf ',
+			step_body,
+		), (
+			f"`Telegram review-blocked judge decision` step must format "
+			f"`JUDGE_SKIP_REASON={reason}` via `printf` so Telegram gets "
+			f"a real newline instead of a literal \\n sequence."
+		)
+
+
 def test_workflow_preserves_max_iterations_fallback() -> None:
 	"""The default `*)` branch of the case must preserve the original
 	"maximum number of autofix iterations" body so legacy callers (no
@@ -418,3 +439,27 @@ def test_jq_filter_no_self_collision_on_non_actions_details_url() -> None:
 		}
 	]
 	assert _run_jq(payload, "12345") == "1"
+
+
+def main() -> int:
+	# Direct `python3 tests/<file>.py` entrypoint — sibling review-blocked
+	# regression modules use this harness, and allowlisted contract tests
+	# invoke them directly to ensure the assertions actually execute.
+	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+	passed = 0
+	failed = 0
+	for func in test_funcs:
+		name = func.__name__
+		try:
+			func()
+			print(f"  PASS  {name}")
+			passed += 1
+		except Exception as exc:
+			print(f"  FAIL  {name}: {exc}")
+			failed += 1
+	print(f"\n{passed} passed, {failed} failed, {passed + failed} total")
+	return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_review_rb_judge_self_run_exclusion.py
+++ b/tests/test_review_rb_judge_self_run_exclusion.py
@@ -35,15 +35,14 @@ The fix
    pending-status predicate with `(_is_self_check_run | not)`. Empty
    $self_run preserves legacy behavior for non-Actions / test callers.
 2. Each refusal path in the merge_with_followup branch now emits a
-   distinct `judge_skip_reason` (unresolved_head_sha,
-   check_runs_query_failed, blocking_check_runs, sync_merge_failed,
-   auto_merge_disabled, merge_conflict, mergeability_pending) so the
+   distinct `judge_skip_reason`, including the pre-existing
+   `missing_followup_details` / `followup_issue_create_failed` paths and
+   the seven merge-gate refusal reasons added by this fix, so the
    workflow can distinguish them from a true "max iterations" exhaustion.
-3. .github/workflows/review_autofix.yml's "Post review-blocked comment
-   on PR (autofix exhaustion)" step now branches on JUDGE_SKIP_REASON
-   and posts a reason-specific body. Empty JUDGE_SKIP_REASON falls
-   through to the original "max iterations" body for backward
-   compatibility.
+3. .github/workflows/review_autofix.yml's review-blocked PR-comment and
+   Telegram-notification steps now branch on JUDGE_SKIP_REASON and post
+   reason-specific bodies. Empty JUDGE_SKIP_REASON falls through to the
+   original "max iterations" messaging for backward compatibility.
 
 These tests pin both the script-side filter shape and the workflow-side
 reason routing so a future refactor cannot silently re-introduce the
@@ -152,6 +151,7 @@ def test_script_excludes_self_in_both_jq_branches() -> None:
 
 
 EXPECTED_MERGE_WITH_FOLLOWUP_SKIP_REASONS = {
+	"missing_followup_details",
 	"unresolved_head_sha",
 	"check_runs_query_failed",
 	"blocking_check_runs",
@@ -159,6 +159,7 @@ EXPECTED_MERGE_WITH_FOLLOWUP_SKIP_REASONS = {
 	"auto_merge_disabled",
 	"merge_conflict",
 	"mergeability_pending",
+	"followup_issue_create_failed",
 }
 
 
@@ -234,6 +235,26 @@ def test_workflow_branches_comment_body_on_each_reason() -> None:
 		)
 
 
+def test_workflow_branches_telegram_message_on_each_reason() -> None:
+	"""The Telegram review-blocked notification must mirror the
+	reason-specific routing so merge_with_followup refusal reasons do not
+	fall through to the generic autofix-exhausted alert."""
+	wf = _review_autofix_text()
+	step_anchor = "- name: Telegram review-blocked judge decision"
+	idx = wf.find(step_anchor)
+	assert idx >= 0
+	next_step = wf.find("\n      - name:", idx + len(step_anchor))
+	step_body = wf[idx:next_step if next_step > 0 else len(wf)]
+
+	for reason in EXPECTED_MERGE_WITH_FOLLOWUP_SKIP_REASONS:
+		assert re.search(rf"\n\s*{re.escape(reason)}\)\s*\n", step_body), (
+			f"`Telegram review-blocked judge decision` step must include "
+			f"a `case` branch for `JUDGE_SKIP_REASON={reason}` so "
+			f"reason-specific refusals do not fall through to the generic "
+			f"autofix-exhausted alert."
+		)
+
+
 def test_workflow_preserves_max_iterations_fallback() -> None:
 	"""The default `*)` branch of the case must preserve the original
 	"maximum number of autofix iterations" body so legacy callers (no
@@ -253,6 +274,9 @@ def test_workflow_preserves_max_iterations_fallback() -> None:
 # ---------------------------------------------------------------------------
 
 
+# Snapshot of the production jq filter. The text-shape tests above are
+# the change-detection guard against drift; keep this copy in sync with
+# scripts/review_rb_judge.sh when the live filter changes.
 JQ_FILTER = '''
 def _is_self_check_run: ($self_run != "") and ((.details_url // "") | test("/actions/runs/" + $self_run + "(/|$)"));
 def _is_pending: .status != "completed" or (.conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped" and .conclusion != "cancelled");

--- a/tests/test_review_rb_judge_self_run_exclusion.py
+++ b/tests/test_review_rb_judge_self_run_exclusion.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Regression tests for the merge_with_followup self-deadlock fix.
+
+Background
+----------
+scripts/review_rb_judge.sh runs inside the `review / codex-agent` job
+hosted by .github/workflows/review_autofix.yml (or its dispatch wrapper
+review_rb_judge_dispatch.yml). When the judge decides
+`merge_with_followup`, the script queries
+`/repos/{owner}/{repo}/commits/{head_sha}/check-runs` and refuses the
+merge while ANY check-run is still incomplete.
+
+Before this fix, that query counted the rb_judge's own host job — itself
+a check-run on the PR head SHA with `status=in_progress` — as a blocking
+check-run, so the gate ALWAYS refused merge_with_followup. The workflow
+then fell through to the generic "max autofix iterations" review-blocked
+comment, which misled operators into thinking the iteration cap was the
+proximate cause. The orchestrator's `_pr_checks_completed` helper in
+scripts/orchestrate_poll_process.sh has the same shape but does not need
+this exclusion because it runs from a separate workflow (the orchestrate
+poller), whose host job is never on the polled SHA's check-run list.
+
+End-to-end evidence: shubhodeep1/tele-funtoken-msg-scoring PR #2989,
+run 25993440211, log line "PR #2989 has 1 blocking check-run(s) for SHA
+c52b838 — refusing merge_with_followup" emitted at 14:32:32Z while the
+hosting codex-agent job ran from 14:23:47Z to 14:33:01Z.
+
+The fix
+-------
+1. scripts/review_rb_judge.sh captures ${GITHUB_RUN_ID} into _self_run_id
+   and threads it into the jq filter via --arg self_run. A new
+   `_is_self_check_run` predicate matches Actions-emitted check-runs by
+   their `details_url` (always `/actions/runs/<run_id>/job/<job_id>` for
+   Actions check-runs). The `select` clauses now AND the existing
+   pending-status predicate with `(_is_self_check_run | not)`. Empty
+   $self_run preserves legacy behavior for non-Actions / test callers.
+2. Each refusal path in the merge_with_followup branch now emits a
+   distinct `judge_skip_reason` (unresolved_head_sha,
+   check_runs_query_failed, blocking_check_runs, sync_merge_failed,
+   auto_merge_disabled, merge_conflict, mergeability_pending) so the
+   workflow can distinguish them from a true "max iterations" exhaustion.
+3. .github/workflows/review_autofix.yml's "Post review-blocked comment
+   on PR (autofix exhaustion)" step now branches on JUDGE_SKIP_REASON
+   and posts a reason-specific body. Empty JUDGE_SKIP_REASON falls
+   through to the original "max iterations" body for backward
+   compatibility.
+
+These tests pin both the script-side filter shape and the workflow-side
+reason routing so a future refactor cannot silently re-introduce the
+self-deadlock or the misleading fallback comment.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import shutil
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RB_JUDGE_SCRIPT = REPO_ROOT / "scripts" / "review_rb_judge.sh"
+REVIEW_AUTOFIX_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "review_autofix.yml"
+
+
+def _rb_judge_text() -> str:
+	return RB_JUDGE_SCRIPT.read_text(encoding="utf-8")
+
+
+def _review_autofix_text() -> str:
+	return REVIEW_AUTOFIX_WORKFLOW.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Script-side: self-run exclusion in the check-runs jq filter.
+# ---------------------------------------------------------------------------
+
+
+def test_script_captures_github_run_id() -> None:
+	"""scripts/review_rb_judge.sh must capture ${GITHUB_RUN_ID:-} into a
+	local variable before invoking jq. A future refactor that drops the
+	capture would re-deadlock the merge_with_followup path because the
+	jq filter would have no value to compare details_url against."""
+	src = _rb_judge_text()
+	assert '_self_run_id="${GITHUB_RUN_ID:-}"' in src, (
+		"scripts/review_rb_judge.sh must capture GITHUB_RUN_ID into "
+		"_self_run_id so the check-runs gate can exclude its own host "
+		"GitHub Actions run from the blocking-check-run count. Without "
+		"this capture, the merge_with_followup path self-deadlocks (see "
+		"tele-funtoken-msg-scoring PR #2989)."
+	)
+
+
+def test_script_threads_self_run_into_jq_arg() -> None:
+	"""The jq invocation that counts incomplete check-runs must pass
+	_self_run_id via --arg self_run. Without the --arg threading, the
+	predicate has no value to compare and the gate self-deadlocks."""
+	src = _rb_judge_text()
+	# Anchor on the merge_with_followup gate's specific jq call —
+	# there are other jq calls in the file we don't want to match.
+	pat = re.compile(
+		r'_incomplete_checks="\$\(printf \'%s\' "\$\{_check_runs_json\}" \| '
+		r'jq -r --arg self_run "\$\{_self_run_id\}"',
+	)
+	assert pat.search(src), (
+		"scripts/review_rb_judge.sh's merge_with_followup check-runs "
+		"gate must invoke jq with `--arg self_run \"${_self_run_id}\"` "
+		"so the filter can identify and exclude the rb_judge's own host "
+		"Actions run."
+	)
+
+
+def test_script_defines_self_check_run_predicate() -> None:
+	"""The jq filter must define a _is_self_check_run predicate that
+	matches an Actions check-run's details_url against the captured run
+	id. The /actions/runs/<id>(/|$) anchor prevents prefix collisions
+	(e.g. run id 12 matching run 123)."""
+	src = _rb_judge_text()
+	assert (
+		'def _is_self_check_run: ($self_run != "") and '
+		'((.details_url // "") | test("/actions/runs/" + $self_run + "(/|$)"));'
+	) in src, (
+		"scripts/review_rb_judge.sh must define _is_self_check_run "
+		"in the check-runs jq filter exactly as documented; the "
+		"empty-$self_run guard preserves legacy behavior for non-Actions "
+		"callers and the (/|$) anchor prevents run-id prefix collisions."
+	)
+
+
+def test_script_excludes_self_in_both_jq_branches() -> None:
+	"""Both jq filter branches (the production --paginate --slurp
+	array-of-pages shape and the legacy single-object shape) must
+	exclude self runs. Dropping the predicate from either branch would
+	leave a path where the gate still self-deadlocks."""
+	src = _rb_judge_text()
+	# The select clause must AND _is_pending with the negated self-check.
+	# We check that BOTH branch lines contain this exact AND clause.
+	expected = "select(_is_pending and (_is_self_check_run | not))"
+	occurrences = src.count(expected)
+	assert occurrences >= 2, (
+		f"scripts/review_rb_judge.sh must apply the self-run exclusion "
+		f"in both jq filter branches (paginated array and legacy single-"
+		f"object). Found {occurrences} occurrence(s) of "
+		f"`{expected}`; expected at least 2."
+	)
+
+
+# ---------------------------------------------------------------------------
+# Script-side: reason emission for every merge_with_followup refusal path.
+# ---------------------------------------------------------------------------
+
+
+EXPECTED_MERGE_WITH_FOLLOWUP_SKIP_REASONS = {
+	"unresolved_head_sha",
+	"check_runs_query_failed",
+	"blocking_check_runs",
+	"sync_merge_failed",
+	"auto_merge_disabled",
+	"merge_conflict",
+	"mergeability_pending",
+}
+
+
+def test_each_merge_with_followup_refusal_emits_distinct_skip_reason() -> None:
+	"""Every refusal path inside the merge_with_followup branch must
+	emit a distinct `judge_skip_reason` to $GITHUB_OUTPUT so the
+	workflow's review-blocked fallback comment can distinguish them
+	from "max iterations reached". Before this fix, these paths left
+	judge_skip_reason empty and the workflow posted a misleading body."""
+	src = _rb_judge_text()
+	for reason in EXPECTED_MERGE_WITH_FOLLOWUP_SKIP_REASONS:
+		needle = f'echo "judge_skip_reason={reason}" >> "$GITHUB_OUTPUT"'
+		assert needle in src, (
+			f"scripts/review_rb_judge.sh must emit "
+			f"`judge_skip_reason={reason}` from the corresponding "
+			f"merge_with_followup refusal path. Without it the workflow "
+			f"falls through to the generic max-iterations body, which "
+			f"is what confused operators on tele-funtoken-msg-scoring "
+			f"PR #2989."
+		)
+
+
+# ---------------------------------------------------------------------------
+# Workflow-side: review-blocked comment routes on JUDGE_SKIP_REASON.
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_threads_judge_skip_reason_into_comment_step() -> None:
+	"""The `Post review-blocked comment on PR (autofix exhaustion)` step
+	must read steps.rb_judge.outputs.judge_skip_reason as env. Without
+	this plumbing the case branches below cannot fire."""
+	wf = _review_autofix_text()
+	# Anchor on the step name to scope the search to this specific step.
+	step_anchor = "- name: Post review-blocked comment on PR (autofix exhaustion)"
+	idx = wf.find(step_anchor)
+	assert idx >= 0, (
+		"`Post review-blocked comment on PR (autofix exhaustion)` step "
+		"must exist in .github/workflows/review_autofix.yml; the fix "
+		"depends on it being present to route the reason-specific body."
+	)
+	# Look at the next ~120 lines following the step header (the step
+	# body) for the env plumbing.
+	step_body = wf[idx:idx + 6000]
+	assert "JUDGE_SKIP_REASON: ${{ steps.rb_judge.outputs.judge_skip_reason }}" in step_body, (
+		"`Post review-blocked comment on PR (autofix exhaustion)` step "
+		"must thread `JUDGE_SKIP_REASON: ${{ steps.rb_judge.outputs."
+		"judge_skip_reason }}` as env so the bash case below can route "
+		"the body."
+	)
+
+
+def test_workflow_branches_comment_body_on_each_reason() -> None:
+	"""The fallback comment step's case statement must include a branch
+	for each merge_with_followup skip reason emitted by the script.
+	Missing a branch means that reason falls through to the generic
+	"max iterations" body, re-introducing the misleading-comment bug."""
+	wf = _review_autofix_text()
+	step_anchor = "- name: Post review-blocked comment on PR (autofix exhaustion)"
+	idx = wf.find(step_anchor)
+	assert idx >= 0
+	# Scope to the step body (until the next "- name:" sibling).
+	next_step = wf.find("\n      - name:", idx + len(step_anchor))
+	step_body = wf[idx:next_step if next_step > 0 else len(wf)]
+
+	for reason in EXPECTED_MERGE_WITH_FOLLOWUP_SKIP_REASONS:
+		# Match the case label "    reason)" line — leading-whitespace
+		# is workflow-indentation-dependent, just check the token.
+		assert re.search(rf"\n\s*{re.escape(reason)}\)\s*\n", step_body), (
+			f"`Post review-blocked comment on PR (autofix exhaustion)` "
+			f"step must include a `case` branch for "
+			f"`JUDGE_SKIP_REASON={reason}` so that reason no longer "
+			f"falls through to the generic max-iterations body."
+		)
+
+
+def test_workflow_preserves_max_iterations_fallback() -> None:
+	"""The default `*)` branch of the case must preserve the original
+	"maximum number of autofix iterations" body so legacy callers (no
+	judge_skip_reason set) keep the same behavior. This is the only
+	backward-compatibility lever for the workflow change."""
+	wf = _review_autofix_text()
+	assert "maximum number of autofix iterations" in wf, (
+		"The `*)` (default) branch of the comment step's case statement "
+		"must keep the original `maximum number of autofix iterations` "
+		"body for backward compatibility with pre-fix script callers "
+		"that don't set judge_skip_reason."
+	)
+
+
+# ---------------------------------------------------------------------------
+# Runtime: actually invoke jq on synthetic fixtures and verify the count.
+# ---------------------------------------------------------------------------
+
+
+JQ_FILTER = '''
+def _is_self_check_run: ($self_run != "") and ((.details_url // "") | test("/actions/runs/" + $self_run + "(/|$)"));
+def _is_pending: .status != "completed" or (.conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped" and .conclusion != "cancelled");
+if (type == "array") then
+  [.[]? | (.check_runs // [])[] | select(_is_pending and (_is_self_check_run | not))] | length
+elif (type == "object" and (.check_runs | type == "array")) then
+  [.check_runs[] | select(_is_pending and (_is_self_check_run | not))] | length
+else
+  empty
+end
+'''
+
+
+def _run_jq(payload: object, self_run: str) -> str:
+	if shutil.which("jq") is None:
+		import pytest
+		pytest.skip("jq binary not available in test environment")
+	result = subprocess.run(
+		["jq", "-r", "--arg", "self_run", self_run, JQ_FILTER],
+		input=json.dumps(payload),
+		capture_output=True,
+		text=True,
+		check=True,
+	)
+	return result.stdout.strip()
+
+
+def test_jq_filter_excludes_self_run_only_blocker() -> None:
+	"""Reproduces the tele-funtoken-msg-scoring PR #2989 scenario: the
+	only in_progress check-run is the rb_judge's own host job. After
+	exclusion the gate should see 0 blocking check-runs and let the
+	merge proceed."""
+	payload = [
+		{
+			"check_runs": [
+				{
+					"name": "review / codex-agent",
+					"status": "in_progress",
+					"conclusion": None,
+					"details_url": "https://github.com/owner/repo/actions/runs/12345/job/789",
+				},
+				{
+					"name": "other-ci",
+					"status": "completed",
+					"conclusion": "success",
+					"details_url": "https://github.com/owner/repo/actions/runs/99999/job/000",
+				},
+			]
+		}
+	]
+	assert _run_jq(payload, "12345") == "0"
+
+
+def test_jq_filter_keeps_genuine_blocker_after_self_exclusion() -> None:
+	"""The exclusion must be narrow — only the matching self run is
+	removed. A second still-running CI check on the same SHA must still
+	count as 1 blocker so the gate refuses the merge."""
+	payload = [
+		{
+			"check_runs": [
+				{
+					"name": "review / codex-agent",
+					"status": "in_progress",
+					"conclusion": None,
+					"details_url": "https://github.com/owner/repo/actions/runs/12345/job/789",
+				},
+				{
+					"name": "blocking-ci",
+					"status": "in_progress",
+					"conclusion": None,
+					"details_url": "https://github.com/owner/repo/actions/runs/99999/job/000",
+				},
+			]
+		}
+	]
+	assert _run_jq(payload, "12345") == "1"
+
+
+def test_jq_filter_legacy_single_object_shape_without_self_run() -> None:
+	"""Empty $self_run (non-Actions callers, tests, or legacy invocation)
+	must disable the exclusion entirely so the gate behaves exactly as
+	before this fix — preserving backward compatibility."""
+	payload = {
+		"check_runs": [
+			{
+				"name": "ci-1",
+				"status": "in_progress",
+				"conclusion": None,
+				"details_url": "https://github.com/owner/repo/actions/runs/77/job/1",
+			},
+			{
+				"name": "ci-2",
+				"status": "completed",
+				"conclusion": "success",
+				"details_url": None,
+			},
+		]
+	}
+	assert _run_jq(payload, "") == "1"
+
+
+def test_jq_filter_self_run_prefix_does_not_match() -> None:
+	"""The (/|$) anchor in the details_url regex must prevent run-id
+	prefix collisions: run id 12 must NOT match a check-run pointing at
+	run 123. Without the anchor, a numerically-shorter $self_run could
+	accidentally exclude an unrelated check-run and let the gate pass
+	while real blockers are still running."""
+	payload = [
+		{
+			"check_runs": [
+				{
+					"name": "blocking-ci",
+					"status": "in_progress",
+					"conclusion": None,
+					"details_url": "https://github.com/owner/repo/actions/runs/123/job/1",
+				},
+			]
+		}
+	]
+	# self_run="12" must NOT match the run-id "123".
+	assert _run_jq(payload, "12") == "1"
+
+
+def test_jq_filter_no_self_collision_on_non_actions_details_url() -> None:
+	"""Non-Actions check-runs (third-party CI integrations) have
+	details_urls that don't carry /actions/runs/<id>/job/<id>. The
+	self-exclusion must NOT match them — they must still count as
+	blockers per their status."""
+	payload = [
+		{
+			"check_runs": [
+				{
+					"name": "third-party-ci",
+					"status": "in_progress",
+					"conclusion": None,
+					"details_url": "https://third-party-ci.example.com/builds/abc",
+				},
+			]
+		}
+	]
+	assert _run_jq(payload, "12345") == "1"


### PR DESCRIPTION
## Summary

- **Self-deadlock fix:** `scripts/review_rb_judge.sh`'s `merge_with_followup` check-runs gate now excludes its own host GitHub Actions run from the blocking-count via the check-run `details_url`. Previously the rb_judge step (which runs inside the `review / codex-agent` job hosted by `review_autofix.yml`) always saw its own still-`in_progress` host job as one blocking check-run and refused the merge — observed end-to-end in `shubhodeep1/tele-funtoken-msg-scoring` PR #2989 (run 25993440211, warning at `14:32:32Z` while the codex-agent host ran `14:23:47Z` → `14:33:01Z`).
- **Reason-aware fallback:** Every `merge_with_followup` refusal path now emits a distinct `judge_skip_reason` (`unresolved_head_sha`, `check_runs_query_failed`, `blocking_check_runs`, `sync_merge_failed`, `auto_merge_disabled`, `merge_conflict`, `mergeability_pending`). The "Post review-blocked comment on PR (autofix exhaustion)" step in `review_autofix.yml` now branches on `JUDGE_SKIP_REASON` and posts a body explaining the actual cause — the misleading "max autofix iterations" body is preserved only for the empty/unknown-reason default.
- **Regression coverage:** `tests/test_review_rb_judge_self_run_exclusion.py` adds 13 tests pinning the jq filter shape, the reason emission for every refusal path, the workflow plumbing, and the runtime jq behavior (self exclusion, no run-id-prefix collisions, non-Actions `details_url` left alone, legacy backward compatibility).

Targeting `stable` (per request) since consumers wrap `@stable` directly and need the fix on this branch to recover from the deadlock.

## Why these changes are safe

- **§6 (naming immutability):** No identifiers renamed; `judge_skip_reason` is an existing output gaining new values.
- **§10 (MongoDB):** Untouched.
- **Backward compatibility:** Empty `$self_run` disables the new exclusion (preserves legacy test paths). Empty `JUDGE_SKIP_REASON` falls through to the original "max iterations" comment body. The orchestrator's parallel `_pr_checks_completed` helper in `scripts/orchestrate_poll_process.sh` is unchanged — it doesn't need the exclusion because it runs from a different workflow.
- **No new GitHub API calls** (per §15): only changes the jq filter applied to the existing `/check-runs` payload.

## Files changed

- `scripts/review_rb_judge.sh` (lines ~1067–1170 of the merge_with_followup branch): self-run capture, jq predicate, seven new `judge_skip_reason` emissions.
- `.github/workflows/review_autofix.yml` (the "Post review-blocked comment on PR (autofix exhaustion)" step around line 4618): adds `JUDGE_SKIP_REASON` env, reason-routed body via bash `case`, fallback to existing body.
- `tests/test_review_rb_judge_self_run_exclusion.py` (new): 13 regression tests.

## Test plan

- [x] `python3 -m pytest tests/test_review_rb_judge_self_run_exclusion.py` — 13/13 pass locally
- [x] `python3 -m pytest tests/test_review_rb_judge_label_propagation.py tests/test_review_rb_judge_reissue_baseline.py` — 41/41 still pass (no regressions)
- [x] `python3 -m pytest tests/test_review_autofix_merge_precheck.py tests/test_review_autofix_failure_log_upload.py tests/test_review_autofix_smoke_editor_override.py` — 22/22 still pass
- [x] `bash -n scripts/review_rb_judge.sh` — syntax OK
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/review_autofix.yml'))"` — YAML parses
- [x] Manual jq fixture verification of the three core scenarios: self-only blocker → 0; self + genuine blocker → 1; empty `$self_run` legacy shape → 1
- [ ] Once merged into `stable` and re-tagged, a consumer `merge_with_followup` flow should land cleanly when only the rb_judge's own host job is still in-flight at the gate

## Manual unstick for the affected PR

This PR does NOT unstick `tele-funtoken-msg-scoring#2989` automatically — that needs a manual `gh pr merge 2989 --squash` against the consumer repo (the judge already approved it; the only blocker was the rb_judge's own host job, which has since completed `success`). The proactive fix only prevents the same deadlock on future PRs.

https://claude.ai/code/session_01DaW7UPx4jbgU4p5YGLxG18

---
_Generated by [Claude Code](https://claude.ai/code/session_01DaW7UPx4jbgU4p5YGLxG18)_