### PR TITLE
review_rb_judge: cap PR_DIFF before codex 1 MB turn/start envelope

### DIFF
--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -38,13 +38,75 @@ if ! command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
   sanitize_codex_prompt_file() { :; }
 fi
 if ! command -v _embed_input_file >/dev/null 2>&1; then
-  _init_prompt_budget() { :; }
-  _cleanup_prompt_budget() { :; }
+  : "${_PROMPT_BUDGET_TOTAL_BYTES:=800000}"
+  _prompt_budget_state_file() {
+    printf '%s/_prompt_input_budget_state.%s\n' "${TMPDIR:-/tmp}" "$$"
+  }
+  _init_prompt_budget() {
+    local _cap="${1:-${_PROMPT_BUDGET_TOTAL_BYTES}}"
+    local _state
+    _state="$(_prompt_budget_state_file)"
+    export _PROMPT_BUDGET_TOTAL_BYTES="${_cap}"
+    printf '0\n' > "${_state}" 2>/dev/null || true
+  }
+  _cleanup_prompt_budget() {
+    local _state
+    _state="$(_prompt_budget_state_file)"
+    rm -f "${_state}" 2>/dev/null || true
+  }
   _embed_input_file() {
     local _p="${1:-}"
+    local _cap="${2:-100000}"
+    local _mode="${3:-head}"
+    local _state _used _budget_remaining _effective_cap _size _emit_bytes
     if [ -z "${_p}" ] || [ ! -e "${_p}" ]; then printf '(missing)\n'; return 0; fi
     if [ ! -s "${_p}" ]; then printf '(empty)\n'; return 0; fi
-    cat "${_p}"
+
+    _state="$(_prompt_budget_state_file)"
+    _used=0
+    if [ -f "${_state}" ]; then
+      _used="$(cat "${_state}" 2>/dev/null)"
+      [ -n "${_used}" ] || _used=0
+    fi
+    _budget_remaining=$(( _PROMPT_BUDGET_TOTAL_BYTES - _used ))
+    if [ "${_budget_remaining}" -le 0 ]; then
+      printf '(omitted — total prompt input budget %d bytes exhausted; %d bytes already inlined)\n' \
+        "${_PROMPT_BUDGET_TOTAL_BYTES}" "${_used}"
+      return 0
+    fi
+
+    _effective_cap="${_cap}"
+    if [ "${_budget_remaining}" -lt "${_effective_cap}" ]; then
+      _effective_cap="${_budget_remaining}"
+    fi
+
+    _size="$(wc -c < "${_p}" 2>/dev/null | tr -d '[:space:]')"
+    [ -n "${_size}" ] || _size=0
+    if [ "${_size}" -le "${_effective_cap}" ]; then
+      cat "${_p}"
+      _emit_bytes="${_size}"
+    else
+      PYTHONDONTWRITEBYTECODE=1 python3 - "${_p}" "${_effective_cap}" 2>/dev/null <<'PY' || head -c "${_effective_cap}" "${_p}"
+from pathlib import Path
+import sys
+
+data = Path(sys.argv[1]).read_bytes()
+cap = int(sys.argv[2])
+if cap > 0 and len(data) > cap:
+    i = cap
+    while i > 0 and (data[i] & 0xC0) == 0x80:
+        i -= 1
+    data = data[:i]
+sys.stdout.buffer.write(data)
+PY
+      printf '\n[... TRUNCATED — file is %s bytes; first %s bytes shown above (mode=%s, per-file cap=%s, budget remaining was %s; fallback embedder) ...]\n' \
+        "${_size}" "${_effective_cap}" "${_mode}" "${_cap}" "${_budget_remaining}"
+      _emit_bytes="${_effective_cap}"
+    fi
+
+    if [ -n "${_emit_bytes}" ] && [ "${_emit_bytes}" -gt 0 ] 2>/dev/null; then
+      printf '%s\n' "$(( _used + _emit_bytes ))" > "${_state}" 2>/dev/null || true
+    fi
   }
 fi
 REVIEW_RB_SEMBLE_HELPERS_AVAILABLE="false"
@@ -322,7 +384,8 @@ PR_DIFF="$(gh_retry gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
 # `head -1000` truncation removed in PR #2564 (commit ebe2ecf3) was
 # the last guard here; this restores one at a byte budget instead
 # of a line budget so the cap is predictable across diff styles.
-# Override via the RB_JUDGE_PR_DIFF_MAX_BYTES repo var.
+# Override via the RB_JUDGE_PR_DIFF_MAX_BYTES environment variable
+# (for example, export a repository variable into env in the caller).
 RB_JUDGE_PR_DIFF_MAX_BYTES="${RB_JUDGE_PR_DIFF_MAX_BYTES:-400000}"
 if ! [[ "${RB_JUDGE_PR_DIFF_MAX_BYTES}" =~ ^[0-9]+$ ]] || [ "${RB_JUDGE_PR_DIFF_MAX_BYTES}" -le 0 ]; then
   echo "::warning::Invalid RB_JUDGE_PR_DIFF_MAX_BYTES='${RB_JUDGE_PR_DIFF_MAX_BYTES}'; using 400000."
@@ -381,7 +444,7 @@ RB_JUDGE_PR_META_RENDER_FILE="${RUNTIME_DIR}/rb_judge_pr_meta.json"
 RB_JUDGE_PR_COMMENTS_RENDER_FILE="${RUNTIME_DIR}/rb_judge_pr_comments.json"
 RB_JUDGE_PR_REVIEW_COMMENTS_RENDER_FILE="${RUNTIME_DIR}/rb_judge_pr_review_comments.json"
 RB_JUDGE_SEMBLE_PREFETCH=""
-trap 'rm -f "${RB_JUDGE_SEMBLE_QUERY_FILE:-}" "${RB_JUDGE_REQUIREMENT_FILE:-}" "${RB_JUDGE_PR_META_RENDER_FILE:-}" "${RB_JUDGE_PR_COMMENTS_RENDER_FILE:-}" "${RB_JUDGE_PR_REVIEW_COMMENTS_RENDER_FILE:-}"' EXIT
+trap '_cleanup_prompt_budget; rm -f "${RB_JUDGE_SEMBLE_QUERY_FILE:-}" "${RB_JUDGE_REQUIREMENT_FILE:-}" "${RB_JUDGE_PR_META_RENDER_FILE:-}" "${RB_JUDGE_PR_COMMENTS_RENDER_FILE:-}" "${RB_JUDGE_PR_REVIEW_COMMENTS_RENDER_FILE:-}"' EXIT
 
 {
   printf '%s\n' 'Review-blocked judge context.'
@@ -404,10 +467,14 @@ RB_JUDGE_SEMBLE_PREFETCH="$(render_review_rb_semble_prefetch "${RB_JUDGE_SEMBLE_
 # Keep the non-diff judge inputs under a shared budget so oversized PR
 # discussions / inline reviews cannot reintroduce the same `turn/start`
 # prompt-envelope failure the PR diff cap was added to prevent.
-if [ -n "${FIRST_ISSUE}" ]; then
+if [ -n "${FIRST_ISSUE}" ] && [ -n "${FIRST_ISSUE_BODY//[[:space:]]/}" ]; then
   printf '%s\n' "${FIRST_ISSUE_BODY}" > "${RB_JUDGE_REQUIREMENT_FILE}"
 else
   {
+    if [ -n "${FIRST_ISSUE}" ]; then
+      echo "[NOTE: linked issue #${FIRST_ISSUE} has no body; using PR title/body as requirement fallback.]"
+      echo
+    fi
     echo "Title: $(jq -r '.title // ""' "${PR_META_FILE}")"
     echo "Body: $(jq -r '.body // ""' "${PR_PAYLOAD_FILE}")"
   } > "${RB_JUDGE_REQUIREMENT_FILE}"
@@ -478,13 +545,15 @@ _init_prompt_budget "${RB_JUDGE_CONTEXT_BUDGET_BYTES}"
   fi
   printf '%s\n' "${PR_DIFF}"
   echo
-  echo "=== PR #${PR_NUMBER} COMMENTS (editor summaries, reviewer findings) ==="
-  echo
-  _embed_input_file "${RB_JUDGE_PR_COMMENTS_RENDER_FILE}" "${RB_JUDGE_PR_COMMENTS_MAX_BYTES}"
-  echo
   echo "=== PR #${PR_NUMBER} INLINE REVIEW COMMENTS ==="
   echo
   _embed_input_file "${RB_JUDGE_PR_REVIEW_COMMENTS_RENDER_FILE}" "${RB_JUDGE_PR_REVIEW_COMMENTS_MAX_BYTES}"
+  echo
+  # Keep the file/line reviewer findings ahead of general PR discussion
+  # so the shared prompt budget preserves the most actionable evidence.
+  echo "=== PR #${PR_NUMBER} COMMENTS (editor summaries, reviewer findings) ==="
+  echo
+  _embed_input_file "${RB_JUDGE_PR_COMMENTS_RENDER_FILE}" "${RB_JUDGE_PR_COMMENTS_MAX_BYTES}"
   echo
   echo "=== REVIEW-BLOCKED CONTEXT ==="
   echo "Review-blocked judge retry: $((RETRY_COUNT + 1)) of ${MAX_REVIEW_BLOCKED_RETRIES}"

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -395,7 +395,8 @@ PR_DIFF_TRUNCATED=false
 PR_DIFF_BYTES_TOTAL="$(printf '%s' "${PR_DIFF}" | wc -c | tr -cd '0-9' || true)"
 [ -n "${PR_DIFF_BYTES_TOTAL}" ] || PR_DIFF_BYTES_TOTAL=0
 if [ "${PR_DIFF_BYTES_TOTAL}" -gt "${RB_JUDGE_PR_DIFF_MAX_BYTES}" ]; then
-  PR_DIFF="$(printf '%s' "${PR_DIFF}" | PYTHONDONTWRITEBYTECODE=1 python3 -c '
+  PR_DIFF_TRUNCATED_CONTENT=""
+  if PR_DIFF_TRUNCATED_CONTENT="$(printf '%s' "${PR_DIFF}" | PYTHONDONTWRITEBYTECODE=1 python3 -c '
 import sys
 
 data = sys.stdin.buffer.read()
@@ -406,7 +407,17 @@ if cap > 0 and len(data) > cap:
         i -= 1
     data = data[:i]
 sys.stdout.buffer.write(data)
-' "${RB_JUDGE_PR_DIFF_MAX_BYTES}")"
+' "${RB_JUDGE_PR_DIFF_MAX_BYTES}" 2>/dev/null)"; then
+    PR_DIFF="${PR_DIFF_TRUNCATED_CONTENT}"
+  else
+    echo "::warning::python3 unavailable for UTF-8-safe PR diff truncation; falling back to a raw byte prefix. sanitize_codex_prompt_file will strip any invalid trailing bytes before codex reads the prompt."
+    PR_DIFF_FALLBACK_FILE="$(mktemp "${TMPDIR:-/tmp}/review-rb-judge-pr-diff.XXXXXX")"
+    printf '%s' "${PR_DIFF}" > "${PR_DIFF_FALLBACK_FILE}"
+    PR_DIFF="$(head -c "${RB_JUDGE_PR_DIFF_MAX_BYTES}" "${PR_DIFF_FALLBACK_FILE}")"
+    rm -f "${PR_DIFF_FALLBACK_FILE}" 2>/dev/null || true
+    unset PR_DIFF_FALLBACK_FILE
+  fi
+  unset PR_DIFF_TRUNCATED_CONTENT
   PR_DIFF_TRUNCATED=true
 fi
 PRELOADED_PR_META="$(jq -c '{
@@ -540,7 +551,7 @@ _init_prompt_budget "${RB_JUDGE_CONTEXT_BUDGET_BYTES}"
   # the model runs and every retry in the reasoning ladder fails
   # identically (see PR shubhodeep1/bitsafe.io#368, run 26092826715).
   if [ "${PR_DIFF_TRUNCATED}" = "true" ]; then
-    echo "[NOTE: PR diff is ${PR_DIFF_BYTES_TOTAL} bytes; truncated to a UTF-8-safe prefix within ${RB_JUDGE_PR_DIFF_MAX_BYTES} bytes to fit codex stdin (1 MB cap). Use exec-read on specific files for the elided tail if needed; the judge runs --sandbox read-only so file reads are available.]"
+    echo "[NOTE: PR diff is ${PR_DIFF_BYTES_TOTAL} bytes; truncated to a prefix within ${RB_JUDGE_PR_DIFF_MAX_BYTES} bytes to fit codex stdin (1 MB cap). Use exec-read on specific files for the elided tail if needed; the judge runs --sandbox read-only so file reads are available.]"
     echo
   fi
   printf '%s\n' "${PR_DIFF}"

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -37,6 +37,16 @@ fi
 if ! command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
   sanitize_codex_prompt_file() { :; }
 fi
+if ! command -v _embed_input_file >/dev/null 2>&1; then
+  _init_prompt_budget() { :; }
+  _cleanup_prompt_budget() { :; }
+  _embed_input_file() {
+    local _p="${1:-}"
+    if [ -z "${_p}" ] || [ ! -e "${_p}" ]; then printf '(missing)\n'; return 0; fi
+    if [ ! -s "${_p}" ]; then printf '(empty)\n'; return 0; fi
+    cat "${_p}"
+  }
+fi
 REVIEW_RB_SEMBLE_HELPERS_AVAILABLE="false"
 REVIEW_RB_SEMBLE_MAX_CHUNKS="4"
 REVIEW_RB_SEMBLE_QUERY_MAX_BYTES="12000"
@@ -366,8 +376,12 @@ fi
 RB_JUDGE_PROMPT="${RUNTIME_DIR}/rb_judge_prompt.txt"
 RB_JUDGE_OUTPUT="${RUNTIME_DIR}/rb_judge_output.txt"
 RB_JUDGE_SEMBLE_QUERY_FILE="${RUNTIME_DIR}/rb_judge_semble_query.txt"
+RB_JUDGE_REQUIREMENT_FILE="${RUNTIME_DIR}/rb_judge_requirement.txt"
+RB_JUDGE_PR_META_RENDER_FILE="${RUNTIME_DIR}/rb_judge_pr_meta.json"
+RB_JUDGE_PR_COMMENTS_RENDER_FILE="${RUNTIME_DIR}/rb_judge_pr_comments.json"
+RB_JUDGE_PR_REVIEW_COMMENTS_RENDER_FILE="${RUNTIME_DIR}/rb_judge_pr_review_comments.json"
 RB_JUDGE_SEMBLE_PREFETCH=""
-trap 'rm -f "${RB_JUDGE_SEMBLE_QUERY_FILE:-}"' EXIT
+trap 'rm -f "${RB_JUDGE_SEMBLE_QUERY_FILE:-}" "${RB_JUDGE_REQUIREMENT_FILE:-}" "${RB_JUDGE_PR_META_RENDER_FILE:-}" "${RB_JUDGE_PR_COMMENTS_RENDER_FILE:-}" "${RB_JUDGE_PR_REVIEW_COMMENTS_RENDER_FILE:-}"' EXIT
 
 {
   printf '%s\n' 'Review-blocked judge context.'
@@ -386,6 +400,33 @@ Body: $(jq -r '.body // ""' "${PR_PAYLOAD_FILE}")" \
   append_review_rb_semble_query_section "PR review comments JSON:" "${PR_REVIEW_COMMENTS}" 2500
 } > "${RB_JUDGE_SEMBLE_QUERY_FILE}"
 RB_JUDGE_SEMBLE_PREFETCH="$(render_review_rb_semble_prefetch "${RB_JUDGE_SEMBLE_QUERY_FILE}" "Review-Blocked Judge Context")"
+
+# Keep the non-diff judge inputs under a shared budget so oversized PR
+# discussions / inline reviews cannot reintroduce the same `turn/start`
+# prompt-envelope failure the PR diff cap was added to prevent.
+if [ -n "${FIRST_ISSUE}" ]; then
+  printf '%s\n' "${FIRST_ISSUE_BODY}" > "${RB_JUDGE_REQUIREMENT_FILE}"
+else
+  {
+    echo "Title: $(jq -r '.title // ""' "${PR_META_FILE}")"
+    echo "Body: $(jq -r '.body // ""' "${PR_PAYLOAD_FILE}")"
+  } > "${RB_JUDGE_REQUIREMENT_FILE}"
+fi
+if ! printf '%s\n' "${PR_META_JSON}" | jq '.' > "${RB_JUDGE_PR_META_RENDER_FILE}" 2>/dev/null; then
+  printf '%s\n' "${PR_META_JSON}" > "${RB_JUDGE_PR_META_RENDER_FILE}"
+fi
+if ! printf '%s\n' "${PR_COMMENTS}" | jq '.' > "${RB_JUDGE_PR_COMMENTS_RENDER_FILE}" 2>/dev/null; then
+  printf '%s\n' "${PR_COMMENTS}" > "${RB_JUDGE_PR_COMMENTS_RENDER_FILE}"
+fi
+if ! printf '%s\n' "${PR_REVIEW_COMMENTS}" | jq '.' > "${RB_JUDGE_PR_REVIEW_COMMENTS_RENDER_FILE}" 2>/dev/null; then
+  printf '%s\n' "${PR_REVIEW_COMMENTS}" > "${RB_JUDGE_PR_REVIEW_COMMENTS_RENDER_FILE}"
+fi
+RB_JUDGE_CONTEXT_BUDGET_BYTES=300000
+RB_JUDGE_REQUIREMENT_MAX_BYTES=50000
+RB_JUDGE_PR_META_MAX_BYTES=50000
+RB_JUDGE_PR_COMMENTS_MAX_BYTES=150000
+RB_JUDGE_PR_REVIEW_COMMENTS_MAX_BYTES=100000
+_init_prompt_budget "${RB_JUDGE_CONTEXT_BUDGET_BYTES}"
 
 {
   if [ -f ./pre_assembled_static.txt ]; then
@@ -408,17 +449,16 @@ RB_JUDGE_SEMBLE_PREFETCH="$(render_review_rb_semble_prefetch "${RB_JUDGE_SEMBLE_
   if [ -n "${FIRST_ISSUE}" ]; then
     echo "=== ISSUE #${FIRST_ISSUE} (original requirement) ==="
     echo
-    echo "${FIRST_ISSUE_BODY}"
+    _embed_input_file "${RB_JUDGE_REQUIREMENT_FILE}" "${RB_JUDGE_REQUIREMENT_MAX_BYTES}"
   else
     echo "=== PR DESCRIPTION (no linked issue) ==="
     echo
-    echo "Title: $(jq -r '.title // ""' "${PR_META_FILE}")"
-    echo "Body: $(jq -r '.body // ""' "${PR_PAYLOAD_FILE}")"
+    _embed_input_file "${RB_JUDGE_REQUIREMENT_FILE}" "${RB_JUDGE_REQUIREMENT_MAX_BYTES}"
   fi
   echo
   echo "=== PR #${PR_NUMBER} METADATA ==="
   echo
-  printf '%s\n' "${PR_META_JSON}" | jq '.'
+  _embed_input_file "${RB_JUDGE_PR_META_RENDER_FILE}" "${RB_JUDGE_PR_META_MAX_BYTES}"
   echo
   echo "=== PR #${PR_NUMBER} DIFF ==="
   echo
@@ -440,11 +480,11 @@ RB_JUDGE_SEMBLE_PREFETCH="$(render_review_rb_semble_prefetch "${RB_JUDGE_SEMBLE_
   echo
   echo "=== PR #${PR_NUMBER} COMMENTS (editor summaries, reviewer findings) ==="
   echo
-  printf '%s\n' "${PR_COMMENTS}" | jq '.'
+  _embed_input_file "${RB_JUDGE_PR_COMMENTS_RENDER_FILE}" "${RB_JUDGE_PR_COMMENTS_MAX_BYTES}"
   echo
   echo "=== PR #${PR_NUMBER} INLINE REVIEW COMMENTS ==="
   echo
-  printf '%s\n' "${PR_REVIEW_COMMENTS}" | jq '.'
+  _embed_input_file "${RB_JUDGE_PR_REVIEW_COMMENTS_RENDER_FILE}" "${RB_JUDGE_PR_REVIEW_COMMENTS_MAX_BYTES}"
   echo
   echo "=== REVIEW-BLOCKED CONTEXT ==="
   echo "Review-blocked judge retry: $((RETRY_COUNT + 1)) of ${MAX_REVIEW_BLOCKED_RETRIES}"
@@ -471,6 +511,7 @@ RB_JUDGE_SEMBLE_PREFETCH="$(render_review_rb_semble_prefetch "${RB_JUDGE_SEMBLE_
     echo "the PR's work should be discarded."
   fi
 } > "${RB_JUDGE_PROMPT}"
+_cleanup_prompt_budget
 rm -f "${RB_JUDGE_SEMBLE_QUERY_FILE}"
 
 # -----------------------------------------------------------

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -322,7 +322,7 @@ PR_DIFF_TRUNCATED=false
 PR_DIFF_BYTES_TOTAL="$(printf '%s' "${PR_DIFF}" | wc -c | tr -cd '0-9' || true)"
 [ -n "${PR_DIFF_BYTES_TOTAL}" ] || PR_DIFF_BYTES_TOTAL=0
 if [ "${PR_DIFF_BYTES_TOTAL}" -gt "${RB_JUDGE_PR_DIFF_MAX_BYTES}" ]; then
-  PR_DIFF="$(printf '%s' "${PR_DIFF}" | PYTHONDONTWRITEBYTECODE=1 python3 - "${RB_JUDGE_PR_DIFF_MAX_BYTES}" <<'PY'
+  PR_DIFF="$(printf '%s' "${PR_DIFF}" | PYTHONDONTWRITEBYTECODE=1 python3 -c '
 import sys
 
 data = sys.stdin.buffer.read()
@@ -333,8 +333,7 @@ if cap > 0 and len(data) > cap:
         i -= 1
     data = data[:i]
 sys.stdout.buffer.write(data)
-PY
-  )"
+' "${RB_JUDGE_PR_DIFF_MAX_BYTES}")"
   PR_DIFF_TRUNCATED=true
 fi
 PRELOADED_PR_META="$(jq -c '{
@@ -555,19 +554,14 @@ PY
 # -----------------------------------------------------------
 # Run the judge
 # -----------------------------------------------------------
-# Surface the rendered prompt size before invoking codex. The CLI's
-# `turn/start` envelope is a hard 1,048,576-character stdin cap; if
-# the prompt crosses it, every retry in the reasoning ladder fails
+# Surface the sanitized prompt size before the first codex exec. The
+# CLI's `turn/start` envelope is a hard 1,048,576-character stdin cap;
+# if the prompt crosses it, every retry in the reasoning ladder fails
 # identically with the same `turn/start: Input exceeds the maximum
 # length` error because the ladder only steps reasoning effort, not
-# input size. Logging here keeps the next regression visible at the
+# input size. Logging here keeps the next regression visible near the
 # top of the failing job instead of buried inside ~75k stderr lines.
-RB_JUDGE_PROMPT_BYTES="$(wc -c < "${RB_JUDGE_PROMPT}" 2>/dev/null | tr -cd '0-9' || true)"
-[ -n "${RB_JUDGE_PROMPT_BYTES}" ] || RB_JUDGE_PROMPT_BYTES=0
-echo "Review-blocked judge prompt size: ${RB_JUDGE_PROMPT_BYTES} bytes (codex stdin cap: 1048576)."
-if [ "${RB_JUDGE_PROMPT_BYTES:-0}" -gt 950000 ]; then
-  echo "::warning::Review-blocked judge prompt is ${RB_JUDGE_PROMPT_BYTES} bytes; close to or over codex 1 MB stdin cap. Expect turn/start failures unless RB_JUDGE_PR_DIFF_MAX_BYTES (current: ${RB_JUDGE_PR_DIFF_MAX_BYTES}) or upstream embed budgets are tightened."
-fi
+RB_JUDGE_PROMPT_SIZE_LOGGED=false
 JUDGE_SUCCESS=false
 JUDGE_STDERR_FILE="${RUNTIME_DIR}/rb_judge_stderr.txt"
 for attempt_idx in "${!JUDGE_ATTEMPT_LEVELS[@]}"; do
@@ -578,6 +572,15 @@ for attempt_idx in "${!JUDGE_ATTEMPT_LEVELS[@]}"; do
     sed -i "s/model_reasoning_effort = \".*\"/model_reasoning_effort = \"${level}\"/" "${HOME}/.codex/config.toml"
   fi
   sanitize_codex_prompt_file "${RB_JUDGE_PROMPT}"
+  if [ "${RB_JUDGE_PROMPT_SIZE_LOGGED}" != "true" ]; then
+    RB_JUDGE_PROMPT_BYTES="$(wc -c < "${RB_JUDGE_PROMPT}" 2>/dev/null | tr -cd '0-9' || true)"
+    [ -n "${RB_JUDGE_PROMPT_BYTES}" ] || RB_JUDGE_PROMPT_BYTES=0
+    echo "Review-blocked judge prompt size: ${RB_JUDGE_PROMPT_BYTES} bytes (codex stdin cap: 1048576)."
+    if [ "${RB_JUDGE_PROMPT_BYTES:-0}" -gt 950000 ]; then
+      echo "::warning::Review-blocked judge prompt is ${RB_JUDGE_PROMPT_BYTES} bytes; close to or over codex 1 MB stdin cap. Expect turn/start failures unless RB_JUDGE_PR_DIFF_MAX_BYTES (current: ${RB_JUDGE_PR_DIFF_MAX_BYTES}) or upstream embed budgets are tightened."
+    fi
+    RB_JUDGE_PROMPT_SIZE_LOGGED=true
+  fi
   if codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox read-only < "${RB_JUDGE_PROMPT}" > "${RB_JUDGE_OUTPUT}" 2>"${JUDGE_STDERR_FILE}"; then
     if grep -q '[^[:space:]]' "${RB_JUDGE_OUTPUT}"; then
       JUDGE_EFFECTIVE_REASONING_EFFORT="${level}"

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -304,6 +304,21 @@ fi
 # -----------------------------------------------------------
 PR_DIFF="$(gh_retry gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
   -H 'Accept: application/vnd.github.diff' 2>/dev/null || echo "(diff unavailable)")"
+# Cap the diff embedded in the judge prompt so codex's `turn/start`
+# stdin envelope (1,048,576 chars) is never breached. The reviewer
+# script uses the same pattern (scripts/review_run_reviewers.sh:447 —
+# `_embed_input_file "${PR_DIFF_FILE}" 400000 diff`). The deleted
+# `head -1000` truncation removed in PR #2564 (commit ebe2ecf3) was
+# the last guard here; this restores one at a byte budget instead
+# of a line budget so the cap is predictable across diff styles.
+# Override via the RB_JUDGE_PR_DIFF_MAX_BYTES repo var.
+RB_JUDGE_PR_DIFF_MAX_BYTES="${RB_JUDGE_PR_DIFF_MAX_BYTES:-400000}"
+PR_DIFF_TRUNCATED=false
+PR_DIFF_BYTES_TOTAL="${#PR_DIFF}"
+if [ "${PR_DIFF_BYTES_TOTAL}" -gt "${RB_JUDGE_PR_DIFF_MAX_BYTES}" ]; then
+  PR_DIFF="${PR_DIFF:0:${RB_JUDGE_PR_DIFF_MAX_BYTES}}"
+  PR_DIFF_TRUNCATED=true
+fi
 PRELOADED_PR_META="$(jq -c '{
   title: (.title // ""),
   body: (.body // ""),
@@ -390,10 +405,20 @@ RB_JUDGE_SEMBLE_PREFETCH="$(render_review_rb_semble_prefetch "${RB_JUDGE_SEMBLE_
   echo
   echo "=== PR #${PR_NUMBER} DIFF ==="
   echo
-  # Pass the full diff to the judge: forcing the model to exec-read
-  # files to reconstruct the truncated tail burns more context per
-  # turn than including the full diff up front. codex compacts older
-  # turns when its window fills, so a long diff degrades gracefully.
+  # Pass the diff to the judge (capped above at RB_JUDGE_PR_DIFF_MAX_BYTES,
+  # default 400000 bytes). Forcing the model to exec-read files to
+  # reconstruct a truncated tail burns more context per turn than
+  # passing what fits up front; codex compacts older turns when its
+  # reasoning window fills, so a long diff degrades gracefully —
+  # provided the CLI accepts the request at all. The hard byte cap
+  # above keeps us under codex's `turn/start` stdin envelope
+  # (1,048,576 chars); without it, a >1 MB diff is rejected before
+  # the model runs and every retry in the reasoning ladder fails
+  # identically (see PR shubhodeep1/bitsafe.io#368, run 26092826715).
+  if [ "${PR_DIFF_TRUNCATED}" = "true" ]; then
+    echo "[NOTE: PR diff is ${PR_DIFF_BYTES_TOTAL} bytes; truncated to first ${RB_JUDGE_PR_DIFF_MAX_BYTES} bytes to fit codex stdin (1 MB cap). Use exec-read on specific files for the elided tail if needed; the judge runs --sandbox read-only so file reads are available.]"
+    echo
+  fi
   printf '%s\n' "${PR_DIFF}"
   echo
   echo "=== PR #${PR_NUMBER} COMMENTS (editor summaries, reviewer findings) ==="
@@ -512,6 +537,18 @@ PY
 # -----------------------------------------------------------
 # Run the judge
 # -----------------------------------------------------------
+# Surface the rendered prompt size before invoking codex. The CLI's
+# `turn/start` envelope is a hard 1,048,576-character stdin cap; if
+# the prompt crosses it, every retry in the reasoning ladder fails
+# identically with the same `turn/start: Input exceeds the maximum
+# length` error because the ladder only steps reasoning effort, not
+# input size. Logging here keeps the next regression visible at the
+# top of the failing job instead of buried inside ~75k stderr lines.
+RB_JUDGE_PROMPT_BYTES="$(wc -c < "${RB_JUDGE_PROMPT}" 2>/dev/null | tr -d ' ' || echo 0)"
+echo "Review-blocked judge prompt size: ${RB_JUDGE_PROMPT_BYTES} bytes (codex stdin cap: 1048576)."
+if [ "${RB_JUDGE_PROMPT_BYTES:-0}" -gt 950000 ]; then
+  echo "::warning::Review-blocked judge prompt is ${RB_JUDGE_PROMPT_BYTES} bytes; close to or over codex 1 MB stdin cap. Expect turn/start failures unless RB_JUDGE_PR_DIFF_MAX_BYTES (current: ${RB_JUDGE_PR_DIFF_MAX_BYTES}) or upstream embed budgets are tightened."
+fi
 JUDGE_SUCCESS=false
 JUDGE_STDERR_FILE="${RUNTIME_DIR}/rb_judge_stderr.txt"
 for attempt_idx in "${!JUDGE_ATTEMPT_LEVELS[@]}"; do

--- a/scripts/review_rb_judge.sh
+++ b/scripts/review_rb_judge.sh
@@ -304,6 +304,7 @@ fi
 # -----------------------------------------------------------
 PR_DIFF="$(gh_retry gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
   -H 'Accept: application/vnd.github.diff' 2>/dev/null || echo "(diff unavailable)")"
+[ -n "${PR_DIFF}" ] || PR_DIFF="(diff unavailable)"
 # Cap the diff embedded in the judge prompt so codex's `turn/start`
 # stdin envelope (1,048,576 chars) is never breached. The reviewer
 # script uses the same pattern (scripts/review_run_reviewers.sh:447 —
@@ -313,10 +314,27 @@ PR_DIFF="$(gh_retry gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
 # of a line budget so the cap is predictable across diff styles.
 # Override via the RB_JUDGE_PR_DIFF_MAX_BYTES repo var.
 RB_JUDGE_PR_DIFF_MAX_BYTES="${RB_JUDGE_PR_DIFF_MAX_BYTES:-400000}"
+if ! [[ "${RB_JUDGE_PR_DIFF_MAX_BYTES}" =~ ^[0-9]+$ ]] || [ "${RB_JUDGE_PR_DIFF_MAX_BYTES}" -le 0 ]; then
+  echo "::warning::Invalid RB_JUDGE_PR_DIFF_MAX_BYTES='${RB_JUDGE_PR_DIFF_MAX_BYTES}'; using 400000."
+  RB_JUDGE_PR_DIFF_MAX_BYTES=400000
+fi
 PR_DIFF_TRUNCATED=false
-PR_DIFF_BYTES_TOTAL="${#PR_DIFF}"
+PR_DIFF_BYTES_TOTAL="$(printf '%s' "${PR_DIFF}" | wc -c | tr -cd '0-9' || true)"
+[ -n "${PR_DIFF_BYTES_TOTAL}" ] || PR_DIFF_BYTES_TOTAL=0
 if [ "${PR_DIFF_BYTES_TOTAL}" -gt "${RB_JUDGE_PR_DIFF_MAX_BYTES}" ]; then
-  PR_DIFF="${PR_DIFF:0:${RB_JUDGE_PR_DIFF_MAX_BYTES}}"
+  PR_DIFF="$(printf '%s' "${PR_DIFF}" | PYTHONDONTWRITEBYTECODE=1 python3 - "${RB_JUDGE_PR_DIFF_MAX_BYTES}" <<'PY'
+import sys
+
+data = sys.stdin.buffer.read()
+cap = int(sys.argv[1])
+if cap > 0 and len(data) > cap:
+    i = cap
+    while i > 0 and (data[i] & 0xC0) == 0x80:
+        i -= 1
+    data = data[:i]
+sys.stdout.buffer.write(data)
+PY
+  )"
   PR_DIFF_TRUNCATED=true
 fi
 PRELOADED_PR_META="$(jq -c '{
@@ -416,7 +434,7 @@ RB_JUDGE_SEMBLE_PREFETCH="$(render_review_rb_semble_prefetch "${RB_JUDGE_SEMBLE_
   # the model runs and every retry in the reasoning ladder fails
   # identically (see PR shubhodeep1/bitsafe.io#368, run 26092826715).
   if [ "${PR_DIFF_TRUNCATED}" = "true" ]; then
-    echo "[NOTE: PR diff is ${PR_DIFF_BYTES_TOTAL} bytes; truncated to first ${RB_JUDGE_PR_DIFF_MAX_BYTES} bytes to fit codex stdin (1 MB cap). Use exec-read on specific files for the elided tail if needed; the judge runs --sandbox read-only so file reads are available.]"
+    echo "[NOTE: PR diff is ${PR_DIFF_BYTES_TOTAL} bytes; truncated to a UTF-8-safe prefix within ${RB_JUDGE_PR_DIFF_MAX_BYTES} bytes to fit codex stdin (1 MB cap). Use exec-read on specific files for the elided tail if needed; the judge runs --sandbox read-only so file reads are available.]"
     echo
   fi
   printf '%s\n' "${PR_DIFF}"
@@ -544,7 +562,8 @@ PY
 # length` error because the ladder only steps reasoning effort, not
 # input size. Logging here keeps the next regression visible at the
 # top of the failing job instead of buried inside ~75k stderr lines.
-RB_JUDGE_PROMPT_BYTES="$(wc -c < "${RB_JUDGE_PROMPT}" 2>/dev/null | tr -d ' ' || echo 0)"
+RB_JUDGE_PROMPT_BYTES="$(wc -c < "${RB_JUDGE_PROMPT}" 2>/dev/null | tr -cd '0-9' || true)"
+[ -n "${RB_JUDGE_PROMPT_BYTES}" ] || RB_JUDGE_PROMPT_BYTES=0
 echo "Review-blocked judge prompt size: ${RB_JUDGE_PROMPT_BYTES} bytes (codex stdin cap: 1048576)."
 if [ "${RB_JUDGE_PROMPT_BYTES:-0}" -gt 950000 ]; then
   echo "::warning::Review-blocked judge prompt is ${RB_JUDGE_PROMPT_BYTES} bytes; close to or over codex 1 MB stdin cap. Expect turn/start failures unless RB_JUDGE_PR_DIFF_MAX_BYTES (current: ${RB_JUDGE_PR_DIFF_MAX_BYTES}) or upstream embed budgets are tightened."


### PR DESCRIPTION
## Summary

Fixes the review-blocked judge path failing on large PRs with `Error: turn/start: turn/start failed: Input exceeds the maximum length of 1048576 characters.` — every retry in the reasoning ladder fails identically because the ladder steps reasoning effort but reuses the same prompt file, so input size never shrinks.

**Trigger:** [`shubhodeep1/bitsafe.io#368`](https://github.com/shubhodeep1/bitsafe.io/pull/368), run `26092826715` — autofix exhausted (5 iterations), then all 3 judge retries (xhigh→high→medium) failed with the identical 1 MB envelope error. PR diff is 1.586 MB, dominated by `apps/api/src/lib/disposable-email-domains.json` (+72,233 lines).

**Regression source:** commit `ebe2ecf3` (PR #2564) deleted the prior `head -1000` PR_DIFF truncation on the premise that codex's reasoning-context compaction would cover. Compaction operates inside the model **after** `turn/start` accepts the request; it does nothing when the CLI rejects the input outright.

## Changes

**`scripts/review_rb_judge.sh:307-321` — Fix 1: cap PR_DIFF**
- Add `RB_JUDGE_PR_DIFF_MAX_BYTES` (default `400000`) and truncate `PR_DIFF` to it after capture.
- Surface a `[NOTE: ... truncated ...]` marker in the prompt so the judge knows to exec-read for the elided tail (judge runs `--sandbox read-only`, so file reads remain available).
- Matches the reviewer script's proven pattern at `scripts/review_run_reviewers.sh:447` (`_embed_input_file ... 400000 diff`).

**`scripts/review_rb_judge.sh:540-550` — Fix 2: prompt-size diagnostic**
- Log the rendered prompt size before the codex exec loop.
- Emit `::warning::` above 950000 bytes so the next regression is visible at-a-glance in the run log instead of buried inside ~75k stderr lines per attempt.

## Sizing rationale

- 400 KB diff cap + ~400 KB allowance for static prefix / metadata / comments / footer = ~800 KB total, matching `_PROMPT_BUDGET_TOTAL_BYTES` in `scripts/gh_helpers.sh:1266`.
- ~250 KB headroom under the codex 1,048,576-char `turn/start` cap.
- Cap is overridable via the `RB_JUDGE_PR_DIFF_MAX_BYTES` repo var for future tuning.

## Test plan

- [ ] `bash -n scripts/review_rb_judge.sh` — already verified locally (syntax OK).
- [ ] After merge + `@stable` retag: re-dispatch the AI Review workflow on `shubhodeep1/bitsafe.io#368` and confirm the judge prompt size + (likely) `[NOTE: ... truncated ...]` marker appear in the log, and codex now accepts the input.
- [ ] Confirm warning fires correctly if a future PR pushes total prompt size > 950 KB.

## Out-of-scope (flagged for follow-up if observed)

- `PR_COMMENTS` / `PR_REVIEW_COMMENTS` (`scripts/review_rb_judge.sh:401, 405`) are still unbounded. PR `#368` had modest comment volume, but a PR with hundreds of reviewer comments could blow the budget even with the diff capped. Not addressed here to keep this PR scoped to the verified failure mode.
- `MAX_REVIEW_BLOCKED_RETRIES` ladder could be made cheaper by classifying `turn/start: Input exceeds` as non-retryable, but with this PR's cap the error should not recur.

https://claude.ai/code/session_01J5jWFxEqYo6m8tDm1t4chw

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5jWFxEqYo6m8tDm1t4chw)_