### PR TITLE
docs(CLAUDE.md): forbid auto-close keywords against ai:orchestrator-tracking issues (§19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -598,6 +598,45 @@ applies, so renames require the §2 ask flow first.
 
 ---
 
+## §19. PR Body Auto-Close Keyword Discipline (MANDATORY)
+
+GitHub auto-closes issues referenced with keywords like `Fixes #N`,
+`Closes #N`, or `Resolves #N` in a PR body when the PR merges into the
+default branch. For orchestrator tracking issues — any issue carrying
+the `ai:orchestrator-tracking` label — this silently kills the
+orchestrator's state machine: once the tracking issue closes, the
+poller treats the project as done and stops dispatching the remaining
+waves.
+
+Rules:
+
+- **NEVER** use auto-close keywords (`close`, `closes`, `closed`, `fix`,
+  `fixes`, `fixed`, `resolve`, `resolves`, `resolved`, case-insensitive)
+  followed by a reference to an `ai:orchestrator-tracking` issue in a
+  PR body, PR title, commit message, or merge commit trailer. Use
+  `Refs #N` or `Related to #N` for semantic linkage instead.
+- A PR that fixes a **blocker bug surfaced by an orchestrator project**
+  is not a fix for the project itself — `Refs #N` is still the correct
+  linkage, not `Fixes #N`. The orchestrator project closes itself via
+  its own state machine when all waves complete.
+- Before drafting a PR body that references an orchestrator project's
+  tracking issue, verify the target's labels (`gh issue view <N> --json
+  labels` or `mcp__github__issue_read` with `method=get_labels`). If
+  `ai:orchestrator-tracking` is present, the auto-close keywords are
+  forbidden against that issue number.
+- This rule is not superseded by §12 (PR Review Mode) or any proactive-
+  fix scope. It applies to every AI-authored PR body in an interactive
+  session.
+
+Historical incident: PR #2760 used `Fixes #2734` in its body. `#2734`
+was an `ai:orchestrator-tracking` issue for the integration-sync
+resolver self-heal project. On merge, GitHub auto-closed `#2734` and
+the orchestrator stopped dispatching waves 2-7; the bulk of the
+project's planned phases never shipped (see
+`docs/completed/integration-sync-resolver-self-heal-plan.md`).
+
+---
+
 ## FINAL REMINDER
 
 If uncertainty exists: **ASK (multiple-choice). DO NOT EXECUTE.**


### PR DESCRIPTION
## Summary

Adds **§19. PR Body Auto-Close Keyword Discipline (MANDATORY)** to `CLAUDE.md`. The new section forbids AI-authored PR bodies, PR titles, commit messages, and merge commit trailers from using GitHub auto-close keywords (`close` / `closes` / `closed` / `fix` / `fixes` / `fixed` / `resolve` / `resolves` / `resolved`, case-insensitive) followed by a reference to any issue carrying the `ai:orchestrator-tracking` label. Correct linkage is `Refs #N` or `Related to #N`.

## Why

Orchestrator tracking issues drive a wave-dispatch state machine. When the tracking issue closes, the poller treats the project as done and stops dispatching the remaining waves. GitHub's auto-close-on-merge — triggered by the keywords above in a PR body — silently kills that state machine even when the merged PR only fixes a *blocker bug* and does not actually deliver the project's work.

## Historical incident referenced in the new section

PR #2760 used `Fixes #2734` in its body. `#2734` was an `ai:orchestrator-tracking` issue for the integration-sync resolver self-heal project. On merge:

- GitHub auto-closed `#2734` 2 seconds after PR #2760's merge commit (`913b15f`) landed.
- Of the 9 planned sub-issues across 7 waves, only Wave 1 had dispatched (#2735 Phase 1A verifier + #2736 Phase 6 spike). Waves 2-7 — Phase 1B follow-up, Phase 2 escape valve, Phase 3 tiered verification, Phase 4A quarantine, Phase 4B drift-audit job, Phase 5 branch rebuild, Wave 7 docs closeout — were never created.
- The plan was reframed in `docs/completed/integration-sync-resolver-self-heal-plan.md` as "Phase 1 shipped / archived reference copy; later phases documented below remain follow-up work".

The fix in PR #2760 was correct code (it patched the resolver-tooling refresh that was clobbering merged sub-issue changes); the mistake was the auto-close keyword in its PR body.

## Files changed

- `CLAUDE.md` — new `## §19. PR Body Auto-Close Keyword Discipline (MANDATORY)` section inserted between §18 and `## FINAL REMINDER`. Section numbers below it are unchanged (no renumbering, per §6).

## Scope notes

- Only `CLAUDE.md` (interactive-session instructions). Unattended pipelines read `unattended_system_instructions.md` and are not modified here — if the same rule should apply there, that's a follow-up.
- This PR uses `Refs #2734`, not `Fixes #2734`, in keeping with the rule it adds.

## Test plan

- [x] Section §19 inserted; §1-§18 unchanged.
- [x] No section numbers renumbered (§6 immutability honored).
- [x] PR body uses `Refs #2734`, not `Fixes #2734`.
- [ ] Future sessions follow §19 — verifiable only over time / via spot-checking AI-authored PR bodies.

Refs #2734

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEdd5y7rqq4qLjFP6s7P4g)_