### PR TITLE
fix(orchestrate_poll_process): detect externally-merged integration PR in the in_progress arm

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -8475,19 +8475,19 @@ for ((tidx=0; tidx<COUNT; tidx++)); do
   # gate re-fired every ~30 min, and the Telegram channel collected
   # several `Wave 2 dispatch BLOCKED` alerts per hour).
   #
-  # Mirror the same blob-recovery shape that
-  # `finalize_integration_merge_if_needed` lines 3940-3951 already
-  # use so the two paths stay structurally identical: read
-  # `final_merge_pr` from state, fetch the PR once via the shared
-  # `_fetch_pr_json` helper, and only transition when `.state` +
-  # `.merged_at` confirm closed-and-merged.  One REST read per poll
-  # tick when a final PR is pinned; skipped entirely when
-  # `final_merge_pr` is unset (most projects pre-finalize) or
-  # `final_merge_status` is already terminal — making this a no-op on
-  # the happy path.
+  # Mirror the same pinned-final-PR recovery shape that
+  # `finalize_integration_merge_if_needed` already uses once a final PR
+  # is recorded in state: read `final_merge_pr`, fetch the PR once via
+  # the shared `_fetch_pr_json` helper, and only transition when
+  # `.state` + `.merged_at` confirm closed-and-merged.  One REST read
+  # per poll tick when a final PR is pinned; skipped entirely when
+  # `final_merge_pr` is unset (most projects pre-finalize),
+  # `final_merge_status` is already terminal, or the project is already
+  # on the dedicated `merge_conflict` finalize path.
   if [ "${PROJECT_STATUS}" != "complete" ] \
     && [ "${PROJECT_STATUS}" != "failed" ] \
-    && [ "${PROJECT_STATUS}" != "validation-failed" ]; then
+    && [ "${PROJECT_STATUS}" != "validation-failed" ] \
+    && [ "${PROJECT_STATUS}" != "merge_conflict" ]; then
     _orch_extfin_pr="$(jq -r '.final_merge_pr // empty' "${STATE_FILE}" 2>/dev/null || true)"
     _orch_extfin_status="$(jq -r '.final_merge_status // "pending"' "${STATE_FILE}" 2>/dev/null || echo "pending")"
     if [ -n "${_orch_extfin_pr}" ] && [ "${_orch_extfin_pr}" != "null" ] \

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -8443,23 +8443,6 @@ for ((tidx=0; tidx<COUNT; tidx++)); do
 
   echo "${STATE_JSON}" > "${STATE_FILE}"
   PROJECT_STATUS="$(jq -r '.status' "${STATE_FILE}")"
-
-  DEFAULT_BRANCH_TRACKING="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}" --jq '.default_branch' || echo "main")"
-  INTEGRATION_BRANCH_TRACKING="$(jq -r '.integration_branch // ""' "${STATE_FILE}")"
-  if [ -n "${INTEGRATION_BRANCH_TRACKING}" ] \
-    && [ "${PROJECT_STATUS}" != "complete" ] \
-    && [ "${PROJECT_STATUS}" != "failed" ] \
-    && [ "${PROJECT_STATUS}" != "merge_conflict" ] \
-    && [ "${PROJECT_STATUS}" != "validation-failed" ]; then
-    if ! sync_default_into_integration_branch "${INTEGRATION_BRANCH_TRACKING}" "${DEFAULT_BRANCH_TRACKING}"; then
-      continue
-    fi
-    PROJECT_STATUS="$(jq -r '.status' "${STATE_FILE}")"
-    if [ "${PROJECT_STATUS}" = "failed" ]; then
-      continue
-    fi
-  fi
-
   TRACKING_LABELS="$(get_issue_labels_json "${TRACKING_NUM}")"
 
   # ---------------------------------------------------------------
@@ -8474,6 +8457,11 @@ for ((tidx=0; tidx<COUNT; tidx++)); do
   # but `final_merge_status` stayed `pending`, the wave-2 dispatch
   # gate re-fired every ~30 min, and the Telegram channel collected
   # several `Wave 2 dispatch BLOCKED` alerts per hour).
+  #
+  # This recovery must run BEFORE sync_default_into_integration_branch:
+  # external squash merges commonly delete the integration branch, and
+  # the sync path would otherwise mark the project failed before this
+  # block can observe the already-merged final PR.
   #
   # Mirror the same pinned-final-PR recovery shape that
   # `finalize_integration_merge_if_needed` already uses once a final PR
@@ -8535,6 +8523,22 @@ The orchestrator detected that the integration PR was squash-merged outside the 
           continue
         fi
       fi
+    fi
+  fi
+
+  DEFAULT_BRANCH_TRACKING="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}" --jq '.default_branch' || echo "main")"
+  INTEGRATION_BRANCH_TRACKING="$(jq -r '.integration_branch // ""' "${STATE_FILE}")"
+  if [ -n "${INTEGRATION_BRANCH_TRACKING}" ] \
+    && [ "${PROJECT_STATUS}" != "complete" ] \
+    && [ "${PROJECT_STATUS}" != "failed" ] \
+    && [ "${PROJECT_STATUS}" != "merge_conflict" ] \
+    && [ "${PROJECT_STATUS}" != "validation-failed" ]; then
+    if ! sync_default_into_integration_branch "${INTEGRATION_BRANCH_TRACKING}" "${DEFAULT_BRANCH_TRACKING}"; then
+      continue
+    fi
+    PROJECT_STATUS="$(jq -r '.status' "${STATE_FILE}")"
+    if [ "${PROJECT_STATUS}" = "failed" ]; then
+      continue
     fi
   fi
 

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -8478,13 +8478,13 @@ for ((tidx=0; tidx<COUNT; tidx++)); do
   # Mirror the same blob-recovery shape that
   # `finalize_integration_merge_if_needed` lines 3940-3951 already
   # use so the two paths stay structurally identical: read
-  # `final_merge_pr` from state, fetch the PR's `.state` +
-  # `.merged_at` once, and only transition when both confirm
-  # closed-and-merged.  Two REST reads per poll tick when a final PR
-  # is pinned (matches CLAUDE.md §15: extends existing call shape,
-  # no new data shape).  Skipped entirely when `final_merge_pr` is
-  # unset (most projects pre-finalize) or `final_merge_status` is
-  # already terminal — making this a no-op on the happy path.
+  # `final_merge_pr` from state, fetch the PR once via the shared
+  # `_fetch_pr_json` helper, and only transition when `.state` +
+  # `.merged_at` confirm closed-and-merged.  One REST read per poll
+  # tick when a final PR is pinned; skipped entirely when
+  # `final_merge_pr` is unset (most projects pre-finalize) or
+  # `final_merge_status` is already terminal — making this a no-op on
+  # the happy path.
   if [ "${PROJECT_STATUS}" != "complete" ] \
     && [ "${PROJECT_STATUS}" != "failed" ] \
     && [ "${PROJECT_STATUS}" != "validation-failed" ]; then
@@ -8492,31 +8492,43 @@ for ((tidx=0; tidx<COUNT; tidx++)); do
     _orch_extfin_status="$(jq -r '.final_merge_status // "pending"' "${STATE_FILE}" 2>/dev/null || echo "pending")"
     if [ -n "${_orch_extfin_pr}" ] && [ "${_orch_extfin_pr}" != "null" ] \
       && [ "${_orch_extfin_status}" = "pending" ]; then
-      _orch_extfin_pr_state="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/pulls/${_orch_extfin_pr}" --jq '.state' 2>/dev/null || echo "")"
-      _orch_extfin_pr_merged="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/pulls/${_orch_extfin_pr}" --jq '.merged_at != null' 2>/dev/null || echo "")"
-      if [ "${_orch_extfin_pr_state}" = "closed" ] && [ "${_orch_extfin_pr_merged}" = "true" ]; then
-        echo "  [external-finalize] PR #${_orch_extfin_pr} merged outside the wave-by-wave flow; transitioning project to complete."
-        jq --argjson final_pr "${_orch_extfin_pr}" \
-          '.final_merge_pr = $final_pr
-           | .final_merge_status = "merged"
-           | .final_merge_error = ""
-           | .status = "complete"
-           | .judge_cycle = ((.judge_cycle // 0) + 1)' \
-          "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
-        post_state_comment || true
-        handle_comprehensive_release_callback_if_needed "complete" "${TRACKING_LABELS}" "${COMMENTS:-[]}"
-        set_tracking_phase_label "ai:merged"
-        post_tracking_comment "## ✅ Project complete — integration PR #${_orch_extfin_pr} merged externally
+      if ! [[ "${_orch_extfin_pr}" =~ ^[0-9]+$ ]]; then
+        echo "::warning::[external-finalize] ignoring non-numeric final_merge_pr in state for issue #${TRACKING_NUM}: ${_orch_extfin_pr}"
+      else
+        _orch_extfin_pr_json="$(_fetch_pr_json "${_orch_extfin_pr}")"
+        _orch_extfin_pr_state="$(_jq_field "${_orch_extfin_pr_json}" '.state' 'open|closed|merged')"
+        _orch_extfin_pr_merged="$(_jq_field "${_orch_extfin_pr_json}" '.merged_at != null' 'true|false')"
+        if [ -z "${_orch_extfin_pr_state}" ] || [ -z "${_orch_extfin_pr_merged}" ]; then
+          echo "::warning::[external-finalize] unable to inspect PR #${_orch_extfin_pr}; leaving final_merge_status pending."
+        elif [ "${_orch_extfin_pr_state}" = "closed" ] && [ "${_orch_extfin_pr_merged}" = "true" ]; then
+          echo "  [external-finalize] PR #${_orch_extfin_pr} merged outside the wave-by-wave flow; transitioning project to complete."
+          if ! jq --argjson final_pr "${_orch_extfin_pr}" \
+            '.final_merge_pr = $final_pr
+             | .final_merge_status = "merged"
+             | .final_merge_error = ""
+             | .status = "complete"
+             | .judge_cycle = ((.judge_cycle // 0) + 1)' \
+            "${STATE_FILE}" > "${STATE_FILE}.tmp" || ! mv "${STATE_FILE}.tmp" "${STATE_FILE}"; then
+            rm -f "${STATE_FILE}.tmp" || true
+            echo "::warning::[external-finalize] failed to persist merged state for PR #${_orch_extfin_pr}; leaving final_merge_status pending."
+            continue
+          fi
+          post_state_comment || true
+          handle_comprehensive_release_callback_if_needed "complete" "${TRACKING_LABELS}" "${COMMENTS:-[]}"
+          set_tracking_phase_label "ai:merged"
+          post_tracking_comment "## ✅ Project complete — integration PR #${_orch_extfin_pr} merged externally
 
 The orchestrator detected that the integration PR was squash-merged outside the wave-by-wave dispatch flow (the typical pattern when an operator finalizes a project ahead of the planner). Transitioning status to \`complete\`; future poll ticks will skip this project and any open wave-dispatch alerts can be ignored."
-        tg_cleanup_msgs "${TRACKING_NUM}"
-        MSG="✅ Project #${TRACKING_NUM} completed (integration PR #${_orch_extfin_pr} merged externally)."
-        MSG+=$'\n'"Tracking: $(_gh_url "issues/${TRACKING_NUM}")"
-        if [ -n "${GITHUB_RUN_ID:-}" ]; then
-          MSG+=$'\n'"Run: $(_gh_url "actions/runs/${GITHUB_RUN_ID}")"
+          tg_cleanup_msgs "${TRACKING_NUM}"
+          MSG="✅ Project #${TRACKING_NUM} completed (integration PR #${_orch_extfin_pr} merged externally)."
+          MSG+=$'\n'"Tracking: $(_gh_url "issues/${TRACKING_NUM}")"
+          if [ -n "${GITHUB_RUN_ID:-}" ]; then
+            MSG+=$'\n'"Run: $(_gh_url "actions/runs/${GITHUB_RUN_ID}")"
+          fi
+          tg_send_msg "${MSG}" >/dev/null
+          PROJECT_STATUS="complete"
+          continue
         fi
-        tg_send_msg "${MSG}" >/dev/null
-        PROJECT_STATUS="complete"
       fi
     fi
   fi

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -8483,11 +8483,16 @@ for ((tidx=0; tidx<COUNT; tidx++)); do
   # per poll tick when a final PR is pinned; skipped entirely when
   # `final_merge_pr` is unset (most projects pre-finalize),
   # `final_merge_status` is already terminal, or the project is already
-  # on the dedicated `merge_conflict` finalize path.
+  # on the dedicated `merge_conflict` / validation-completion paths.
+  # Validated projects must keep flowing through
+  # `mark_validation_complete` so `validation_completed_cycle` and the
+  # `ai:validated` label stay aligned with the final merge result.
   if [ "${PROJECT_STATUS}" != "complete" ] \
     && [ "${PROJECT_STATUS}" != "failed" ] \
     && [ "${PROJECT_STATUS}" != "validation-failed" ] \
-    && [ "${PROJECT_STATUS}" != "merge_conflict" ]; then
+    && [ "${PROJECT_STATUS}" != "merge_conflict" ] \
+    && [ "${PROJECT_STATUS}" != "validating" ] \
+    && [ "${PROJECT_STATUS}" != "validation-fixing" ]; then
     _orch_extfin_pr="$(jq -r '.final_merge_pr // empty' "${STATE_FILE}" 2>/dev/null || true)"
     _orch_extfin_status="$(jq -r '.final_merge_status // "pending"' "${STATE_FILE}" 2>/dev/null || echo "pending")"
     if [ -n "${_orch_extfin_pr}" ] && [ "${_orch_extfin_pr}" != "null" ] \

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -8526,12 +8526,17 @@ The orchestrator detected that the integration PR was squash-merged outside the 
     fi
   fi
 
+  # Validation-owned states must bypass sync so mark_validation_complete
+  # can own externally merged/deleted final-PR completion without the
+  # integration-branch missing/conflict path preempting it.
   DEFAULT_BRANCH_TRACKING="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}" --jq '.default_branch' || echo "main")"
   INTEGRATION_BRANCH_TRACKING="$(jq -r '.integration_branch // ""' "${STATE_FILE}")"
   if [ -n "${INTEGRATION_BRANCH_TRACKING}" ] \
     && [ "${PROJECT_STATUS}" != "complete" ] \
     && [ "${PROJECT_STATUS}" != "failed" ] \
     && [ "${PROJECT_STATUS}" != "merge_conflict" ] \
+    && [ "${PROJECT_STATUS}" != "validating" ] \
+    && [ "${PROJECT_STATUS}" != "validation-fixing" ] \
     && [ "${PROJECT_STATUS}" != "validation-failed" ]; then
     if ! sync_default_into_integration_branch "${INTEGRATION_BRANCH_TRACKING}" "${DEFAULT_BRANCH_TRACKING}"; then
       continue

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -8462,6 +8462,65 @@ for ((tidx=0; tidx<COUNT; tidx++)); do
 
   TRACKING_LABELS="$(get_issue_labels_json "${TRACKING_NUM}")"
 
+  # ---------------------------------------------------------------
+  # External-finalize detect: if the orchestrator previously recorded
+  # a final integration PR and an operator (or any other actor)
+  # squash-merged it outside the orchestrator's wave-by-wave flow,
+  # `finalize_integration_merge_if_needed` is never reached from the
+  # `in_progress` arm — it only fires from the `merge_conflict` branch
+  # and from the judge-`complete` verdict.  Without this hook, the
+  # poller keeps cycling on wave-dispatch indefinitely (e.g.
+  # orchestrator/project-2734: PR #2750 merged 2026-05-18T21:31:50Z
+  # but `final_merge_status` stayed `pending`, the wave-2 dispatch
+  # gate re-fired every ~30 min, and the Telegram channel collected
+  # several `Wave 2 dispatch BLOCKED` alerts per hour).
+  #
+  # Mirror the same blob-recovery shape that
+  # `finalize_integration_merge_if_needed` lines 3940-3951 already
+  # use so the two paths stay structurally identical: read
+  # `final_merge_pr` from state, fetch the PR's `.state` +
+  # `.merged_at` once, and only transition when both confirm
+  # closed-and-merged.  Two REST reads per poll tick when a final PR
+  # is pinned (matches CLAUDE.md §15: extends existing call shape,
+  # no new data shape).  Skipped entirely when `final_merge_pr` is
+  # unset (most projects pre-finalize) or `final_merge_status` is
+  # already terminal — making this a no-op on the happy path.
+  if [ "${PROJECT_STATUS}" != "complete" ] \
+    && [ "${PROJECT_STATUS}" != "failed" ] \
+    && [ "${PROJECT_STATUS}" != "validation-failed" ]; then
+    _orch_extfin_pr="$(jq -r '.final_merge_pr // empty' "${STATE_FILE}" 2>/dev/null || true)"
+    _orch_extfin_status="$(jq -r '.final_merge_status // "pending"' "${STATE_FILE}" 2>/dev/null || echo "pending")"
+    if [ -n "${_orch_extfin_pr}" ] && [ "${_orch_extfin_pr}" != "null" ] \
+      && [ "${_orch_extfin_status}" = "pending" ]; then
+      _orch_extfin_pr_state="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/pulls/${_orch_extfin_pr}" --jq '.state' 2>/dev/null || echo "")"
+      _orch_extfin_pr_merged="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/pulls/${_orch_extfin_pr}" --jq '.merged_at != null' 2>/dev/null || echo "")"
+      if [ "${_orch_extfin_pr_state}" = "closed" ] && [ "${_orch_extfin_pr_merged}" = "true" ]; then
+        echo "  [external-finalize] PR #${_orch_extfin_pr} merged outside the wave-by-wave flow; transitioning project to complete."
+        jq --argjson final_pr "${_orch_extfin_pr}" \
+          '.final_merge_pr = $final_pr
+           | .final_merge_status = "merged"
+           | .final_merge_error = ""
+           | .status = "complete"
+           | .judge_cycle = ((.judge_cycle // 0) + 1)' \
+          "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
+        post_state_comment || true
+        handle_comprehensive_release_callback_if_needed "complete" "${TRACKING_LABELS}" "${COMMENTS:-[]}"
+        set_tracking_phase_label "ai:merged"
+        post_tracking_comment "## ✅ Project complete — integration PR #${_orch_extfin_pr} merged externally
+
+The orchestrator detected that the integration PR was squash-merged outside the wave-by-wave dispatch flow (the typical pattern when an operator finalizes a project ahead of the planner). Transitioning status to \`complete\`; future poll ticks will skip this project and any open wave-dispatch alerts can be ignored."
+        tg_cleanup_msgs "${TRACKING_NUM}"
+        MSG="✅ Project #${TRACKING_NUM} completed (integration PR #${_orch_extfin_pr} merged externally)."
+        MSG+=$'\n'"Tracking: $(_gh_url "issues/${TRACKING_NUM}")"
+        if [ -n "${GITHUB_RUN_ID:-}" ]; then
+          MSG+=$'\n'"Run: $(_gh_url "actions/runs/${GITHUB_RUN_ID}")"
+        fi
+        tg_send_msg "${MSG}" >/dev/null
+        PROJECT_STATUS="complete"
+      fi
+    fi
+  fi
+
   if [ "${PROJECT_STATUS}" = "merge_conflict" ]; then
     FINAL_INTEGRATION_BRANCH="$(jq -r '.integration_branch // ""' "${STATE_FILE}")"
     FINAL_DEFAULT_BRANCH="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}" --jq '.default_branch' || echo "main")"

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -8025,6 +8025,112 @@ def test_resolver_tooling_refresh_allowlist_includes_both_retry_preludes():
 	)
 
 
+def test_external_finalize_detect_marks_project_complete_when_final_pr_already_merged():
+	# Regression guard for the orchestrator/project-2734 wave-2 dispatch
+	# loop (issue #2734): the orchestrator created the final integration
+	# PR (`final_merge_pr=2750`) eagerly via the self-healing pipeline,
+	# an operator squash-merged it at 2026-05-18T21:31:50Z, but
+	# `final_merge_status` stayed `pending` because
+	# `finalize_integration_merge_if_needed` is only invoked from the
+	# `merge_conflict` and judge-`complete` arms — never from the plain
+	# `in_progress` arm.  The poller kept cycling on the wave-dispatch
+	# gate (which fired Telegram `Wave 2 dispatch BLOCKED` alerts every
+	# ~30 min) and never noticed PR #2750 had merged.
+	#
+	# The fix is an external-finalize detect block placed AFTER
+	# `TRACKING_LABELS` is fetched and BEFORE the
+	# `if [ "${PROJECT_STATUS}" = "merge_conflict" ]` switch in the
+	# orchestrator's per-tracking-issue loop: read `final_merge_pr` +
+	# `final_merge_status` from state, fetch the PR's `.state` +
+	# `.merged_at` via the same `gh_retry _safe_gh_jq` call shape as
+	# `finalize_integration_merge_if_needed`, and on confirmed
+	# closed-and-merged, transition status to `complete` so the
+	# existing `[ "${PROJECT_STATUS}" = "complete" ]` early-skip kicks
+	# in on the same tick.  This test pins the placement, the gate
+	# condition (status pending + PR pinned), AND the state mutation
+	# shape (status=complete + final_merge_status=merged) so a future
+	# refactor cannot silently drop any of the three.
+	poller_body = POLLER_SCRIPT.read_text(encoding="utf-8")
+	# Anchor on the `TRACKING_LABELS=` fetch that precedes the
+	# external-finalize block.  Only one such assignment exists in the
+	# main per-tracking-issue loop scope (the other two occurrences
+	# live inside the validation-fixing arm and a separate label-repair
+	# helper), and it is the documented insertion landmark; pinning on
+	# it makes the placement assertion robust against unrelated edits
+	# elsewhere in the file.
+	anchor = '  TRACKING_LABELS="$(get_issue_labels_json "${TRACKING_NUM}")"'
+	anchor_idx = poller_body.find(anchor)
+	assert anchor_idx != -1, (
+		"TRACKING_LABELS=... fetch (the documented insertion landmark for "
+		"the external-finalize detect block) is missing or renamed in "
+		"scripts/orchestrate_poll_process.sh; update this test to match "
+		"the new landmark."
+	)
+	# Bound the search window to the block between the TRACKING_LABELS
+	# fetch and the merge_conflict switch so the assertion enforces
+	# *placement*, not just "appears anywhere in the file" (which would
+	# false-positive if a refactor moved the block to an unreachable
+	# branch).
+	merge_conflict_marker = 'if [ "${PROJECT_STATUS}" = "merge_conflict" ]; then'
+	merge_conflict_idx = poller_body.find(merge_conflict_marker, anchor_idx)
+	assert merge_conflict_idx != -1, (
+		'merge_conflict switch `if [ "${PROJECT_STATUS}" = "merge_conflict" ]` '
+		"is missing from the per-tracking-issue loop; the external-finalize "
+		"block must precede it so the new state transition is visible to "
+		"the same poll tick's project-status switch."
+	)
+	window = poller_body[anchor_idx:merge_conflict_idx]
+	# Gate condition: only fire when state is non-terminal AND a final
+	# PR is pinned AND `final_merge_status` is still `pending`.  Each
+	# of these three protects a different failure mode (terminal states
+	# already handled, no PR pinned yet means orchestrator hasn't even
+	# created the integration PR, non-pending status means another
+	# code path already finalized).
+	for needle, why in (
+		('.final_merge_pr // empty', "external-finalize block no longer reads `.final_merge_pr` from state; without it the block has no PR to inspect."),
+		('.final_merge_status // "pending"', "external-finalize block no longer reads `.final_merge_status` from state; without it the block cannot tell pending from already-finalized projects and would re-finalize on every tick."),
+		('= "pending"', "external-finalize block no longer guards on `final_merge_status = pending`; without this guard the block would re-fire after the orchestrator's own finalize path already ran."),
+		('repos/${GITHUB_REPOSITORY}/pulls/', "external-finalize block no longer fetches the pinned PR's state via the gh REST `pulls/{number}` endpoint; without it the block has no way to detect an external merge."),
+		("'.state'", "external-finalize block no longer reads the pinned PR's `.state` field; without it the block cannot tell open from closed PRs."),
+		("'.merged_at != null'", "external-finalize block no longer reads the pinned PR's `.merged_at` field; without it the block would mis-treat a closed-without-merge PR as a successful finalize."),
+	):
+		assert needle in window, (
+			f"external-finalize detect block in scripts/orchestrate_poll_process.sh "
+			f"no longer contains `{needle}` between the TRACKING_LABELS fetch and "
+			f"the merge_conflict switch — {why}"
+		)
+	# State mutation shape: must set BOTH status=complete AND
+	# final_merge_status=merged in the same jq pass.  Setting only one
+	# would leave the other path inconsistent: status=complete without
+	# final_merge_status=merged would re-trigger finalize on the next
+	# tick (wasting API budget); final_merge_status=merged without
+	# status=complete would leave the project stuck in `in_progress`
+	# and the wave-dispatch loop running.
+	for needle, why in (
+		('.status = "complete"', "external-finalize block no longer transitions project status to `complete`; without this the project stays in_progress and the wave-dispatch loop keeps firing on every tick."),
+		('.final_merge_status = "merged"', "external-finalize block no longer marks `final_merge_status = merged`; finalize_integration_merge_if_needed's early-return check at line 3917 would re-enter the merge flow on the next tick if it were ever called."),
+	):
+		assert needle in window, (
+			f"external-finalize detect block no longer performs the state "
+			f"mutation `{needle}` between TRACKING_LABELS and the merge_conflict "
+			f"switch — {why}"
+		)
+	# Side-effect surface: tracking comment + Telegram cleanup must
+	# both fire so the operator's open `Wave dispatch BLOCKED` alerts
+	# on the tracking issue + Telegram channel are explicitly
+	# superseded.  Without these the user sees stale BLOCKED comments
+	# at the top of the tracking issue indefinitely.
+	for needle, why in (
+		('post_tracking_comment', "external-finalize block no longer posts a tracking comment explaining the external-merge transition; operators would have to guess why the project suddenly went quiet."),
+		('tg_cleanup_msgs', "external-finalize block no longer calls tg_cleanup_msgs so prior `Wave dispatch BLOCKED` Telegram alerts stay pinned in the channel after the project completes — defeats half of the user-visible silence."),
+		('set_tracking_phase_label "ai:merged"', "external-finalize block no longer sets the `ai:merged` phase label, so downstream label-driven automation (release callbacks, label-repair sweeps) cannot detect that this project is done."),
+	):
+		assert needle in window, (
+			f"external-finalize detect block no longer triggers `{needle}` "
+			f"in its side-effect block — {why}"
+		)
+
+
 def test_review_autofix_workflow_wires_optional_verifier_bootstrap_and_gate():
 	# The resolver run: blocks were extracted into
 	# scripts/review_conflict_prepare.sh and

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -3029,6 +3029,38 @@ def test_external_finalize_detect_skips_terminal_fallthrough():
 	assert "Project already complete, skipping." not in result["stdout"]
 
 
+def test_external_finalize_detect_preempts_sync_branch_missing_failure():
+	state = _base_state(status="in_progress")
+	state["integration_branch"] = "orchestrator/project-192"
+	state["final_merge_pr"] = 358
+	state["final_merge_status"] = "pending"
+	prs = [
+		{
+			"number": 358,
+			"state": "closed",
+			"merged": True,
+			"baseRefName": "main",
+			"headRefName": "orchestrator/project-192",
+			"mergeable": None,
+			"mergeable_state": "unknown",
+		},
+	]
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		issue_labels={10: ["ai:merged"]},
+		prs=prs,
+		existing_branches=["main"],
+	)
+	tracking_bodies = [c.get("body", "") for c in result["issues"]["192"]["comments"]]
+	assert result["latest_state"]["status"] == "complete"
+	assert result["latest_state"]["final_merge_pr"] == 358
+	assert result["latest_state"]["final_merge_status"] == "merged"
+	assert "ai:merged" in result["tracking_labels"]
+	assert not any("Integration branch missing" in body for body in tracking_bodies)
+
+
 def test_standalone_conflict_sweep_skips_integration_base_prs():
 	state = _base_state(status="complete")
 	prs = [
@@ -8135,29 +8167,34 @@ def test_external_finalize_detect_marks_project_complete_when_final_pr_already_m
 	# ~30 min) and never noticed PR #2750 had merged.
 	#
 	# The fix is an external-finalize detect block placed AFTER
-	# `TRACKING_LABELS` is fetched and BEFORE the
-	# `if [ "${PROJECT_STATUS}" = "merge_conflict" ]` switch in the
-	# orchestrator's per-tracking-issue loop: read `final_merge_pr` +
+	# `TRACKING_LABELS` is fetched and BEFORE
+	# `sync_default_into_integration_branch` in the orchestrator's
+	# per-tracking-issue loop: read `final_merge_pr` +
 	# `final_merge_status` from state, fetch the PR once via the shared
 	# `_fetch_pr_json` + `_jq_field` helper path, and on confirmed
-	# closed-and-merged, transition status to `complete` so the
-	# existing `[ "${PROJECT_STATUS}" = "complete" ]` early-skip kicks
-	# in on the same tick while leaving `merge_conflict`, `validating`,
-	# and `validation-fixing` projects on their dedicated
-	# finalize/validation-completion paths.  This test pins the
+	# closed-and-merged, transition status to `complete` before the sync
+	# path can mark a deleted integration branch as failed. The dedicated
+	# `merge_conflict`, `validating`, and `validation-fixing` paths still
+	# own their validation/finalize bookkeeping. This test pins the
 	# placement, the gate condition, AND the state mutation shape
 	# (status=complete + final_merge_status=merged) so a future refactor
 	# cannot silently drop any of the three.
 	poller_body = POLLER_SCRIPT.read_text(encoding="utf-8")
+	sync_marker = '    if ! sync_default_into_integration_branch "${INTEGRATION_BRANCH_TRACKING}" "${DEFAULT_BRANCH_TRACKING}"; then'
+	sync_idx = poller_body.find(sync_marker)
+	assert sync_idx != -1, (
+		"sync_default_into_integration_branch call is missing from the "
+		"per-tracking-issue loop; the external-finalize block must precede "
+		"that sync path so deleted integration branches cannot preempt the "
+		"merged-PR recovery."
+	)
 	# Anchor on the `TRACKING_LABELS=` fetch that precedes the
-	# external-finalize block.  Only one such assignment exists in the
-	# main per-tracking-issue loop scope (the other two occurrences
-	# live inside the validation-fixing arm and a separate label-repair
-	# helper), and it is the documented insertion landmark; pinning on
-	# it makes the placement assertion robust against unrelated edits
-	# elsewhere in the file.
+	# external-finalize block. Several helpers reuse the same assignment,
+	# so search backward from the sync call and take the nearest preceding
+	# occurrence — that is the per-tracking-issue-loop landmark this
+	# regression is pinning.
 	anchor = '  TRACKING_LABELS="$(get_issue_labels_json "${TRACKING_NUM}")"'
-	anchor_idx = poller_body.find(anchor)
+	anchor_idx = poller_body.rfind(anchor, 0, sync_idx)
 	assert anchor_idx != -1, (
 		"TRACKING_LABELS=... fetch (the documented insertion landmark for "
 		"the external-finalize detect block) is missing or renamed in "
@@ -8165,19 +8202,19 @@ def test_external_finalize_detect_marks_project_complete_when_final_pr_already_m
 		"the new landmark."
 	)
 	# Bound the search window to the block between the TRACKING_LABELS
-	# fetch and the merge_conflict switch so the assertion enforces
-	# *placement*, not just "appears anywhere in the file" (which would
-	# false-positive if a refactor moved the block to an unreachable
-	# branch).
+	# fetch and the sync call so the assertion enforces *placement*, not
+	# just "appears anywhere in the file" (which would false-positive if
+	# a refactor moved the block back below the sync path and reintroduced
+	# the deleted-branch failure).
 	merge_conflict_marker = 'if [ "${PROJECT_STATUS}" = "merge_conflict" ]; then'
-	merge_conflict_idx = poller_body.find(merge_conflict_marker, anchor_idx)
+	merge_conflict_idx = poller_body.find(merge_conflict_marker, sync_idx)
 	assert merge_conflict_idx != -1, (
 		'merge_conflict switch `if [ "${PROJECT_STATUS}" = "merge_conflict" ]` '
-		"is missing from the per-tracking-issue loop; the external-finalize "
-		"block must precede it so the new state transition is visible to "
-		"the same poll tick's project-status switch."
+		"is missing from the per-tracking-issue loop; the sync block must "
+		"still flow into the later merge_conflict arm after the external-"
+		"finalize pre-check."
 	)
-	window = poller_body[anchor_idx:merge_conflict_idx]
+	window = poller_body[anchor_idx:sync_idx]
 	# Gate condition: only fire when state is non-terminal, not already
 	# on the dedicated `merge_conflict` / validation-completion paths,
 	# a final PR is pinned, and `final_merge_status` is still `pending`.
@@ -8199,11 +8236,11 @@ def test_external_finalize_detect_marks_project_complete_when_final_pr_already_m
 		assert needle in window, (
 			f"external-finalize detect block in scripts/orchestrate_poll_process.sh "
 			f"no longer contains `{needle}` between the TRACKING_LABELS fetch and "
-			f"the merge_conflict switch — {why}"
+			f"the sync_default_into_integration_branch call — {why}"
 		)
 	assert window.count('_fetch_pr_json "${_orch_extfin_pr}"') == 1, (
-		"external-finalize detect block no longer uses a single PR fetch between "
-		"the TRACKING_LABELS fetch and the merge_conflict switch; duplicate "
+		"external-finalize detect block no longer uses a single PR fetch before "
+		"the sync_default_into_integration_branch call; duplicate "
 		"PR fetches reintroduce avoidable API churn and a narrow "
 		"state/merged-at race."
 	)
@@ -8220,8 +8257,8 @@ def test_external_finalize_detect_marks_project_complete_when_final_pr_already_m
 	):
 		assert needle in window, (
 			f"external-finalize detect block no longer performs the state "
-			f"mutation `{needle}` between TRACKING_LABELS and the merge_conflict "
-			f"switch — {why}"
+			f"mutation `{needle}` before the sync_default_into_integration_branch "
+			f"call — {why}"
 		)
 	# Side-effect surface: tracking comment + Telegram cleanup must
 	# both fire so the operator's open `Wave dispatch BLOCKED` alerts

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -2999,6 +2999,79 @@ def test_external_finalize_detect_leaves_validation_completion_path_intact():
 	assert "ai:merged" not in result["tracking_labels"]
 
 
+def test_validation_completion_preempts_sync_branch_missing_failure_when_final_pr_already_merged():
+	state = _base_state(status="validating")
+	state["integration_branch"] = "orchestrator/project-192"
+	state["validation_cycle"] = 2
+	state["final_merge_pr"] = 359
+	state["final_merge_status"] = "pending"
+	prs = [
+		{
+			"number": 359,
+			"state": "closed",
+			"merged": True,
+			"baseRefName": "main",
+			"headRefName": "orchestrator/project-192",
+			"mergeable": None,
+			"mergeable_state": "unknown",
+		},
+	]
+	result = _run_poller(
+		state=state,
+		enable_validation="true",
+		max_validate_cycles="3",
+		tracking_labels=["ai:validated"],
+		issue_labels={10: ["ai:merged"]},
+		prs=prs,
+		existing_branches=["main"],
+	)
+	tracking_bodies = [c.get("body", "") for c in result["issues"]["192"]["comments"]]
+	assert result["latest_state"]["status"] == "complete"
+	assert result["latest_state"]["validation_completed_cycle"] == 2
+	assert result["latest_state"]["final_merge_pr"] == 359
+	assert result["latest_state"]["final_merge_status"] == "merged"
+	assert "ai:validated" in result["tracking_labels"]
+	assert "ai:merged" not in result["tracking_labels"]
+	assert not any("Integration branch missing" in body for body in tracking_bodies)
+
+
+def test_validation_fixing_completion_preempts_sync_branch_missing_failure_when_final_pr_already_merged():
+	state = _base_state(status="validation-fixing")
+	state["integration_branch"] = "orchestrator/project-192"
+	state["validation_cycle"] = 2
+	state["validation_active_fix_issues"] = []
+	state["final_merge_pr"] = 360
+	state["final_merge_status"] = "pending"
+	prs = [
+		{
+			"number": 360,
+			"state": "closed",
+			"merged": True,
+			"baseRefName": "main",
+			"headRefName": "orchestrator/project-192",
+			"mergeable": None,
+			"mergeable_state": "unknown",
+		},
+	]
+	result = _run_poller(
+		state=state,
+		enable_validation="true",
+		max_validate_cycles="3",
+		tracking_labels=["ai:validated"],
+		issue_labels={10: ["ai:merged"]},
+		prs=prs,
+		existing_branches=["main"],
+	)
+	tracking_bodies = [c.get("body", "") for c in result["issues"]["192"]["comments"]]
+	assert result["latest_state"]["status"] == "complete"
+	assert result["latest_state"]["validation_completed_cycle"] == 2
+	assert result["latest_state"]["final_merge_pr"] == 360
+	assert result["latest_state"]["final_merge_status"] == "merged"
+	assert "ai:validated" in result["tracking_labels"]
+	assert "ai:merged" not in result["tracking_labels"]
+	assert not any("Integration branch missing" in body for body in tracking_bodies)
+
+
 def test_external_finalize_detect_skips_terminal_fallthrough():
 	state = _base_state(status="in_progress")
 	state["integration_branch"] = "orchestrator/project-192"

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -2932,6 +2932,39 @@ def test_merge_conflict_state_completes_when_final_pr_already_merged_and_branch_
 	assert result["release_dispatches"] == []
 
 
+def test_external_finalize_detect_leaves_merge_conflict_validation_path_intact():
+	state = _base_state(status="merge_conflict")
+	state["integration_branch"] = "orchestrator/project-192"
+	state["final_merge_pr"] = 356
+	state["final_merge_status"] = "pending"
+	prs = [
+		{
+			"number": 356,
+			"state": "closed",
+			"merged": True,
+			"baseRefName": "main",
+			"headRefName": "orchestrator/project-192",
+			"mergeable": None,
+			"mergeable_state": "unknown",
+		},
+	]
+	result = _run_poller(
+		state=state,
+		enable_validation="true",
+		max_validate_cycles="3",
+		tracking_labels=["ai:validated"],
+		issue_labels={10: ["ai:merged"]},
+		prs=prs,
+		existing_branches=["main", "orchestrator/project-192"],
+	)
+	assert result["latest_state"]["status"] == "complete"
+	assert result["latest_state"]["final_merge_pr"] == 356
+	assert result["latest_state"]["final_merge_status"] == "merged"
+	assert result["latest_state"]["validation_completed_cycle"] == 1
+	assert "ai:validated" in result["tracking_labels"]
+	assert "ai:merged" not in result["tracking_labels"]
+
+
 def test_external_finalize_detect_skips_terminal_fallthrough():
 	state = _base_state(status="in_progress")
 	state["integration_branch"] = "orchestrator/project-192"
@@ -8071,15 +8104,15 @@ def test_external_finalize_detect_marks_project_complete_when_final_pr_already_m
 	# `TRACKING_LABELS` is fetched and BEFORE the
 	# `if [ "${PROJECT_STATUS}" = "merge_conflict" ]` switch in the
 	# orchestrator's per-tracking-issue loop: read `final_merge_pr` +
-	# `final_merge_status` from state, fetch the PR's `.state` +
-	# `.merged_at` via the same `gh_retry _safe_gh_jq` call shape as
-	# `finalize_integration_merge_if_needed`, and on confirmed
+	# `final_merge_status` from state, fetch the PR once via the shared
+	# `_fetch_pr_json` + `_jq_field` helper path, and on confirmed
 	# closed-and-merged, transition status to `complete` so the
 	# existing `[ "${PROJECT_STATUS}" = "complete" ]` early-skip kicks
-	# in on the same tick.  This test pins the placement, the gate
-	# condition (status pending + PR pinned), AND the state mutation
-	# shape (status=complete + final_merge_status=merged) so a future
-	# refactor cannot silently drop any of the three.
+	# in on the same tick while leaving `merge_conflict` projects on
+	# their dedicated finalize/validation path.  This test pins the
+	# placement, the gate condition, AND the state mutation shape
+	# (status=complete + final_merge_status=merged) so a future refactor
+	# cannot silently drop any of the three.
 	poller_body = POLLER_SCRIPT.read_text(encoding="utf-8")
 	# Anchor on the `TRACKING_LABELS=` fetch that precedes the
 	# external-finalize block.  Only one such assignment exists in the
@@ -8110,17 +8143,19 @@ def test_external_finalize_detect_marks_project_complete_when_final_pr_already_m
 		"the same poll tick's project-status switch."
 	)
 	window = poller_body[anchor_idx:merge_conflict_idx]
-	# Gate condition: only fire when state is non-terminal AND a final
-	# PR is pinned AND `final_merge_status` is still `pending`.  Each
-	# of these three protects a different failure mode (terminal states
-	# already handled, no PR pinned yet means orchestrator hasn't even
-	# created the integration PR, non-pending status means another
-	# code path already finalized).
+	# Gate condition: only fire when state is non-terminal, not already
+	# on the dedicated `merge_conflict` finalize path, a final PR is
+	# pinned, and `final_merge_status` is still `pending`.  Each guard
+	# protects a different failure mode (terminal states already
+	# handled, `merge_conflict` needs its own finalize/validation path,
+	# no PR pinned yet means orchestrator hasn't even created the
+	# integration PR, non-pending status means another code path already
+	# finalized).
 	for needle, why in (
 		('.final_merge_pr // empty', "external-finalize block no longer reads `.final_merge_pr` from state; without it the block has no PR to inspect."),
 		('.final_merge_status // "pending"', "external-finalize block no longer reads `.final_merge_status` from state; without it the block cannot tell pending from already-finalized projects and would re-finalize on every tick."),
+		('!= "merge_conflict"', "external-finalize block no longer excludes `merge_conflict`; without that guard the block steals work from the dedicated finalize/validation path and duplicates final-PR reads on every merge_conflict poll tick."),
 		('= "pending"', "external-finalize block no longer guards on `final_merge_status = pending`; without this guard the block would re-fire after the orchestrator's own finalize path already ran."),
-		('repos/${GITHUB_REPOSITORY}/pulls/', "external-finalize block no longer fetches the pinned PR's state via the gh REST `pulls/{number}` endpoint; without it the block has no way to detect an external merge."),
 		("'.state'", "external-finalize block no longer reads the pinned PR's `.state` field; without it the block cannot tell open from closed PRs."),
 		("'.merged_at != null'", "external-finalize block no longer reads the pinned PR's `.merged_at` field; without it the block would mis-treat a closed-without-merge PR as a successful finalize."),
 	):
@@ -8144,7 +8179,7 @@ def test_external_finalize_detect_marks_project_complete_when_final_pr_already_m
 	# and the wave-dispatch loop running.
 	for needle, why in (
 		('.status = "complete"', "external-finalize block no longer transitions project status to `complete`; without this the project stays in_progress and the wave-dispatch loop keeps firing on every tick."),
-		('.final_merge_status = "merged"', "external-finalize block no longer marks `final_merge_status = merged`; finalize_integration_merge_if_needed's early-return check at line 3917 would re-enter the merge flow on the next tick if it were ever called."),
+		('.final_merge_status = "merged"', "external-finalize block no longer marks `final_merge_status = merged`; finalize_integration_merge_if_needed's early-return check would re-enter the merge flow on the next tick if it were ever called."),
 	):
 		assert needle in window, (
 			f"external-finalize detect block no longer performs the state "

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -2932,6 +2932,36 @@ def test_merge_conflict_state_completes_when_final_pr_already_merged_and_branch_
 	assert result["release_dispatches"] == []
 
 
+def test_external_finalize_detect_skips_terminal_fallthrough():
+	state = _base_state(status="in_progress")
+	state["integration_branch"] = "orchestrator/project-192"
+	state["final_merge_pr"] = 355
+	state["final_merge_status"] = "pending"
+	prs = [
+		{
+			"number": 355,
+			"state": "closed",
+			"merged": True,
+			"baseRefName": "main",
+			"headRefName": "orchestrator/project-192",
+			"mergeable": None,
+			"mergeable_state": "unknown",
+		},
+	]
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		issue_labels={10: ["ai:merged"]},
+		prs=prs,
+		existing_branches=["main", "orchestrator/project-192"],
+	)
+	assert result["latest_state"]["status"] == "complete"
+	assert result["latest_state"]["final_merge_pr"] == 355
+	assert result["latest_state"]["final_merge_status"] == "merged"
+	assert "Project already complete, skipping." not in result["stdout"]
+
+
 def test_standalone_conflict_sweep_skips_integration_base_prs():
 	state = _base_state(status="complete")
 	prs = [
@@ -8099,6 +8129,12 @@ def test_external_finalize_detect_marks_project_complete_when_final_pr_already_m
 			f"no longer contains `{needle}` between the TRACKING_LABELS fetch and "
 			f"the merge_conflict switch — {why}"
 		)
+	assert window.count('_fetch_pr_json "${_orch_extfin_pr}"') == 1, (
+		"external-finalize detect block no longer uses a single PR fetch between "
+		"the TRACKING_LABELS fetch and the merge_conflict switch; duplicate "
+		"PR fetches reintroduce avoidable API churn and a narrow "
+		"state/merged-at race."
+	)
 	# State mutation shape: must set BOTH status=complete AND
 	# final_merge_status=merged in the same jq pass.  Setting only one
 	# would leave the other path inconsistent: status=complete without
@@ -8129,6 +8165,12 @@ def test_external_finalize_detect_marks_project_complete_when_final_pr_already_m
 			f"external-finalize detect block no longer triggers `{needle}` "
 			f"in its side-effect block — {why}"
 		)
+	assert re.search(r'PROJECT_STATUS="complete"\s+continue', window) is not None, (
+		"external-finalize detect block no longer short-circuits after setting "
+		"`PROJECT_STATUS=complete`; without the `continue`, the same tick falls "
+		"through to the terminal-state skip block and logs a misleading "
+		"`Project already complete, skipping.` line."
+	)
 
 
 def test_review_autofix_workflow_wires_optional_verifier_bootstrap_and_gate():

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -2965,6 +2965,40 @@ def test_external_finalize_detect_leaves_merge_conflict_validation_path_intact()
 	assert "ai:merged" not in result["tracking_labels"]
 
 
+def test_external_finalize_detect_leaves_validation_completion_path_intact():
+	state = _base_state(status="validating")
+	state["integration_branch"] = "orchestrator/project-192"
+	state["validation_cycle"] = 2
+	state["final_merge_pr"] = 357
+	state["final_merge_status"] = "pending"
+	prs = [
+		{
+			"number": 357,
+			"state": "closed",
+			"merged": True,
+			"baseRefName": "main",
+			"headRefName": "orchestrator/project-192",
+			"mergeable": None,
+			"mergeable_state": "unknown",
+		},
+	]
+	result = _run_poller(
+		state=state,
+		enable_validation="true",
+		max_validate_cycles="3",
+		tracking_labels=["ai:validated"],
+		issue_labels={10: ["ai:merged"]},
+		prs=prs,
+		existing_branches=["main", "orchestrator/project-192"],
+	)
+	assert result["latest_state"]["status"] == "complete"
+	assert result["latest_state"]["final_merge_pr"] == 357
+	assert result["latest_state"]["final_merge_status"] == "merged"
+	assert result["latest_state"]["validation_completed_cycle"] == 2
+	assert "ai:validated" in result["tracking_labels"]
+	assert "ai:merged" not in result["tracking_labels"]
+
+
 def test_external_finalize_detect_skips_terminal_fallthrough():
 	state = _base_state(status="in_progress")
 	state["integration_branch"] = "orchestrator/project-192"
@@ -8108,8 +8142,9 @@ def test_external_finalize_detect_marks_project_complete_when_final_pr_already_m
 	# `_fetch_pr_json` + `_jq_field` helper path, and on confirmed
 	# closed-and-merged, transition status to `complete` so the
 	# existing `[ "${PROJECT_STATUS}" = "complete" ]` early-skip kicks
-	# in on the same tick while leaving `merge_conflict` projects on
-	# their dedicated finalize/validation path.  This test pins the
+	# in on the same tick while leaving `merge_conflict`, `validating`,
+	# and `validation-fixing` projects on their dedicated
+	# finalize/validation-completion paths.  This test pins the
 	# placement, the gate condition, AND the state mutation shape
 	# (status=complete + final_merge_status=merged) so a future refactor
 	# cannot silently drop any of the three.
@@ -8144,17 +8179,19 @@ def test_external_finalize_detect_marks_project_complete_when_final_pr_already_m
 	)
 	window = poller_body[anchor_idx:merge_conflict_idx]
 	# Gate condition: only fire when state is non-terminal, not already
-	# on the dedicated `merge_conflict` finalize path, a final PR is
-	# pinned, and `final_merge_status` is still `pending`.  Each guard
-	# protects a different failure mode (terminal states already
-	# handled, `merge_conflict` needs its own finalize/validation path,
-	# no PR pinned yet means orchestrator hasn't even created the
-	# integration PR, non-pending status means another code path already
-	# finalized).
+	# on the dedicated `merge_conflict` / validation-completion paths,
+	# a final PR is pinned, and `final_merge_status` is still `pending`.
+	# Each guard protects a different failure mode (terminal states
+	# already handled, `merge_conflict`/validated states need their own
+	# finalize path, no PR pinned yet means orchestrator hasn't even
+	# created the integration PR, non-pending status means another code
+	# path already finalized).
 	for needle, why in (
 		('.final_merge_pr // empty', "external-finalize block no longer reads `.final_merge_pr` from state; without it the block has no PR to inspect."),
 		('.final_merge_status // "pending"', "external-finalize block no longer reads `.final_merge_status` from state; without it the block cannot tell pending from already-finalized projects and would re-finalize on every tick."),
 		('!= "merge_conflict"', "external-finalize block no longer excludes `merge_conflict`; without that guard the block steals work from the dedicated finalize/validation path and duplicates final-PR reads on every merge_conflict poll tick."),
+		('!= "validating"', "external-finalize block no longer excludes `validating`; without that guard an externally merged final PR bypasses `mark_validation_complete` and drops `validation_completed_cycle` / `ai:validated` on the final validation-complete tick."),
+		('!= "validation-fixing"', "external-finalize block no longer excludes `validation-fixing`; without that guard the shortcut can bypass the validation-completion path that owns the final validated-state transition."),
 		('= "pending"', "external-finalize block no longer guards on `final_merge_status = pending`; without this guard the block would re-fire after the orchestrator's own finalize path already ran."),
 		("'.state'", "external-finalize block no longer reads the pinned PR's `.state` field; without it the block cannot tell open from closed PRs."),
 		("'.merged_at != null'", "external-finalize block no longer reads the pinned PR's `.merged_at` field; without it the block would mis-treat a closed-without-merge PR as a successful finalize."),


### PR DESCRIPTION
## Summary

Closes the orchestrator self-healing gap that left project #2734 cycling on `Wave 2 dispatch BLOCKED` alerts indefinitely after its integration PR was squash-merged externally.

`finalize_integration_merge_if_needed` (`scripts/orchestrate_poll_process.sh:3905`) is the only function that flips `final_merge_status` from `pending` → `merged` when the integration PR was finalized outside the wave-by-wave flow. But it's invoked from only two arms of the per-tracking-issue loop:
- `PROJECT_STATUS == "merge_conflict"` (line 8465)
- `JUDGE_STATUS == "complete"` (judge verdict arm)

A project sitting in plain `in_progress` whose integration PR has already merged externally never reaches either arm, so `final_merge_status` stays `pending` forever. The poller keeps trying to advance to the next wave, the wave-dispatch gate trips on the residual integration-branch fingerprint state, and Telegram collects `Wave N dispatch BLOCKED` alerts every poll tick.

Project #2734 hit this exact failure mode: PR #2750 (integration PR) was squash-merged at `2026-05-18T21:31:50Z`, `final_merge_pr=2750` was already pinned in state, but `final_merge_status` stayed `pending`. Operator silenced the live alerts by closing #2734 — once this PR lands, that workaround is no longer needed and the orchestrator self-heals.

## What the new block does

Right after the `TRACKING_LABELS` fetch and before the `merge_conflict` switch:

1. Skip when `PROJECT_STATUS` is already terminal (`complete` / `failed` / `validation-failed`).
2. Read `final_merge_pr` + `final_merge_status` from state. Skip when no PR is pinned (most projects pre-finalize) or status is already not-pending.
3. Otherwise issue two REST reads via the same `gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq …` call shape that `finalize_integration_merge_if_needed:3943-3944` already uses (CLAUDE.md §15: extends an existing data shape, no new call pattern).
4. On confirmed `state="closed"` AND `merged_at != null`, mutate state in a single `jq` pass: `final_merge_status="merged"`, `final_merge_error=""`, `status="complete"`, `judge_cycle += 1`.
5. Fire the same side-effect surface as the merge_conflict completion arm at `scripts/orchestrate_poll_process.sh:8480-8492`: `post_state_comment`, `handle_comprehensive_release_callback_if_needed`, `set_tracking_phase_label "ai:merged"`, `post_tracking_comment` (explains the external-merge transition), `tg_cleanup_msgs` (drops prior `Wave dispatch BLOCKED` Telegram pins), Telegram completion notify.
6. Local `PROJECT_STATUS=complete` so the existing early-skip at line 8914 short-circuits the rest of this tick on the same iteration.

## Why not just call `finalize_integration_merge_if_needed`?

That function would correctly flip `final_merge_status=merged`, but it does not transition `PROJECT_STATUS` — that transition only happens in the merge_conflict and judge-complete arms after `finalize` returns. Without a status transition, the wave-dispatch gate keeps firing on the next tick. The new block does both in one place so the project actually exits the wave-dispatch loop.

## Files changed

- `scripts/orchestrate_poll_process.sh` — new ~50-line external-finalize block between the TRACKING_LABELS fetch (line 8463) and the merge_conflict switch (line 8465). No identifiers renamed (CLAUDE.md §6), no public contracts changed.
- `tests/test_orchestrate_poll_process.py` — new `test_external_finalize_detect_marks_project_complete_when_final_pr_already_merged` static regression test that pins the placement (anchored on the `TRACKING_LABELS` landmark + the `merge_conflict` switch), the gate condition (pending status + pinned PR), the REST read shape (`pulls/{number}` + `.state` + `.merged_at`), the state mutation shape (both `status=complete` AND `final_merge_status=merged`), and the side-effect surface (`post_tracking_comment`, `tg_cleanup_msgs`, `ai:merged` label).

## Test plan

- [x] `bash -n scripts/orchestrate_poll_process.sh` clean.
- [x] `test_external_finalize_detect_marks_project_complete_when_final_pr_already_merged` passes.
- [x] `test_resolver_tooling_refresh_allowlist_includes_both_retry_preludes` still passes (no regression).
- [x] Simulation: pinning `final_merge_pr=2750` with `final_merge_status=pending` and gh returning `state=closed` + `merged_at != null` correctly enters the block; absent any of (`final_merge_pr` set, `final_merge_status=pending`, PR closed-and-merged) the block is a no-op.

## Follow-up

Once this is merged, re-opening #2734 (currently closed to silence today's alerts) would let the orchestrator's next poll tick auto-transition the state via this block. The two `ORCHESTRATOR_STATE_V2 part=1/3` and `part=2/3` orphan comments on #2734 can be ignored — neither forms a valid chain on its own.

https://claude.ai/code/session_01HSrx72bv2yTPMx4o3ai1hk

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSrx72bv2yTPMx4o3ai1hk)_