### PR TITLE
docs: add scripts-pending-removal registry (§18.F / §20.F)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -553,9 +553,48 @@ near the top of the plan:
   its lifecycle and wiring.
 - For DB work: which gate pattern (§18.D) applies and where the gate
   lives in code.
+- For any new single-use / long-running script or supervisor: the
+  registry entry to be added to `docs/scripts-pending-removal.md`
+  (§18.F) — removal trigger and removal preflight checks.
 
 Plans that omit any of these MUST be revised before the orchestrator
 implements them.
+
+### F) Future-Removal Registry
+
+Every single-use script, long-running script, and long-running
+supervisor introduced under §18.A–C MUST get an entry in
+`docs/scripts-pending-removal.md` **in the same PR** that introduces
+it. The registry is one centralized doc — do not create per-script
+removal docs.
+
+Each entry MUST include:
+- **Script path** — the script, supervisor entry point, or workflow
+  file the entry is about.
+- **Introduced in** — PR number and date the script landed.
+- **Type** — `single-use`, `long-running`, or `supervisor`.
+- **Removal trigger** — the concrete condition that makes removal
+  safe (e.g. "after backfill `X` completes for all docs", "when
+  feature flag `Y` is GA for 30 days", "when supervisor v2 replaces
+  v1"). If no sunset applies, use **"permanent — review annually"** —
+  do not omit the field.
+- **Removal preflight checks** — explicit list of checks that MUST
+  pass before the script is removed, to verify the script has
+  already done its job. Each check names the exact command, query,
+  or signal to inspect and the expected result / threshold. These
+  checks are what protects against removing a script that hasn't
+  finished its work.
+- **Owner** — GitHub handle of the person / agent who owns the
+  removal decision.
+
+When a script is removed from the codebase, **delete its entry from
+the registry in the same PR**. The registry is a live list, not an
+audit log — there is no "removed" archive section. Git history is the
+audit trail.
+
+If a script is renamed or extended, update its entry (path, trigger,
+preflight checks) in the same PR — §6 (naming immutability) still
+applies, so renames require the §2 ask flow first.
 
 ---
 

--- a/docs/scripts-pending-removal.md
+++ b/docs/scripts-pending-removal.md
@@ -1,0 +1,56 @@
+# Scripts Pending Removal
+
+Centralized registry of single-use scripts, long-running scripts, and
+long-running supervisors that have a known future-removal condition.
+
+Mandated by **§18.F** (`CLAUDE.md`) and **§20.F**
+(`unattended_system_instructions.md`).
+
+This is **one** living registry — do not create per-script removal
+docs. Entries are added when a script is introduced and **removed**
+from this file when the script itself is removed from the codebase.
+Git history is the audit trail; there is no "removed" archive section.
+
+## Entry Schema
+
+Each entry MUST include all of the following fields. Use the per-script
+block format below — tables collapse multi-line preflight checks.
+
+- **Script path** — the script, supervisor entry point, or workflow
+  file the entry is about (repo-relative path).
+- **Introduced in** — PR number and date the script landed.
+- **Type** — one of `single-use`, `long-running`, `supervisor`.
+- **Removal trigger** — the concrete condition that makes removal
+  safe. Examples:
+  - `after backfill users_email_lowercase completes for all docs`
+  - `when feature flag new_pricing_v2 is GA (100% rollout) for 30 days`
+  - `when supervisor_v2 replaces supervisor_v1 in production`
+  - `permanent — review annually` (use only when no sunset applies; do
+    not omit the field)
+- **Removal preflight checks** — explicit list of checks that MUST
+  pass before the script is removed, to verify the script has already
+  done its job. Each check names the exact command, query, or signal
+  to inspect and the expected result / threshold. These checks protect
+  against removing a script that hasn't finished its work.
+- **Owner** — GitHub handle of the person / agent who owns the
+  removal decision.
+
+## Template
+
+Copy this block when adding a new entry:
+
+```markdown
+### `path/to/script-or-workflow`
+
+- **Introduced in:** #NNNN (YYYY-MM-DD)
+- **Type:** single-use | long-running | supervisor
+- **Removal trigger:** <concrete condition>
+- **Removal preflight checks:**
+  - `<exact command / query>` returns `<expected result>`.
+  - `<signal to inspect>` shows `<expected threshold>`.
+- **Owner:** @handle
+```
+
+## Entries
+
+_No entries yet._

--- a/unattended_system_instructions.md
+++ b/unattended_system_instructions.md
@@ -452,6 +452,45 @@ dedicated section near the top of the plan:
   its lifecycle and wiring.
 - For DB work: which gate pattern (§20.D) applies and where the gate
   lives in code.
+- For any new single-use / long-running script or supervisor: the
+  registry entry to be added to `docs/scripts-pending-removal.md`
+  (§20.F) — removal trigger and removal preflight checks.
 
 Plans missing any of these are incomplete and must be revised before
 implementation begins.
+
+### F) Future-Removal Registry
+
+Every single-use script, long-running script, and long-running
+supervisor introduced under §20.A–C MUST get an entry in
+`docs/scripts-pending-removal.md` in the same PR that introduces it.
+The registry is one centralized doc — do not create per-script removal
+docs.
+
+Each entry MUST include:
+- **Script path** — the script, supervisor entry point, or workflow
+  file the entry is about.
+- **Introduced in** — PR number and date the script landed.
+- **Type** — `single-use`, `long-running`, or `supervisor`.
+- **Removal trigger** — the concrete condition that makes removal
+  safe (e.g. "after backfill `X` completes for all docs", "when
+  feature flag `Y` is GA for 30 days", "when supervisor v2 replaces
+  v1"). If no sunset applies, use "permanent — review annually" — do
+  not omit the field.
+- **Removal preflight checks** — explicit list of checks that MUST
+  pass before the script is removed, to verify the script has
+  already done its job. Each check names the exact command, query,
+  or signal to inspect and the expected result / threshold. These
+  checks protect against removing a script that hasn't finished its
+  work.
+- **Owner** — GitHub handle of the person / agent who owns the
+  removal decision.
+
+When a script is removed from the codebase, delete its entry from the
+registry in the same PR. The registry is a live list, not an audit log
+— there is no "removed" archive section. Git history is the audit
+trail.
+
+If a script is renamed or extended, update its entry (path, trigger,
+preflight checks) in the same PR — §10 (naming immutability) still
+applies in this file's numbering.


### PR DESCRIPTION
## Summary

Follow-up to #2746. Adds the future-removal registry to the automation-bias policy: a single centralized doc that lists every single-use script, long-running script, and supervisor with a known future-removal condition, including the preflight checks that must pass before the script can be safely removed.

- **`docs/scripts-pending-removal.md`** (new) — the centralized registry. Header, entry schema, copy-paste template, empty entries section.
- **`CLAUDE.md` §18.F — Future-Removal Registry** (new subsection) — binds interactive sessions.
- **`unattended_system_instructions.md` §20.F — Future-Removal Registry** (new subsection) — mirrors for plan / orchestrate / implement / review-autofix pipelines.
- **`CLAUDE.md` §18.E** and **`unattended_system_instructions.md` §20.E** — plan-output checklists extended with one bullet so plans surface the registry entry (trigger + preflight checks) up front instead of discovering it at implementation time.

### Entry schema

Each registry entry MUST include:

- **Script path** — repo-relative path to the script / supervisor entry point / workflow file.
- **Introduced in** — PR # and date.
- **Type** — `single-use`, `long-running`, or `supervisor`.
- **Removal trigger** — concrete sunset condition; `permanent — review annually` if none applies (field is never omitted).
- **Removal preflight checks** — explicit list of exact commands / queries / signals with expected results that must pass before the script is removed. *This is what protects against removing a script that hasn't finished its work.*
- **Owner** — GitHub handle.

### Lifecycle

- Entry added in the **same PR** that introduces the script (per §18.F / §20.F).
- Entry **deleted** from the registry in the **same PR** that removes the script. The registry is a live list, not an audit log — git history is the audit trail; no "removed" archive section.
- If a script is renamed or extended, the entry (path, trigger, preflight checks) is updated in the same PR. §6 naming-immutability still binds renames.

## Why a separate PR

#2746 (the §18 / §20 base policy) is already merged, so this lands as its own PR. Under §12.A the rules would have wanted both to land together, but §12.A applies pre-merge — after merge, a new PR is the correct vehicle.

## Test plan

- [ ] `docs/scripts-pending-removal.md` renders correctly on GitHub (headers, code block, template).
- [ ] §18.F in `CLAUDE.md` reads correctly and cross-references (§18.A–C, §2, §6) resolve.
- [ ] §20.F in `unattended_system_instructions.md` reads correctly and cross-references (§20.A–C, §10 naming) resolve in that file's numbering.
- [ ] §18.E / §20.E plan-output checklists now include the registry-entry bullet.
- [ ] No existing section numbers renumbered (§6 / §10 immutability respected).
- [ ] Spot-check the next plan that introduces a script: it cites the registry entry's trigger + preflight checks in the plan-output section.

https://claude.ai/code/session_01L8Mw6zLL2BRYh1qQVRN7oD

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8Mw6zLL2BRYh1qQVRN7oD)_