### PR TITLE
docs: add automation-bias policy (§18 CLAUDE.md, §20 unattended)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,6 +473,92 @@ Spawn rules:
 
 ---
 
+## §18. Automation Bias (Reduce Human Involvement)
+
+The overarching goal of every task, plan, and change is to **minimize
+human-in-the-loop**. Operations should run from code on a schedule, not
+from an operator typing into a shell. Plans that require an operator to
+run a script, run a mongo command, or babysit a process are incomplete
+and must be revised before they reach the orchestrator.
+
+### A) No Standalone Manual Scripts (Hard Rule)
+
+When making changes — or drafting plans for the orchestrator to
+implement — do NOT introduce standalone scripts that require manual
+shell invocation to run. Fold the work into an existing script or
+workflow that already runs automatically.
+
+If a manual-invocation script appears to be the only viable option,
+**STOP and ask** in the Q/A format (§2) before adding one, and record
+the justification in the plan. Default answer is "no — wire it in
+instead."
+
+### B) Wire Into the Scheduler
+
+Any new operation that is not folded into an existing script MUST be
+wired into the existing scheduler / PR-push automation so it runs on
+PR push (or the relevant trigger) without operator action. Plans MUST
+cite the specific workflow / cron file the change will touch so the
+orchestrator knows exactly where to wire it. Code changes MUST land the
+wiring in the same PR — never plan or accept a "wiring lands later"
+handoff.
+
+### C) Long-Running Supervisor
+
+If the work needs to run continuously, react to events between PRs, or
+supervise other automation, a long-running supervisor is required. If
+no suitable supervisor already exists, **one must be created as part of
+the same change** — do not defer it.
+
+Plans MUST specify:
+- Whether a new supervisor is being introduced or an existing one
+  extended.
+- Lifecycle: entry point, restart policy, shutdown signal handling,
+  crash-recovery behavior.
+- How the supervisor is wired into the scheduler / startup automation
+  so it comes up without operator action.
+
+A supervisor that needs an operator to start it is not a supervisor —
+it is a manual script (§18.A) and is subject to the same hard rule.
+
+### D) Database Operations Run From Code (Hard Rule)
+
+Database operations — one-time backfills, schema migrations, index
+rebuilds, long-running maintenance, recurring cleanup — MUST run from
+code with appropriate gates so they execute only as much as needed.
+Do NOT plan or accept "operator runs this mongo shell command" steps.
+
+Gates must use the patterns already established in §10:
+- Idempotency keys backed by unique indexes (§10.E) and atomic upserts
+  so repeated runs converge instead of duplicating.
+- Distributed locks via `_locks` with lease expiry (§10.C) for any
+  operation that must run at most once across processes.
+- Explicit "already applied" sentinels (run flags, marker documents,
+  versioned migration records) so the gate is observable and
+  auditable.
+
+If the right gate is not obvious for a given DB operation, route to
+§2 (STOP and ASK) — do not ship an ungated DB operation.
+
+### E) Plan Output Requirements
+
+Every plan for the orchestrator MUST surface, in a dedicated section
+near the top of the plan:
+
+- Whether the change introduces a new script, extends an existing one,
+  or only modifies existing code.
+- The exact scheduler / PR-push entry point the change wires into
+  (file path + trigger).
+- Whether a new long-running supervisor is required (§18.C), and if so
+  its lifecycle and wiring.
+- For DB work: which gate pattern (§18.D) applies and where the gate
+  lives in code.
+
+Plans that omit any of these MUST be revised before the orchestrator
+implements them.
+
+---
+
 ## FINAL REMINDER
 
 If uncertainty exists: **ASK (multiple-choice). DO NOT EXECUTE.**

--- a/unattended_system_instructions.md
+++ b/unattended_system_instructions.md
@@ -371,3 +371,87 @@ new `@stable` release is tagged.
 - Format: JSON array of `"owner/repo"` strings
 - The `GH_PAT` used in release workflows must have `repo` scope on every
   listed consumer repo for the dispatch to succeed.
+
+---
+
+## §20. Automation Bias (Reduce Human Involvement)
+
+The overarching goal of every plan and implementation is to minimize
+human-in-the-loop. Operations must run from code on a schedule, not from
+an operator typing into a shell. Plans that depend on an operator
+running a script, running a mongo command, or babysitting a process are
+incomplete and must be revised before implementation begins.
+
+### A) No Standalone Manual Scripts
+
+When generating plans or implementing changes, do NOT introduce
+standalone scripts that require manual shell invocation to run. Fold
+the work into an existing script or workflow that already runs
+automatically.
+
+If a manual-invocation script appears to be the only viable option,
+surface it explicitly in the plan output (and, for implementations, in
+the PR description) with the justification — do not silently ship it.
+Default to wiring it into an existing script or the scheduler instead.
+
+### B) Wire Into the Scheduler
+
+Any new operation that is not folded into an existing script MUST be
+wired into the existing scheduler / PR-push automation so it runs on
+PR push (or the relevant trigger) without operator action. Plans MUST
+cite the specific workflow / cron file the change will touch so the
+implement agent knows exactly where to wire it. Implement agents MUST
+land the wiring in the same PR — never plan or accept a "wiring lands
+later" handoff.
+
+### C) Long-Running Supervisor
+
+If the work needs to run continuously, react to events between PRs, or
+supervise other automation, a long-running supervisor is required. If
+no suitable supervisor already exists, one must be created as part of
+the same change — do not defer it.
+
+Plans MUST specify:
+- Whether a new supervisor is being introduced or an existing one
+  extended.
+- Lifecycle: entry point, restart policy, shutdown signal handling,
+  crash-recovery behavior.
+- How the supervisor is wired into the scheduler / startup automation
+  so it comes up without operator action.
+
+Implement agents MUST deliver the supervisor and its wiring in the same
+PR. A supervisor that needs an operator to start it is a manual script
+(§20.A) and is subject to the same constraint.
+
+### D) Database Operations Run From Code
+
+Database operations — one-time backfills, schema migrations, index
+rebuilds, long-running maintenance, recurring cleanup — MUST run from
+code with appropriate gates so they execute only as much as needed.
+Do NOT plan or implement "operator runs this mongo shell command"
+steps.
+
+Use the gate patterns established in §12 (MongoDB Rules):
+- Idempotency keys + atomic upserts so repeated runs converge.
+- Distributed locks via `_locks` with lease expiry for at-most-once
+  operations across processes.
+- Explicit "already applied" sentinels (run flags, marker documents,
+  versioned migration records) so the gate is observable and
+  auditable.
+
+### E) Plan Output Requirements
+
+Every plan emitted for orchestrator implementation MUST surface, in a
+dedicated section near the top of the plan:
+
+- Whether the change introduces a new script, extends an existing one,
+  or only modifies existing code.
+- The exact scheduler / PR-push entry point the change wires into
+  (file path + trigger).
+- Whether a new long-running supervisor is required (§20.C), and if so
+  its lifecycle and wiring.
+- For DB work: which gate pattern (§20.D) applies and where the gate
+  lives in code.
+
+Plans missing any of these are incomplete and must be revised before
+implementation begins.


### PR DESCRIPTION
## Summary

Codifies an "automation bias" policy so that plans and changes the orchestrator implements minimize human-in-the-loop. Adds a new section in both the interactive and unattended system-instruction files; no existing sections renumbered (§6 immutability respected).

- **CLAUDE.md §18 — Automation Bias (Reduce Human Involvement)** (interactive sessions)
- **unattended_system_instructions.md §20 — Automation Bias (Reduce Human Involvement)** (codex-cli pipelines: plan / orchestrate / implement / review-autofix / etc.)

Both sections cover the same five rules, retoned for each audience (CLAUDE.md routes ambiguity to STOP-and-ASK per §2; the unattended mirror routes it to plan/PR-description surfacing per its bias-to-action style):

- **A. No standalone manual scripts** — fold new work into existing scripts/workflows; manual-invocation scripts are a hard rule violation in CLAUDE.md (must STOP and ASK before adding) and a planning red flag in unattended.
- **B. Wire into the scheduler** — anything not folded into an existing script must be wired into the existing scheduler / PR-push automation in the same PR. Plans must cite the specific workflow / cron file the change touches.
- **C. Long-running supervisor** — if continuous / between-PR / supervisory work is needed and no suitable supervisor exists, one must be created in the same change. Plans must spell out lifecycle and scheduler wiring. A supervisor that needs an operator to start it is a manual script and falls under (A).
- **D. Database operations run from code** — one-time backfills, migrations, index rebuilds, recurring cleanup all run from code with gates: idempotency keys + atomic upserts, `_locks` lease expiry for at-most-once, "already applied" sentinels. No `operator runs this mongo shell command` steps.
- **E. Plan output requirements** — every plan must surface up-front: new-vs-existing script, scheduler entry point (file + trigger), supervisor needs, and DB gate pattern.

## Why

Reduces operator toil and the surface area for "forgot to run the script" / "ran the backfill twice" failure modes. Binds both the interactive author (CLAUDE.md) and the unattended pipelines that actually execute plans (unattended_system_instructions.md) so the policy is enforced end-to-end rather than only at draft time.

## Test plan

- [ ] Review §18 in `CLAUDE.md` reads correctly and cross-references (§2, §10.C, §10.E) resolve.
- [ ] Review §20 in `unattended_system_instructions.md` reads correctly and cross-references to §12 (MongoDB) resolve in that file's numbering.
- [ ] Confirm no existing section numbers were renumbered (§6 immutability) — section headers grep shows §18 added at end of CLAUDE.md and §20 at end of unattended file with all prior sections intact.
- [ ] Spot-check the next plan/orchestrate run includes the §18.E / §20.E plan-output checklist items.

https://claude.ai/code/session_01L8Mw6zLL2BRYh1qQVRN7oD

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8Mw6zLL2BRYh1qQVRN7oD)_