### PR TITLE
orchestrate_poll_process: block empty-commit stall recovery while a review_autofix run is in-flight

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -5738,9 +5738,11 @@ STALL_EOF
           # caller workflows that rename the display name are still
           # caught.  Zombie filter (STALL_THRESHOLD_MINUTES) mirrors
           # build_active_issue_set at line 4944-4954 so a genuinely
-          # hung run does not block recovery indefinitely.  Fail-open
-          # on any jq/cache error: empty result falls through to the
-          # legacy empty-commit path.
+          # hung run does not block recovery indefinitely.  Malformed or
+          # blank timestamps on a same-branch review run are treated as
+          # fresh so we conservatively avoid invalidating a potentially
+          # live autofix pass.  Other jq/cache errors still fail open:
+          # empty result falls through to the legacy empty-commit path.
           local _rtr_inflight_blob _rtr_inflight_id _rtr_now_epoch _rtr_stall_secs
           _rtr_inflight_blob="$(_load_actions_runs_cached 2>/dev/null || echo '{"workflow_runs":[]}')"
           _rtr_now_epoch="$(date +%s)"
@@ -5760,8 +5762,12 @@ STALL_EOF
                  or ((.path // "") | endswith("internal-review.yml"))
                  or ((.path // "") | endswith("review_autofix.yml"))
                )
-             | (.run_started_at // .created_at // "1970-01-01T00:00:00Z") as $ts
-             | ($ts | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) as $start_epoch
+             | ([.run_started_at, .created_at]
+                | map(select(type == "string" and . != ""))[0] // "") as $ts
+             | (if $ts != ""
+                then (try ($ts | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) catch $now)
+                else $now
+                end) as $start_epoch
              | select(($now - $start_epoch) < $threshold)
             ] | (.[0].id // empty)
           ' 2>/dev/null || echo "")"

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -5745,7 +5745,7 @@ STALL_EOF
           # live autofix pass.  Other jq/cache errors still fail open,
           # and if date +%s is unavailable we skip the guard entirely:
           # empty result falls through to the legacy empty-commit path.
-          local _rtr_inflight_blob _rtr_inflight_id _rtr_now_epoch _rtr_stall_secs
+          local _rtr_inflight_blob _rtr_inflight_id _rtr_now_epoch _rtr_stall_secs _rtr_origin_head_sha
           _rtr_inflight_blob="$(_load_actions_runs_cached 2>/dev/null || echo '{"workflow_runs":[]}')"
           _rtr_now_epoch="$(date +%s 2>/dev/null || echo "")"
           _rtr_stall_secs=$(( STALL_THRESHOLD_MINUTES * 60 ))
@@ -5782,15 +5782,22 @@ STALL_EOF
             STALL_RECOVERY_EFFECTIVE_ACTION="retrigger_review_skipped_inflight"
             return 1
           fi
-          if git fetch origin "${head_ref}:refs/remotes/origin/${head_ref}" 2>/dev/null && \
-             git checkout "origin/${head_ref}" 2>/dev/null; then
-            git config user.name "codex-bot"
-            git config user.email "codex@users.noreply.github.com"
-            git commit --allow-empty -m "[orchestrator] stall recovery: re-trigger review for issue #${issue_num}" 2>/dev/null || true
-            if git push origin "HEAD:${head_ref}" 2>/dev/null; then
-              tg_notify "Stall recovery: re-triggered review for PR #${pr_num} (issue #${issue_num}, stuck ${stall_minutes}m, attempt $((recovery_count + 1)))."$'\n'"PR: $(_gh_url "pull/${pr_num}")"$'\n'"Issue: $(_gh_url "issues/${issue_num}")" "WARNING"
+          if git fetch origin "${head_ref}:refs/remotes/origin/${head_ref}" 2>/dev/null; then
+            _rtr_origin_head_sha="$(git rev-parse --verify "refs/remotes/origin/${head_ref}" 2>/dev/null || echo "")"
+            if [[ "${_rtr_head_sha}" =~ ^[0-9a-f]{40}$ ]] && [[ "${_rtr_origin_head_sha}" =~ ^[0-9a-f]{40}$ ]] && \
+               [ "${_rtr_origin_head_sha}" != "${_rtr_head_sha}" ]; then
+              echo "  Issue #${issue_num} PR #${pr_num} head advanced from ${_rtr_head_sha} to ${_rtr_origin_head_sha} after the PR-state snapshot; skipping empty-commit push to avoid racing newer review work."
+              return 1
             fi
-            git checkout --detach HEAD 2>/dev/null || true
+            if git checkout "origin/${head_ref}" 2>/dev/null; then
+              git config user.name "codex-bot"
+              git config user.email "codex@users.noreply.github.com"
+              git commit --allow-empty -m "[orchestrator] stall recovery: re-trigger review for issue #${issue_num}" 2>/dev/null || true
+              if git push origin "HEAD:${head_ref}" 2>/dev/null; then
+                tg_notify "Stall recovery: re-triggered review for PR #${pr_num} (issue #${issue_num}, stuck ${stall_minutes}m, attempt $((recovery_count + 1)))."$'\n'"PR: $(_gh_url "pull/${pr_num}")"$'\n'"Issue: $(_gh_url "issues/${issue_num}")" "WARNING"
+              fi
+              git checkout --detach HEAD 2>/dev/null || true
+            fi
           fi
         fi
       else

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -5742,37 +5742,41 @@ STALL_EOF
           # not block recovery indefinitely.  Malformed or
           # blank timestamps on a same-branch review run are treated as
           # fresh so we conservatively avoid invalidating a potentially
-          # live autofix pass.  Other jq/cache errors still fail open:
+          # live autofix pass.  Other jq/cache errors still fail open,
+          # and if date +%s is unavailable we skip the guard entirely:
           # empty result falls through to the legacy empty-commit path.
           local _rtr_inflight_blob _rtr_inflight_id _rtr_now_epoch _rtr_stall_secs
           _rtr_inflight_blob="$(_load_actions_runs_cached 2>/dev/null || echo '{"workflow_runs":[]}')"
           _rtr_now_epoch="$(date +%s 2>/dev/null || echo "")"
-          [[ "${_rtr_now_epoch}" =~ ^[0-9]+$ ]] || _rtr_now_epoch=0
           _rtr_stall_secs=$(( STALL_THRESHOLD_MINUTES * 60 ))
-          _rtr_inflight_id="$(printf '%s' "${_rtr_inflight_blob}" | jq -r \
-            --arg br "${head_ref}" \
-            --argjson now "${_rtr_now_epoch}" \
-            --argjson threshold "${_rtr_stall_secs}" '
-            [.workflow_runs[]?
-             | select((.status // "") == "in_progress" or (.status // "") == "queued")
-             | select((.head_branch // "") == $br)
-             | select(
-                 (.name // "") == "AI Review"
-                 or (.name // "") == "Internal Review"
-                 or (.name // "") == "Review Autofix"
-                 or ((.path // "") | endswith("ai-review.yml"))
-                 or ((.path // "") | endswith("internal-review.yml"))
-                 or ((.path // "") | endswith("review_autofix.yml"))
-               )
-             | ([.run_started_at, .created_at]
-                | map(select(type == "string" and . != ""))[0] // "") as $ts
-             | (if $ts != ""
-                then (try ($ts | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) catch $now)
-                else $now
-                end) as $start_epoch
-             | select(($now - $start_epoch) < $threshold)
-            ] | (.[0].id // empty)
-          ' 2>/dev/null || echo "")"
+          if [[ "${_rtr_now_epoch}" =~ ^[0-9]+$ ]]; then
+            _rtr_inflight_id="$(printf '%s' "${_rtr_inflight_blob}" | jq -r \
+              --arg br "${head_ref}" \
+              --argjson now "${_rtr_now_epoch}" \
+              --argjson threshold "${_rtr_stall_secs}" '
+              [.workflow_runs[]?
+               | select((.status // "") == "in_progress" or (.status // "") == "queued")
+               | select((.head_branch // "") == $br)
+               | select(
+                   (.name // "") == "AI Review"
+                   or (.name // "") == "Internal Review"
+                   or (.name // "") == "Review Autofix"
+                   or ((.path // "") | endswith("ai-review.yml"))
+                   or ((.path // "") | endswith("internal-review.yml"))
+                   or ((.path // "") | endswith("review_autofix.yml"))
+                 )
+               | ([.run_started_at, .created_at]
+                  | map(select(type == "string" and . != ""))[0] // "") as $ts
+               | (if $ts != ""
+                  then (try ($ts | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) catch $now)
+                  else $now
+                  end) as $start_epoch
+               | select(($now - $start_epoch) < $threshold)
+              ] | (.[0].id // empty)
+            ' 2>/dev/null || echo "")"
+          else
+            _rtr_inflight_id=""
+          fi
           if [ -n "${_rtr_inflight_id}" ]; then
             echo "  Issue #${issue_num} PR #${pr_num} has in-flight review run #${_rtr_inflight_id} on ${head_ref} (fresh, <${STALL_THRESHOLD_MINUTES}m); skipping empty-commit push to avoid invalidating its stale-base gate."
             STALL_RECOVERY_EFFECTIVE_ACTION="retrigger_review_skipped_inflight"

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -5747,10 +5747,11 @@ STALL_EOF
           # autofix pass.  Other jq/cache errors still fail open, and
           # if date +%s is unavailable we skip the guard entirely:
           # empty result falls through to the legacy empty-commit path.
-          local _rtr_inflight_blob _rtr_inflight_id _rtr_now_epoch _rtr_stall_secs _rtr_origin_head_sha
+          local _rtr_inflight_blob _rtr_inflight_id _rtr_now_epoch _rtr_stall_secs _rtr_origin_head_sha _rtr_push_succeeded
           _rtr_inflight_blob="$(_load_actions_runs_cached 2>/dev/null || echo '{"workflow_runs":[]}')"
           _rtr_now_epoch="$(date +%s 2>/dev/null || echo "")"
           _rtr_stall_secs=$(( STALL_THRESHOLD_MINUTES * 60 ))
+          _rtr_push_succeeded="false"
           if [[ "${_rtr_now_epoch}" =~ ^[0-9]+$ ]]; then
             _rtr_inflight_id="$(printf '%s' "${_rtr_inflight_blob}" | jq -r \
               --arg br "${head_ref}" \
@@ -5801,9 +5802,14 @@ STALL_EOF
               git commit --allow-empty -m "[orchestrator] stall recovery: re-trigger review for issue #${issue_num}" 2>/dev/null || true
               if git push origin "HEAD:${head_ref}" 2>/dev/null; then
                 tg_notify "Stall recovery: re-triggered review for PR #${pr_num} (issue #${issue_num}, stuck ${stall_minutes}m, attempt $((recovery_count + 1)))."$'\n'"PR: $(_gh_url "pull/${pr_num}")"$'\n'"Issue: $(_gh_url "issues/${issue_num}")" "WARNING"
+                _rtr_push_succeeded="true"
               fi
               git checkout --detach HEAD 2>/dev/null || true
             fi
+          fi
+          if [ "${_rtr_push_succeeded}" != "true" ]; then
+            echo "  Issue #${issue_num} PR #${pr_num} empty-commit retrigger did not reach a successful push; skipping recovery increment."
+            return 1
           fi
         fi
       else

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -7543,7 +7543,10 @@ STALL_EOF
         local pr_num
         local pr_lookup_ok="false"
         local head_ref
+        local head_sha
         local pr_json
+        local _std_rtr_inflight_blob _std_rtr_inflight_id _std_rtr_now_epoch _std_rtr_stall_secs _std_rtr_origin_head_sha _std_rtr_push_succeeded
+        _std_rtr_push_succeeded="false"
         if [[ "${_STD_ITER_PR_NUM_CACHED:-}" =~ ^[0-9]+$ ]]; then
           pr_num="${_STD_ITER_PR_NUM_CACHED}"
           pr_lookup_ok="true"
@@ -7566,12 +7569,84 @@ STALL_EOF
             pr_json="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_num}" 2>/dev/null || echo "")"
           fi
           head_ref="$(printf '%s' "${pr_json}" | jq -r 'if (type == "object" and .head.ref?) then .head.ref else empty end' 2>/dev/null | tail -n1)"
-          if [ -n "${head_ref}" ] && git fetch origin "${head_ref}:refs/remotes/origin/${head_ref}" 2>/dev/null && git checkout "origin/${head_ref}" 2>/dev/null; then
-            git config user.name "codex-bot"
-            git config user.email "codex@users.noreply.github.com"
-            git commit --allow-empty -m "[standalone] stall recovery: re-trigger review for issue #${issue_num}" 2>/dev/null || true
-            git push origin "HEAD:${head_ref}" 2>/dev/null || true
-            git checkout --detach HEAD 2>/dev/null || true
+          head_sha="$(printf '%s' "${pr_json}" | jq -r 'if (type == "object" and .head.sha?) then .head.sha else empty end' 2>/dev/null | tail -n1)"
+          if [ -n "${head_ref}" ] && { [ -z "${head_sha}" ] || [ "${head_sha}" = "null" ]; }; then
+            # The standalone conflict guard seeds _STD_ITER_PR_JSON_CACHED
+            # with a minimal {number, head.ref} payload to avoid a
+            # redundant pulls/{n} fetch on the fast path.  The
+            # retrigger-review empty-commit guard also needs head.sha for
+            # workflow_dispatch matching and remote-head rechecks, so
+            # refresh to the full PR payload only when the cached shape
+            # omitted it.
+            pr_json="$(gh_retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_num}" 2>/dev/null || echo "${pr_json}")"
+            head_ref="$(printf '%s' "${pr_json}" | jq -r 'if (type == "object" and .head.ref?) then .head.ref else empty end' 2>/dev/null | tail -n1)"
+            head_sha="$(printf '%s' "${pr_json}" | jq -r 'if (type == "object" and .head.sha?) then .head.sha else empty end' 2>/dev/null | tail -n1)"
+          fi
+          if [ -n "${head_ref}" ] && [ "${head_ref}" != "null" ]; then
+            # Mirror execute_stall_recovery_action(retrigger_review):
+            # if issue_has_active_workflow misses a live review run on
+            # this PR, an empty-commit push here can still trip the
+            # stale-base gate and discard in-flight editor work.
+            _std_rtr_inflight_blob="$(_load_actions_runs_cached 2>/dev/null || echo '{"workflow_runs":[]}')"
+            _std_rtr_now_epoch="$(date +%s 2>/dev/null || echo "")"
+            _std_rtr_stall_secs=$(( STALL_THRESHOLD_MINUTES * 60 ))
+            if [[ "${_std_rtr_now_epoch}" =~ ^[0-9]+$ ]]; then
+              _std_rtr_inflight_id="$(printf '%s' "${_std_rtr_inflight_blob}" | jq -r \
+                --arg br "${head_ref}" \
+                --arg sha "${head_sha}" \
+                --argjson now "${_std_rtr_now_epoch}" \
+                --argjson threshold "${_std_rtr_stall_secs}" '
+                [.workflow_runs[]?
+                 | select((.status // "") == "in_progress" or (.status // "") == "queued")
+                 | select(
+                     ((.head_branch // "") == $br)
+                     or ((.head_branch // "") == "" and $sha != "" and (.head_sha // "") == $sha)
+                   )
+                 | select(
+                     (.name // "") == "AI Review"
+                     or (.name // "") == "Internal Review"
+                     or (.name // "") == "Review Autofix"
+                     or ((.path // "") | endswith("ai-review.yml"))
+                     or ((.path // "") | endswith("internal-review.yml"))
+                     or ((.path // "") | endswith("review_autofix.yml"))
+                   )
+                 | ([.run_started_at, .created_at]
+                    | map(select(type == "string" and . != ""))[0] // "") as $ts
+                 | (if $ts != ""
+                    then (try ($ts | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) catch $now)
+                    else $now
+                    end) as $start_epoch
+                 | select(($now - $start_epoch) < $threshold)
+                ] | (.[0].id // empty)
+              ' 2>/dev/null || echo "")"
+            else
+              _std_rtr_inflight_id=""
+            fi
+            if [ -n "${_std_rtr_inflight_id}" ]; then
+              echo "  [standalone-stall] Issue #${issue_num} PR #${pr_num} has in-flight review run #${_std_rtr_inflight_id} on ${head_ref} (fresh, <${STALL_THRESHOLD_MINUTES}m); skipping empty-commit push to avoid invalidating its stale-base gate."
+              STALL_RECOVERY_EFFECTIVE_ACTION="retrigger_review_skipped_inflight"
+            elif git fetch origin "${head_ref}:refs/remotes/origin/${head_ref}" 2>/dev/null; then
+              _std_rtr_origin_head_sha="$(git rev-parse --verify "refs/remotes/origin/${head_ref}" 2>/dev/null || echo "")"
+              if [[ "${head_sha}" =~ ^[0-9a-f]{40}$ ]] && [[ "${_std_rtr_origin_head_sha}" =~ ^[0-9a-f]{40}$ ]] && \
+                 [ "${_std_rtr_origin_head_sha}" != "${head_sha}" ]; then
+                echo "  [standalone-stall] Issue #${issue_num} PR #${pr_num} head advanced from ${head_sha} to ${_std_rtr_origin_head_sha} after the PR-state snapshot; skipping empty-commit push to avoid racing newer review work."
+              elif git checkout "origin/${head_ref}" 2>/dev/null; then
+                git config user.name "codex-bot"
+                git config user.email "codex@users.noreply.github.com"
+                git commit --allow-empty -m "[standalone] stall recovery: re-trigger review for issue #${issue_num}" 2>/dev/null || true
+                if git push origin "HEAD:${head_ref}" 2>/dev/null; then
+                  _std_rtr_push_succeeded="true"
+                fi
+                git checkout --detach HEAD 2>/dev/null || true
+              fi
+            fi
+          fi
+          if [ "${_std_rtr_push_succeeded}" = "true" ]; then
+            tg_notify_issue "${issue_num}" "Standalone stall recovery: re-triggered review flow (stuck ${elapsed_minutes}m, attempt $((recovery_count + 1)))." "WARNING"
+            STALL_RECOVERY_SHOULD_INCREMENT="true"
+            took_action="true"
+          elif [ "${STALL_RECOVERY_EFFECTIVE_ACTION}" != "retrigger_review_skipped_inflight" ]; then
+            echo "  [standalone-stall] Issue #${issue_num} PR #${pr_num} empty-commit retrigger did not reach a successful push; skipping recovery increment."
           fi
         elif [ "${pr_lookup_ok}" = "true" ]; then
           gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${issue_num}/comments" -f body="$(cat <<'STALL_EOF'
@@ -7580,10 +7655,10 @@ STALL_EOF
 _Standalone stall recovery: issue marked done but no linked PR found. Re-triggering implementation._
 STALL_EOF
 )" >/dev/null 2>&1 || true
+          tg_notify_issue "${issue_num}" "Standalone stall recovery: re-triggered review flow (stuck ${elapsed_minutes}m, attempt $((recovery_count + 1)))." "WARNING"
+          STALL_RECOVERY_SHOULD_INCREMENT="true"
+          took_action="true"
         fi
-        tg_notify_issue "${issue_num}" "Standalone stall recovery: re-triggered review flow (stuck ${elapsed_minutes}m, attempt $((recovery_count + 1)))." "WARNING"
-        STALL_RECOVERY_SHOULD_INCREMENT="true"
-        took_action="true"
         ;;
       attempt_merge)
         local merge_pr

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -5723,9 +5723,10 @@ STALL_EOF
           # editor's work is discarded and a brand-new review cycle
           # starts from the empty commit.
           #
-          # The active-workflow guard at line 7887 (build_active_issue_set
-          # consumed via issue_has_active_workflow) is the primary
-          # protection, but a single missed run in that 50-item blob
+          # The active-workflow guard in recover_stalled_issue (via
+          # issue_has_active_workflow consuming build_active_issue_set)
+          # is the primary protection, but a single missed run in that
+          # 50-item blob
           # (cache TTL, pagination edge, head_branch=null on
           # workflow_dispatch) defeats every downstream stall check.
           # This is a targeted defense-in-depth at the only push site
@@ -5733,19 +5734,20 @@ STALL_EOF
           #
           # Reads from the per-tick _ACTIONS_RUNS_BLOB_CACHE populated
           # by _load_actions_runs_cached so this adds zero API calls
-          # (§15).  Workflow filter mirrors cancel_zombie_runs_for_issue
-          # at line 5031-5038 — both .name and .path so consumer-repo
-          # caller workflows that rename the display name are still
-          # caught.  Zombie filter (STALL_THRESHOLD_MINUTES) mirrors
-          # build_active_issue_set at line 4944-4954 so a genuinely
-          # hung run does not block recovery indefinitely.  Malformed or
+          # (§15).  Workflow filter mirrors
+          # cancel_zombie_runs_for_issue — both .name and .path so
+          # consumer-repo caller workflows that rename the display name
+          # are still caught.  Zombie filter (STALL_THRESHOLD_MINUTES)
+          # mirrors build_active_issue_set so a genuinely hung run does
+          # not block recovery indefinitely.  Malformed or
           # blank timestamps on a same-branch review run are treated as
           # fresh so we conservatively avoid invalidating a potentially
           # live autofix pass.  Other jq/cache errors still fail open:
           # empty result falls through to the legacy empty-commit path.
           local _rtr_inflight_blob _rtr_inflight_id _rtr_now_epoch _rtr_stall_secs
           _rtr_inflight_blob="$(_load_actions_runs_cached 2>/dev/null || echo '{"workflow_runs":[]}')"
-          _rtr_now_epoch="$(date +%s)"
+          _rtr_now_epoch="$(date +%s 2>/dev/null || echo "")"
+          [[ "${_rtr_now_epoch}" =~ ^[0-9]+$ ]] || _rtr_now_epoch=0
           _rtr_stall_secs=$(( STALL_THRESHOLD_MINUTES * 60 ))
           _rtr_inflight_id="$(printf '%s' "${_rtr_inflight_blob}" | jq -r \
             --arg br "${head_ref}" \

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -5737,13 +5737,15 @@ STALL_EOF
           # (§15).  Workflow filter mirrors
           # cancel_zombie_runs_for_issue — both .name and .path so
           # consumer-repo caller workflows that rename the display name
-          # are still caught.  Zombie filter (STALL_THRESHOLD_MINUTES)
-          # mirrors build_active_issue_set so a genuinely hung run does
-          # not block recovery indefinitely.  Malformed or
-          # blank timestamps on a same-branch review run are treated as
-          # fresh so we conservatively avoid invalidating a potentially
-          # live autofix pass.  Other jq/cache errors still fail open,
-          # and if date +%s is unavailable we skip the guard entirely:
+          # are still caught.  Run matching prefers head_branch, with a
+          # blank-head_branch head_sha fallback for workflow_dispatch
+          # runs.  Zombie filter (STALL_THRESHOLD_MINUTES) mirrors
+          # build_active_issue_set so a genuinely hung run does not
+          # block recovery indefinitely.  Malformed or blank timestamps
+          # on a matching review run are treated as fresh so we
+          # conservatively avoid invalidating a potentially live
+          # autofix pass.  Other jq/cache errors still fail open, and
+          # if date +%s is unavailable we skip the guard entirely:
           # empty result falls through to the legacy empty-commit path.
           local _rtr_inflight_blob _rtr_inflight_id _rtr_now_epoch _rtr_stall_secs _rtr_origin_head_sha
           _rtr_inflight_blob="$(_load_actions_runs_cached 2>/dev/null || echo '{"workflow_runs":[]}')"
@@ -5752,11 +5754,15 @@ STALL_EOF
           if [[ "${_rtr_now_epoch}" =~ ^[0-9]+$ ]]; then
             _rtr_inflight_id="$(printf '%s' "${_rtr_inflight_blob}" | jq -r \
               --arg br "${head_ref}" \
+              --arg sha "${_rtr_head_sha}" \
               --argjson now "${_rtr_now_epoch}" \
               --argjson threshold "${_rtr_stall_secs}" '
               [.workflow_runs[]?
                | select((.status // "") == "in_progress" or (.status // "") == "queued")
-               | select((.head_branch // "") == $br)
+               | select(
+                   ((.head_branch // "") == $br)
+                   or ((.head_branch // "") == "" and $sha != "" and (.head_sha // "") == $sha)
+                 )
                | select(
                    (.name // "") == "AI Review"
                    or (.name // "") == "Internal Review"

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -5709,6 +5709,67 @@ STALL_EOF
           fi
         fi
         if [ -n "${head_ref}" ] && [ "${head_ref}" != "null" ]; then
+          # In-flight review guard.  An empty-commit push here flips the
+          # mid-run stale-base gate on any review_autofix run that is
+          # currently editing this branch: the orchestrator's commit
+          # subject does not match the [ai-autofix] / [ai-merge-resolve]
+          # prefixes in check_external_branch_advance.sh (line 151-160),
+          # so the gate prints ADVANCE=external, the pre-review
+          # (review_autofix.yml:2972-3009) and pre-editor
+          # (review_autofix.yml:3268-3309) steps set
+          # AUTOFIX_STALE_BASE_SKIP=true, and the editor commit / push /
+          # mark-ready-to-merge / re-trigger tail steps that are gated on
+          # AUTOFIX_STALE_BASE_SKIP != 'true' are all skipped — the
+          # editor's work is discarded and a brand-new review cycle
+          # starts from the empty commit.
+          #
+          # The active-workflow guard at line 7887 (build_active_issue_set
+          # consumed via issue_has_active_workflow) is the primary
+          # protection, but a single missed run in that 50-item blob
+          # (cache TTL, pagination edge, head_branch=null on
+          # workflow_dispatch) defeats every downstream stall check.
+          # This is a targeted defense-in-depth at the only push site
+          # that materially harms in-flight review_autofix runs.
+          #
+          # Reads from the per-tick _ACTIONS_RUNS_BLOB_CACHE populated
+          # by _load_actions_runs_cached so this adds zero API calls
+          # (§15).  Workflow filter mirrors cancel_zombie_runs_for_issue
+          # at line 5031-5038 — both .name and .path so consumer-repo
+          # caller workflows that rename the display name are still
+          # caught.  Zombie filter (STALL_THRESHOLD_MINUTES) mirrors
+          # build_active_issue_set at line 4944-4954 so a genuinely
+          # hung run does not block recovery indefinitely.  Fail-open
+          # on any jq/cache error: empty result falls through to the
+          # legacy empty-commit path.
+          local _rtr_inflight_blob _rtr_inflight_id _rtr_now_epoch _rtr_stall_secs
+          _rtr_inflight_blob="$(_load_actions_runs_cached 2>/dev/null || echo '{"workflow_runs":[]}')"
+          _rtr_now_epoch="$(date +%s)"
+          _rtr_stall_secs=$(( STALL_THRESHOLD_MINUTES * 60 ))
+          _rtr_inflight_id="$(printf '%s' "${_rtr_inflight_blob}" | jq -r \
+            --arg br "${head_ref}" \
+            --argjson now "${_rtr_now_epoch}" \
+            --argjson threshold "${_rtr_stall_secs}" '
+            [.workflow_runs[]?
+             | select((.status // "") == "in_progress" or (.status // "") == "queued")
+             | select((.head_branch // "") == $br)
+             | select(
+                 (.name // "") == "AI Review"
+                 or (.name // "") == "Internal Review"
+                 or (.name // "") == "Review Autofix"
+                 or ((.path // "") | endswith("ai-review.yml"))
+                 or ((.path // "") | endswith("internal-review.yml"))
+                 or ((.path // "") | endswith("review_autofix.yml"))
+               )
+             | (.run_started_at // .created_at // "1970-01-01T00:00:00Z") as $ts
+             | ($ts | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) as $start_epoch
+             | select(($now - $start_epoch) < $threshold)
+            ] | (.[0].id // empty)
+          ' 2>/dev/null || echo "")"
+          if [ -n "${_rtr_inflight_id}" ]; then
+            echo "  Issue #${issue_num} PR #${pr_num} has in-flight review run #${_rtr_inflight_id} on ${head_ref} (fresh, <${STALL_THRESHOLD_MINUTES}m); skipping empty-commit push to avoid invalidating its stale-base gate."
+            STALL_RECOVERY_EFFECTIVE_ACTION="retrigger_review_skipped_inflight"
+            return 1
+          fi
           if git fetch origin "${head_ref}:refs/remotes/origin/${head_ref}" 2>/dev/null && \
              git checkout "origin/${head_ref}" 2>/dev/null; then
             git config user.name "codex-bot"

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -1570,10 +1570,10 @@ if args[0] == 'api':
 				'workflow_runs': workflow_runs,
 			}
 			p = subprocess.run(['jq', '-r', jq], input=json.dumps(body_obj), capture_output=True, text=True)
-			save()
 			if p.returncode != 0:
 				sys.stderr.write(p.stderr)
 				sys.exit(p.returncode)
+			save()
 			sys.stdout.write(p.stdout)
 			sys.exit(0)
 		status_text = 'OK' if status == 200 else 'Not Modified'
@@ -5705,8 +5705,8 @@ def test_retrigger_review_skips_empty_commit_when_review_run_inflight():
 	issue["status_since_ts"] = 1
 	issue["stall_recovery_count"] = 0
 	head_ref = "claude/retrigger-review-inflight-run"
-	# run_started_at is "now" (the poller's clock), so the run is well
-	# under the STALL_THRESHOLD_MINUTES zombie cutoff.
+	# run_started_at uses a far-future sentinel so the run is guaranteed
+	# to stay under the STALL_THRESHOLD_MINUTES zombie cutoff.
 	result = _run_poller(
 		state=state,
 		enable_validation="false",

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -1561,8 +1561,11 @@ if args[0] == 'api':
 		#      body so its `--argjson` merge stays valid.
 		# Distinguish via the presence of `jq` (the second case sets it).
 		if jq:
+			# Persist request bookkeeping even when the caller's jq filter
+			# fails: the HTTP round-trip already happened, so later calls in
+			# the same mock session should observe the consumed status/counts.
+			save()
 			if status != 200:
-				save()
 				print(f'actions runs mock failed: HTTP {status}', file=sys.stderr)
 				sys.exit(1)
 			body_obj = {
@@ -1573,7 +1576,6 @@ if args[0] == 'api':
 			if p.returncode != 0:
 				sys.stderr.write(p.stderr)
 				sys.exit(p.returncode)
-			save()
 			sys.stdout.write(p.stdout)
 			sys.exit(0)
 		status_text = 'OK' if status == 200 else 'Not Modified'

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -5857,6 +5857,15 @@ def test_retrigger_review_ignores_inflight_run_on_unrelated_branch():
 				"head_branch": "claude/some-other-branch",
 				"run_started_at": "2999-01-01T00:00:00Z",
 			},
+			{
+				"id": 99999998,
+				"name": "Review Autofix",
+				"path": ".github/workflows/review_autofix.yml",
+				"status": "queued",
+				"head_branch": "",
+				"head_sha": "b" * 40,
+				"created_at": "2999-01-01T00:00:00Z",
+			},
 		],
 		mock_git_push_success=True,
 	)

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -3166,6 +3166,62 @@ def test_standalone_conflict_sweep_consumes_budget_after_override_cap():
 	assert len([d for d in result["review_dispatches"] if str(d.get("pr_number")) == "416"]) == 1
 
 
+def test_standalone_retrigger_review_skips_empty_commit_when_review_run_has_blank_head_branch_but_matching_sha():
+	state = _base_state(status="complete")
+	standalone_state_comment = (
+		"<!-- AI_STANDALONE_STALL_STATE_V1\n"
+		+ json.dumps({
+			"schema_version": 1,
+			"last_seen_phase": "ai:done",
+			"status_since_ts": 1,
+			"stall_recovery_count": 0,
+		})
+		+ "\nAI_STANDALONE_STALL_STATE_V1 -->"
+	)
+	head_ref = "claude/issue-501"
+	head_sha = "a" * 40
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		issue_labels={10: ["ai:merged"], 501: ["ai:done"]},
+		issue_comments={501: [standalone_state_comment]},
+		issue_linked_prs={501: 416},
+		mock_gh_issue_list_label_filter=True,
+		prs=[
+			{
+				"number": 416,
+				"state": "open",
+				"baseRefName": "main",
+				"headRefName": head_ref,
+				"headRefFromApi": head_ref,
+				"headSha": head_sha,
+				"mergeable": True,
+				"mergeable_state": "clean",
+			},
+		],
+		actions_runs_workflow_runs=[
+			{
+				"id": 26088864017,
+				"name": "Review Autofix",
+				"path": ".github/workflows/review_autofix.yml",
+				"status": "queued",
+				"head_branch": "",
+				"head_sha": head_sha,
+				"created_at": "2999-01-01T00:00:00Z",
+			},
+		],
+		mock_git_push_success=True,
+	)
+	standalone_state = _extract_latest_standalone_state(result["issues"]["501"]["comments"])
+	assert standalone_state is not None
+	assert standalone_state["stall_recovery_count"] == 0
+	assert result.get("git_push_calls", []) == [], (
+		f"expected no standalone empty-commit push when a blank-head_branch run matches "
+		f"the PR head_sha; got push calls {result.get('git_push_calls', [])}"
+	)
+
+
 def test_standalone_stall_recovery_skips_when_phase_attempts_exhausted():
 	state = _base_state(status="complete")
 	standalone_state_comment = (
@@ -3221,6 +3277,51 @@ def test_standalone_stall_recovery_honors_ai_done_phase_attempt_override():
 	assert standalone_state["stall_recovery_count"] == 1
 	assert standalone_state["phase_attempts"]["ai:done"] == 6
 	assert "ai:closed" not in result["issues"]["501"]["labels"]
+
+
+def test_standalone_retrigger_review_does_not_increment_when_empty_commit_checkout_fails():
+	state = _base_state(status="complete")
+	standalone_state_comment = (
+		"<!-- AI_STANDALONE_STALL_STATE_V1\n"
+		+ json.dumps({
+			"schema_version": 1,
+			"last_seen_phase": "ai:done",
+			"status_since_ts": 1,
+			"stall_recovery_count": 0,
+		})
+		+ "\nAI_STANDALONE_STALL_STATE_V1 -->"
+	)
+	head_ref = "claude/issue-502"
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		issue_labels={10: ["ai:merged"], 502: ["ai:done"]},
+		issue_comments={502: [standalone_state_comment]},
+		issue_linked_prs={502: 417},
+		mock_gh_issue_list_label_filter=True,
+		prs=[
+			{
+				"number": 417,
+				"state": "open",
+				"baseRefName": "main",
+				"headRefName": head_ref,
+				"headRefFromApi": head_ref,
+				"headSha": "sha417",
+				"mergeable": True,
+				"mergeable_state": "clean",
+			},
+		],
+		mock_git_push_success=True,
+		mock_git_checkout_fail=True,
+	)
+	standalone_state = _extract_latest_standalone_state(result["issues"]["502"]["comments"])
+	assert standalone_state is not None
+	assert standalone_state["stall_recovery_count"] == 0
+	assert result.get("git_push_calls", []) == [], (
+		f"expected checkout failure to skip the standalone empty-commit push; "
+		f"got push calls {result.get('git_push_calls', [])}"
+	)
 
 
 

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -670,6 +670,7 @@ def _run_poller(
 		gh_mock = r'''#!/usr/bin/env python3
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -1560,13 +1561,19 @@ if args[0] == 'api':
 		#      body so its `--argjson` merge stays valid.
 		# Distinguish via the presence of `jq` (the second case sets it).
 		if jq:
+			if status != 200:
+				save()
+				print(f'actions runs mock failed: HTTP {status}', file=sys.stderr)
+				sys.exit(1)
 			body_obj = {
 				'total_count': len(workflow_runs),
 				'workflow_runs': workflow_runs,
 			}
-			import subprocess as _sp
-			p = _sp.run(['jq', '-r', jq], input=json.dumps(body_obj), capture_output=True, text=True)
+			p = subprocess.run(['jq', '-r', jq], input=json.dumps(body_obj), capture_output=True, text=True)
 			save()
+			if p.returncode != 0:
+				sys.stderr.write(p.stderr)
+				sys.exit(p.returncode)
 			sys.stdout.write(p.stdout)
 			sys.exit(0)
 		status_text = 'OK' if status == 200 else 'Not Modified'

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -1647,19 +1647,31 @@ if len(args) >= 2 and args[0] == 'merge-tree' and args[1] == '--write-tree' and 
 	sys.exit(0)
 
 if len(args) >= 2 and args[0] == 'push' and os.environ.get('MOCK_GIT_PUSH_SUCCESS', '') == 'true':
+	store.setdefault('git_push_calls', []).append(args[1:])
+	store_path.write_text(json.dumps(store), encoding='utf-8')
 	sys.exit(0)
 
-if len(args) == 4 and args[0] == 'fetch' and args[1] == '--no-tags' and args[2] == 'origin':
-	refspec = args[3]
-	if ':' in refspec:
+if args and args[0] == 'fetch':
+	refspec = None
+	if len(args) == 4 and args[1] == '--no-tags' and args[2] == 'origin':
+		refspec = args[3]
+	elif len(args) == 3 and args[1] == 'origin':
+		refspec = args[2]
+	if refspec and ':' in refspec:
 		src_ref, dst_ref = refspec.split(':', 1)
 		src_prefix = 'refs/heads/'
 		dst_prefix = 'refs/remotes/origin/'
-		if src_ref.startswith(src_prefix) and dst_ref.startswith(dst_prefix):
-			src_branch = src_ref[len(src_prefix):]
+		src_branch = src_ref[len(src_prefix):] if src_ref.startswith(src_prefix) else src_ref
+		if dst_ref.startswith(dst_prefix):
 			dst_branch = dst_ref[len(dst_prefix):]
+			known_branches = set(store.get('existing_branches', []))
+			known_branches.update(
+				str(pr.get('headRefFromApi', pr.get('headRefName', '')))
+				for pr in store.get('prs', [])
+				if pr.get('headRefFromApi', pr.get('headRefName', ''))
+			)
 			if src_branch == dst_branch:
-				if src_branch in set(store.get('existing_branches', [])):
+				if src_branch in known_branches:
 					head_rev = subprocess.run([real_git, 'rev-parse', 'HEAD'], capture_output=True, text=True)
 					if head_rev.returncode != 0:
 						sys.exit(head_rev.returncode)
@@ -5847,6 +5859,48 @@ def test_retrigger_review_inflight_guard_treats_zombie_run_as_eligible():
 	assert issue_entry["stall_recovery_count"] == 1, (
 		f"expected empty-commit push to proceed past zombie in-flight run; "
 		f"got stall_recovery_count={issue_entry['stall_recovery_count']}"
+	)
+
+
+def test_retrigger_review_skips_empty_commit_when_pr_head_advanced_after_snapshot():
+	# Defense-in-depth for the narrower PR-fetch→git-fetch race: if the
+	# PR head SHA changed after `_fetch_pr_json` captured `.head.sha`, the
+	# empty-commit retrigger should bail out instead of racing newer work.
+	state = _base_state(status="in_progress")
+	issue = state["waves"][0]["issues"][0]
+	issue["status"] = "in_progress"
+	issue["last_seen_phase"] = "ai:done"
+	issue["status_since_ts"] = 1
+	issue["stall_recovery_count"] = 0
+	head_ref = "claude/retrigger-review-advanced-head"
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		issue_labels={10: ["ai:done"]},
+		issue_linked_prs={10: 83},
+		prs=[
+			{
+				"number": 83,
+				"state": "open",
+				"mergeable": True,
+				"mergeable_state": "clean",
+				"headRefName": head_ref,
+				"headRefFromApi": head_ref,
+				"headSha": "0" * 40,
+				"baseRefName": "main",
+			},
+		],
+		mock_git_push_success=True,
+	)
+	issue_entry = result["latest_state"]["waves"][0]["issues"][0]
+	assert issue_entry["stall_recovery_count"] == 0, (
+		f"expected stale PR head snapshot to leave stall_recovery_count at 0; "
+		f"got {issue_entry['stall_recovery_count']}"
+	)
+	assert result.get("git_push_calls", []) == [], (
+		f"expected no empty-commit push when the PR head advanced; "
+		f"got push calls {result.get('git_push_calls', [])}"
 	)
 
 

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -5762,6 +5762,62 @@ def test_retrigger_review_skips_empty_commit_when_review_run_inflight():
 	)
 
 
+def test_retrigger_review_skips_empty_commit_when_review_run_has_blank_head_branch_but_matching_sha():
+	# workflow_dispatch review runs can report a blank/null head_branch in
+	# /actions/runs even though they still target the PR head SHA. Those
+	# runs must still block the empty-commit push; otherwise the new guard
+	# misses the same head_branch=null case called out in the PR summary.
+	state = _base_state(status="in_progress")
+	issue = state["waves"][0]["issues"][0]
+	issue["status"] = "in_progress"
+	issue["last_seen_phase"] = "ai:done"
+	issue["status_since_ts"] = 1
+	issue["stall_recovery_count"] = 0
+	head_ref = "claude/retrigger-review-blank-branch"
+	head_sha = "a" * 40
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		issue_labels={10: ["ai:done"]},
+		issue_linked_prs={10: 84},
+		prs=[
+			{
+				"number": 84,
+				"state": "open",
+				"mergeable": True,
+				"mergeable_state": "clean",
+				"headRefName": head_ref,
+				"headRefFromApi": head_ref,
+				"headSha": head_sha,
+				"baseRefName": "main",
+			},
+		],
+		actions_runs_workflow_runs=[
+			{
+				"id": 26088864016,
+				"name": "Review Autofix",
+				"path": ".github/workflows/review_autofix.yml",
+				"status": "in_progress",
+				"head_branch": "",
+				"head_sha": head_sha,
+				"run_started_at": "2999-01-01T00:00:00Z",
+			},
+		],
+		mock_git_push_success=True,
+	)
+	issue_entry = result["latest_state"]["waves"][0]["issues"][0]
+	assert issue_entry["stall_recovery_count"] == 0, (
+		f"expected blank-head_branch review run with matching head_sha to "
+		f"block the empty-commit push; got stall_recovery_count="
+		f"{issue_entry['stall_recovery_count']}"
+	)
+	assert result.get("git_push_calls", []) == [], (
+		f"expected no empty-commit push when a blank-head_branch run matches "
+		f"the PR head_sha; got push calls {result.get('git_push_calls', [])}"
+	)
+
+
 def test_retrigger_review_ignores_inflight_run_on_unrelated_branch():
 	# Defense-in-depth: an in-flight review run on a DIFFERENT branch
 	# must NOT block the empty-commit push for this PR.  Without the

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -528,6 +528,7 @@ def _run_poller(
 	codex_touch_file: str | None = None,
 	mock_orch_state_v2_pack_mode: str | None = None,
 	mock_git_push_success: bool = False,
+	mock_git_checkout_fail: bool = False,
 	enable_stall_judge: str = "true",
 	stall_judge_trigger_count: str = "2",
 	enable_stall_human_terminalization: str = "false",
@@ -1653,6 +1654,9 @@ if len(args) >= 2 and args[0] == 'push' and os.environ.get('MOCK_GIT_PUSH_SUCCES
 	store_path.write_text(json.dumps(store), encoding='utf-8')
 	sys.exit(0)
 
+if args and args[0] == 'checkout' and os.environ.get('MOCK_GIT_CHECKOUT_FAIL', '') == 'true':
+	sys.exit(1)
+
 if args and args[0] == 'fetch':
 	refspec = None
 	if len(args) == 4 and args[1] == '--no-tags' and args[2] == 'origin':
@@ -1888,6 +1892,7 @@ sys.exit(proc.returncode)
 				"REAL_PYTHON_BIN": real_python,
 				"MOCK_CODEX_JSON": json.dumps(codex_json),
 				"MOCK_GIT_PUSH_SUCCESS": "true" if mock_git_push_success else "false",
+				"MOCK_GIT_CHECKOUT_FAIL": "true" if mock_git_checkout_fail else "false",
 				"PATH": f"{bin_dir}:{env.get('PATH', '')}",
 			}
 		)
@@ -5967,6 +5972,46 @@ def test_retrigger_review_skips_empty_commit_when_pr_head_advanced_after_snapsho
 	)
 	assert result.get("git_push_calls", []) == [], (
 		f"expected no empty-commit push when the PR head advanced; "
+		f"got push calls {result.get('git_push_calls', [])}"
+	)
+
+
+def test_retrigger_review_does_not_increment_when_empty_commit_checkout_fails():
+	state = _base_state(status="in_progress")
+	issue = state["waves"][0]["issues"][0]
+	issue["status"] = "in_progress"
+	issue["last_seen_phase"] = "ai:done"
+	issue["status_since_ts"] = 1
+	issue["stall_recovery_count"] = 0
+	head_ref = "claude/retrigger-review-checkout-fails"
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		issue_labels={10: ["ai:done"]},
+		issue_linked_prs={10: 85},
+		prs=[
+			{
+				"number": 85,
+				"state": "open",
+				"mergeable": True,
+				"mergeable_state": "clean",
+				"headRefName": head_ref,
+				"headRefFromApi": head_ref,
+				"headSha": "sha85",
+				"baseRefName": "main",
+			},
+		],
+		mock_git_push_success=True,
+		mock_git_checkout_fail=True,
+	)
+	issue_entry = result["latest_state"]["waves"][0]["issues"][0]
+	assert issue_entry["stall_recovery_count"] == 0, (
+		f"expected checkout failure to leave stall_recovery_count at 0; "
+		f"got {issue_entry['stall_recovery_count']}"
+	)
+	assert result.get("git_push_calls", []) == [], (
+		f"expected checkout failure to skip the empty-commit push; "
 		f"got push calls {result.get('git_push_calls', [])}"
 	)
 

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -1551,6 +1551,24 @@ if args[0] == 'api':
 
 		etag = store.get('actions_runs_etag', '"etag-initial"')
 		workflow_runs = list(store.get('actions_runs_workflow_runs', []))
+		# The script calls this endpoint in two distinct shapes:
+		#   1. gh api -i ... (no --jq)  -> caller (_load_actions_runs_cached's
+		#      primary in_progress fetch) needs the full HTTP response with
+		#      headers so it can parse ETag and detect 304.
+		#   2. gh api ... --jq '.workflow_runs' (no -i)  -> caller
+		#      (_safe_gh_jq for queued/completed) needs just the jq-filtered
+		#      body so its `--argjson` merge stays valid.
+		# Distinguish via the presence of `jq` (the second case sets it).
+		if jq:
+			body_obj = {
+				'total_count': len(workflow_runs),
+				'workflow_runs': workflow_runs,
+			}
+			import subprocess as _sp
+			p = _sp.run(['jq', '-r', jq], input=json.dumps(body_obj), capture_output=True, text=True)
+			save()
+			sys.stdout.write(p.stdout)
+			sys.exit(0)
 		status_text = 'OK' if status == 200 else 'Not Modified'
 		headers = [
 			f'HTTP/1.1 {status} {status_text}',
@@ -5661,6 +5679,168 @@ def test_retrigger_review_does_not_increment_when_redispatch_skipped():
 	)
 	issue_entry = result["latest_state"]["waves"][0]["issues"][0]
 	assert issue_entry["stall_recovery_count"] == 0
+
+
+def test_retrigger_review_skips_empty_commit_when_review_run_inflight():
+	# When a fresh review_autofix run is already in_progress on the PR's
+	# head branch, retrigger_review must NOT push an empty commit — that
+	# push would flip the in-flight run's stale-base gate
+	# (check_external_branch_advance.sh classifies the orchestrator's
+	# commit subject as ADVANCE=external because it doesn't match the
+	# [ai-autofix] / [ai-merge-resolve] prefixes), causing the editor
+	# commit and downstream push/mark-ready steps to be skipped, which
+	# is exactly the 6h cycle observed on shubhodeep1/tele-funtoken-msg-scoring#3057.
+	# Recovery counter must NOT be incremented (no work was done).
+	state = _base_state(status="in_progress")
+	issue = state["waves"][0]["issues"][0]
+	issue["status"] = "in_progress"
+	issue["last_seen_phase"] = "ai:done"
+	issue["status_since_ts"] = 1
+	issue["stall_recovery_count"] = 0
+	head_ref = "claude/retrigger-review-inflight-run"
+	# run_started_at is "now" (the poller's clock), so the run is well
+	# under the STALL_THRESHOLD_MINUTES zombie cutoff.
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		issue_labels={10: ["ai:done"]},
+		issue_linked_prs={10: 80},
+		prs=[
+			{
+				"number": 80,
+				"state": "open",
+				"mergeable": True,
+				"mergeable_state": "clean",
+				"headRefName": head_ref,
+				"headRefFromApi": head_ref,
+				"headSha": "sha80",
+				"baseRefName": "main",
+			},
+		],
+		actions_runs_workflow_runs=[
+			{
+				"id": 26088864015,
+				"name": "Review Autofix",
+				"path": ".github/workflows/review_autofix.yml",
+				"status": "in_progress",
+				"head_branch": head_ref,
+				"run_started_at": "2999-01-01T00:00:00Z",
+			},
+		],
+		mock_git_push_success=True,
+	)
+	issue_entry = result["latest_state"]["waves"][0]["issues"][0]
+	assert issue_entry["stall_recovery_count"] == 0, (
+		f"expected stall_recovery_count to stay at 0 when an in-flight "
+		f"review_autofix run blocks the empty-commit push; "
+		f"got {issue_entry['stall_recovery_count']}"
+	)
+	dispatches_for_pr = [d for d in result.get("review_dispatches", []) if str(d.get("pr_number")) == "80"]
+	assert dispatches_for_pr == [], (
+		f"expected no redispatch when in-flight run blocks recovery; "
+		f"got: {dispatches_for_pr}"
+	)
+
+
+def test_retrigger_review_ignores_inflight_run_on_unrelated_branch():
+	# Defense-in-depth: an in-flight review run on a DIFFERENT branch
+	# must NOT block the empty-commit push for this PR.  Without the
+	# head_branch filter, the guard would deadlock recovery whenever
+	# any other PR has a live review.
+	state = _base_state(status="in_progress")
+	issue = state["waves"][0]["issues"][0]
+	issue["status"] = "in_progress"
+	issue["last_seen_phase"] = "ai:done"
+	issue["status_since_ts"] = 1
+	issue["stall_recovery_count"] = 0
+	head_ref = "claude/retrigger-review-this-branch"
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		issue_labels={10: ["ai:done"]},
+		issue_linked_prs={10: 81},
+		prs=[
+			{
+				"number": 81,
+				"state": "open",
+				"mergeable": True,
+				"mergeable_state": "clean",
+				"headRefName": head_ref,
+				"headRefFromApi": head_ref,
+				"headSha": "sha81",
+				"baseRefName": "main",
+			},
+		],
+		actions_runs_workflow_runs=[
+			{
+				"id": 99999999,
+				"name": "Review Autofix",
+				"path": ".github/workflows/review_autofix.yml",
+				"status": "in_progress",
+				"head_branch": "claude/some-other-branch",
+				"run_started_at": "2999-01-01T00:00:00Z",
+			},
+		],
+		mock_git_push_success=True,
+	)
+	issue_entry = result["latest_state"]["waves"][0]["issues"][0]
+	assert issue_entry["stall_recovery_count"] == 1, (
+		f"expected empty-commit push to proceed when in-flight run is on a "
+		f"different branch; got stall_recovery_count="
+		f"{issue_entry['stall_recovery_count']}"
+	)
+
+
+def test_retrigger_review_inflight_guard_treats_zombie_run_as_eligible():
+	# A run older than STALL_THRESHOLD_MINUTES is a zombie and must NOT
+	# block recovery — otherwise a stuck Actions runner could deadlock
+	# the autofix loop forever.  Mirrors the zombie cutoff in
+	# build_active_issue_set (line 4944-4954).
+	state = _base_state(status="in_progress")
+	issue = state["waves"][0]["issues"][0]
+	issue["status"] = "in_progress"
+	issue["last_seen_phase"] = "ai:done"
+	issue["status_since_ts"] = 1
+	issue["stall_recovery_count"] = 0
+	head_ref = "claude/retrigger-review-zombie-run"
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		issue_labels={10: ["ai:done"]},
+		issue_linked_prs={10: 82},
+		prs=[
+			{
+				"number": 82,
+				"state": "open",
+				"mergeable": True,
+				"mergeable_state": "clean",
+				"headRefName": head_ref,
+				"headRefFromApi": head_ref,
+				"headSha": "sha82",
+				"baseRefName": "main",
+			},
+		],
+		actions_runs_workflow_runs=[
+			{
+				"id": 11111111,
+				"name": "Review Autofix",
+				"path": ".github/workflows/review_autofix.yml",
+				"status": "in_progress",
+				"head_branch": head_ref,
+				# Far in the past — past any reasonable STALL_THRESHOLD_MINUTES.
+				"run_started_at": "1970-01-02T00:00:00Z",
+			},
+		],
+		mock_git_push_success=True,
+	)
+	issue_entry = result["latest_state"]["waves"][0]["issues"][0]
+	assert issue_entry["stall_recovery_count"] == 1, (
+		f"expected empty-commit push to proceed past zombie in-flight run; "
+		f"got stall_recovery_count={issue_entry['stall_recovery_count']}"
+	)
 
 
 def test_stall_judge_unknown_action_falls_back_to_declarative_recovery():


### PR DESCRIPTION
## Summary

The `retrigger_review` stall recovery action pushes an empty commit (`[orchestrator] stall recovery: re-trigger review for issue #N`) on the PR's head branch. When a `review_autofix` run is concurrently editing the same branch, this push advances the remote tip past the in-flight run's `INITIAL_HEAD_SHA`. The mid-run stale-base gate (`scripts/check_external_branch_advance.sh:151-160` classifies the orchestrator's commit subject as `ADVANCE=external` because it lacks the `[ai-autofix]` / `[ai-merge-resolve]` prefix) then sets `AUTOFIX_STALE_BASE_SKIP=true` in the in-flight run, which gates off the editor commit push, mark-ready-to-merge, and re-trigger tail steps — the editor's work is discarded. The empty commit itself fires `pull_request.synchronize`, starting a fresh review cycle that repeats the race indefinitely (observed as a 6h+ autofix loop on a consumer-repo PR pinned at `@stable`).

The active-workflow guard at `scripts/orchestrate_poll_process.sh:7887` (`issue_has_active_workflow` consuming `build_active_issue_set`) is the primary protection, but a single missed run in that 50-item blob (cache TTL, pagination edge, `head_branch=null` on `workflow_dispatch`) defeats every downstream stall check. This PR adds a targeted defense-in-depth check right before the empty-commit push:

- Reads the per-tick `_ACTIONS_RUNS_BLOB_CACHE` populated by `_load_actions_runs_cached` — **zero additional API calls** (§15)
- Filters for fresh `in_progress`/`queued` runs on the same `head_ref` whose `.name` or `.path` matches `AI Review` / `Internal Review` / `Review Autofix` (mirrors the workflow filter at `:5031-5038` including the path-based fallback so consumer-repo caller workflows that rename the display name are still caught)
- Applies the same `STALL_THRESHOLD_MINUTES` zombie cutoff as `build_active_issue_set` (`:4944-4954`) so a genuinely hung Actions runner does not deadlock recovery
- Bails out with `return 1`, so the recovery counter is **not consumed** (no work was performed)
- Fails open on any `jq`/cache error — empty result falls through to the legacy empty-commit path, preserving today's behaviour

## Test fixture change

The mock for `/actions/runs` previously ignored `--jq`, which corrupted the supplemental queued/completed sub-fetches inside `_load_actions_runs_cached` (their `--argjson` merge fails on raw HTTP headers) and zeroed out the merged blob in tests. The mock now honours `--jq` for that endpoint so the cache machinery behaves the same way under test as in production. The `gh api -i` path that needs raw HTTP headers + body for ETag parsing is unchanged — distinguished by the absence of `--jq`.

## Test plan

- [x] `tests/test_orchestrate_poll_process.py::test_retrigger_review_skips_empty_commit_when_review_run_inflight` — fresh in-flight `review_autofix` run on the head branch blocks the empty-commit push and does NOT increment the recovery counter
- [x] `tests/test_orchestrate_poll_process.py::test_retrigger_review_ignores_inflight_run_on_unrelated_branch` — in-flight run on a different branch does NOT block recovery for this PR
- [x] `tests/test_orchestrate_poll_process.py::test_retrigger_review_inflight_guard_treats_zombie_run_as_eligible` — in-flight run older than `STALL_THRESHOLD_MINUTES` is treated as a zombie and does NOT block recovery
- [x] All 195 existing tests in `tests/test_orchestrate_poll_process.py` still pass
- [x] `bash -n scripts/orchestrate_poll_process.sh` — no syntax errors

## Notes for reviewers

- This PR targets `stable` because the race ships there and propagates to every consumer repo pinned at `@stable` on the next poll tick. Per `CLAUDE.md` §6 no identifier is renamed, and per §15 the guard reuses the shared per-tick blob rather than introducing a new API call.
- The `STALL_RECOVERY_EFFECTIVE_ACTION="retrigger_review_skipped_inflight"` value is new (visibility/observability only) — no consumer of that variable matches it as an enum, so adding a new value is safe.

---
_Generated by [Claude Code](https://claude.ai/code/session_011FJfdcsvgwmTDqB9pgYMgd)_