### PR TITLE
Preserve Telegram alert history on failure / closed-unmerged PRs

### DIFF
--- a/.github/workflows/issue_pr_status.yml
+++ b/.github/workflows/issue_pr_status.yml
@@ -538,7 +538,7 @@ jobs:
           fi
 
       - name: Cleanup tracked Telegram messages
-        if: always()
+        if: always() && github.event.pull_request.merged == true
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}

--- a/README.md
+++ b/README.md
@@ -1299,9 +1299,9 @@ For non-orchestrator issues, human-intervention alerts are cleaned up automatica
 - **Clarification required** — sent by `clarify.yml` and `plan.yml` for non-orchestrator issues only, deleted when `plan.yml` runs (stored as `<!-- tg_phase:clarify:id -->`). Orchestrator-managed issues skip this alert because clarify uses a label-based fast path (`ai:orchestrator-managed`) that auto-posts `/answer [auto-answered-by-orchestrator]` unless a human forces `/reclarify`; if `plan.yml` cannot auto-parse recommended clarification answers it sends a general tracked `WARNING` and waits for a human `/answer`.
 - **Plan awaiting approval** — sent by `plan.yml` (when `AUTO_IMPLEMENT_ON_CLEAR_PLAN` is not true), deleted when `implement.yml` runs (stored as `<!-- tg_phase:plan:id -->`)
 
-**General tracked alerts (deleted at terminal state):**
-- Orchestrator-managed issue alerts use general tracking (`<!-- tg_cleanup:id1,id2,... -->`), cleaned up when the tracking issue reaches a terminal state (complete or failed) via the poller.
-- Any remaining tracked messages (general or phase) are cleaned up when a PR is closed/merged by `issue_pr_status.yml`.
+**General tracked alerts (deleted at successful terminal state only):**
+- Orchestrator-managed issue alerts use general tracking (`<!-- tg_cleanup:id1,id2,... -->`), cleaned up only when the tracking issue reaches a **successful** terminal state (project complete / validated and merged) via the poller. Failure / blocked terminal states (integration branch missing, validation failed deterministically, validation recovery exhausted, final-merge budget exhausted, judge stall-cycle limit exceeded, judge repeat-fingerprint breaker, recovery attempts exhausted) deliberately leave the tracked alert history intact so the alert chat retains the breadcrumb trail needed to diagnose the underlying issue.
+- Any remaining tracked messages (general or phase) are cleaned up by `issue_pr_status.yml` only when a PR is **merged**. PRs closed without merging (abandoned / failed) deliberately preserve their tracked alerts for post-mortem.
 
 **Requirements:**
 - `TG_BOT_SECRET` must be set (same secret used for sending).

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -2279,7 +2279,6 @@ mark_integration_branch_missing_failed() {
 ${reason}"
   _tracking_labels="$(get_issue_labels_json "${TRACKING_NUM}")"
   handle_comprehensive_release_callback_if_needed "failed" "${_tracking_labels}" "${COMMENTS:-[]}"
-  tg_cleanup_msgs "${TRACKING_NUM}"
   tg_notify "❌ Project #${TRACKING_NUM} failed: ${tg_reason}."
 }
 
@@ -4453,7 +4452,6 @@ ${reason}
 
 Failure class \`${_deterministic_class}\` is environment-deterministic; retrying this workflow on the same runner image will not help. Skipping the recovery budget. Manual intervention required."
     tg_notify "Project #${TRACKING_NUM} validation failed deterministically (class=${_deterministic_class}). Manual intervention required." "CRITICAL"
-    tg_cleanup_msgs "${TRACKING_NUM}"
     return 0
   fi
 
@@ -4496,7 +4494,6 @@ ${reason}
 
 Validation recovery exhausted (${val_recovery_count}/${MAX_VALIDATION_RECOVERY_ATTEMPTS}). Manual intervention required."
   tg_notify "Project #${TRACKING_NUM} validation failed after ${val_recovery_count} recovery attempt(s). Manual intervention required." "CRITICAL"
-  tg_cleanup_msgs "${TRACKING_NUM}"
 }
 
 mark_validation_complete() {
@@ -4565,7 +4562,6 @@ Runtime validation passed, but the final squash merge of \`${integration_branch}
 - Last recorded error: ${_final_err:-No specific error recorded; check final PR for branch protection or required-check failures.}
 
 Manual intervention required: resolve the blocking condition on the final PR (merge conflicts, required checks, branch protections) and re-trigger the poller, or merge manually."
-    tg_cleanup_msgs "${TRACKING_NUM}"
     tg_notify "Project #${TRACKING_NUM} blocked: validation passed but integration→${default_branch} merge did not land after ${MAX_FINAL_MERGE_ATTEMPTS} attempts. Manual intervention required." "CRITICAL"
     return 0
   fi
@@ -11452,7 +11448,6 @@ Judge has used ${JUDGE_STALL_CYCLES} stall cycle(s) (recovery/fix-ups) out of ${
 Clean wave advances do not count against this limit.
 Manual intervention required." >/dev/null
     tg_notify "Project #${TRACKING_NUM} FAILED: judge stall cycle limit (${JUDGE_STALL_CYCLES}/${MAX_JUDGE}) exceeded." "CRITICAL"
-    tg_cleanup_msgs "${TRACKING_NUM}"
     continue
   fi
 
@@ -11872,7 +11867,6 @@ The judge produced the same normalized failure fingerprint for ${JUDGE_FINGERPRI
 
 To avoid repeating the same recovery loop, the orchestrator is not creating additional fix-up issues or running another judge-driven auto-recovery cycle. Manual intervention is required."
 
-        tg_cleanup_msgs "${TRACKING_NUM}"
         tg_notify "Project #${TRACKING_NUM} blocked: repeated judge failure fingerprint exceeded JUDGE_REPEAT_FINGERPRINT_MAX=${JUDGE_REPEAT_FINGERPRINT_MAX}. Manual intervention required." "CRITICAL"
         continue
       fi
@@ -11895,7 +11889,6 @@ Recovery was attempted ${RECOVERY_COUNT} time(s) (max ${MAX_RECOVERY_ATTEMPTS}) 
 **Assessment:** ${JUDGE_ASSESSMENT}" >/dev/null
 
         tg_notify "Project #${TRACKING_NUM} FAILED after ${RECOVERY_COUNT} recovery attempt(s). Manual intervention needed." "CRITICAL"
-        tg_cleanup_msgs "${TRACKING_NUM}"
         continue
       fi
 


### PR DESCRIPTION
## Summary

Stops the orchestrator and `issue_pr_status.yml` from wiping the tracked Telegram alert chain on failure / blocked / closed-unmerged paths, so the alert chat keeps the breadcrumbs needed to diagnose the underlying issue.

- **`scripts/orchestrate_poll_process.sh`** — removed `tg_cleanup_msgs "${TRACKING_NUM}"` from the 7 failure / blocked terminal paths:
  - `mark_integration_branch_missing_failed` (integration branch missing)
  - deterministic validation failure
  - validation recovery exhausted
  - `MAX_FINAL_MERGE_ATTEMPTS` exhausted (validated but merge blocked)
  - judge stall-cycle limit exceeded
  - judge repeat-fingerprint breaker tripped
  - recovery attempts exhausted
- **`.github/workflows/issue_pr_status.yml`** — the "Cleanup tracked Telegram messages" step is now gated on `github.event.pull_request.merged == true`, so a PR closed without being merged (abandoned / failed) keeps its tracked alerts. Merged-PR cleanup is unchanged.
- **`README.md`** — updated the "Telegram Notifications & Cleanup" section to document the new "successful terminal state only" cleanup contract.

Success-state cleanups left intact:
- `orchestrate_poll_process.sh:4580` (validated + final merge landed)
- `orchestrate_poll_process.sh:8426` (project complete mid-run)
- `orchestrate_poll_process.sh:11803` (project complete, validation disabled)
- `issue_pr_status.yml` PR-merged path

## Test plan

- [ ] Trigger an orchestrator failure path (e.g. force `MAX_RECOVERY_ATTEMPTS` exhaustion in a test project) and confirm tracked TG alerts remain in the admin chat after the CRITICAL "Manual intervention required" alert fires.
- [ ] Close an open PR without merging it and confirm `issue_pr_status.yml`'s cleanup step is skipped (`if:` evaluates false); confirm the merge path still cleans up.
- [ ] Take a successful orchestrator project to validated/merged and confirm the success-path cleanup still wipes tracked alerts as before.
- [ ] `bash -n scripts/orchestrate_poll_process.sh` passes (already verified locally).

https://claude.ai/code/session_01SYrHFUgsdbZ61Wtkp2vPc1

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYrHFUgsdbZ61Wtkp2vPc1)_