### PR TITLE
fix: prevent silent project-incomplete claims (#2734 postmortem)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,15 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_lint_pr_body_auto_close.py
 
+      - name: Plan-archival completeness lint unit tests
+        # P6 from docs/postmortems/2026-05-18-project-2734-stall.md.
+        # Pins the docs/completed/ archival check that requires either
+        # all tracking-issue checkboxes ticked or an explicit
+        # `## De-scoped phases` section in the PR body.
+        run: |
+          set -euo pipefail
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_lint_plan_archival_completeness.py
+
       - name: Merge probe unit tests
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,15 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_poll_process.py
 
+      - name: PR body auto-close lint unit tests
+        # P1 from docs/postmortems/2026-05-18-project-2734-stall.md.
+        # Pins the keyword list, regex, label-lookup contract, and exit
+        # codes of scripts/lint_pr_body_auto_close.py so the §19
+        # enforcement workflow cannot regress silently.
+        run: |
+          set -euo pipefail
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_lint_pr_body_auto_close.py
+
       - name: Merge probe unit tests
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,14 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_lint_plan_archival_completeness.py
 
+      - name: Integration PR readiness check unit tests
+        # P3 from docs/postmortems/2026-05-18-project-2734-stall.md.
+        # Pins the branch-name derivation + checkbox-counting logic
+        # for the integration PR readiness commit status.
+        run: |
+          set -euo pipefail
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_check_integration_pr_readiness.py
+
       - name: Merge probe unit tests
         run: |
           set -euo pipefail

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -3836,7 +3836,7 @@ jobs:
             exit 1
           }
 
-      - name: Pre-flight — lint PR body for auto-close keywords against tracking issues
+      - name: Pre-flight — lint PR title/body for auto-close keywords against tracking issues
         # P4 from docs/postmortems/2026-05-18-project-2734-stall.md.
         # The body composed below uses `Closes ${ISSUE_URL}` — correct
         # when ISSUE_NUMBER points to a sub-issue (the convention), but
@@ -3853,13 +3853,21 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "${RUNTIME_DIR}/pr-body-lint"
+          PR_TITLE_FILE="${RUNTIME_DIR}/pr-body-lint/title.txt"
           PR_BODY_FILE="${RUNTIME_DIR}/pr-body-lint/body.txt"
+          PR_LINT_FILE="${RUNTIME_DIR}/pr-body-lint/lint-input.txt"
+          PR_TITLE="AI implementation for issue #${ISSUE_NUMBER}"
+          printf '%s\n' "${PR_TITLE}" > "${PR_TITLE_FILE}"
           # Build the exact body that the next step will pass to gh pr
-          # create. Keep these two strings in lockstep — drift means the
-          # lint is checking a different body than the one submitted.
+          # create, plus the title/body squash-merge artifact that the
+          # lint validates. Keep these strings in lockstep — drift means
+          # the lint is checking a different artifact than the one
+          # submitted.
           printf 'Automated implementation. Closes %s\n' "${ISSUE_URL}" > "${PR_BODY_FILE}"
+          printf '%s\n\n' "${PR_TITLE}" > "${PR_LINT_FILE}"
+          cat "${PR_BODY_FILE}" >> "${PR_LINT_FILE}"
           PYTHONDONTWRITEBYTECODE=1 python3 scripts/lint_pr_body_auto_close.py \
-            --pr-body-file "${PR_BODY_FILE}" \
+            --pr-body-file "${PR_LINT_FILE}" \
             --repo "${GITHUB_REPOSITORY}"
 
       - name: Create Pull Request
@@ -3871,11 +3879,17 @@ jobs:
           set -euo pipefail
           source scripts/gh_helpers.sh 2>/dev/null || true
           type gh_retry &>/dev/null || gh_retry() { "$@"; }
+          PR_TITLE_FILE="${RUNTIME_DIR}/pr-body-lint/title.txt"
           PR_BODY_FILE="${RUNTIME_DIR}/pr-body-lint/body.txt"
+          if [ ! -f "${PR_TITLE_FILE}" ]; then
+            echo "::error::expected PR title file missing: ${PR_TITLE_FILE}" >&2
+            exit 1
+          fi
           if [ ! -f "${PR_BODY_FILE}" ]; then
             echo "::error::expected PR body file missing: ${PR_BODY_FILE}" >&2
             exit 1
           fi
+          PR_TITLE="$(cat "${PR_TITLE_FILE}")"
 
           # Atomically apply force-review + e2e-smoke-test labels at PR
           # creation time when this is a smoke-test run. Applying them
@@ -3892,7 +3906,7 @@ jobs:
             --repo "${{ github.repository }}"
             --base "${PR_BASE_BRANCH}"
             --head "${TARGET_BRANCH}"
-            --title "AI implementation for issue #${ISSUE_NUMBER}"
+            --title "${PR_TITLE}"
             --body-file "${PR_BODY_FILE}"
           )
           if [ "${IS_SMOKE_TEST:-false}" = "true" ]; then

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -3871,6 +3871,11 @@ jobs:
           set -euo pipefail
           source scripts/gh_helpers.sh 2>/dev/null || true
           type gh_retry &>/dev/null || gh_retry() { "$@"; }
+          PR_BODY_FILE="${RUNTIME_DIR}/pr-body-lint/body.txt"
+          if [ ! -f "${PR_BODY_FILE}" ]; then
+            echo "::error::expected PR body file missing: ${PR_BODY_FILE}" >&2
+            exit 1
+          fi
 
           # Atomically apply force-review + e2e-smoke-test labels at PR
           # creation time when this is a smoke-test run. Applying them
@@ -3888,7 +3893,7 @@ jobs:
             --base "${PR_BASE_BRANCH}"
             --head "${TARGET_BRANCH}"
             --title "AI implementation for issue #${ISSUE_NUMBER}"
-            --body "Automated implementation. Closes ${ISSUE_URL}"
+            --body-file "${PR_BODY_FILE}"
           )
           if [ "${IS_SMOKE_TEST:-false}" = "true" ]; then
             PR_CREATE_ARGS+=(--label "force-review" --label "e2e-smoke-test")

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -3836,6 +3836,32 @@ jobs:
             exit 1
           }
 
+      - name: Pre-flight — lint PR body for auto-close keywords against tracking issues
+        # P4 from docs/postmortems/2026-05-18-project-2734-stall.md.
+        # The body composed below uses `Closes ${ISSUE_URL}` — correct
+        # when ISSUE_NUMBER points to a sub-issue (the convention), but
+        # if a future change or misconfiguration ever points it at an
+        # ai:orchestrator-tracking issue, the resulting auto-close would
+        # kill the orchestrator's wave dispatch (the project-#2734
+        # failure mode). Catch the violation at composition time so the
+        # PR is never created.  See unattended_system_instructions.md
+        # §21 and CLAUDE.md §19.
+        if: env.SKIP_IMPLEMENT != 'true' && steps.commit_changes.outputs.did_commit == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNTIME_DIR}/pr-body-lint"
+          PR_BODY_FILE="${RUNTIME_DIR}/pr-body-lint/body.txt"
+          # Build the exact body that the next step will pass to gh pr
+          # create. Keep these two strings in lockstep — drift means the
+          # lint is checking a different body than the one submitted.
+          printf 'Automated implementation. Closes %s\n' "${ISSUE_URL}" > "${PR_BODY_FILE}"
+          PYTHONDONTWRITEBYTECODE=1 python3 scripts/lint_pr_body_auto_close.py \
+            --pr-body-file "${PR_BODY_FILE}" \
+            --repo "${GITHUB_REPOSITORY}"
+
       - name: Create Pull Request
         if: env.SKIP_IMPLEMENT != 'true' && steps.commit_changes.outputs.did_commit == 'true'
         id: create_pr

--- a/.github/workflows/integration-pr-readiness.yml
+++ b/.github/workflows/integration-pr-readiness.yml
@@ -42,10 +42,11 @@ jobs:
   readiness:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Only run on orchestrator integration PRs. Non-orchestrator PRs
-    # would otherwise emit a "no-op success" status, which clutters the
-    # required-checks UI. Match `orchestrator/project-*` head refs.
-    if: startsWith(github.event.pull_request.head.ref, 'orchestrator/project-')
+    # Run on every PR so the status context exists when branch
+    # protection marks it required. The script itself posts a no-op
+    # success on non-orchestrator branches, which keeps the trust
+    # boundary out of workflow expressions and avoids actionlint's
+    # untrusted-inline-script warning path.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -66,10 +67,13 @@ jobs:
       - name: Check integration PR readiness and post status
         env:
           GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_integration_pr_readiness.py \
-            --head-ref "${{ github.event.pull_request.head.ref }}" \
-            --head-sha "${{ github.event.pull_request.head.sha }}" \
+            --head-ref "${HEAD_REF}" \
+            --head-sha "${HEAD_SHA}" \
             --pr-labels-file /tmp/integration-pr-readiness/labels.txt \
-            --repo "${GITHUB_REPOSITORY}"
+            --repo "${REPO}"

--- a/.github/workflows/integration-pr-readiness.yml
+++ b/.github/workflows/integration-pr-readiness.yml
@@ -1,0 +1,75 @@
+---
+# P3 from docs/postmortems/2026-05-18-project-2734-stall.md.
+#
+# Orchestrator integration PRs (head ref `orchestrator/project-<N>`) are
+# opened eagerly by the self-healing pipeline so main <-> integration
+# drift can be resolved continuously rather than only at finalize time.
+# Without a readiness gate, any human or another Claude session can
+# manually squash-merge a partially-complete integration PR — exactly
+# what happened with PR #2750 (only Wave 1 shipped; Waves 2-7 had
+# `status=not_created` and `github_issue=null` at merge time).
+#
+# This workflow posts a commit status `orchestrator/integration-pr-not-ready`
+# on every change to such a PR. The status is failure while any sub-issue
+# checkbox in the tracking issue body is unchecked, and success when all
+# are ticked. An auditable escape valve — applying the
+# `ai:override-incomplete-merge` label to the PR — flips the status to
+# success without ticking the boxes, for the rare case where the operator
+# explicitly chooses to merge with de-scoped phases.
+#
+# Configure this status as a required check in repository branch
+# protection settings so the PR cannot be merged while the status is
+# failing.
+name: Integration PR readiness check
+
+"on":
+  pull_request:
+    # `labeled` and `unlabeled` so applying/removing the override label
+    # immediately re-evaluates. `edited` for tracking-issue body changes
+    # would be ideal but pull_request edited fires on PR body edits, not
+    # on referenced-issue body edits — the next push/sync to the PR will
+    # re-run the check anyway.
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    branches: [main, stable]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  readiness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Only run on orchestrator integration PRs. Non-orchestrator PRs
+    # would otherwise emit a "no-op success" status, which clutters the
+    # required-checks UI. Match `orchestrator/project-*` head refs.
+    if: startsWith(github.event.pull_request.head.ref, 'orchestrator/project-')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Write PR labels to file
+        env:
+          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels) }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/integration-pr-readiness
+          # Extract label names from the event payload; one per line.
+          printf '%s' "${PR_LABELS_JSON}" \
+            | python3 -c "import json,sys; print('\n'.join(l['name'] for l in json.load(sys.stdin)))" \
+            > /tmp/integration-pr-readiness/labels.txt
+
+      - name: Check integration PR readiness and post status
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_integration_pr_readiness.py \
+            --head-ref "${{ github.event.pull_request.head.ref }}" \
+            --head-sha "${{ github.event.pull_request.head.sha }}" \
+            --pr-labels-file /tmp/integration-pr-readiness/labels.txt \
+            --repo "${GITHUB_REPOSITORY}"

--- a/.github/workflows/lint-plan-archival.yml
+++ b/.github/workflows/lint-plan-archival.yml
@@ -1,0 +1,72 @@
+---
+# P6 from docs/postmortems/2026-05-18-project-2734-stall.md.
+#
+# Project #2734's integration PR moved the plan to `docs/completed/` and
+# labelled the tracking issue `ai:merged` while 7 of 9 sub-issue checkboxes
+# in the tracking issue body remained unchecked. The plan file's presence
+# in `docs/completed/` then became a load-bearing-but-misleading signal:
+# "this plan is done" when in fact most of it was unshipped.
+#
+# This workflow enforces that PRs adding files under `docs/completed/`
+# either:
+#   - reference a tracking issue whose checkboxes are ALL ticked, OR
+#   - include an explicit `## De-scoped phases` section in the PR body
+#     listing every unshipped item with rationale.
+name: Lint plan-archival completeness
+
+"on":
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+    branches: [main, stable]
+    paths:
+      - 'docs/completed/**'
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          # Need the merge-base diff to enumerate added files. Default
+          # checkout depth on pull_request is the merge commit; bump to
+          # full history so `git diff --diff-filter=A` against the base
+          # branch enumerates every added file in the PR.
+          fetch-depth: 0
+
+      - name: Write PR body to file
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/plan-archival-lint
+          printf '%s' "${PR_BODY:-}" > /tmp/plan-archival-lint/body.txt
+
+      - name: Enumerate added files in PR
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # --diff-filter=A keeps only added files; --name-only emits one
+          # path per line. Skip empty output (PR with no added files) by
+          # touching the output file first.
+          : > /tmp/plan-archival-lint/added.txt
+          git diff --diff-filter=A --name-only "${BASE_SHA}" "${HEAD_SHA}" \
+            > /tmp/plan-archival-lint/added.txt
+
+      - name: Run plan-archival completeness lint
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          PYTHONDONTWRITEBYTECODE=1 python3 scripts/lint_plan_archival_completeness.py \
+            --pr-body-file /tmp/plan-archival-lint/body.txt \
+            --added-files-file /tmp/plan-archival-lint/added.txt \
+            --repo "${GITHUB_REPOSITORY}"

--- a/.github/workflows/lint-pr-body-auto-close.yml
+++ b/.github/workflows/lint-pr-body-auto-close.yml
@@ -1,13 +1,16 @@
 ---
 # P1 from docs/postmortems/2026-05-18-project-2734-stall.md.
 #
-# Enforces CLAUDE.md §19 (and the mirror in unattended_system_instructions.md):
-# no `Fixes/Closes/Resolves #N` keyword may reference an
-# `ai:orchestrator-tracking` issue in a PR body, PR title, or commit message
-# that will land on the default branch. On squash-merge GitHub uses the PR
-# title + body for the squash commit message and auto-closes referenced
-# issues, which kills the orchestrator's wave-by-wave dispatch (poller
-# filters tracking issues by `--state open`).
+# Enforces CLAUDE.md §19 (and the mirror in unattended_system_instructions.md)
+# on the merge path this repo actually uses: squash merge. On squash-merge,
+# GitHub uses the PR title + body for the squash commit message and
+# auto-closes referenced issues, which kills the orchestrator's wave-by-wave
+# dispatch (poller filters tracking issues by `--state open`).
+#
+# The companion script still supports optional commit-message scanning for
+# callers that need it, but this workflow intentionally checks the PR body
+# only so already-pushed historical commit bodies do not require history
+# rewrites to merge a preventive-fix PR.
 #
 # This was the layer-3 failure mode in project #2734: PR #2760 used
 # `Fixes #2734` in its body → GitHub auto-closed #2734 → orchestrator
@@ -59,30 +62,13 @@ jobs:
           mkdir -p /tmp/pr-body-lint
           printf '%s' "${PR_BODY:-}" > /tmp/pr-body-lint/body.txt
 
-      - name: Fetch commit messages for this PR
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUM: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          # Stream the PR's commit messages via the GitHub API. Each commit
-          # message is written as a NUL-separated record so the lint script
-          # can recover record boundaries reliably (commit messages may
-          # contain newlines).
-          # CLAUDE.md §15: one paginated GraphQL/REST call covers up to 250
-          # commits per PR; well under any single-tick threshold.
-          gh api -X GET "repos/${REPO}/pulls/${PR_NUM}/commits" \
-            --paginate --jq '.[].commit.message' \
-            | awk 'BEGIN{first=1} {if(!first){printf "\0"} first=0; print}' \
-            > /tmp/pr-body-lint/commits.bin
-
       - name: Run auto-close keyword lint
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          # This required check validates the PR body — the text that
+          # squash merge copies onto the default branch in this repo.
           PYTHONDONTWRITEBYTECODE=1 python3 scripts/lint_pr_body_auto_close.py \
             --pr-body-file /tmp/pr-body-lint/body.txt \
-            --commit-messages-file /tmp/pr-body-lint/commits.bin \
             --repo "${GITHUB_REPOSITORY}"

--- a/.github/workflows/lint-pr-body-auto-close.yml
+++ b/.github/workflows/lint-pr-body-auto-close.yml
@@ -8,9 +8,10 @@
 # dispatch (poller filters tracking issues by `--state open`).
 #
 # The companion script still supports optional commit-message scanning for
-# callers that need it, but this workflow intentionally checks the PR body
-# only so already-pushed historical commit bodies do not require history
-# rewrites to merge a preventive-fix PR.
+# callers that need it, but this workflow intentionally checks the squash-
+# merge artifact (PR title + body) only so already-pushed historical
+# commit bodies do not require history rewrites to merge a preventive-fix
+# PR.
 #
 # This was the layer-3 failure mode in project #2734: PR #2760 used
 # `Fixes #2734` in its body → GitHub auto-closed #2734 → orchestrator
@@ -21,8 +22,8 @@ name: Lint PR body for auto-close keywords against orchestrator-tracking issues
 
 "on":
   pull_request:
-    # `edited` catches PR body changes after creation; `synchronize`
-    # catches new commits pushed to the PR head; `reopened` and
+    # `edited` catches PR title/body changes after creation;
+    # `synchronize` catches new commits pushed to the PR head; `reopened` and
     # `ready_for_review` ensure the check re-runs when a draft PR
     # transitions to ready-for-review (which is when the merge button
     # becomes available).
@@ -50,25 +51,26 @@ jobs:
           # via the GH API below (no local git log needed).
           fetch-depth: 1
 
-      - name: Write PR body to file
+      - name: Write PR title and body to file
         env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
-          # The pull_request event payload exposes the PR body directly;
-          # write it to disk so the lint script can read it from a stable
-          # path. Empty body is fine — the script will exit 0 with no
-          # violations.
+          # Squash merge uses the PR title + body as the merge-commit
+          # message. Write the exact merge artifact shape (title, blank
+          # line, body) to disk so the lint script validates the same
+          # text GitHub will evaluate for auto-close keywords.
           mkdir -p /tmp/pr-body-lint
-          printf '%s' "${PR_BODY:-}" > /tmp/pr-body-lint/body.txt
+          printf '%s\n\n%s' "${PR_TITLE:-}" "${PR_BODY:-}" > /tmp/pr-body-lint/body.txt
 
       - name: Run auto-close keyword lint
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # This required check validates the PR body — the text that
-          # squash merge copies onto the default branch in this repo.
+          # This required check validates the squash-merge artifact
+          # (PR title + body) that lands on the default branch.
           PYTHONDONTWRITEBYTECODE=1 python3 scripts/lint_pr_body_auto_close.py \
             --pr-body-file /tmp/pr-body-lint/body.txt \
             --repo "${GITHUB_REPOSITORY}"

--- a/.github/workflows/lint-pr-body-auto-close.yml
+++ b/.github/workflows/lint-pr-body-auto-close.yml
@@ -1,0 +1,88 @@
+---
+# P1 from docs/postmortems/2026-05-18-project-2734-stall.md.
+#
+# Enforces CLAUDE.md §19 (and the mirror in unattended_system_instructions.md):
+# no `Fixes/Closes/Resolves #N` keyword may reference an
+# `ai:orchestrator-tracking` issue in a PR body, PR title, or commit message
+# that will land on the default branch. On squash-merge GitHub uses the PR
+# title + body for the squash commit message and auto-closes referenced
+# issues, which kills the orchestrator's wave-by-wave dispatch (poller
+# filters tracking issues by `--state open`).
+#
+# This was the layer-3 failure mode in project #2734: PR #2760 used
+# `Fixes #2734` in its body → GitHub auto-closed #2734 → orchestrator
+# stopped dispatching Waves 2-7 → 7 of 9 sub-issues never shipped code.
+# §19 was added (PR #2776) as a prose reaction to this incident; this
+# workflow turns the prose into an enforced check.
+name: Lint PR body for auto-close keywords against orchestrator-tracking issues
+
+"on":
+  pull_request:
+    # `edited` catches PR body changes after creation; `synchronize`
+    # catches new commits pushed to the PR head; `reopened` and
+    # `ready_for_review` ensure the check re-runs when a draft PR
+    # transitions to ready-for-review (which is when the merge button
+    # becomes available).
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+    branches: [main, stable]
+
+permissions:
+  # Read-only on issues so the lint can resolve labels of referenced
+  # issues. No write permissions needed — the lint only fails the check.
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          # Only need the lint script + the commit range for this PR. The
+          # workflow does not run any tooling that needs full history.
+          # Fetch enough history to enumerate commits between base and head
+          # via the GH API below (no local git log needed).
+          fetch-depth: 1
+
+      - name: Write PR body to file
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          # The pull_request event payload exposes the PR body directly;
+          # write it to disk so the lint script can read it from a stable
+          # path. Empty body is fine — the script will exit 0 with no
+          # violations.
+          mkdir -p /tmp/pr-body-lint
+          printf '%s' "${PR_BODY:-}" > /tmp/pr-body-lint/body.txt
+
+      - name: Fetch commit messages for this PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Stream the PR's commit messages via the GitHub API. Each commit
+          # message is written as a NUL-separated record so the lint script
+          # can recover record boundaries reliably (commit messages may
+          # contain newlines).
+          # CLAUDE.md §15: one paginated GraphQL/REST call covers up to 250
+          # commits per PR; well under any single-tick threshold.
+          gh api -X GET "repos/${REPO}/pulls/${PR_NUM}/commits" \
+            --paginate --jq '.[].commit.message' \
+            | awk 'BEGIN{first=1} {if(!first){printf "\0"} first=0; print}' \
+            > /tmp/pr-body-lint/commits.bin
+
+      - name: Run auto-close keyword lint
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          PYTHONDONTWRITEBYTECODE=1 python3 scripts/lint_pr_body_auto_close.py \
+            --pr-body-file /tmp/pr-body-lint/body.txt \
+            --commit-messages-file /tmp/pr-body-lint/commits.bin \
+            --repo "${GITHUB_REPOSITORY}"

--- a/.github/workflows/mark-stable.yml
+++ b/.github/workflows/mark-stable.yml
@@ -214,6 +214,9 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_lib.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_poll_process.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_lint_pr_body_auto_close.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_lint_plan_archival_completeness.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_check_integration_pr_readiness.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_mark_stable_release_tag_refspec_contract.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_targeted_file_context.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_detect_editor_changes_lost.py

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3203,6 +3203,9 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_lib.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_poll_process.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_lint_pr_body_auto_close.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_lint_plan_archival_completeness.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_check_integration_pr_readiness.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_mark_stable_release_tag_refspec_contract.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_targeted_file_context.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_detect_editor_changes_lost.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -627,13 +627,29 @@ Rules:
 - This rule is not superseded by §12 (PR Review Mode) or any proactive-
   fix scope. It applies to every AI-authored PR body in an interactive
   session.
+- The rule is enforced by **two** mechanisms, both anchored on
+  `scripts/lint_pr_body_auto_close.py`:
+  1. The `Lint PR body for auto-close keywords against orchestrator-tracking
+     issues` GitHub workflow (`.github/workflows/lint-pr-body-auto-close.yml`)
+     runs on every pull request and fails the check when a violation
+     is found.
+  2. The unattended pipelines' PR-body composition paths invoke the
+     same script as a pre-flight check before `gh pr create --body` —
+     see `unattended_system_instructions.md` §21 and the
+     `Pre-flight — lint PR body for auto-close keywords against
+     tracking issues` step in `.github/workflows/implement.yml`.
+  Both layers exist because §19 is a load-bearing invariant: a single
+  violation kills the orchestrator's state machine for the project it
+  targets.
 
 Historical incident: PR #2760 used `Fixes #2734` in its body. `#2734`
 was an `ai:orchestrator-tracking` issue for the integration-sync
 resolver self-heal project. On merge, GitHub auto-closed `#2734` and
 the orchestrator stopped dispatching waves 2-7; the bulk of the
 project's planned phases never shipped (see
-`docs/completed/integration-sync-resolver-self-heal-plan.md`).
+`docs/completed/integration-sync-resolver-self-heal-plan.md` and the
+full forensic timeline in
+`docs/postmortems/2026-05-18-project-2734-stall.md`).
 
 ---
 

--- a/docs/postmortems/2026-05-18-project-2734-stall.md
+++ b/docs/postmortems/2026-05-18-project-2734-stall.md
@@ -61,8 +61,8 @@ incident, not before it.
 | 2026-05-19 04:18 | Operator session `01HSrx72bv2yTPMx4o3ai1hk` attempted manual state correction via 3-chunk `ORCHESTRATOR_STATE_V2` comment | Comments #29-32 |
 | 2026-05-19 04:18-04:46 | Manual correction failed — MCP `add_issue_comment` truncated part 1 by 44 bytes mid-base64, sha256 manifest mismatch, extractor fell back | Comment #33 |
 | 2026-05-19 04:49 | Same operator session manually closed #2734 to silence alerts, with note "Reversible: re-open... by that point the code fix in the new PR (incoming next) will be on main" | Comment #33 |
+| 2026-05-19 04:50 | PR #2776 added §19 to CLAUDE.md (interactive-session policy) to forbid auto-close keywords against `ai:orchestrator-tracking` issues | PR #2776 |
 | 2026-05-19 07:54 | PR #2777 merged — added `[external-finalize]` block to detect externally-merged integration PRs | PR #2777 |
-| 2026-05-19 04:50 | PR #2776 added §19 to CLAUDE.md to forbid auto-close keywords against `ai:orchestrator-tracking` issues | PR #2776 |
 | (between) | #2734 was reopened (state_reason=reopened) | Issue API |
 | 2026-05-19 11:27 | Poll run `26094146507` fired: `[external-finalize] PR #2750 merged outside the wave-by-wave flow; transitioning project to complete.` Status set to `complete`, `ai:merged` applied, "✅ Project complete" Telegram | Workflow run, comments #38-39 |
 
@@ -230,7 +230,7 @@ triggered this investigation.
 - `unattended_system_instructions.md` (codex-cli pipeline rules)
 - [PR #2750](https://github.com/shubhodeep1/coding-workflows/pull/2750) — integration PR squash-merged with only Wave 1 content
 - [PR #2760](https://github.com/shubhodeep1/coding-workflows/pull/2760) — refresh-clobber fix; auto-close violation source
-- [PR #2776](https://github.com/shubhodeep1/coding-workflows/pull/2776) — added §19 to CLAUDE.md
+- [PR #2776](https://github.com/shubhodeep1/coding-workflows/pull/2776) — added §19 to CLAUDE.md (interactive-session policy)
 - [PR #2777](https://github.com/shubhodeep1/coding-workflows/pull/2777) — added `[external-finalize]` block (no completeness gate)
 - [Issue #2734](https://github.com/shubhodeep1/coding-workflows/issues/2734) — tracking issue, 39 comments
 - [Workflow run 26094146507](https://github.com/shubhodeep1/coding-workflows/actions/runs/26094146507) — first false `✅ Project complete` broadcast

--- a/docs/postmortems/2026-05-18-project-2734-stall.md
+++ b/docs/postmortems/2026-05-18-project-2734-stall.md
@@ -1,0 +1,237 @@
+# Postmortem: Project #2734 stall + false "complete" claim
+
+> **Date of incident:** 2026-05-18 → 2026-05-19
+> **Tracking issue:** [#2734](https://github.com/shubhodeep1/coding-workflows/issues/2734)
+> **Project:** integration-sync resolver self-heal plan (7 waves, 9 sub-issues)
+> **Outcome:** Only Wave 1 (Phase 1A + Phase 6 spike) shipped; Phases 2, 3, 4A, 4B,
+> and 5 were never dispatched. Orchestrator later reported the project as
+> `complete` based solely on the external squash-merge of integration PR #2750,
+> with no completeness check against the sub-issue list.
+
+---
+
+## Summary
+
+A 7-wave orchestrator project decomposed into 9 sub-issues stalled after Wave 1
+because a resolver-tooling refresh silently reverted the Wave-1 sub-issue's
+changes on the integration branch. The fix PR for that refresh bug used an
+auto-close keyword (`Fixes #2734`) in its body and on merge closed the tracking
+issue, which prevented the orchestrator from dispatching Waves 2-7. The eager
+integration PR was then squash-merged externally with only Wave 1's content. A
+subsequent self-heal patch (PR #2777) added external-finalize detection but did
+not verify sub-issue completeness, so on the next poll tick the orchestrator
+broadcast `✅ Project #2734 completed` while 5 of 7 planned phases had no
+shipped code.
+
+This was the first observed end-to-end occurrence of the failure mode that
+CLAUDE.md §19 was added to forbid — §19 was written as a reaction to this
+incident, not before it.
+
+---
+
+## Failure modes observed
+
+- **F1.** Orchestrator broadcast `✅ Project #2734 completed (integration PR #2750
+  merged externally)` (Telegram, poll log `26094146507`) while Phases 2, 3, 4A,
+  4B, and 5 of the plan had shipped zero code.
+- **F2.** Plan file was copied (not moved) to `docs/completed/`; tracking issue
+  was labelled `ai:merged` while all 9 sub-issue checkboxes in its body remained
+  unchecked.
+- **F3.** Operator received ~10 identical `## ⚠️ Wave 2 dispatch BLOCKED`
+  comments on #2734 over 26 hours, plus matching Telegram alerts — alert
+  fatigue that led to a manual close-to-silence remediation.
+
+---
+
+## Timeline (UTC)
+
+| When | What | Where |
+|---|---|---|
+| 2026-05-18 09:48 | Project #2734 opened by orchestrator (9 sub-issues across 7 waves) | Issue body |
+| 2026-05-18 09:48 | Wave 1 dispatched — sub-issues #2735 (Phase 1A) + #2736 (Phase 6 spike) created | Comment #2 |
+| 2026-05-18 ~10:08 | #2736 (Phase 6 discovery spike) merged via its sub-issue PR | Issue list |
+| 2026-05-18 ~13:11 | #2735 (Phase 1A) merged via PR #2738 (commit `e67f0f7`) | `git log` |
+| 2026-05-18 ~13:15 | `_refresh_integration_resolver_tooling` ran on integration branch, saw `verify_integration_fingerprints.py` ≠ main, force-checked-out main's older version — silently reverted Phase 1A | Workflow run [`26040740781`](https://github.com/shubhodeep1/coding-workflows/actions/runs/26040740781), PR #2760 body |
+| 2026-05-18 13:37 | PR #2750 opened eagerly (`Refs #2734`, body: "Squash merge of orchestrator project #2734") | PR #2750 |
+| 2026-05-18 13:38 | First `Wave 2 dispatch BLOCKED` comment posted | Comment #9 |
+| 2026-05-18 13:38 – 04:50 | Poll loop emits BLOCKED comment + Telegram alert every ~30-60min | Comments #9, 13, 15, 17, 19, 21, 23, 25, 27, 36 |
+| 2026-05-18 15:16 | PR #2760 opened by `claude/fix-dispatch-fingerprint-Gc8bo` to fix the refresh-clobber bug. Body: `Fixes #2734` | PR #2760 body |
+| 2026-05-18 18:21 | PR #2760 merged → GitHub auto-closed #2734 → orchestrator stopped dispatching | PR #2760, comment #29 |
+| 2026-05-18 21:31 | PR #2750 manually squash-merged externally with only Phase 1A + hand-rolled Phase 1B + Phase 6 spike + partial closeout | PR #2750 |
+| 2026-05-19 04:18 | Operator session `01HSrx72bv2yTPMx4o3ai1hk` attempted manual state correction via 3-chunk `ORCHESTRATOR_STATE_V2` comment | Comments #29-32 |
+| 2026-05-19 04:18-04:46 | Manual correction failed — MCP `add_issue_comment` truncated part 1 by 44 bytes mid-base64, sha256 manifest mismatch, extractor fell back | Comment #33 |
+| 2026-05-19 04:49 | Same operator session manually closed #2734 to silence alerts, with note "Reversible: re-open... by that point the code fix in the new PR (incoming next) will be on main" | Comment #33 |
+| 2026-05-19 07:54 | PR #2777 merged — added `[external-finalize]` block to detect externally-merged integration PRs | PR #2777 |
+| 2026-05-19 04:50 | PR #2776 added §19 to CLAUDE.md to forbid auto-close keywords against `ai:orchestrator-tracking` issues | PR #2776 |
+| (between) | #2734 was reopened (state_reason=reopened) | Issue API |
+| 2026-05-19 11:27 | Poll run `26094146507` fired: `[external-finalize] PR #2750 merged outside the wave-by-wave flow; transitioning project to complete.` Status set to `complete`, `ai:merged` applied, "✅ Project complete" Telegram | Workflow run, comments #38-39 |
+
+---
+
+## Causal chain (six layered bugs)
+
+Defense-in-depth failed at every layer. None is THE root cause — that's the
+point.
+
+### Layer 1 — Resolver-tooling refresh clobber
+
+`_refresh_integration_resolver_tooling` in `scripts/orchestrate_poll_process.sh`
+compared each allowlisted file's hash on the integration branch to its hash on
+main. When they differed (e.g. because a sub-issue PR merge had landed
+new code on integration), it force-checked-out main's version, treating
+"merged sub-issue work" as "stale tooling needing refresh." This silently
+reverted Phase 1A on the integration branch within minutes of #2735 merging.
+
+**Cited:** PR #2760 body, §Root cause; workflow run `26040740781`.
+**Status:** PR #2760 shipped a merge-base divergence guard. Bug class is
+mitigated, not eliminated.
+
+### Layer 2 — Wave-dispatch gate firing on a problem caused by Layer 1
+
+The reverted verifier failed its own fingerprint contract → orchestrator
+refused to dispatch Wave 2 (correct in isolation). With the underlying clobber
+recurring every poll tick (`*/5 * * * *`), the BLOCKED gate fired indefinitely.
+
+**Status:** Gate behavior is correct. Mitigation depends on Layer 1.
+
+### Layer 3 — PR-body auto-close hygiene
+
+PR #2760 was the fix for Layer 1. Its body opened with `Fixes #2734`. When
+merged, GitHub auto-closed #2734. The orchestrator's poll loop filters tracking
+issues by `--state open` (`.github/workflows/orchestrate_poll.yml:119`) → closed
+tracking issue dropped out of `tracking_issues.json` → wave dispatch stopped.
+
+CLAUDE.md §19 forbids exactly this pattern, but §19 did not exist when PR #2760
+was authored; it was added in PR #2776 *as a reaction to* this incident. The
+rule lives only in prose.
+
+**Status:** §19 documented in CLAUDE.md (interactive sessions only) and in
+`unattended_system_instructions.md`. **Not yet enforced by CI.**
+
+### Layer 4 — Eager integration PR + external merge with no completeness gate
+
+PR #2750 was opened eagerly at 13:37Z (the "continuous main↔integration drift
+resolution" design). When the orchestrator stalled, the integration PR was
+manually squash-merged at 21:31Z with whatever was on the branch — Phase 1A,
+a hand-rolled Phase 1B, the Phase 6 spike doc, plan-copied-to-`docs/completed/`,
+and one-paragraph doc edits. No gate required all sub-issues to be merged
+before the integration PR could merge.
+
+**Status:** No safeguard. P3 prevention (integration-PR readiness status check)
+addresses this.
+
+### Layer 5 — Destructive manual state correction
+
+When the orchestrator stalled, operator session `01HSrx72bv2yTPMx4o3ai1hk`
+tried to manual-correct state via a 3-chunk `ORCHESTRATOR_STATE_V2` comment
+that claimed `status=complete`. The third-party MCP `add_issue_comment` tool
+truncated part 1 by 44 bytes mid-base64 → sha256 manifest mismatch → extractor
+correctly rejected and fell back. The operator then closed #2734 manually to
+silence alerts, with the explicit comment "Reversible: re-open #2734 any time
+the orchestrator should resume processing it."
+
+Both actions papered over the underlying problem (missing waves) rather than
+acknowledging them. The "Reversible" promise depended on Layer 6's fix being
+correct.
+
+**Status:** No process gate; the operator made the correct decision given the
+information they had (alert spam, no machine-checkable scope to verify).
+
+### Layer 6 — External-finalize block has no completeness gate
+
+PR #2777 was the self-heal patch for the unresolvable poll loop. The new block
+(`scripts/orchestrate_poll_process.sh:8478-8527`) detects externally-merged
+integration PRs and transitions `status=complete` whenever `final_merge_pr`
+is pinned AND `.state == "closed"` AND `.merged_at != null`. It never checks
+`.waves[].issues[]` for completeness.
+
+Result: when #2734 was reopened (expecting Layer 6 to recompute state
+correctly), today's poll fired the block, marked complete, applied `ai:merged`,
+and posted the "✅ Project complete" Telegram — the false-positive claim that
+triggered this investigation.
+
+**Status:** Direct fix via P2 (this PR).
+
+---
+
+## What was actually shipped vs planned
+
+| Phase | Planned deliverables | Shipped? |
+|---|---|---|
+| Phase 1A | `verify_integration_fingerprints.py` baseline/delta, regression coverage | ✅ Yes — #2738 |
+| Phase 1B | `MAIN_PRIMARY_BOOTSTRAP_SCRIPTS` in `review_autofix.yml` | ✅ Hand-rolled into PR #2750 (not via Wave-2 sub-issue) |
+| Phase 2 | Retry-state escalation, `ai:resolver-escalated`, `RESOLVER_ESCAPE_THRESHOLD_N`, `AUTOFIX_RESOLVER_RETRY_STATE_V1`, tests | ❌ None |
+| Phase 3 | `--verification-tier` flag, tier semantics, `FINGERPRINT_TIER_DOWNGRADED_V1`, tests | ❌ None |
+| Phase 4A | `fingerprint_quarantine.v1.json`, `_load_quarantine_list`, `FINGERPRINT_QUARANTINED_V1` marker, tests | ❌ None |
+| Phase 4B | `.github/workflows/drift-audit.yml`, `scripts/drift_audit.sh`, tests | ❌ None |
+| Phase 5 | `_check_branch_rebuild_threshold`, `BRANCH_REBUILD_*` env vars, audit schema, tests | ❌ None |
+| Phase 6 | `docs/plans/sub-issue-test-runs-spike.md` discovery report | ✅ Yes — #2736 (NO-GO recommendation) |
+| Wave 7 closeout | README + agents.md updates documenting Phases 2-5 env vars; move plan to `docs/completed/` | ⚠️ Partial — plan copied (not moved); README/agents.md docs Phase-1-only |
+
+---
+
+## Lessons
+
+1. **Documentation rules without enforcement get violated by the next person
+   who didn't see them.** §19 existed only as prose when PR #2760 was authored.
+   Make the rule executable (CI check, generator-side helper).
+2. **Self-healing code must be conservative about what counts as "healed."**
+   PR #2777 traded "alert spam" for "false completion." A self-healing transition
+   that doesn't preserve every invariant the wave-by-wave flow preserved is a
+   regression, not a heal.
+3. **Eager integration PRs need readiness gates if humans can merge them.**
+   PR #2750's eager-create design is sound (continuous drift resolution), but
+   without a "all sub-issues merged" status check, any human (or another Claude
+   session) can ship a partial project as if it were complete.
+4. **Alert fatigue is a failure mode, not just an annoyance.** The operator's
+   "close to silence" decision was rational given 10 identical alerts and no
+   escape valve. The plan's own Phase 2 (signature-dedup'd sticky comment +
+   escape valve) was specifically designed to prevent this — and it never
+   shipped because this incident stopped its sub-issue from being dispatched.
+5. **Manual state-correction tooling needs better validation primitives.**
+   The MCP `add_issue_comment` 44-byte truncation that poisoned the 3-chunk
+   `ORCHESTRATOR_STATE_V2` update is an external-tool reliability issue, but
+   the manual-correction path could detect the truncation locally before
+   posting (round-trip the chain through the same extractor before committing).
+6. **"Plan archived to `docs/completed/`" is a load-bearing signal.** When this
+   directory contains a plan whose checkboxes are unticked, the signal is
+   actively misleading. Archival should require the same completeness invariant
+   that `ai:merged` requires.
+
+---
+
+## Preventive fixes (this PR)
+
+| Layer | Fix | What it does |
+|---|---|---|
+| Layer 3 | **P1** — CI check forbidding auto-close keywords against `ai:orchestrator-tracking` issues | Reject any PR body / commit message containing `Fixes/Closes/Resolves #N` where #N has `ai:orchestrator-tracking`. Turns §19 from prose into an enforced check. |
+| Layer 3 | **P4** — Generator-side block in unattended PR-body composition paths | Hard-fail at composition time if an orchestrator-authored PR body would include an auto-close keyword for a tracking issue. Belt-and-braces alongside P1. |
+| Layer 4 | **P3** — Integration-PR readiness status check | New required GitHub status check on the integration PR that fails while any sub-issue is `not_created`/`pending`/`in_progress`. Makes the partial external squash-merge hard-fail. |
+| Layer 4 + 5 | **P6** — Plan-archival pre-condition | CI check: any diff that creates `docs/completed/<plan>.md` or applies `ai:merged` must come with all tracking-issue checkboxes ticked OR explicitly de-scoped sub-issues with a reason. |
+| Layer 6 | **P2** — Completeness gate on `[external-finalize]` block | Before transitioning `status=complete`, require every `.waves[].issues[]` entry to have `.status ∈ {merged, closed, skipped}` and no `.status == "not_created"`. On mismatch: emit a structured `[external-finalize-partial]` warning, fire one Telegram alert with the missing-sub-issue list, leave state untouched. |
+| Layer 1 | **P5** — 3-way merge fallback alongside PR #2760's divergence guard | Keep the merge-base divergence guard (fast-path); add `git merge-file` 3-way merge as the fallback when the guard says "integration differs from merge-base." Defense-in-depth. |
+
+### Recommendations explicitly out of scope of this PR
+
+- **P7** (alert-fatigue escape valve) — the prevention version was traded off
+  against P2 + P3 indirectly closing the same operator-silences-alerts path.
+  Full Phase 2 of the original plan remains future work if revived.
+- **Reviving Phases 2-5** of the original plan — the project was marked
+  effectively de-scoped. If revived, reopen a fresh tracking issue with the
+  remaining work (not #2734).
+- **MCP `add_issue_comment` 44-byte truncation root cause** — external tool
+  reliability issue; out of scope for this repo. Track separately.
+
+---
+
+## References
+
+- CLAUDE.md §19 (auto-close keyword discipline against tracking issues)
+- `unattended_system_instructions.md` (codex-cli pipeline rules)
+- [PR #2750](https://github.com/shubhodeep1/coding-workflows/pull/2750) — integration PR squash-merged with only Wave 1 content
+- [PR #2760](https://github.com/shubhodeep1/coding-workflows/pull/2760) — refresh-clobber fix; auto-close violation source
+- [PR #2776](https://github.com/shubhodeep1/coding-workflows/pull/2776) — added §19 to CLAUDE.md
+- [PR #2777](https://github.com/shubhodeep1/coding-workflows/pull/2777) — added `[external-finalize]` block (no completeness gate)
+- [Issue #2734](https://github.com/shubhodeep1/coding-workflows/issues/2734) — tracking issue, 39 comments
+- [Workflow run 26094146507](https://github.com/shubhodeep1/coding-workflows/actions/runs/26094146507) — first false `✅ Project complete` broadcast
+- `docs/completed/integration-sync-resolver-self-heal-plan.md` — archived plan (prematurely; Phases 2-5 unshipped)

--- a/scripts/check_integration_pr_readiness.py
+++ b/scripts/check_integration_pr_readiness.py
@@ -115,10 +115,12 @@ def _post_commit_status(
 		args += ["-f", f"target_url={target_url}"]
 	try:
 		result = subprocess.run(args, capture_output=True, text=True, timeout=30, check=False)
-	except (subprocess.SubprocessError, OSError):
+	except (subprocess.SubprocessError, OSError) as exc:
+		print(f"::warning::[integration-pr-readiness] commit status POST failed: {exc}", file=sys.stderr)
 		return False
 	if result.returncode != 0:
-		print(f"::warning::commit status POST failed: {result.stderr}", file=sys.stderr)
+		detail = (result.stderr or result.stdout or "").strip() or f"gh api exited {result.returncode}"
+		print(f"::warning::[integration-pr-readiness] commit status POST failed: {detail}", file=sys.stderr)
 		return False
 	return True
 
@@ -133,7 +135,7 @@ def _post_commit_status_or_error(
 	if _post_commit_status(repo, sha, state, description, target_url):
 		return True
 	print(
-		"::error::failed to post readiness commit status; required status context may be missing or stale",
+		"::error::[integration-pr-readiness] failed to post readiness commit status; required status context may be missing or stale",
 		file=sys.stderr,
 	)
 	return False

--- a/scripts/check_integration_pr_readiness.py
+++ b/scripts/check_integration_pr_readiness.py
@@ -24,10 +24,10 @@ no-op success status so the required-check context exists on every PR
 targeting the protected branch.
 
 Exit codes:
-  0 — readiness check posted (success or failure), OR the head ref is
-      outside `orchestrator/project-*` so the check does not apply.
-  1 — head ref matched `orchestrator/project-*` but the script could not
-      fetch the tracking issue or hit another unrecoverable error.
+  0 — readiness result emitted and, when not in `--dry-run`, the
+      corresponding commit status POST succeeded.
+  1 — the script could not fetch the tracking issue, could not post the
+      required commit status, or hit another unrecoverable error.
   2 — usage error.
 
 Usage:
@@ -123,6 +123,22 @@ def _post_commit_status(
 	return True
 
 
+def _post_commit_status_or_error(
+	repo: str,
+	sha: str,
+	state: str,
+	description: str,
+	target_url: str = "",
+) -> bool:
+	if _post_commit_status(repo, sha, state, description, target_url):
+		return True
+	print(
+		"::error::failed to post readiness commit status; required status context may be missing or stale",
+		file=sys.stderr,
+	)
+	return False
+
+
 def main() -> int:
 	parser = argparse.ArgumentParser(description=__doc__)
 	parser.add_argument("--head-ref", required=True)
@@ -142,11 +158,13 @@ def main() -> int:
 		# Not an orchestrator integration branch — no readiness check
 		# applies. Post a neutral success so the required-check context
 		# still exists on non-orchestrator PRs when branch protection
-		# marks this status required.
+		# marks this status required. If that POST fails, return non-zero
+		# so the workflow does not silently pass without the required
+		# status context.
 		desc = f"head ref {args.head_ref!r} is not an orchestrator/project-* branch — readiness check does not apply"
 		print(f"::notice::{desc}")
-		if not args.dry_run:
-			_post_commit_status(args.repo, args.head_sha, "success", desc)
+		if not args.dry_run and not _post_commit_status_or_error(args.repo, args.head_sha, "success", desc):
+			return 1
 		return 0
 
 	tracking_url = f"https://github.com/{args.repo}/issues/{tracking_num}"
@@ -159,8 +177,8 @@ def main() -> int:
 	if issue is None:
 		desc = f"could not fetch tracking issue #{tracking_num}; cannot assess readiness"
 		print(f"::warning::{desc}")
-		if not args.dry_run:
-			_post_commit_status(args.repo, args.head_sha, "error", desc, tracking_url)
+		if not args.dry_run and not _post_commit_status_or_error(args.repo, args.head_sha, "error", desc, tracking_url):
+			return 1
 		return 1
 
 	if TRACKING_LABEL not in issue["labels"]:
@@ -168,8 +186,8 @@ def main() -> int:
 		# not actually a tracking issue. Surface as neutral success.
 		desc = f"issue #{tracking_num} is not labeled {TRACKING_LABEL}; readiness check does not apply"
 		print(f"::notice::{desc}")
-		if not args.dry_run:
-			_post_commit_status(args.repo, args.head_sha, "success", desc, tracking_url)
+		if not args.dry_run and not _post_commit_status_or_error(args.repo, args.head_sha, "success", desc, tracking_url):
+			return 1
 		return 0
 
 	unchecked, total = _count_checkboxes(issue["body"])
@@ -180,8 +198,8 @@ def main() -> int:
 			f"merging despite {len(unchecked)}/{total} unchecked sub-issues on #{tracking_num}"
 		)
 		print(f"::notice::{desc}")
-		if not args.dry_run:
-			_post_commit_status(args.repo, args.head_sha, "success", desc, tracking_url)
+		if not args.dry_run and not _post_commit_status_or_error(args.repo, args.head_sha, "success", desc, tracking_url):
+			return 1
 		return 0
 
 	if total == 0:
@@ -190,15 +208,15 @@ def main() -> int:
 		# integration PR merge with zero completeness signal.
 		desc = f"tracking issue #{tracking_num} has no checkbox items in its body; readiness check cannot verify completeness"
 		print(f"::error::[integration-pr-readiness] {desc}", file=sys.stderr)
-		if not args.dry_run:
-			_post_commit_status(args.repo, args.head_sha, "failure", desc, tracking_url)
+		if not args.dry_run and not _post_commit_status_or_error(args.repo, args.head_sha, "failure", desc, tracking_url):
+			return 1
 		return 0
 
 	if not unchecked:
 		desc = f"all {total} sub-issue(s) on #{tracking_num} are ticked — integration PR is ready"
 		print(f"[ready] {desc}")
-		if not args.dry_run:
-			_post_commit_status(args.repo, args.head_sha, "success", desc, tracking_url)
+		if not args.dry_run and not _post_commit_status_or_error(args.repo, args.head_sha, "success", desc, tracking_url):
+			return 1
 		return 0
 
 	# Not ready: emit failure status + structured log.
@@ -212,8 +230,8 @@ def main() -> int:
 		f"apply the {OVERRIDE_LABEL!r} label to this PR.",
 		file=sys.stderr,
 	)
-	if not args.dry_run:
-		_post_commit_status(args.repo, args.head_sha, "failure", desc, tracking_url)
+	if not args.dry_run and not _post_commit_status_or_error(args.repo, args.head_sha, "failure", desc, tracking_url):
+		return 1
 	return 0
 
 

--- a/scripts/check_integration_pr_readiness.py
+++ b/scripts/check_integration_pr_readiness.py
@@ -14,17 +14,20 @@ sub-issue checkboxes, and posts a commit status of:
   - success when 0 unchecked items, OR when an explicit override
     label `ai:override-incomplete-merge` is applied to the integration
     PR (auditable escape valve).
-  - failure when >0 unchecked items AND no override label.
+  - failure when >0 unchecked items, OR when the tracking issue body
+    contains no parseable checkbox items, AND no override label.
 
 The integration PR's head ref is the input — by convention orchestrator
 integration branches are `orchestrator/project-<N>`. The script derives
-the tracking issue number from the branch name.
+the tracking issue number from the branch name. Non-matching refs get a
+no-op success status so the required-check context exists on every PR
+targeting the protected branch.
 
 Exit codes:
-  0 — readiness check posted (success or pending or failure — the script
-      itself always succeeds; the commit status is what gates merge).
-  1 — could not derive tracking issue from branch name; could not fetch
-      tracking issue; or any other unrecoverable error.
+  0 — readiness check posted (success or failure), OR the head ref is
+	      outside `orchestrator/project-*` so the check does not apply.
+  1 — head ref matched `orchestrator/project-*` but the script could not
+	      fetch the tracking issue or hit another unrecoverable error.
   2 — usage error.
 
 Usage:
@@ -51,7 +54,7 @@ TRACKING_LABEL = "ai:orchestrator-tracking"
 OVERRIDE_LABEL = "ai:override-incomplete-merge"
 
 BRANCH_RE = re.compile(r"^orchestrator/project-(?P<n>\d+)$")
-CHECKBOX_RE = re.compile(r"^\s*-\s*\[(?P<state>[ xX])\]\s+(?P<text>.+)$")
+CHECKBOX_RE = re.compile(r"^\s*-\s*\[(?P<state>[ xX])\]\s*(?P<text>.*)$")
 
 
 def _derive_tracking_issue(head_ref: str) -> int | None:
@@ -88,7 +91,8 @@ def _count_checkboxes(body: str) -> tuple[list[str], int]:
 		if m:
 			total += 1
 			if m.group("state") == " ":
-				unchecked.append(m.group("text").strip())
+				text = (m.group("text") or "").strip()
+				unchecked.append(text or "<blank checkbox item>")
 	return unchecked, total
 
 
@@ -136,8 +140,9 @@ def main() -> int:
 	tracking_num = _derive_tracking_issue(args.head_ref)
 	if tracking_num is None:
 		# Not an orchestrator integration branch — no readiness check
-		# applies. Post a neutral success so the status appears but
-		# does not block merge.
+		# applies. Post a neutral success so the required-check context
+		# still exists on non-orchestrator PRs when branch protection
+		# marks this status required.
 		desc = f"head ref {args.head_ref!r} is not an orchestrator/project-* branch — readiness check does not apply"
 		print(f"::notice::{desc}")
 		if not args.dry_run:
@@ -180,13 +185,13 @@ def main() -> int:
 		return 0
 
 	if total == 0:
-		# Tracking issue body has no checkboxes at all — either an
-		# unusual project shape or a body that hasn't been initialised.
-		# Treat as neutral success but note it.
-		desc = f"tracking issue #{tracking_num} has no checkboxes in its body; readiness check has no signal to gate on"
-		print(f"::notice::{desc}")
+		# Fail closed when the tracking issue body has no parseable task
+		# list items. A vacuous success would let an incomplete
+		# integration PR merge with zero completeness signal.
+		desc = f"tracking issue #{tracking_num} has no checkbox items in its body; readiness check cannot verify completeness"
+		print(f"::error::[integration-pr-readiness] {desc}", file=sys.stderr)
 		if not args.dry_run:
-			_post_commit_status(args.repo, args.head_sha, "success", desc, tracking_url)
+			_post_commit_status(args.repo, args.head_sha, "failure", desc, tracking_url)
 		return 0
 
 	if not unchecked:

--- a/scripts/check_integration_pr_readiness.py
+++ b/scripts/check_integration_pr_readiness.py
@@ -25,9 +25,9 @@ targeting the protected branch.
 
 Exit codes:
   0 — readiness check posted (success or failure), OR the head ref is
-	      outside `orchestrator/project-*` so the check does not apply.
+      outside `orchestrator/project-*` so the check does not apply.
   1 — head ref matched `orchestrator/project-*` but the script could not
-	      fetch the tracking issue or hit another unrecoverable error.
+      fetch the tracking issue or hit another unrecoverable error.
   2 — usage error.
 
 Usage:
@@ -77,7 +77,7 @@ def _fetch_issue(repo: str, n: int) -> dict | None:
 	except json.JSONDecodeError:
 		return None
 	return {
-		"labels": [l["name"] for l in data.get("labels", []) if isinstance(l, dict) and "name" in l],
+		"labels": [label["name"] for label in data.get("labels", []) if isinstance(label, dict) and "name" in label],
 		"body": data.get("body", "") or "",
 	}
 

--- a/scripts/check_integration_pr_readiness.py
+++ b/scripts/check_integration_pr_readiness.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Check whether an orchestrator integration PR is ready to merge based on
+the tracking issue's sub-issue checkbox state.
+
+P3 from docs/postmortems/2026-05-18-project-2734-stall.md. Project #2734's
+integration PR (#2750) was eagerly opened (the orchestrator's
+continuous-drift-resolution design) and later squash-merged externally
+with only Wave 1 content; Waves 2-7 of the tracking-issue body were still
+unchecked at merge time. Without a gate, any human (or another Claude
+session) can ship a partial integration PR as if it were complete.
+
+This script reads the tracking issue's body, counts unticked `[ ]`
+sub-issue checkboxes, and posts a commit status of:
+  - success when 0 unchecked items, OR when an explicit override
+    label `ai:override-incomplete-merge` is applied to the integration
+    PR (auditable escape valve).
+  - failure when >0 unchecked items AND no override label.
+
+The integration PR's head ref is the input — by convention orchestrator
+integration branches are `orchestrator/project-<N>`. The script derives
+the tracking issue number from the branch name.
+
+Exit codes:
+  0 — readiness check posted (success or pending or failure — the script
+      itself always succeeds; the commit status is what gates merge).
+  1 — could not derive tracking issue from branch name; could not fetch
+      tracking issue; or any other unrecoverable error.
+  2 — usage error.
+
+Usage:
+  python3 scripts/check_integration_pr_readiness.py \\
+    --head-ref orchestrator/project-2734 \\
+    --head-sha <commit-sha-to-attach-status-to> \\
+    [--pr-labels-file <path>]               # newline-separated labels on the PR
+    [--repo <owner/repo>]                   # default: $GITHUB_REPOSITORY
+    [--dry-run]                             # print status, don't post
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+CONTEXT = "orchestrator/integration-pr-not-ready"
+TRACKING_LABEL = "ai:orchestrator-tracking"
+OVERRIDE_LABEL = "ai:override-incomplete-merge"
+
+BRANCH_RE = re.compile(r"^orchestrator/project-(?P<n>\d+)$")
+CHECKBOX_RE = re.compile(r"^\s*-\s*\[(?P<state>[ xX])\]\s+(?P<text>.+)$")
+
+
+def _derive_tracking_issue(head_ref: str) -> int | None:
+	m = BRANCH_RE.match(head_ref.strip())
+	if not m:
+		return None
+	return int(m.group("n"))
+
+
+def _fetch_issue(repo: str, n: int) -> dict | None:
+	cmd = ["gh", "issue", "view", str(n), "--repo", repo, "--json", "labels,body"]
+	try:
+		result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
+	except (subprocess.SubprocessError, OSError):
+		return None
+	if result.returncode != 0:
+		return None
+	try:
+		data = json.loads(result.stdout or "{}")
+	except json.JSONDecodeError:
+		return None
+	return {
+		"labels": [l["name"] for l in data.get("labels", []) if isinstance(l, dict) and "name" in l],
+		"body": data.get("body", "") or "",
+	}
+
+
+def _count_checkboxes(body: str) -> tuple[list[str], int]:
+	"""Return (unchecked_item_texts, total_count)."""
+	unchecked: list[str] = []
+	total = 0
+	for line in body.splitlines():
+		m = CHECKBOX_RE.match(line)
+		if m:
+			total += 1
+			if m.group("state") == " ":
+				unchecked.append(m.group("text").strip())
+	return unchecked, total
+
+
+def _post_commit_status(
+	repo: str,
+	sha: str,
+	state: str,
+	description: str,
+	target_url: str = "",
+) -> bool:
+	"""POST a commit status via gh api. Returns True on HTTP 2xx."""
+	args = [
+		"gh", "api", "-X", "POST",
+		f"repos/{repo}/statuses/{sha}",
+		"-f", f"state={state}",
+		"-f", f"context={CONTEXT}",
+		"-f", f"description={description[:140]}",
+	]
+	if target_url:
+		args += ["-f", f"target_url={target_url}"]
+	try:
+		result = subprocess.run(args, capture_output=True, text=True, timeout=30, check=False)
+	except (subprocess.SubprocessError, OSError):
+		return False
+	if result.returncode != 0:
+		print(f"::warning::commit status POST failed: {result.stderr}", file=sys.stderr)
+		return False
+	return True
+
+
+def main() -> int:
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument("--head-ref", required=True)
+	parser.add_argument("--head-sha", required=True)
+	parser.add_argument("--pr-labels-file", type=Path, default=None,
+		help="Path to a newline-separated file of label names on the PR.")
+	parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+	parser.add_argument("--dry-run", action="store_true")
+	args = parser.parse_args()
+
+	if not args.repo:
+		print("::error::no repo (pass --repo or set GITHUB_REPOSITORY)", file=sys.stderr)
+		return 2
+
+	tracking_num = _derive_tracking_issue(args.head_ref)
+	if tracking_num is None:
+		# Not an orchestrator integration branch — no readiness check
+		# applies. Post a neutral success so the status appears but
+		# does not block merge.
+		desc = f"head ref {args.head_ref!r} is not an orchestrator/project-* branch — readiness check does not apply"
+		print(f"::notice::{desc}")
+		if not args.dry_run:
+			_post_commit_status(args.repo, args.head_sha, "success", desc)
+		return 0
+
+	tracking_url = f"https://github.com/{args.repo}/issues/{tracking_num}"
+
+	pr_labels: list[str] = []
+	if args.pr_labels_file and args.pr_labels_file.exists():
+		pr_labels = [line.strip() for line in args.pr_labels_file.read_text().splitlines() if line.strip()]
+
+	issue = _fetch_issue(args.repo, tracking_num)
+	if issue is None:
+		desc = f"could not fetch tracking issue #{tracking_num}; cannot assess readiness"
+		print(f"::warning::{desc}")
+		if not args.dry_run:
+			_post_commit_status(args.repo, args.head_sha, "error", desc, tracking_url)
+		return 1
+
+	if TRACKING_LABEL not in issue["labels"]:
+		# Branch matches orchestrator/project-N but the linked issue is
+		# not actually a tracking issue. Surface as neutral success.
+		desc = f"issue #{tracking_num} is not labeled {TRACKING_LABEL}; readiness check does not apply"
+		print(f"::notice::{desc}")
+		if not args.dry_run:
+			_post_commit_status(args.repo, args.head_sha, "success", desc, tracking_url)
+		return 0
+
+	unchecked, total = _count_checkboxes(issue["body"])
+
+	if OVERRIDE_LABEL in pr_labels:
+		desc = (
+			f"override label {OVERRIDE_LABEL!r} applied: "
+			f"merging despite {len(unchecked)}/{total} unchecked sub-issues on #{tracking_num}"
+		)
+		print(f"::notice::{desc}")
+		if not args.dry_run:
+			_post_commit_status(args.repo, args.head_sha, "success", desc, tracking_url)
+		return 0
+
+	if total == 0:
+		# Tracking issue body has no checkboxes at all — either an
+		# unusual project shape or a body that hasn't been initialised.
+		# Treat as neutral success but note it.
+		desc = f"tracking issue #{tracking_num} has no checkboxes in its body; readiness check has no signal to gate on"
+		print(f"::notice::{desc}")
+		if not args.dry_run:
+			_post_commit_status(args.repo, args.head_sha, "success", desc, tracking_url)
+		return 0
+
+	if not unchecked:
+		desc = f"all {total} sub-issue(s) on #{tracking_num} are ticked — integration PR is ready"
+		print(f"[ready] {desc}")
+		if not args.dry_run:
+			_post_commit_status(args.repo, args.head_sha, "success", desc, tracking_url)
+		return 0
+
+	# Not ready: emit failure status + structured log.
+	preview = ", ".join(item[:60] for item in unchecked[:5])
+	if len(unchecked) > 5:
+		preview += f", … +{len(unchecked) - 5} more"
+	desc = f"{len(unchecked)}/{total} sub-issues on #{tracking_num} still unchecked: {preview}"
+	print(f"::error::[integration-pr-readiness] {desc}", file=sys.stderr)
+	print(
+		f"::error::To merge anyway (rare; e.g. de-scoping the remaining work), "
+		f"apply the {OVERRIDE_LABEL!r} label to this PR.",
+		file=sys.stderr,
+	)
+	if not args.dry_run:
+		_post_commit_status(args.repo, args.head_sha, "failure", desc, tracking_url)
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/scripts/lint_plan_archival_completeness.py
+++ b/scripts/lint_plan_archival_completeness.py
@@ -76,6 +76,7 @@ CHECKBOX_RE = re.compile(r"^\s*-\s*\[(?P<state>[ xX])\]\s*(?P<text>.*)$")
 # insensitive so a contributor doesn't have to memorise capitalisation.
 DESCOPE_HEADING_RE = re.compile(r"^\s{0,3}#{2,6}\s+de[- ]scoped\s+phases\b", re.IGNORECASE | re.MULTILINE)
 SECTION_HEADING_RE = re.compile(r"^\s{0,3}#{2,6}\s+\S")
+LIST_ITEM_RE = re.compile(r"^\s{0,3}(?:[-*+]\s+\S|\d+\.\s+\S)")
 
 # Files under this directory trigger the check.
 ARCHIVED_PLAN_DIR = "docs/completed/"
@@ -134,14 +135,14 @@ def _enumerate_unchecked_boxes(issue_body: str) -> list[str]:
 
 def _has_descope_section_content(pr_body: str) -> bool:
 	"""Return True when the de-scope heading exists and is followed by at
-	least one non-empty line before the next markdown heading."""
+	least one non-empty list item before the next markdown heading."""
 	match = DESCOPE_HEADING_RE.search(pr_body)
 	if match is None:
 		return False
 	for line in pr_body[match.end():].splitlines():
 		if SECTION_HEADING_RE.match(line):
 			break
-		if line.strip():
+		if LIST_ITEM_RE.match(line):
 			return True
 	return False
 

--- a/scripts/lint_plan_archival_completeness.py
+++ b/scripts/lint_plan_archival_completeness.py
@@ -52,17 +52,23 @@ from pathlib import Path
 
 TRACKING_LABEL = "ai:orchestrator-tracking"
 
-# Matches `Refs #N`, `Related to #N`, `Closes #N`, `Fixes #N`, etc. We
+# Matches both `#N` and full GitHub issue URL forms in PR bodies. We
 # accept all reference forms — the §19 lint (lint_pr_body_auto_close.py)
 # is responsible for forbidding auto-close keywords against tracking
-# issues; here we just need to harvest every #N the PR body mentions, then
+# issues; here we just need to harvest every referenced issue number, then
 # filter to tracking-labeled ones.
-ISSUE_REF_RE = re.compile(r"(?<![\w-])#(?P<issue>\d+)(?![\w-])")
+ISSUE_REF_RE = re.compile(
+	r"(?:"
+	r"(?<![\w-])#(?P<issue_short>\d+)(?![\w-])"
+	r"|"
+	r"https?://github\.com/[\w.-]+/[\w.-]+/issues/(?P<issue_url>\d+)"
+	r")"
+)
 
 # Matches a GitHub markdown task list item. Capture the state ([ ] / [x] /
 # [X]) and the rest of the line so we can name unchecked items in the
 # error message.
-CHECKBOX_RE = re.compile(r"^\s*-\s*\[(?P<state>[ xX])\]\s+(?P<text>.+)$")
+CHECKBOX_RE = re.compile(r"^\s*-\s*\[(?P<state>[ xX])\]\s*(?P<text>.*)$")
 
 # Signature for the explicit de-scope acknowledgement section in the PR
 # body. The matched text must include a markdown heading (## or ###) and
@@ -101,11 +107,14 @@ def _fetch_issue_via_gh(repo: str, issue_number: int) -> dict | None:
 
 
 def _extract_referenced_issues(pr_body: str) -> list[int]:
-	"""Unique issue numbers referenced by `#N` in the PR body, in order of first appearance."""
+	"""Unique issue numbers referenced in the PR body, in order of first appearance."""
 	seen: set[int] = set()
 	ordered: list[int] = []
 	for m in ISSUE_REF_RE.finditer(pr_body):
-		n = int(m.group("issue"))
+		issue_str = m.group("issue_short") or m.group("issue_url")
+		if not issue_str:
+			continue
+		n = int(issue_str)
 		if n not in seen:
 			seen.add(n)
 			ordered.append(n)
@@ -118,7 +127,8 @@ def _enumerate_unchecked_boxes(issue_body: str) -> list[str]:
 	for line in issue_body.splitlines():
 		m = CHECKBOX_RE.match(line)
 		if m and m.group("state") == " ":
-			unchecked.append(m.group("text").strip())
+			text = (m.group("text") or "").strip()
+			unchecked.append(text or "<blank checkbox item>")
 	return unchecked
 
 

--- a/scripts/lint_plan_archival_completeness.py
+++ b/scripts/lint_plan_archival_completeness.py
@@ -69,6 +69,7 @@ CHECKBOX_RE = re.compile(r"^\s*-\s*\[(?P<state>[ xX])\]\s+(?P<text>.+)$")
 # the literal phrase "De-scoped phases" — the comparison is case-
 # insensitive so a contributor doesn't have to memorise capitalisation.
 DESCOPE_HEADING_RE = re.compile(r"^\s{0,3}#{2,6}\s+de[- ]scoped\s+phases\b", re.IGNORECASE | re.MULTILINE)
+SECTION_HEADING_RE = re.compile(r"^\s{0,3}#{2,6}\s+\S")
 
 # Files under this directory trigger the check.
 ARCHIVED_PLAN_DIR = "docs/completed/"
@@ -121,6 +122,20 @@ def _enumerate_unchecked_boxes(issue_body: str) -> list[str]:
 	return unchecked
 
 
+def _has_descope_section_content(pr_body: str) -> bool:
+	"""Return True when the de-scope heading exists and is followed by at
+	least one non-empty line before the next markdown heading."""
+	match = DESCOPE_HEADING_RE.search(pr_body)
+	if match is None:
+		return False
+	for line in pr_body[match.end():].splitlines():
+		if SECTION_HEADING_RE.match(line):
+			break
+		if line.strip():
+			return True
+	return False
+
+
 def lint(
 	*,
 	pr_body: str,
@@ -155,7 +170,7 @@ def lint(
 			[],
 		)
 
-	has_descope_section = DESCOPE_HEADING_RE.search(pr_body) is not None
+	has_descope_section = _has_descope_section_content(pr_body)
 
 	violations: list[str] = []
 	lookup_errors: list[str] = []
@@ -178,7 +193,8 @@ def lint(
 		more = f"\n      … and {len(unchecked) - 10} more" if len(unchecked) > 10 else ""
 		violations.append(
 			f"Tracking issue #{issue_num} has {len(unchecked)} unchecked sub-issue "
-			f"checkbox(es), but PR archives plan to docs/completed/ without an "
+			f"checkbox(es), but PR archives plan to docs/completed/ without a "
+			f"non-empty "
 			f"explicit `## De-scoped phases` section in the body. Either tick the "
 			f"checkboxes on issue #{issue_num} before merging, or add a "
 			f"`## De-scoped phases` section to the PR body that lists every "

--- a/scripts/lint_plan_archival_completeness.py
+++ b/scripts/lint_plan_archival_completeness.py
@@ -74,8 +74,8 @@ CHECKBOX_RE = re.compile(r"^\s*-\s*\[(?P<state>[ xX])\]\s*(?P<text>.*)$")
 # body. The matched text must include a markdown heading (## or ###) and
 # the literal phrase "De-scoped phases" — the comparison is case-
 # insensitive so a contributor doesn't have to memorise capitalisation.
-DESCOPE_HEADING_RE = re.compile(r"^\s{0,3}#{2,6}\s+de[- ]scoped\s+phases\b", re.IGNORECASE | re.MULTILINE)
-SECTION_HEADING_RE = re.compile(r"^\s{0,3}#{2,6}\s+\S")
+DESCOPE_HEADING_RE = re.compile(r"^\s{0,3}(?P<hashes>#{2,6})\s+de[- ]scoped\s+phases\b", re.IGNORECASE | re.MULTILINE)
+SECTION_HEADING_RE = re.compile(r"^\s{0,3}(?P<hashes>#{1,6})\s+\S")
 LIST_ITEM_RE = re.compile(r"^\s{0,3}(?:[-*+]\s+\S|\d+\.\s+\S)")
 
 # Files under this directory trigger the check.
@@ -135,12 +135,15 @@ def _enumerate_unchecked_boxes(issue_body: str) -> list[str]:
 
 def _has_descope_section_content(pr_body: str) -> bool:
 	"""Return True when the de-scope heading exists and is followed by at
-	least one non-empty list item before the next markdown heading."""
+	least one non-empty list item before the next same-or-higher-level
+	markdown heading."""
 	match = DESCOPE_HEADING_RE.search(pr_body)
 	if match is None:
 		return False
+	descope_level = len(match.group("hashes"))
 	for line in pr_body[match.end():].splitlines():
-		if SECTION_HEADING_RE.match(line):
+		heading_match = SECTION_HEADING_RE.match(line)
+		if heading_match and len(heading_match.group("hashes")) <= descope_level:
 			break
 		if LIST_ITEM_RE.match(line):
 			return True

--- a/scripts/lint_plan_archival_completeness.py
+++ b/scripts/lint_plan_archival_completeness.py
@@ -95,7 +95,7 @@ def _fetch_issue_via_gh(repo: str, issue_number: int) -> dict | None:
 	except json.JSONDecodeError:
 		return None
 	return {
-		"labels": [l["name"] for l in data.get("labels", []) if isinstance(l, dict) and "name" in l],
+		"labels": [label["name"] for label in data.get("labels", []) if isinstance(label, dict) and "name" in label],
 		"body": data.get("body", "") or "",
 	}
 

--- a/scripts/lint_plan_archival_completeness.py
+++ b/scripts/lint_plan_archival_completeness.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Lint a PR that adds files under docs/completed/ for plan-archival completeness.
+
+Project #2734's integration PR moved the plan to `docs/completed/` and
+labelled the tracking issue `ai:merged` while 7 of 9 sub-issue checkboxes
+in the tracking issue body remained unchecked (see
+`docs/postmortems/2026-05-18-project-2734-stall.md` layer 4). The plan
+file's presence in `docs/completed/` then became a load-bearing-but-
+misleading signal: "this plan is done" when in fact most of it was
+unshipped.
+
+This lint enforces P6 from the postmortem: any PR that creates a
+`docs/completed/<plan>.md` file must, for every `ai:orchestrator-tracking`
+issue referenced from the PR body, either:
+
+  A. Have all `[ ]` checkboxes in the tracking issue body checked
+     (`[x]`) — i.e. the plan really is complete; OR
+  B. Have a structured `## De-scoped phases` section in the PR body
+     that explicitly lists every unshipped checkbox with a rationale.
+
+Either A or B is sufficient; neither is fatal-by-omission alone. The
+intent is to force the PR author to be explicit about scope when
+archiving a plan, so the `docs/completed/` directory remains an
+honest record.
+
+Exit codes:
+  0 — no `docs/completed/` files added; OR every referenced tracking
+      issue passes A or B.
+  1 — at least one tracking issue has unchecked sub-issues AND the PR
+      body lacks the de-scope section. Each violation is surfaced as
+      a structured `::error::[lint_plan_archival]` line.
+  2 — usage error or unrecoverable lookup failure (gh CLI unavailable
+      and `--fail-open-on-lookup-error` not set).
+
+Usage:
+  python3 scripts/lint_plan_archival_completeness.py \\
+    --pr-body-file <path>                # required
+    --added-files-file <path>            # required; one path per line
+    [--repo <owner/repo>]                # default: $GITHUB_REPOSITORY
+    [--fail-open-on-lookup-error]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+TRACKING_LABEL = "ai:orchestrator-tracking"
+
+# Matches `Refs #N`, `Related to #N`, `Closes #N`, `Fixes #N`, etc. We
+# accept all reference forms — the §19 lint (lint_pr_body_auto_close.py)
+# is responsible for forbidding auto-close keywords against tracking
+# issues; here we just need to harvest every #N the PR body mentions, then
+# filter to tracking-labeled ones.
+ISSUE_REF_RE = re.compile(r"(?<![\w-])#(?P<issue>\d+)(?![\w-])")
+
+# Matches a GitHub markdown task list item. Capture the state ([ ] / [x] /
+# [X]) and the rest of the line so we can name unchecked items in the
+# error message.
+CHECKBOX_RE = re.compile(r"^\s*-\s*\[(?P<state>[ xX])\]\s+(?P<text>.+)$")
+
+# Signature for the explicit de-scope acknowledgement section in the PR
+# body. The matched text must include a markdown heading (## or ###) and
+# the literal phrase "De-scoped phases" — the comparison is case-
+# insensitive so a contributor doesn't have to memorise capitalisation.
+DESCOPE_HEADING_RE = re.compile(r"^\s{0,3}#{2,6}\s+de[- ]scoped\s+phases\b", re.IGNORECASE | re.MULTILINE)
+
+# Files under this directory trigger the check.
+ARCHIVED_PLAN_DIR = "docs/completed/"
+
+
+def _fetch_issue_via_gh(repo: str, issue_number: int) -> dict | None:
+	"""Return {'labels': [...], 'body': '...'} for an issue, or None on failure."""
+	if not repo:
+		return None
+	cmd = [
+		"gh", "issue", "view", str(issue_number),
+		"--repo", repo,
+		"--json", "labels,body",
+	]
+	try:
+		result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
+	except (subprocess.SubprocessError, OSError):
+		return None
+	if result.returncode != 0:
+		return None
+	try:
+		data = json.loads(result.stdout or "{}")
+	except json.JSONDecodeError:
+		return None
+	return {
+		"labels": [l["name"] for l in data.get("labels", []) if isinstance(l, dict) and "name" in l],
+		"body": data.get("body", "") or "",
+	}
+
+
+def _extract_referenced_issues(pr_body: str) -> list[int]:
+	"""Unique issue numbers referenced by `#N` in the PR body, in order of first appearance."""
+	seen: set[int] = set()
+	ordered: list[int] = []
+	for m in ISSUE_REF_RE.finditer(pr_body):
+		n = int(m.group("issue"))
+		if n not in seen:
+			seen.add(n)
+			ordered.append(n)
+	return ordered
+
+
+def _enumerate_unchecked_boxes(issue_body: str) -> list[str]:
+	"""Return the text of every unchecked task list item in the issue body."""
+	unchecked: list[str] = []
+	for line in issue_body.splitlines():
+		m = CHECKBOX_RE.match(line)
+		if m and m.group("state") == " ":
+			unchecked.append(m.group("text").strip())
+	return unchecked
+
+
+def lint(
+	*,
+	pr_body: str,
+	added_files: list[str],
+	repo: str,
+	fail_open_on_lookup_error: bool,
+	issue_fetcher=None,
+) -> tuple[list[str], list[str]]:
+	"""Return (violations, lookup_errors). issue_fetcher is an injectable
+	callable for tests (signature: (repo, issue_number) -> dict | None);
+	defaults to _fetch_issue_via_gh.
+	"""
+	if issue_fetcher is None:
+		issue_fetcher = _fetch_issue_via_gh
+
+	archived = [f for f in added_files if f.startswith(ARCHIVED_PLAN_DIR)]
+	if not archived:
+		return [], []  # Not an archival PR; nothing to check.
+
+	referenced_issues = _extract_referenced_issues(pr_body)
+	if not referenced_issues:
+		# The PR archives a plan but references no issues. Surface as a
+		# violation — without a Refs #N the operator cannot trace the
+		# archival back to a project.
+		return (
+			[
+				"PR adds files under docs/completed/ but the PR body references no "
+				"issues. Include `Refs #N` for the tracking issue this plan belonged "
+				"to, so the archival can be audited against the issue's checkboxes. "
+				f"Archived files: {', '.join(archived)}"
+			],
+			[],
+		)
+
+	has_descope_section = DESCOPE_HEADING_RE.search(pr_body) is not None
+
+	violations: list[str] = []
+	lookup_errors: list[str] = []
+	for issue_num in referenced_issues:
+		issue = issue_fetcher(repo, issue_num)
+		if issue is None:
+			lookup_errors.append(
+				f"could not fetch issue #{issue_num} from {repo!r}; check gh auth."
+			)
+			continue
+		if TRACKING_LABEL not in issue["labels"]:
+			continue  # Not a tracking issue; not in scope for this lint.
+		unchecked = _enumerate_unchecked_boxes(issue["body"])
+		if not unchecked:
+			continue  # Tracking issue is fully ticked — scenario A satisfied.
+		if has_descope_section:
+			continue  # Scenario B satisfied — PR body acknowledges the scope.
+		# Neither A nor B — violation.
+		preview = "\n".join(f"      - {item[:100]}" for item in unchecked[:10])
+		more = f"\n      … and {len(unchecked) - 10} more" if len(unchecked) > 10 else ""
+		violations.append(
+			f"Tracking issue #{issue_num} has {len(unchecked)} unchecked sub-issue "
+			f"checkbox(es), but PR archives plan to docs/completed/ without an "
+			f"explicit `## De-scoped phases` section in the body. Either tick the "
+			f"checkboxes on issue #{issue_num} before merging, or add a "
+			f"`## De-scoped phases` section to the PR body that lists every "
+			f"unshipped phase with rationale.\n"
+			f"    Archived files: {', '.join(archived)}\n"
+			f"    Unchecked items:\n{preview}{more}"
+		)
+	return violations, lookup_errors
+
+
+def main() -> int:
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument("--pr-body-file", required=True, type=Path)
+	parser.add_argument("--added-files-file", required=True, type=Path,
+		help="Path to a file containing one added-file path per line.")
+	parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+	parser.add_argument("--fail-open-on-lookup-error", action="store_true")
+	args = parser.parse_args()
+
+	if not args.pr_body_file.exists():
+		print(f"::error::PR body file not found: {args.pr_body_file}", file=sys.stderr)
+		return 2
+	if not args.added_files_file.exists():
+		print(f"::error::added files file not found: {args.added_files_file}", file=sys.stderr)
+		return 2
+
+	pr_body = args.pr_body_file.read_text(encoding="utf-8", errors="replace")
+	added_files = [line.strip() for line in args.added_files_file.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+	if not args.repo:
+		print("::error::no repo (pass --repo or set GITHUB_REPOSITORY)", file=sys.stderr)
+		return 2
+
+	violations, lookup_errors = lint(
+		pr_body=pr_body,
+		added_files=added_files,
+		repo=args.repo,
+		fail_open_on_lookup_error=args.fail_open_on_lookup_error,
+	)
+
+	for err in lookup_errors:
+		print(f"::warning::[lint_plan_archival] {err}", file=sys.stderr)
+
+	if violations:
+		for v in violations:
+			print(f"::error::[lint_plan_archival] {v}", file=sys.stderr)
+		print(
+			f"::error::[lint_plan_archival] {len(violations)} plan-archival "
+			f"completeness violation(s). See "
+			f"docs/postmortems/2026-05-18-project-2734-stall.md (layer 4) for "
+			f"why archival without scope acknowledgement is forbidden.",
+			file=sys.stderr,
+		)
+		return 1
+
+	if lookup_errors and not args.fail_open_on_lookup_error:
+		print("::error::[lint_plan_archival] lookup errors blocked the check", file=sys.stderr)
+		return 2
+
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/scripts/lint_pr_body_auto_close.py
+++ b/scripts/lint_pr_body_auto_close.py
@@ -30,6 +30,10 @@ Usage:
 Generator-side usage (P4 in docs/postmortems/2026-05-18-project-2734-stall.md):
   call this script BEFORE submitting an AI-authored PR body and refuse to
   create the PR if exit code != 0.
+
+Markdown note: PR bodies are scanned after masking fenced code blocks and
+inline code spans so historical examples like `` `Fixes #2734` `` do not
+false-positive. Commit messages remain plain-text scans.
 """
 
 from __future__ import annotations
@@ -80,6 +84,8 @@ AUTO_CLOSE_RE = re.compile(
 # against an issue with this label are forbidden because closing the
 # tracking issue stops wave dispatch.
 TRACKING_LABEL = "ai:orchestrator-tracking"
+FENCED_CODE_RE = re.compile(r"^\s*(```+|~~~+)")
+INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
 
 
 class LintViolation:
@@ -142,7 +148,7 @@ def _fetch_issue_labels_gh(repo: str, issue_number: int) -> list[str] | None:
 	return [str(label) for label in labels]
 
 
-def _scan_text(source: str, text: str) -> list[tuple[int, str, str, int]]:
+def _scan_text(source: str, text: str, *, markdown: bool = False) -> list[tuple[int, str, str, int]]:
 	"""Return a list of (line_no, line, keyword, issue_number) tuples for every
 	auto-close keyword match in `text`. line_no is 1-based.
 
@@ -152,7 +158,27 @@ def _scan_text(source: str, text: str) -> list[tuple[int, str, str, int]]:
 	match; we pick whichever fired.
 	"""
 	matches: list[tuple[int, str, str, int]] = []
-	for line_no, line in enumerate(text.splitlines(), start=1):
+	in_fenced_code = False
+	fence_char = ""
+	fence_len = 0
+	for line_no, raw_line in enumerate(text.splitlines(), start=1):
+		line = raw_line
+		if markdown:
+			stripped = raw_line.lstrip()
+			if in_fenced_code:
+				if stripped.startswith(fence_char * fence_len):
+					in_fenced_code = False
+					fence_char = ""
+					fence_len = 0
+				continue
+			fence_match = FENCED_CODE_RE.match(raw_line)
+			if fence_match:
+				fence_token = fence_match.group(1)
+				in_fenced_code = True
+				fence_char = fence_token[0]
+				fence_len = len(fence_token)
+				continue
+			line = INLINE_CODE_RE.sub("", raw_line)
 		for m in AUTO_CLOSE_RE.finditer(line):
 			issue_str = m.group("issue_short") or m.group("issue_url")
 			if not issue_str:
@@ -187,7 +213,7 @@ def lint(
 		label_lookup = _fetch_issue_labels_gh
 
 	candidate_matches: list[tuple[str, int, str, str, int]] = []
-	for line_no, line, keyword, issue in _scan_text("PR body", pr_body):
+	for line_no, line, keyword, issue in _scan_text("PR body", pr_body, markdown=True):
 		candidate_matches.append(("PR body", line_no, line, keyword, issue))
 	for rec_no, msg in commit_messages:
 		for line_no, line, keyword, issue in _scan_text(f"commit message #{rec_no}", msg):

--- a/scripts/lint_pr_body_auto_close.py
+++ b/scripts/lint_pr_body_auto_close.py
@@ -87,7 +87,10 @@ AUTO_CLOSE_RE = re.compile(
 # tracking issue stops wave dispatch.
 TRACKING_LABEL = "ai:orchestrator-tracking"
 FENCED_CODE_RE = re.compile(r"^\s*(```+|~~~+)")
-INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+# Match inline code spans delimited by one or more backticks, reusing the
+# exact same fence length for the closer so double-backtick spans like
+# ``Fixes #2734`` are masked before keyword scanning.
+INLINE_CODE_RE = re.compile(r"(?P<fence>`+)(?P<code>[^\n]*?)(?P=fence)")
 
 
 class LintViolation:
@@ -238,13 +241,16 @@ def lint(
 	lookup_errors: list[str] = []
 	# Cache per-(repo, issue) lookups so a body with multiple references to the
 	# same issue makes one gh call, not N (CLAUDE.md §15).
-	issue_label_cache: dict[tuple[str, int], list[str] | None] = {}
+	issue_label_cache: dict[tuple[str, int], list[str]] = {}
 	for source, line_no, line, keyword, referenced_repo, issue in candidate_matches:
 		lookup_repo = referenced_repo or repo
 		cache_key = (lookup_repo, issue)
-		if cache_key not in issue_label_cache:
-			issue_label_cache[cache_key] = label_lookup(lookup_repo, issue)
-		labels = issue_label_cache[cache_key]
+		if cache_key in issue_label_cache:
+			labels = issue_label_cache[cache_key]
+		else:
+			labels = label_lookup(lookup_repo, issue)
+			if labels is not None:
+				issue_label_cache[cache_key] = labels
 		if labels is None:
 			lookup_errors.append(
 				f"could not fetch labels for {lookup_repo}#{issue} (matched in {source}:line {line_no}); "

--- a/scripts/lint_pr_body_auto_close.py
+++ b/scripts/lint_pr_body_auto_close.py
@@ -74,9 +74,9 @@ _KEYWORD_ALT = "|".join(AUTO_CLOSE_KEYWORDS)
 AUTO_CLOSE_RE = re.compile(
 	rf"(?i)(?<![\w-])(?P<keyword>{_KEYWORD_ALT})\s*:?\s+"
 	rf"(?:"
-	rf"(?:[\w.-]+/[\w.-]+)?#(?P<issue_short>\d+)"
+	rf"(?:(?P<issue_repo_short>[\w.-]+/[\w.-]+))?#(?P<issue_short>\d+)"
 	rf"|"
-	rf"https?://github\.com/[\w.-]+/[\w.-]+/issues/(?P<issue_url>\d+)"
+	rf"https?://github\.com/(?P<issue_repo_url>[\w.-]+/[\w.-]+)/issues/(?P<issue_url>\d+)"
 	rf")(?![\w-])"
 )
 
@@ -91,18 +91,28 @@ INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
 class LintViolation:
 	"""A single auto-close keyword that references an orchestrator-tracking issue."""
 
-	def __init__(self, source: str, line_no: int, line: str, keyword: str, issue: int):
+	def __init__(
+		self,
+		source: str,
+		line_no: int,
+		line: str,
+		keyword: str,
+		issue: int,
+		issue_repo: str | None = None,
+	):
 		self.source = source
 		self.line_no = line_no
 		self.line = line.rstrip("\n")
 		self.keyword = keyword
 		self.issue = issue
+		self.issue_repo = issue_repo
 
 	def format(self) -> str:
+		issue_ref = f"{self.issue_repo}#{self.issue}" if self.issue_repo else f"#{self.issue}"
 		return (
 			f"::error::[lint_pr_body_auto_close] {self.source}:line {self.line_no} — "
 			f"auto-close keyword '{self.keyword}' references ai:orchestrator-tracking "
-			f"issue #{self.issue}. On merge this would auto-close the tracking issue "
+			f"issue {issue_ref}. On merge this would auto-close the tracking issue "
 			f"and stop the orchestrator's wave dispatch (see CLAUDE.md §19 and "
 			f"docs/postmortems/2026-05-18-project-2734-stall.md). Use 'Refs #' or "
 			f"'Related to #' instead.\n"
@@ -148,16 +158,18 @@ def _fetch_issue_labels_gh(repo: str, issue_number: int) -> list[str] | None:
 	return [str(label) for label in labels]
 
 
-def _scan_text(source: str, text: str, *, markdown: bool = False) -> list[tuple[int, str, str, int]]:
-	"""Return a list of (line_no, line, keyword, issue_number) tuples for every
-	auto-close keyword match in `text`. line_no is 1-based.
+def _scan_text(source: str, text: str, *, markdown: bool = False) -> list[tuple[int, str, str, str | None, int]]:
+	"""Return a list of (line_no, line, keyword, referenced_repo, issue_number)
+	tuples for every auto-close keyword match in `text`. line_no is 1-based.
 
 	The regex has two named groups for the issue number — `issue_short`
 	(for `#N` and `owner/repo#N` forms) and `issue_url` (for the full
 	`https://github.com/.../issues/N` form). Exactly one is populated per
-	match; we pick whichever fired.
+	match; we pick whichever fired. `referenced_repo` is None for same-repo
+	short-form references and `owner/repo` for cross-repo short or URL
+	forms so label lookup can target the actual referenced issue.
 	"""
-	matches: list[tuple[int, str, str, int]] = []
+	matches: list[tuple[int, str, str, str | None, int]] = []
 	in_fenced_code = False
 	fence_char = ""
 	fence_len = 0
@@ -183,7 +195,8 @@ def _scan_text(source: str, text: str, *, markdown: bool = False) -> list[tuple[
 			issue_str = m.group("issue_short") or m.group("issue_url")
 			if not issue_str:
 				continue
-			matches.append((line_no, line, m.group("keyword"), int(issue_str)))
+			referenced_repo = m.group("issue_repo_short") or m.group("issue_repo_url") or None
+			matches.append((line_no, line, m.group("keyword"), referenced_repo, int(issue_str)))
 	return matches
 
 
@@ -212,26 +225,28 @@ def lint(
 	if label_lookup is None:
 		label_lookup = _fetch_issue_labels_gh
 
-	candidate_matches: list[tuple[str, int, str, str, int]] = []
-	for line_no, line, keyword, issue in _scan_text("PR body", pr_body, markdown=True):
-		candidate_matches.append(("PR body", line_no, line, keyword, issue))
+	candidate_matches: list[tuple[str, int, str, str, str | None, int]] = []
+	for line_no, line, keyword, referenced_repo, issue in _scan_text("PR body", pr_body, markdown=True):
+		candidate_matches.append(("PR body", line_no, line, keyword, referenced_repo, issue))
 	for rec_no, msg in commit_messages:
-		for line_no, line, keyword, issue in _scan_text(f"commit message #{rec_no}", msg):
-			candidate_matches.append((f"commit message #{rec_no}", line_no, line, keyword, issue))
+		for line_no, line, keyword, referenced_repo, issue in _scan_text(f"commit message #{rec_no}", msg):
+			candidate_matches.append((f"commit message #{rec_no}", line_no, line, keyword, referenced_repo, issue))
 
 	violations: list[LintViolation] = []
 	lookup_errors: list[str] = []
-	# Cache per-issue lookups so a body with multiple references to the same
-	# issue makes one gh call, not N (CLAUDE.md §15).
-	issue_label_cache: dict[int, list[str] | None] = {}
-	for source, line_no, line, keyword, issue in candidate_matches:
-		if issue not in issue_label_cache:
-			issue_label_cache[issue] = label_lookup(repo, issue)
-		labels = issue_label_cache[issue]
+	# Cache per-(repo, issue) lookups so a body with multiple references to the
+	# same issue makes one gh call, not N (CLAUDE.md §15).
+	issue_label_cache: dict[tuple[str, int], list[str] | None] = {}
+	for source, line_no, line, keyword, referenced_repo, issue in candidate_matches:
+		lookup_repo = referenced_repo or repo
+		cache_key = (lookup_repo, issue)
+		if cache_key not in issue_label_cache:
+			issue_label_cache[cache_key] = label_lookup(lookup_repo, issue)
+		labels = issue_label_cache[cache_key]
 		if labels is None:
 			lookup_errors.append(
-				f"could not fetch labels for #{issue} (matched in {source}:line {line_no}); "
-				f"check gh auth and {repo!r} accessibility"
+				f"could not fetch labels for {lookup_repo}#{issue} (matched in {source}:line {line_no}); "
+				f"check gh auth and {lookup_repo!r} accessibility"
 			)
 			if fail_open_on_lookup_error:
 				continue
@@ -240,7 +255,7 @@ def lint(
 			# Surface as a lookup error which the caller maps to exit 2.
 			continue
 		if TRACKING_LABEL in labels:
-			violations.append(LintViolation(source, line_no, line, keyword, issue))
+			violations.append(LintViolation(source, line_no, line, keyword, issue, referenced_repo))
 	return violations, lookup_errors
 
 

--- a/scripts/lint_pr_body_auto_close.py
+++ b/scripts/lint_pr_body_auto_close.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Lint a PR body (and optionally its commit messages) for GitHub auto-close
-keywords that target ai:orchestrator-tracking issues.
+"""Lint PR title/body text (and optionally commit messages) for GitHub auto-
+close keywords that target ai:orchestrator-tracking issues.
 
 Enforces CLAUDE.md §19 (and the mirror in unattended_system_instructions.md):
 no `Fixes/Closes/Resolves #N` keyword may reference an `ai:orchestrator-tracking`
@@ -19,7 +19,7 @@ Exit codes:
 
 Usage:
   python3 scripts/lint_pr_body_auto_close.py \\
-    --pr-body-file <path>            # required; path to PR body text file
+    --pr-body-file <path>            # required; path to PR title/body text file
     [--commit-messages-file <path>]  # optional; one commit message per record,
                                      #   records separated by NUL bytes
     [--repo <owner/repo>]            # default: $GITHUB_REPOSITORY
@@ -68,11 +68,13 @@ AUTO_CLOSE_KEYWORDS = (
 #   1. `keyword #N`                                          (same-repo short form)
 #   2. `keyword owner/repo#N`                                (cross-repo short form)
 #   3. `keyword https://github.com/owner/repo/issues/N`      (URL form)
+# Colon forms like `Closes: #N` are intentionally NOT matched because
+# GitHub does not auto-close on that syntax.
 # Boundaries `(?<![\w-])` / `(?![\w-])` prevent matches inside words
 # (e.g. "prefix" should not match "fix").
 _KEYWORD_ALT = "|".join(AUTO_CLOSE_KEYWORDS)
 AUTO_CLOSE_RE = re.compile(
-	rf"(?i)(?<![\w-])(?P<keyword>{_KEYWORD_ALT})\s*:?\s+"
+	rf"(?i)(?<![\w-])(?P<keyword>{_KEYWORD_ALT})\s+"
 	rf"(?:"
 	rf"(?:(?P<issue_repo_short>[\w.-]+/[\w.-]+))?#(?P<issue_short>\d+)"
 	rf"|"
@@ -261,10 +263,10 @@ def lint(
 
 def main() -> int:
 	parser = argparse.ArgumentParser(
-		description="Lint a PR body for auto-close keywords against ai:orchestrator-tracking issues.",
+		description="Lint PR title/body text for auto-close keywords against ai:orchestrator-tracking issues.",
 	)
 	parser.add_argument("--pr-body-file", required=True, type=Path,
-		help="Path to the PR body text file.")
+		help="Path to the PR title/body text file.")
 	parser.add_argument("--commit-messages-file", type=Path, default=None,
 		help="Optional path to a file containing NUL-separated commit messages.")
 	parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""),

--- a/scripts/lint_pr_body_auto_close.py
+++ b/scripts/lint_pr_body_auto_close.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Lint a PR body (and optionally its commit messages) for GitHub auto-close
+keywords that target ai:orchestrator-tracking issues.
+
+Enforces CLAUDE.md §19 (and the mirror in unattended_system_instructions.md):
+no `Fixes/Closes/Resolves #N` keyword may reference an `ai:orchestrator-tracking`
+issue in a PR body, PR title, or commit message that will land on the default
+branch. On squash-merge GitHub uses the PR title + body for the squash commit
+message and auto-closes referenced issues, which kills the orchestrator's
+state machine (the poller filters tracking issues by `--state open`).
+
+Exit codes:
+  0 — no violations (no auto-close keywords, OR none reference an
+      ai:orchestrator-tracking issue).
+  1 — at least one violation. Each violation is printed to stderr with the
+      matched text, issue number, and remediation guidance.
+  2 — usage error or unrecoverable lookup failure (e.g. gh CLI unavailable
+      AND `--fail-open-on-lookup-error` not set).
+
+Usage:
+  python3 scripts/lint_pr_body_auto_close.py \\
+    --pr-body-file <path>            # required; path to PR body text file
+    [--commit-messages-file <path>]  # optional; one commit message per record,
+                                     #   records separated by NUL bytes
+    [--repo <owner/repo>]            # default: $GITHUB_REPOSITORY
+    [--fail-open-on-lookup-error]    # treat gh lookup failures as 'no label'
+                                     #   rather than as exit-2. Use in local
+                                     #   dev where gh may not be authenticated.
+
+Generator-side usage (P4 in docs/postmortems/2026-05-18-project-2734-stall.md):
+  call this script BEFORE submitting an AI-authored PR body and refuse to
+  create the PR if exit code != 0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# CLAUDE.md §19 auto-close keyword list (case-insensitive). Matches the
+# exact wording GitHub uses to auto-close referenced issues on merge to the
+# default branch — see https://docs.github.com/articles/closing-issues-using-keywords
+# Keep this list IN SYNC with the §19 ban list in CLAUDE.md and the mirror
+# in unattended_system_instructions.md; if GitHub adds a new keyword, both
+# the docs and this list must be updated together.
+AUTO_CLOSE_KEYWORDS = (
+	"close",
+	"closes",
+	"closed",
+	"fix",
+	"fixes",
+	"fixed",
+	"resolve",
+	"resolves",
+	"resolved",
+)
+
+# The pattern catches `keyword #N`, `keyword: #N`, and `keyword <space(s)> #N`
+# (with optional `owner/repo` qualifier before `#N`). The `(?<![\w-])` /
+# `(?![\w-])` boundaries prevent matches inside words (e.g. "prefix" should
+# not match "fix").
+_KEYWORD_ALT = "|".join(AUTO_CLOSE_KEYWORDS)
+AUTO_CLOSE_RE = re.compile(
+	rf"(?i)(?<![\w-])(?P<keyword>{_KEYWORD_ALT})\s*:?\s+(?:[\w.-]+/[\w.-]+)?#(?P<issue>\d+)(?![\w-])"
+)
+
+# Label that marks an orchestrator tracking issue. Auto-close keywords
+# against an issue with this label are forbidden because closing the
+# tracking issue stops wave dispatch.
+TRACKING_LABEL = "ai:orchestrator-tracking"
+
+
+class LintViolation:
+	"""A single auto-close keyword that references an orchestrator-tracking issue."""
+
+	def __init__(self, source: str, line_no: int, line: str, keyword: str, issue: int):
+		self.source = source
+		self.line_no = line_no
+		self.line = line.rstrip("\n")
+		self.keyword = keyword
+		self.issue = issue
+
+	def format(self) -> str:
+		return (
+			f"::error::[lint_pr_body_auto_close] {self.source}:line {self.line_no} — "
+			f"auto-close keyword '{self.keyword}' references ai:orchestrator-tracking "
+			f"issue #{self.issue}. On merge this would auto-close the tracking issue "
+			f"and stop the orchestrator's wave dispatch (see CLAUDE.md §19 and "
+			f"docs/postmortems/2026-05-18-project-2734-stall.md). Use 'Refs #' or "
+			f"'Related to #' instead.\n"
+			f"    Matched line: {self.line}"
+		)
+
+
+def _fetch_issue_labels_gh(repo: str, issue_number: int) -> list[str] | None:
+	"""Return the label names for an issue via the `gh` CLI, or None on lookup
+	failure. None means "could not determine"; the caller decides whether to
+	treat that as fail-open or fail-closed.
+	"""
+	if not repo:
+		return None
+	cmd = [
+		"gh", "issue", "view", str(issue_number),
+		"--repo", repo,
+		"--json", "labels",
+		"--jq", "[.labels[].name]",
+	]
+	try:
+		result = subprocess.run(
+			cmd,
+			capture_output=True,
+			text=True,
+			timeout=30,
+			check=False,
+		)
+	except (subprocess.SubprocessError, OSError):
+		return None
+	if result.returncode != 0:
+		return None
+	out = (result.stdout or "").strip()
+	if not out:
+		return []
+	import json as _json
+	try:
+		labels = _json.loads(out)
+	except _json.JSONDecodeError:
+		return None
+	if not isinstance(labels, list):
+		return None
+	return [str(label) for label in labels]
+
+
+def _scan_text(source: str, text: str) -> list[tuple[int, str, str, int]]:
+	"""Return a list of (line_no, line, keyword, issue_number) tuples for every
+	auto-close keyword match in `text`. line_no is 1-based.
+	"""
+	matches: list[tuple[int, str, str, int]] = []
+	for line_no, line in enumerate(text.splitlines(), start=1):
+		for m in AUTO_CLOSE_RE.finditer(line):
+			matches.append((line_no, line, m.group("keyword"), int(m.group("issue"))))
+	return matches
+
+
+def _load_commit_messages(path: Path) -> list[tuple[int, str]]:
+	"""Read NUL-separated commit messages; return [(record_no, message)]."""
+	raw = path.read_bytes()
+	# Strip a trailing NUL so a clean `--format=%B%x00` doesn't add an empty record.
+	if raw.endswith(b"\x00"):
+		raw = raw[:-1]
+	records = raw.split(b"\x00") if raw else []
+	return [(idx + 1, rec.decode("utf-8", errors="replace")) for idx, rec in enumerate(records)]
+
+
+def lint(
+	*,
+	pr_body: str,
+	commit_messages: list[tuple[int, str]],
+	repo: str,
+	fail_open_on_lookup_error: bool,
+	label_lookup=None,
+) -> tuple[list[LintViolation], list[str]]:
+	"""Return (violations, lookup_errors). label_lookup is an injectable
+	callable for tests (signature: (repo: str, issue_number: int) -> list[str] | None);
+	default uses _fetch_issue_labels_gh.
+	"""
+	if label_lookup is None:
+		label_lookup = _fetch_issue_labels_gh
+
+	candidate_matches: list[tuple[str, int, str, str, int]] = []
+	for line_no, line, keyword, issue in _scan_text("PR body", pr_body):
+		candidate_matches.append(("PR body", line_no, line, keyword, issue))
+	for rec_no, msg in commit_messages:
+		for line_no, line, keyword, issue in _scan_text(f"commit message #{rec_no}", msg):
+			candidate_matches.append((f"commit message #{rec_no}", line_no, line, keyword, issue))
+
+	violations: list[LintViolation] = []
+	lookup_errors: list[str] = []
+	# Cache per-issue lookups so a body with multiple references to the same
+	# issue makes one gh call, not N (CLAUDE.md §15).
+	issue_label_cache: dict[int, list[str] | None] = {}
+	for source, line_no, line, keyword, issue in candidate_matches:
+		if issue not in issue_label_cache:
+			issue_label_cache[issue] = label_lookup(repo, issue)
+		labels = issue_label_cache[issue]
+		if labels is None:
+			lookup_errors.append(
+				f"could not fetch labels for #{issue} (matched in {source}:line {line_no}); "
+				f"check gh auth and {repo!r} accessibility"
+			)
+			if fail_open_on_lookup_error:
+				continue
+			# Without fail-open, treat lookup failure as a violation candidate
+			# only if we cannot prove the issue is NOT a tracking issue.
+			# Surface as a lookup error which the caller maps to exit 2.
+			continue
+		if TRACKING_LABEL in labels:
+			violations.append(LintViolation(source, line_no, line, keyword, issue))
+	return violations, lookup_errors
+
+
+def main() -> int:
+	parser = argparse.ArgumentParser(
+		description="Lint a PR body for auto-close keywords against ai:orchestrator-tracking issues.",
+	)
+	parser.add_argument("--pr-body-file", required=True, type=Path,
+		help="Path to the PR body text file.")
+	parser.add_argument("--commit-messages-file", type=Path, default=None,
+		help="Optional path to a file containing NUL-separated commit messages.")
+	parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""),
+		help="owner/repo for issue label lookups. Defaults to $GITHUB_REPOSITORY.")
+	parser.add_argument("--fail-open-on-lookup-error", action="store_true",
+		help="If a gh lookup fails, treat the issue as having no labels rather "
+			"than as a hard error. Use in local dev where gh may not be authenticated.")
+	args = parser.parse_args()
+
+	if not args.pr_body_file.exists():
+		print(f"::error::PR body file not found: {args.pr_body_file}", file=sys.stderr)
+		return 2
+
+	pr_body = args.pr_body_file.read_text(encoding="utf-8", errors="replace")
+	commit_messages: list[tuple[int, str]] = []
+	if args.commit_messages_file:
+		if not args.commit_messages_file.exists():
+			print(f"::error::commit messages file not found: {args.commit_messages_file}", file=sys.stderr)
+			return 2
+		commit_messages = _load_commit_messages(args.commit_messages_file)
+
+	if not args.repo:
+		print(
+			"::error::no repo configured (pass --repo owner/repo or set GITHUB_REPOSITORY)",
+			file=sys.stderr,
+		)
+		return 2
+
+	violations, lookup_errors = lint(
+		pr_body=pr_body,
+		commit_messages=commit_messages,
+		repo=args.repo,
+		fail_open_on_lookup_error=args.fail_open_on_lookup_error,
+	)
+
+	for err in lookup_errors:
+		print(f"::warning::[lint_pr_body_auto_close] {err}", file=sys.stderr)
+
+	if violations:
+		for v in violations:
+			print(v.format(), file=sys.stderr)
+		print(
+			f"::error::[lint_pr_body_auto_close] {len(violations)} auto-close "
+			f"keyword violation(s) against ai:orchestrator-tracking issues. "
+			f"Replace 'Fixes/Closes/Resolves' with 'Refs' or 'Related to' for "
+			f"these references and re-push.",
+			file=sys.stderr,
+		)
+		return 1
+
+	if lookup_errors and not args.fail_open_on_lookup_error:
+		print(
+			"::error::[lint_pr_body_auto_close] one or more issue label "
+			"lookups failed; cannot prove the PR body is clean. Either fix "
+			"the lookup error or re-run with --fail-open-on-lookup-error.",
+			file=sys.stderr,
+		)
+		return 2
+
+	# Quiet success.
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/scripts/lint_pr_body_auto_close.py
+++ b/scripts/lint_pr_body_auto_close.py
@@ -59,13 +59,21 @@ AUTO_CLOSE_KEYWORDS = (
 	"resolved",
 )
 
-# The pattern catches `keyword #N`, `keyword: #N`, and `keyword <space(s)> #N`
-# (with optional `owner/repo` qualifier before `#N`). The `(?<![\w-])` /
-# `(?![\w-])` boundaries prevent matches inside words (e.g. "prefix" should
-# not match "fix").
+# The pattern catches both `#N` form and full GitHub URL form, which
+# GitHub's auto-close logic treats equivalently. Three accepted shapes:
+#   1. `keyword #N`                                          (same-repo short form)
+#   2. `keyword owner/repo#N`                                (cross-repo short form)
+#   3. `keyword https://github.com/owner/repo/issues/N`      (URL form)
+# Boundaries `(?<![\w-])` / `(?![\w-])` prevent matches inside words
+# (e.g. "prefix" should not match "fix").
 _KEYWORD_ALT = "|".join(AUTO_CLOSE_KEYWORDS)
 AUTO_CLOSE_RE = re.compile(
-	rf"(?i)(?<![\w-])(?P<keyword>{_KEYWORD_ALT})\s*:?\s+(?:[\w.-]+/[\w.-]+)?#(?P<issue>\d+)(?![\w-])"
+	rf"(?i)(?<![\w-])(?P<keyword>{_KEYWORD_ALT})\s*:?\s+"
+	rf"(?:"
+	rf"(?:[\w.-]+/[\w.-]+)?#(?P<issue_short>\d+)"
+	rf"|"
+	rf"https?://github\.com/[\w.-]+/[\w.-]+/issues/(?P<issue_url>\d+)"
+	rf")(?![\w-])"
 )
 
 # Label that marks an orchestrator tracking issue. Auto-close keywords
@@ -137,11 +145,19 @@ def _fetch_issue_labels_gh(repo: str, issue_number: int) -> list[str] | None:
 def _scan_text(source: str, text: str) -> list[tuple[int, str, str, int]]:
 	"""Return a list of (line_no, line, keyword, issue_number) tuples for every
 	auto-close keyword match in `text`. line_no is 1-based.
+
+	The regex has two named groups for the issue number — `issue_short`
+	(for `#N` and `owner/repo#N` forms) and `issue_url` (for the full
+	`https://github.com/.../issues/N` form). Exactly one is populated per
+	match; we pick whichever fired.
 	"""
 	matches: list[tuple[int, str, str, int]] = []
 	for line_no, line in enumerate(text.splitlines(), start=1):
 		for m in AUTO_CLOSE_RE.finditer(line):
-			matches.append((line_no, line, m.group("keyword"), int(m.group("issue"))))
+			issue_str = m.group("issue_short") or m.group("issue_url")
+			if not issue_str:
+				continue
+			matches.append((line_no, line, m.group("keyword"), int(issue_str)))
 	return matches
 
 

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -3391,23 +3391,33 @@ _refresh_integration_resolver_tooling() {
               skipped_count=$((skipped_count + 1))
               continue
             fi
-            git cat-file -p "${base_hash}" > "${merge_tmpdir}/base" 2>/dev/null || : > "${merge_tmpdir}/base"
-            git cat-file -p "${int_hash}"  > "${merge_tmpdir}/int"  2>/dev/null
-            git cat-file -p "${main_hash}" > "${merge_tmpdir}/main" 2>/dev/null
+            if ! git cat-file -p "${base_hash}" > "${merge_tmpdir}/base" 2>/dev/null \
+              || ! git cat-file -p "${int_hash}" > "${merge_tmpdir}/int" 2>/dev/null \
+              || ! git cat-file -p "${main_hash}" > "${merge_tmpdir}/main" 2>/dev/null; then
+              echo "::warning::${log_prefix} could not materialize one or more 3-way merge inputs for ${f}; skipping." >&2
+              skipped_count=$((skipped_count + 1))
+              rm -rf "${merge_tmpdir}" 2>/dev/null || true
+              continue
+            fi
             if git merge-file --quiet -L integration -L merge-base -L main \
                 "${merge_tmpdir}/int" "${merge_tmpdir}/base" "${merge_tmpdir}/main" 2>/dev/null; then
               # Clean merge (exit 0): integration + main edits combined
               # without conflict. Stage the merged content as the new
               # integration-branch version.
-              if cp "${merge_tmpdir}/int" "${f}" 2>/dev/null && git add -- "${f}" 2>/dev/null; then
-                refreshed_count=$((refreshed_count + 1))
-                refreshed_list+="${f} "
-                merged_3way_count=$((merged_3way_count + 1))
-                local _m_int_short="${int_hash:0:8}"
-                local _m_main_short="${main_hash:0:8}"
-                echo "  ${log_prefix} 3-way merged ${f} — combined integration (${_m_int_short}) and main (${_m_main_short}) edits since merge-base."
+              if cp "${merge_tmpdir}/int" "${f}" 2>/dev/null; then
+                if git add -- "${f}" 2>/dev/null; then
+                  refreshed_count=$((refreshed_count + 1))
+                  refreshed_list+="${f} "
+                  merged_3way_count=$((merged_3way_count + 1))
+                  local _m_int_short="${int_hash:0:8}"
+                  local _m_main_short="${main_hash:0:8}"
+                  echo "  ${log_prefix} 3-way merged ${f} — combined integration (${_m_int_short}) and main (${_m_main_short}) edits since merge-base."
+                else
+                  git checkout -- "${f}" 2>/dev/null || true
+                  echo "::warning::${log_prefix} git add failed after 3-way merge of ${f}; reverted worktree copy and excluded it from the refresh commit." >&2
+                fi
               else
-                echo "::warning::${log_prefix} 3-way merge of ${f} succeeded but staging failed; excluding from refresh commit." >&2
+                echo "::warning::${log_prefix} could not copy 3-way merge result for ${f}; excluding from refresh commit." >&2
               fi
             else
               # Non-zero exit: conflicts (1+) or merge-file error

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -3417,7 +3417,8 @@ _refresh_integration_resolver_tooling() {
                   echo "::warning::${log_prefix} git add failed after 3-way merge of ${f}; reverted worktree copy and excluded it from the refresh commit." >&2
                 fi
               else
-                echo "::warning::${log_prefix} could not copy 3-way merge result for ${f}; excluding from refresh commit." >&2
+                git checkout -- "${f}" 2>/dev/null || true
+                echo "::warning::${log_prefix} could not copy 3-way merge result for ${f}; reverted worktree copy and excluded it from the refresh commit." >&2
               fi
             else
               # Non-zero exit: conflicts (1+) or merge-file error

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -3320,6 +3320,12 @@ _refresh_integration_resolver_tooling() {
       local refreshed_list=""
       local drifted_count=0
       local skipped_count=0
+      # Subset of refreshed_count: files that were staged via the 3-way
+      # merge fallback rather than the deadlock-breaker checkout. Tracked
+      # separately so the post-refresh summary + commit-message body can
+      # name them — operators reviewing the refresh commit should see at
+      # a glance which files came from a clean overwrite vs a merge.
+      local merged_3way_count=0
       local f main_hash int_hash base_hash
       for f in "${refresh_files[@]}"; do
         # Skip if file does not exist on default_branch — never delete
@@ -3343,20 +3349,77 @@ _refresh_integration_resolver_tooling() {
         # but main has fixed — overwriting a file the integration
         # branch HAS touched would silently revert merged sub-issue
         # PR intent and trip the fingerprint verifier (issue #2734).
-        # Any legitimate main-side change to such a file must arrive
-        # via the normal main->integration sync (with 3-way merge),
-        # not via this refresh.  `[ -z "${base_hash}" ]` covers the
-        # "file did not exist at merge-base, integration added it"
-        # case the same way — never clobber an added file.
+        # `[ -z "${base_hash}" ]` covers the "file did not exist at
+        # merge-base, integration added it" case the same way — never
+        # clobber an added file.
+        #
+        # P5 from docs/postmortems/2026-05-18-project-2734-stall.md:
+        # When BOTH main and integration have changed since the
+        # merge-base, try `git merge-file` (3-way merge) before
+        # skipping. This is the layered defense-in-depth that PR
+        # #2760's divergence guard left as future work: when both
+        # branches edited the same allowlisted toolchain file in
+        # non-overlapping ways, the merge cleanly combines them, the
+        # toolchain ships its update to integration without losing the
+        # sub-issue PR intent, AND the deadlock-breaker stays alive.
+        # Only when the 3-way merge produces conflicts do we fall back
+        # to the conservative skip (let the normal main->integration
+        # sync handle the conflict resolution under operator review).
         if [ -n "${merge_base}" ]; then
           base_hash="$(git rev-parse --verify --quiet "${merge_base}:${f}" 2>/dev/null || echo "")"
           if [ "${int_hash}" != "${base_hash}" ]; then
-            skipped_count=$((skipped_count + 1))
-            local _int_short="${int_hash:0:8}"
-            local _base_short="${base_hash:0:8}"
-            [ -n "${_base_short}" ] || _base_short="none"
-            [ -n "${_int_short}" ] || _int_short="none"
-            echo "  ${log_prefix} skip ${f} — integration branch has committed changes since merge-base (int=${_int_short}, base=${_base_short}); main version must arrive via normal sync, not refresh."
+            # Sub-case (a): main is unchanged from the merge-base
+            # (only integration moved). Nothing to refresh from main.
+            # base_hash empty means "file added on integration" — still
+            # sub-case (a) because main has nothing to contribute.
+            if [ -z "${base_hash}" ] || [ "${main_hash}" = "${base_hash}" ]; then
+              skipped_count=$((skipped_count + 1))
+              local _int_short="${int_hash:0:8}"
+              local _base_short="${base_hash:0:8}"
+              [ -n "${_base_short}" ] || _base_short="none"
+              [ -n "${_int_short}" ] || _int_short="none"
+              echo "  ${log_prefix} skip ${f} — integration branch has committed changes since merge-base (int=${_int_short}, base=${_base_short}); main version must arrive via normal sync, not refresh."
+              continue
+            fi
+            # Sub-case (b): BOTH main and integration changed since
+            # the merge-base. Try a 3-way merge; on conflict, fall
+            # back to skip.
+            local merge_tmpdir
+            merge_tmpdir="$(mktemp -d 2>/dev/null || echo "")"
+            if [ -z "${merge_tmpdir}" ] || [ ! -d "${merge_tmpdir}" ]; then
+              echo "::warning::${log_prefix} could not create tmpdir for 3-way merge of ${f}; skipping." >&2
+              skipped_count=$((skipped_count + 1))
+              continue
+            fi
+            git cat-file -p "${base_hash}" > "${merge_tmpdir}/base" 2>/dev/null || : > "${merge_tmpdir}/base"
+            git cat-file -p "${int_hash}"  > "${merge_tmpdir}/int"  2>/dev/null
+            git cat-file -p "${main_hash}" > "${merge_tmpdir}/main" 2>/dev/null
+            if git merge-file --quiet -L integration -L merge-base -L main \
+                "${merge_tmpdir}/int" "${merge_tmpdir}/base" "${merge_tmpdir}/main" 2>/dev/null; then
+              # Clean merge (exit 0): integration + main edits combined
+              # without conflict. Stage the merged content as the new
+              # integration-branch version.
+              if cp "${merge_tmpdir}/int" "${f}" 2>/dev/null && git add -- "${f}" 2>/dev/null; then
+                refreshed_count=$((refreshed_count + 1))
+                refreshed_list+="${f} "
+                merged_3way_count=$((merged_3way_count + 1))
+                local _m_int_short="${int_hash:0:8}"
+                local _m_main_short="${main_hash:0:8}"
+                echo "  ${log_prefix} 3-way merged ${f} — combined integration (${_m_int_short}) and main (${_m_main_short}) edits since merge-base."
+              else
+                echo "::warning::${log_prefix} 3-way merge of ${f} succeeded but staging failed; excluding from refresh commit." >&2
+              fi
+            else
+              # Non-zero exit: conflicts (1+) or merge-file error
+              # (e.g. binary file at 255). Fall back to skip — the
+              # normal main->integration sync will surface the
+              # conflict under operator review.
+              skipped_count=$((skipped_count + 1))
+              local _c_int_short="${int_hash:0:8}"
+              local _c_base_short="${base_hash:0:8}"
+              echo "  ${log_prefix} skip ${f} — 3-way merge produced conflicts (int=${_c_int_short}, base=${_c_base_short}); main version must arrive via normal sync."
+            fi
+            rm -rf "${merge_tmpdir}" 2>/dev/null || true
             continue
           fi
         fi
@@ -3385,6 +3448,13 @@ _refresh_integration_resolver_tooling() {
         exit 0
       fi
 
+      if [ "${merged_3way_count}" -gt 0 ]; then
+        # Surface the 3-way merges in the per-tick log so they're easy to
+        # find when an operator audits the refresh commit. The commit-
+        # message body further down also records the count.
+        echo "  ${log_prefix} ${merged_3way_count} file(s) refreshed via 3-way merge (combined integration + main edits)."
+      fi
+
       if git diff --cached --quiet; then
         # Edge case: checkout reported success but git sees no staged
         # change (e.g. mode-only update on a filesystem without exec
@@ -3399,6 +3469,14 @@ _refresh_integration_resolver_tooling() {
       for _f in ${refreshed_list}; do
         body+=" - ${_f}"$'\n'
       done
+      if [ "${merged_3way_count}" -gt 0 ]; then
+        body+=$'\n'
+        body+="${merged_3way_count} file(s) refreshed via 3-way merge (combined integration"$'\n'
+        body+="and ${default_branch} edits since merge-base). The remaining $((refreshed_count - merged_3way_count))"$'\n'
+        body+="file(s) were refreshed by direct checkout of ${default_branch}'s version"$'\n'
+        body+="because the integration branch had not modified them since the"$'\n'
+        body+="merge-base."$'\n'
+      fi
       body+=$'\n'
       body+="Brings the integration branch's resolver toolchain up to date with"$'\n'
       body+="${default_branch} so any bug fixes shipped there take effect on the next"$'\n'

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -8494,6 +8494,56 @@ for ((tidx=0; tidx<COUNT; tidx++)); do
         if [ -z "${_orch_extfin_pr_state}" ] || [ -z "${_orch_extfin_pr_merged}" ]; then
           echo "::warning::[external-finalize] unable to inspect PR #${_orch_extfin_pr}; leaving final_merge_status pending."
         elif [ "${_orch_extfin_pr_state}" = "closed" ] && [ "${_orch_extfin_pr_merged}" = "true" ]; then
+          # Completeness gate (P2 from docs/postmortems/2026-05-18-project-2734-stall.md).
+          # An externally-merged integration PR is necessary but NOT sufficient
+          # evidence of project completion: a human (or another Claude session)
+          # can squash-merge the eager integration PR with only Wave 1 content
+          # while later waves remain undispatched (see project #2734, where 7
+          # of 9 sub-issues were never created). Without this gate the orchestrator
+          # would broadcast "✅ Project complete" while most of the planned work
+          # has shipped no code. Refuse to transition and alert the operator
+          # once per missing-issue-set; reviving some-but-not-all waves
+          # re-alerts because the set's signature changes.
+          #
+          # Filter is narrow on purpose: only `status == "not_created"`
+          # entries are caught. Sub-issues that were dispatched (have a
+          # github_issue number) and are merely in a transient
+          # `pending`/`active`/`in_progress` status while the orchestrator's
+          # own per-tick label reconciliation lags behind the GitHub merge
+          # event are NOT caught — those self-resolve on the next tick.
+          # The project #2734 incident specifically had Wave 2-7 sub-issues
+          # with `status == "not_created"` and `github_issue == null` for
+          # the entire 26-hour stall window, which is the case this gate
+          # exists to catch.
+          _orch_extfin_incomplete_json="$(jq -c \
+            '[.waves[]?.issues[]?
+              | select(.status == "not_created")
+              | {id: (.id // "<no-id>"), status: (.status // "unknown"), github_issue: (.github_issue // null)}]' \
+            "${STATE_FILE}" 2>/dev/null || echo "[]")"
+          _orch_extfin_incomplete_count="$(echo "${_orch_extfin_incomplete_json}" | jq 'length' 2>/dev/null || echo 0)"
+          if [ "${_orch_extfin_incomplete_count}" -gt 0 ]; then
+            _orch_extfin_missing_list="$(echo "${_orch_extfin_incomplete_json}" \
+              | jq -r '.[] | "  - " + .id + " [status=" + .status + "] github_issue=" + (.github_issue | tostring)')"
+            echo "::warning::[external-finalize-partial] PR #${_orch_extfin_pr} merged but ${_orch_extfin_incomplete_count} sub-issue(s) not in terminal-success state — refusing to transition project to complete."
+            echo "${_orch_extfin_missing_list}"
+            # Dedup the Telegram alert by hashing the missing-issue set.
+            _orch_extfin_missing_sig="$(echo "${_orch_extfin_incomplete_json}" | jq -S -c '.' 2>/dev/null | sha256sum | awk '{print $1}')"
+            _orch_extfin_prev_sig="$(jq -r '.external_finalize_partial_alert_sig // ""' "${STATE_FILE}" 2>/dev/null || echo "")"
+            if [ "${_orch_extfin_missing_sig}" != "${_orch_extfin_prev_sig}" ]; then
+              _orch_extfin_tg_msg="⚠️ Project #${TRACKING_NUM}: integration PR #${_orch_extfin_pr} merged externally, but ${_orch_extfin_incomplete_count} sub-issue(s) are still not terminal:"$'\n'"${_orch_extfin_missing_list}"$'\n'"Refusing to mark project complete. Either revive the missing waves or close them with rationale."
+              _orch_extfin_tg_msg+=$'\n'"Tracking: $(_gh_url "issues/${TRACKING_NUM}")"
+              tg_notify "${_orch_extfin_tg_msg}" "WARNING" || true
+              if jq --arg sig "${_orch_extfin_missing_sig}" \
+                '.external_finalize_partial_alert_sig = $sig' \
+                "${STATE_FILE}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "${STATE_FILE}"; then
+                :
+              else
+                rm -f "${STATE_FILE}.tmp" || true
+                echo "::warning::[external-finalize-partial] failed to persist alert-dedup signature; may re-alert on next tick."
+              fi
+            fi
+            continue
+          fi
           echo "  [external-finalize] PR #${_orch_extfin_pr} merged outside the wave-by-wave flow; transitioning project to complete."
           if ! jq --argjson final_pr "${_orch_extfin_pr}" \
             '.final_merge_pr = $final_pr

--- a/tests/test_check_integration_pr_readiness.py
+++ b/tests/test_check_integration_pr_readiness.py
@@ -158,6 +158,28 @@ def test_main_posts_noop_success_for_non_orchestrator_branch():
 		mod._fetch_issue = original_fetch
 
 
+def test_main_errors_when_non_orchestrator_status_post_fails():
+	mod = _import()
+	original_post = mod._post_commit_status
+	original_fetch = mod._fetch_issue
+	old_argv = sys.argv
+	try:
+		mod._post_commit_status = lambda repo, sha, state, description, target_url="": False
+		mod._fetch_issue = lambda repo, n: (_ for _ in ()).throw(AssertionError("_fetch_issue should not run for non-orchestrator branches"))
+		sys.argv = [
+			"check_integration_pr_readiness.py",
+			"--head-ref", "claude/fix-something",
+			"--head-sha", "deadbeef",
+			"--repo", "owner/repo",
+		]
+		rc = mod.main()
+		assert rc == 1
+	finally:
+		sys.argv = old_argv
+		mod._post_commit_status = original_post
+		mod._fetch_issue = original_fetch
+
+
 def test_main_fails_closed_when_tracking_issue_has_no_checkboxes():
 	mod = _import()
 	posted: list[tuple[str, str]] = []
@@ -179,6 +201,31 @@ def test_main_fails_closed_when_tracking_issue_has_no_checkboxes():
 			"failure",
 			"tracking issue #2734 has no checkbox items in its body; readiness check cannot verify completeness",
 		)]
+	finally:
+		sys.argv = old_argv
+		mod._post_commit_status = original_post
+		mod._fetch_issue = original_fetch
+
+
+def test_main_errors_when_failure_status_cannot_be_posted():
+	mod = _import()
+	original_post = mod._post_commit_status
+	original_fetch = mod._fetch_issue
+	old_argv = sys.argv
+	try:
+		mod._post_commit_status = lambda repo, sha, state, description, target_url="": False
+		mod._fetch_issue = lambda repo, n: {
+			"labels": [mod.TRACKING_LABEL],
+			"body": "- [ ] outstanding work\n",
+		}
+		sys.argv = [
+			"check_integration_pr_readiness.py",
+			"--head-ref", "orchestrator/project-2734",
+			"--head-sha", "deadbeef",
+			"--repo", "owner/repo",
+		]
+		rc = mod.main()
+		assert rc == 1
 	finally:
 		sys.argv = old_argv
 		mod._post_commit_status = original_post

--- a/tests/test_check_integration_pr_readiness.py
+++ b/tests/test_check_integration_pr_readiness.py
@@ -86,6 +86,14 @@ def test_count_checkboxes_no_checkboxes_in_body():
 	assert unchecked == []
 
 
+def test_count_checkboxes_blank_checkbox_item_counts_as_unchecked():
+	mod = _import()
+	body = "- [ ]\n- [x] done\n"
+	unchecked, total = mod._count_checkboxes(body)
+	assert total == 2
+	assert unchecked == ["<blank checkbox item>"]
+
+
 def test_count_checkboxes_handles_project_2734_body_shape():
 	# Pin against the actual project-#2734 body shape (the orchestrator-
 	# emitted template). If this regresses, the script silently
@@ -121,6 +129,60 @@ def test_count_checkboxes_handles_project_2734_body_shape():
 	unchecked, total = mod._count_checkboxes(body)
 	assert total == 9, f"expected 9 (project #2734 had 9 sub-issues), got {total}"
 	assert len(unchecked) == 9, f"expected 9 unchecked, got {len(unchecked)}"
+
+
+def test_main_posts_noop_success_for_non_orchestrator_branch():
+	mod = _import()
+	posted: list[tuple[str, str]] = []
+	original_post = mod._post_commit_status
+	original_fetch = mod._fetch_issue
+	old_argv = sys.argv
+	try:
+		mod._post_commit_status = lambda repo, sha, state, description, target_url="": posted.append((state, description)) or True
+		mod._fetch_issue = lambda repo, n: (_ for _ in ()).throw(AssertionError("_fetch_issue should not run for non-orchestrator branches"))
+		sys.argv = [
+			"check_integration_pr_readiness.py",
+			"--head-ref", "claude/fix-something",
+			"--head-sha", "deadbeef",
+			"--repo", "owner/repo",
+		]
+		rc = mod.main()
+		assert rc == 0
+		assert posted == [(
+			"success",
+			"head ref 'claude/fix-something' is not an orchestrator/project-* branch — readiness check does not apply",
+		)]
+	finally:
+		sys.argv = old_argv
+		mod._post_commit_status = original_post
+		mod._fetch_issue = original_fetch
+
+
+def test_main_fails_closed_when_tracking_issue_has_no_checkboxes():
+	mod = _import()
+	posted: list[tuple[str, str]] = []
+	original_post = mod._post_commit_status
+	original_fetch = mod._fetch_issue
+	old_argv = sys.argv
+	try:
+		mod._post_commit_status = lambda repo, sha, state, description, target_url="": posted.append((state, description)) or True
+		mod._fetch_issue = lambda repo, n: {"labels": [mod.TRACKING_LABEL], "body": "Just prose."}
+		sys.argv = [
+			"check_integration_pr_readiness.py",
+			"--head-ref", "orchestrator/project-2734",
+			"--head-sha", "deadbeef",
+			"--repo", "owner/repo",
+		]
+		rc = mod.main()
+		assert rc == 0
+		assert posted == [(
+			"failure",
+			"tracking issue #2734 has no checkbox items in its body; readiness check cannot verify completeness",
+		)]
+	finally:
+		sys.argv = old_argv
+		mod._post_commit_status = original_post
+		mod._fetch_issue = original_fetch
 
 
 def main() -> int:

--- a/tests/test_check_integration_pr_readiness.py
+++ b/tests/test_check_integration_pr_readiness.py
@@ -10,7 +10,9 @@ HTTP call.
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import sys
 from pathlib import Path
 
@@ -160,11 +162,12 @@ def test_main_posts_noop_success_for_non_orchestrator_branch():
 
 def test_main_errors_when_non_orchestrator_status_post_fails():
 	mod = _import()
+	posted: list[tuple[str, str, str]] = []
 	original_post = mod._post_commit_status
 	original_fetch = mod._fetch_issue
 	old_argv = sys.argv
 	try:
-		mod._post_commit_status = lambda repo, sha, state, description, target_url="": False
+		mod._post_commit_status = lambda repo, sha, state, description, target_url="": posted.append((state, description, target_url)) or False
 		mod._fetch_issue = lambda repo, n: (_ for _ in ()).throw(AssertionError("_fetch_issue should not run for non-orchestrator branches"))
 		sys.argv = [
 			"check_integration_pr_readiness.py",
@@ -172,8 +175,16 @@ def test_main_errors_when_non_orchestrator_status_post_fails():
 			"--head-sha", "deadbeef",
 			"--repo", "owner/repo",
 		]
-		rc = mod.main()
+		stderr = io.StringIO()
+		with contextlib.redirect_stderr(stderr):
+			rc = mod.main()
 		assert rc == 1
+		assert posted == [(
+			"success",
+			"head ref 'claude/fix-something' is not an orchestrator/project-* branch — readiness check does not apply",
+			"",
+		)]
+		assert "::error::[integration-pr-readiness] failed to post readiness commit status" in stderr.getvalue()
 	finally:
 		sys.argv = old_argv
 		mod._post_commit_status = original_post
@@ -209,11 +220,12 @@ def test_main_fails_closed_when_tracking_issue_has_no_checkboxes():
 
 def test_main_errors_when_failure_status_cannot_be_posted():
 	mod = _import()
+	posted: list[tuple[str, str, str]] = []
 	original_post = mod._post_commit_status
 	original_fetch = mod._fetch_issue
 	old_argv = sys.argv
 	try:
-		mod._post_commit_status = lambda repo, sha, state, description, target_url="": False
+		mod._post_commit_status = lambda repo, sha, state, description, target_url="": posted.append((state, description, target_url)) or False
 		mod._fetch_issue = lambda repo, n: {
 			"labels": [mod.TRACKING_LABEL],
 			"body": "- [ ] outstanding work\n",
@@ -224,12 +236,34 @@ def test_main_errors_when_failure_status_cannot_be_posted():
 			"--head-sha", "deadbeef",
 			"--repo", "owner/repo",
 		]
-		rc = mod.main()
+		stderr = io.StringIO()
+		with contextlib.redirect_stderr(stderr):
+			rc = mod.main()
 		assert rc == 1
+		assert posted == [(
+			"failure",
+			"1/1 sub-issues on #2734 still unchecked: outstanding work",
+			"https://github.com/owner/repo/issues/2734",
+		)]
+		assert "::error::[integration-pr-readiness] failed to post readiness commit status" in stderr.getvalue()
 	finally:
 		sys.argv = old_argv
 		mod._post_commit_status = original_post
 		mod._fetch_issue = original_fetch
+
+
+def test_post_commit_status_logs_subprocess_failures():
+	mod = _import()
+	original_run = mod.subprocess.run
+	try:
+		mod.subprocess.run = lambda *args, **kwargs: (_ for _ in ()).throw(OSError("gh missing"))
+		stderr = io.StringIO()
+		with contextlib.redirect_stderr(stderr):
+			ok = mod._post_commit_status("owner/repo", "deadbeef", "success", "desc")
+		assert ok is False
+		assert "::warning::[integration-pr-readiness] commit status POST failed: gh missing" in stderr.getvalue()
+	finally:
+		mod.subprocess.run = original_run
 
 
 def main() -> int:

--- a/tests/test_check_integration_pr_readiness.py
+++ b/tests/test_check_integration_pr_readiness.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check_integration_pr_readiness.py (P3 from
+docs/postmortems/2026-05-18-project-2734-stall.md).
+
+Tests focus on the pure logic (branch derivation, checkbox counting,
+state decision tree). The commit-status POST is exercised separately
+via the workflow itself; we test the function shape rather than the
+HTTP call.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_integration_pr_readiness.py"
+
+
+def _import():
+	spec = importlib.util.spec_from_file_location("check_integration_pr_readiness", SCRIPT_PATH)
+	assert spec is not None and spec.loader is not None
+	mod = importlib.util.module_from_spec(spec)
+	sys.modules["check_integration_pr_readiness"] = mod
+	spec.loader.exec_module(mod)
+	return mod
+
+
+def test_derive_tracking_issue_from_canonical_branch():
+	mod = _import()
+	assert mod._derive_tracking_issue("orchestrator/project-2734") == 2734
+	assert mod._derive_tracking_issue("orchestrator/project-1") == 1
+	assert mod._derive_tracking_issue("orchestrator/project-999999") == 999999
+
+
+def test_derive_tracking_issue_rejects_non_orchestrator_branches():
+	mod = _import()
+	# Branches that aren't orchestrator integration branches must return
+	# None so the readiness check no-ops on them (a feature PR from
+	# claude/foo or main is not subject to this check).
+	for branch in (
+		"main",
+		"stable",
+		"claude/fix-something",
+		"feature/whatever",
+		"orchestrator/project-",        # missing number
+		"orchestrator/project-abc",     # non-numeric
+		"orchestrator/foo-100",         # wrong prefix
+		"orchestrator/project-2734-x",  # suffix
+	):
+		assert mod._derive_tracking_issue(branch) is None, f"expected None for {branch!r}"
+
+
+def test_count_checkboxes_canonical_body():
+	mod = _import()
+	body = """## Project: Some project
+
+### Wave 1
+- [ ] **issue-a**: First sub-issue
+- [x] **issue-b**: Second sub-issue (done)
+
+### Wave 2
+- [ ] **issue-c**: Third (priority 1)
+- [X] **issue-d**: Fourth (capital X also counts as checked)
+
+Some prose with `- [ ]` mid-line (not a real task list item).
+"""
+	unchecked, total = mod._count_checkboxes(body)
+	# 4 task list items at line start (`^\s*-\s*\[...]` matches);
+	# the in-backtick mid-line literal is correctly ignored because
+	# its dash is not at the line start.
+	assert total == 4, f"expected 4 total checkboxes, got {total}"
+	# 'issue-a' and 'issue-c' are unchecked; 'issue-b' (lowercase x)
+	# and 'issue-d' (capital X) are both checked.
+	assert len(unchecked) == 2, f"expected 2 unchecked, got {unchecked!r}"
+	assert any("issue-a" in t for t in unchecked)
+	assert any("issue-c" in t for t in unchecked)
+
+
+def test_count_checkboxes_no_checkboxes_in_body():
+	mod = _import()
+	body = "Just some prose.\n\nNo checkboxes at all."
+	unchecked, total = mod._count_checkboxes(body)
+	assert total == 0
+	assert unchecked == []
+
+
+def test_count_checkboxes_handles_project_2734_body_shape():
+	# Pin against the actual project-#2734 body shape (the orchestrator-
+	# emitted template). If this regresses, the script silently
+	# mis-counts on real tracking issues.
+	mod = _import()
+	body = """## Project: Implement the resolver self-heal plan
+
+**Total issues:** 9 | **Waves:** 7
+
+### Wave 1
+- [ ] **phase1-verifier-baseline-delta**: Phase 1A (priority 1)
+- [ ] **phase6-subissue-test-runs-spike**: Phase 6 spike (priority 4)
+
+### Wave 2
+- [ ] **phase1-resolver-bootstrap-wiring**: Phase 1B (priority 1)
+
+### Wave 3
+- [ ] **phase2-retry-state-escalation**: Phase 2 (priority 2)
+
+### Wave 4
+- [ ] **phase3-tiered-verification**: Phase 3 (priority 2)
+
+### Wave 5
+- [ ] **phase4-quarantine-core**: Phase 4A (priority 3)
+
+### Wave 6
+- [ ] **phase4-drift-audit-job**: Phase 4B (priority 4)
+- [ ] **phase5-branch-rebuild**: Phase 5 (priority 4)
+
+### Wave 7
+- [ ] **docs-closeout-and-plan-move**: Close out (priority 5)
+"""
+	unchecked, total = mod._count_checkboxes(body)
+	assert total == 9, f"expected 9 (project #2734 had 9 sub-issues), got {total}"
+	assert len(unchecked) == 9, f"expected 9 unchecked, got {len(unchecked)}"
+
+
+def main() -> int:
+	try:
+		import sys as _sys
+		_sys.stdout.reconfigure(line_buffering=True)
+	except Exception:
+		pass
+	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+	passed = 0
+	failed = 0
+	for func in test_funcs:
+		name = func.__name__
+		try:
+			func()
+			print(f"  PASS  {name}", flush=True)
+			passed += 1
+		except Exception as e:
+			print(f"  FAIL  {name}: {e}", flush=True)
+			failed += 1
+	print(f"\n{passed} passed, {failed} failed, {passed + failed} total", flush=True)
+	return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_lint_plan_archival_completeness.py
+++ b/tests/test_lint_plan_archival_completeness.py
@@ -150,6 +150,26 @@ def test_archival_with_unticked_tracking_issue_but_descope_section_passes():
 	assert errors == []
 
 
+def test_archival_with_empty_descope_section_still_fails():
+	# The heading alone is not enough — the PR body must contain some
+	# acknowledgement content under the de-scope section.
+	mod = _import_lint()
+	def fetch(repo: str, n: int) -> dict | None:
+		if n == 2734:
+			return {"labels": ["ai:orchestrator-tracking"], "body": _PROJECT_2734_BODY}
+		return None
+	violations, errors = mod.lint(
+		pr_body="Refs #2734\n\n## De-scoped phases\n\n",
+		added_files=["docs/completed/integration-sync-resolver-self-heal-plan.md"],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		issue_fetcher=fetch,
+	)
+	assert errors == []
+	assert len(violations) == 1
+	assert "non-empty explicit `## De-scoped phases` section" in violations[0]
+
+
 def test_archival_with_non_tracking_ref_is_silent_pass():
 	# The PR archives a plan, references a non-tracking issue. Lint
 	# doesn't fire — only tracking issues are in scope.

--- a/tests/test_lint_plan_archival_completeness.py
+++ b/tests/test_lint_plan_archival_completeness.py
@@ -75,6 +75,26 @@ def test_archival_without_any_refs_is_violation():
 	assert "Refs #N" in violations[0]
 
 
+def test_archival_with_url_form_tracking_ref_is_checked():
+	# Full GitHub issue URLs must be harvested too; otherwise a PR body can
+	# bypass the archival gate by swapping `Refs #2734` for the URL form.
+	mod = _import_lint()
+	def fetch(repo: str, n: int) -> dict | None:
+		if n == 2734:
+			return {"labels": ["ai:orchestrator-tracking"], "body": _PROJECT_2734_BODY}
+		return {"labels": [], "body": ""}
+	violations, errors = mod.lint(
+		pr_body="Archive plan. Refs https://github.com/owner/repo/issues/2734\n",
+		added_files=["docs/completed/integration-sync-resolver-self-heal-plan.md"],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		issue_fetcher=fetch,
+	)
+	assert errors == []
+	assert len(violations) == 1
+	assert "#2734" in violations[0]
+
+
 def test_archival_with_unticked_tracking_issue_no_descope_fails():
 	# THIS IS THE PROJECT-#2734 SCENARIO. The PR archives the plan but
 	# the tracking issue's checkboxes are all unticked and the PR body
@@ -168,6 +188,29 @@ def test_archival_with_empty_descope_section_still_fails():
 	assert errors == []
 	assert len(violations) == 1
 	assert "non-empty explicit `## De-scoped phases` section" in violations[0]
+
+
+def test_archival_with_blank_unchecked_checkbox_still_fails():
+	# Blank checkbox items count as unchecked in the readiness gate; the
+	# archival lint must classify them the same way.
+	mod = _import_lint()
+	def fetch(repo: str, n: int) -> dict | None:
+		if n == 2734:
+			return {
+				"labels": ["ai:orchestrator-tracking"],
+				"body": "## Project\n\n- [ ]\n- [x] done\n",
+			}
+		return None
+	violations, errors = mod.lint(
+		pr_body="Refs #2734\n",
+		added_files=["docs/completed/plan.md"],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		issue_fetcher=fetch,
+	)
+	assert errors == []
+	assert len(violations) == 1
+	assert "<blank checkbox item>" in violations[0]
 
 
 def test_archival_with_non_tracking_ref_is_silent_pass():

--- a/tests/test_lint_plan_archival_completeness.py
+++ b/tests/test_lint_plan_archival_completeness.py
@@ -190,6 +190,27 @@ def test_archival_with_empty_descope_section_still_fails():
 	assert "non-empty explicit `## De-scoped phases` section" in violations[0]
 
 
+def test_archival_with_placeholder_descope_text_still_fails():
+	# Placeholder prose is not an explicit phase list. The de-scope section
+	# must enumerate at least one list item so a bare "TODO" cannot satisfy
+	# the archival gate.
+	mod = _import_lint()
+	def fetch(repo: str, n: int) -> dict | None:
+		if n == 2734:
+			return {"labels": ["ai:orchestrator-tracking"], "body": _PROJECT_2734_BODY}
+		return None
+	violations, errors = mod.lint(
+		pr_body="Refs #2734\n\n## De-scoped phases\n\nTODO\n",
+		added_files=["docs/completed/integration-sync-resolver-self-heal-plan.md"],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		issue_fetcher=fetch,
+	)
+	assert errors == []
+	assert len(violations) == 1
+	assert "non-empty explicit `## De-scoped phases` section" in violations[0]
+
+
 def test_archival_with_blank_unchecked_checkbox_still_fails():
 	# Blank checkbox items count as unchecked in the readiness gate; the
 	# archival lint must classify them the same way.

--- a/tests/test_lint_plan_archival_completeness.py
+++ b/tests/test_lint_plan_archival_completeness.py
@@ -211,6 +211,30 @@ def test_archival_with_placeholder_descope_text_still_fails():
 	assert "non-empty explicit `## De-scoped phases` section" in violations[0]
 
 
+def test_descope_section_allows_subheadings_before_list_items():
+	# Sub-headings inside the de-scope section are valid structure and
+	# must not hide later list items.
+	mod = _import_lint()
+	def fetch(repo: str, n: int) -> dict | None:
+		if n == 2734:
+			return {"labels": ["ai:orchestrator-tracking"], "body": _PROJECT_2734_BODY}
+		return None
+	violations, errors = mod.lint(
+		pr_body=(
+			"Refs #2734\n\n"
+			"## De-scoped phases\n\n"
+			"### Phase 2\n"
+			"- Retry-state escalation: deferred to follow-up tracking issue.\n"
+		),
+		added_files=["docs/completed/integration-sync-resolver-self-heal-plan.md"],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		issue_fetcher=fetch,
+	)
+	assert errors == []
+	assert violations == []
+
+
 def test_archival_with_blank_unchecked_checkbox_still_fails():
 	# Blank checkbox items count as unchecked in the readiness gate; the
 	# archival lint must classify them the same way.

--- a/tests/test_lint_plan_archival_completeness.py
+++ b/tests/test_lint_plan_archival_completeness.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lint_plan_archival_completeness.py (P6 from
+docs/postmortems/2026-05-18-project-2734-stall.md).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "lint_plan_archival_completeness.py"
+
+
+def _import_lint():
+	spec = importlib.util.spec_from_file_location("lint_plan_archival", SCRIPT_PATH)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	sys.modules["lint_plan_archival"] = module
+	spec.loader.exec_module(module)
+	return module
+
+
+_PROJECT_2734_BODY = """## Project: Integration-sync resolver self-heal
+
+**Total issues:** 9 | **Waves:** 7
+
+### Wave 1
+- [ ] **phase1-verifier-baseline-delta**: Phase 1A (priority 1)
+- [ ] **phase6-subissue-test-runs-spike**: Phase 6 spike (priority 4)
+
+### Wave 2
+- [ ] **phase1-resolver-bootstrap-wiring**: Phase 1B (priority 1)
+
+### Wave 3
+- [ ] **phase2-retry-state-escalation**: Phase 2 (priority 2)
+
+### Wave 4
+- [ ] **phase3-tiered-verification**: Phase 3 (priority 2)
+
+`ai:orchestrator-tracking`
+"""
+
+_FULLY_TICKED_BODY = _PROJECT_2734_BODY.replace("- [ ]", "- [x]")
+
+
+def test_no_docs_completed_changes_is_silent_pass():
+	# A PR with no archival changes never triggers the check.
+	mod = _import_lint()
+	violations, errors = mod.lint(
+		pr_body="just a normal PR. Refs #2734.",
+		added_files=["scripts/some_other_change.sh"],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		issue_fetcher=lambda r, n: {"labels": [], "body": ""},
+	)
+	assert violations == []
+	assert errors == []
+
+
+def test_archival_without_any_refs_is_violation():
+	# The PR archives a plan but doesn't say which tracking issue it
+	# belongs to — operator can't audit.
+	mod = _import_lint()
+	violations, errors = mod.lint(
+		pr_body="Move the plan file. No refs at all.",
+		added_files=["docs/completed/some-plan.md"],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		issue_fetcher=lambda r, n: {"labels": [], "body": ""},
+	)
+	assert len(violations) == 1
+	assert "references no issues" in violations[0]
+	assert "Refs #N" in violations[0]
+
+
+def test_archival_with_unticked_tracking_issue_no_descope_fails():
+	# THIS IS THE PROJECT-#2734 SCENARIO. The PR archives the plan but
+	# the tracking issue's checkboxes are all unticked and the PR body
+	# has no `## De-scoped phases` section. Must fail.
+	mod = _import_lint()
+	def fetch(repo: str, n: int) -> dict | None:
+		if n == 2734:
+			return {"labels": ["ai:orchestrator-tracking"], "body": _PROJECT_2734_BODY}
+		return {"labels": [], "body": ""}
+	violations, errors = mod.lint(
+		pr_body=(
+			"Squash merge of orchestrator project #2734.\n\n"
+			"Refs #2734\n"
+		),
+		added_files=["docs/completed/integration-sync-resolver-self-heal-plan.md"],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		issue_fetcher=fetch,
+	)
+	assert errors == []
+	assert len(violations) == 1
+	v = violations[0]
+	assert "#2734" in v
+	assert "5 unchecked" in v  # the 5 checkboxes in our fixture body
+	assert "De-scoped phases" in v
+	assert "docs/completed/integration-sync-resolver-self-heal-plan.md" in v
+	# The error must surface the names of unchecked items so the operator
+	# can write the de-scope section without re-reading the issue.
+	assert "phase1-verifier-baseline-delta" in v
+
+
+def test_archival_with_all_ticked_tracking_issue_passes():
+	# Scenario A: every checkbox is ticked. No de-scope section needed.
+	mod = _import_lint()
+	def fetch(repo: str, n: int) -> dict | None:
+		if n == 2734:
+			return {"labels": ["ai:orchestrator-tracking"], "body": _FULLY_TICKED_BODY}
+		return None
+	violations, errors = mod.lint(
+		pr_body="Squash merge.\n\nRefs #2734\n",
+		added_files=["docs/completed/integration-sync-resolver-self-heal-plan.md"],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		issue_fetcher=fetch,
+	)
+	assert violations == []
+	assert errors == []
+
+
+def test_archival_with_unticked_tracking_issue_but_descope_section_passes():
+	# Scenario B: the PR body explicitly acknowledges the de-scoped
+	# phases. Lint passes.
+	mod = _import_lint()
+	def fetch(repo: str, n: int) -> dict | None:
+		if n == 2734:
+			return {"labels": ["ai:orchestrator-tracking"], "body": _PROJECT_2734_BODY}
+		return None
+	pr_body = (
+		"Squash merge of project #2734.\n\n"
+		"Refs #2734\n\n"
+		"## De-scoped phases\n\n"
+		"- Phase 2: deferred to follow-up tracking issue (alert ladder).\n"
+		"- Phase 3-5: descoped — alternative approach selected.\n"
+	)
+	violations, errors = mod.lint(
+		pr_body=pr_body,
+		added_files=["docs/completed/integration-sync-resolver-self-heal-plan.md"],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		issue_fetcher=fetch,
+	)
+	assert violations == []
+	assert errors == []
+
+
+def test_archival_with_non_tracking_ref_is_silent_pass():
+	# The PR archives a plan, references a non-tracking issue. Lint
+	# doesn't fire — only tracking issues are in scope.
+	mod = _import_lint()
+	def fetch(repo: str, n: int) -> dict | None:
+		return {"labels": ["bug"], "body": "no checkboxes here"}
+	violations, errors = mod.lint(
+		pr_body="archive. Refs #100\n",
+		added_files=["docs/completed/some-plan.md"],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		issue_fetcher=fetch,
+	)
+	assert violations == []
+	assert errors == []
+
+
+def test_descope_heading_case_insensitive():
+	# The de-scope heading match must be case-insensitive so contributors
+	# don't trip on capitalisation. Both `## de-scoped phases` and
+	# `### DE-SCOPED PHASES` should satisfy scenario B.
+	mod = _import_lint()
+	def fetch(repo: str, n: int) -> dict | None:
+		return {"labels": ["ai:orchestrator-tracking"], "body": _PROJECT_2734_BODY}
+	for heading in ("## de-scoped phases", "### DE-SCOPED PHASES", "## De Scoped Phases"):
+		pr_body = f"Refs #2734\n\n{heading}\n\n- item\n"
+		violations, _ = mod.lint(
+			pr_body=pr_body,
+			added_files=["docs/completed/plan.md"],
+			repo="owner/repo",
+			fail_open_on_lookup_error=False,
+			issue_fetcher=fetch,
+		)
+		assert violations == [], f"heading {heading!r} should have satisfied scenario B"
+
+
+def test_lookup_failure_with_fail_open_skips_violation():
+	mod = _import_lint()
+	def fetch(repo: str, n: int) -> dict | None:
+		return None
+	violations, errors = mod.lint(
+		pr_body="Refs #2734\n",
+		added_files=["docs/completed/plan.md"],
+		repo="owner/repo",
+		fail_open_on_lookup_error=True,
+		issue_fetcher=fetch,
+	)
+	# With fail-open, no violation can be raised because we cannot
+	# prove the issue is tracking-labeled.
+	assert violations == []
+	assert len(errors) == 1
+
+
+def main() -> int:
+	try:
+		import sys as _sys
+		_sys.stdout.reconfigure(line_buffering=True)
+	except Exception:
+		pass
+	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+	passed = 0
+	failed = 0
+	for func in test_funcs:
+		name = func.__name__
+		try:
+			func()
+			print(f"  PASS  {name}", flush=True)
+			passed += 1
+		except Exception as e:
+			print(f"  FAIL  {name}: {e}", flush=True)
+			failed += 1
+	print(f"\n{passed} passed, {failed} failed, {passed + failed} total", flush=True)
+	return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_lint_pr_body_auto_close.py
+++ b/tests/test_lint_pr_body_auto_close.py
@@ -71,7 +71,7 @@ def test_regex_matches_canonical_cases():
 		("Fixes #2734", "Fixes", None, 2734),
 		("fixes #2734", "fixes", None, 2734),
 		("FIXES #2734", "FIXES", None, 2734),
-		("Closes: #100", "Closes", None, 100),
+		("Closes #100", "Closes", None, 100),
 		("Resolves owner/repo#42", "Resolves", "owner/repo", 42),
 		("fixed #1", "fixed", None, 1),
 		("resolves #999999", "resolves", None, 999999),
@@ -101,7 +101,7 @@ def test_regex_matches_github_url_issue_form():
 	cases = [
 		("Closes https://github.com/owner/repo/issues/2734", "Closes", "owner/repo", 2734),
 		("Fixes https://github.com/owner/repo/issues/100", "Fixes", "owner/repo", 100),
-		("Resolves: https://github.com/owner/repo/issues/9", "Resolves", "owner/repo", 9),
+		("Resolves https://github.com/owner/repo/issues/9", "Resolves", "owner/repo", 9),
 		# Lowercase + http (no s) — GitHub treats both the same.
 		("fixes http://github.com/owner/repo/issues/1", "fixes", "owner/repo", 1),
 	]
@@ -129,6 +129,8 @@ def test_regex_does_not_match_substring_or_unrelated_words():
 		"link to #2734",       # no keyword
 		"Refs #2734",          # the recommended replacement — must NOT be flagged
 		"Related to #2734",    # also the recommended replacement
+		"Closes: #2734",       # GitHub does not auto-close on colon-form syntax
+		"Resolves: https://github.com/owner/repo/issues/9",
 	]
 	for text in false_positives:
 		matches = mod._scan_text("test", text)
@@ -150,6 +152,13 @@ def test_markdown_code_examples_in_pr_body_are_ignored():
 	matches = mod._scan_text("PR body", text, markdown=True)
 	assert len(matches) == 1, f"expected only the non-code-span directive to match, got {matches!r}"
 	assert matches[0][4] == 99
+
+
+def test_workflow_lints_pr_title_and_body_together():
+	workflow = (REPO_ROOT / ".github/workflows/lint-pr-body-auto-close.yml").read_text(encoding="utf-8")
+	assert 'PR_TITLE: ${{ github.event.pull_request.title }}' in workflow
+	assert 'PR_BODY: ${{ github.event.pull_request.body }}' in workflow
+	assert "printf '%s\\n\\n%s' \"${PR_TITLE:-}\" \"${PR_BODY:-}\" > /tmp/pr-body-lint/body.txt" in workflow
 
 
 def test_cross_repo_reference_looks_up_referenced_repo_not_current_repo():

--- a/tests/test_lint_pr_body_auto_close.py
+++ b/tests/test_lint_pr_body_auto_close.py
@@ -154,11 +154,32 @@ def test_markdown_code_examples_in_pr_body_are_ignored():
 	assert matches[0][4] == 99
 
 
+def test_markdown_double_backtick_code_examples_are_ignored():
+	mod = _import_lint_module()
+	text = (
+		"Historical example: ``Fixes #2734`` should not be linted.\n\n"
+		"Real directive: Closes #99\n"
+	)
+	matches = mod._scan_text("PR body", text, markdown=True)
+	assert len(matches) == 1, f"expected only the non-code-span directive to match, got {matches!r}"
+	assert matches[0][4] == 99
+
+
 def test_workflow_lints_pr_title_and_body_together():
 	workflow = (REPO_ROOT / ".github/workflows/lint-pr-body-auto-close.yml").read_text(encoding="utf-8")
 	assert 'PR_TITLE: ${{ github.event.pull_request.title }}' in workflow
 	assert 'PR_BODY: ${{ github.event.pull_request.body }}' in workflow
 	assert "printf '%s\\n\\n%s' \"${PR_TITLE:-}\" \"${PR_BODY:-}\" > /tmp/pr-body-lint/body.txt" in workflow
+
+
+def test_implement_preflight_lints_title_and_body_together():
+	workflow = (REPO_ROOT / ".github/workflows/implement.yml").read_text(encoding="utf-8")
+	assert 'PR_TITLE_FILE="${RUNTIME_DIR}/pr-body-lint/title.txt"' in workflow
+	assert 'PR_BODY_FILE="${RUNTIME_DIR}/pr-body-lint/body.txt"' in workflow
+	assert 'PR_LINT_FILE="${RUNTIME_DIR}/pr-body-lint/lint-input.txt"' in workflow
+	assert 'PR_TITLE="AI implementation for issue #${ISSUE_NUMBER}"' in workflow
+	assert "printf '%s\\n\\n' \"${PR_TITLE}\" > \"${PR_LINT_FILE}\"" in workflow
+	assert 'cat "${PR_BODY_FILE}" >> "${PR_LINT_FILE}"' in workflow
 
 
 def test_cross_repo_reference_looks_up_referenced_repo_not_current_repo():
@@ -259,6 +280,27 @@ def test_lookup_failure_without_fail_open_reports_error_for_exit_2():
 	# errors are populated so main() returns exit 2.
 	assert violations == []
 	assert len(errors) == 1
+
+
+def test_lookup_failure_is_not_cached_across_later_references():
+	mod = _import_lint_module()
+	call_count = {"n": 0}
+	def flaky_lookup(repo: str, issue: int) -> list[str] | None:
+		call_count["n"] += 1
+		if call_count["n"] == 1:
+			return None
+		return ["ai:orchestrator-tracking"]
+	violations, errors = mod.lint(
+		pr_body="Fixes #2734\nCloses #2734\n",
+		commit_messages=[],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		label_lookup=flaky_lookup,
+	)
+	assert call_count["n"] == 2
+	assert len(errors) == 1
+	assert len(violations) == 1
+	assert violations[0].keyword.lower() == "closes"
 
 
 def test_commit_messages_are_scanned_in_addition_to_pr_body():

--- a/tests/test_lint_pr_body_auto_close.py
+++ b/tests/test_lint_pr_body_auto_close.py
@@ -136,6 +136,20 @@ def test_regex_does_not_match_substring_or_unrelated_words():
 		)
 
 
+def test_markdown_code_examples_in_pr_body_are_ignored():
+	mod = _import_lint_module()
+	text = (
+		"Historical example: `Fixes #2734` should not be linted.\n\n"
+		"```markdown\n"
+		"Closes #2734\n"
+		"```\n\n"
+		"Real directive: Closes #99\n"
+	)
+	matches = mod._scan_text("PR body", text, markdown=True)
+	assert len(matches) == 1, f"expected only the non-code-span directive to match, got {matches!r}"
+	assert matches[0][3] == 99
+
+
 def test_tracking_labeled_issue_produces_violation():
 	mod = _import_lint_module()
 	def fake_lookup(repo: str, issue: int) -> list[str]:

--- a/tests/test_lint_pr_body_auto_close.py
+++ b/tests/test_lint_pr_body_auto_close.py
@@ -68,24 +68,25 @@ def test_keyword_list_covers_all_github_auto_close_variants():
 def test_regex_matches_canonical_cases():
 	mod = _import_lint_module()
 	cases = [
-		("Fixes #2734", "Fixes", 2734),
-		("fixes #2734", "fixes", 2734),
-		("FIXES #2734", "FIXES", 2734),
-		("Closes: #100", "Closes", 100),
-		("Resolves owner/repo#42", "Resolves", 42),
-		("fixed #1", "fixed", 1),
-		("resolves #999999", "resolves", 999999),
+		("Fixes #2734", "Fixes", None, 2734),
+		("fixes #2734", "fixes", None, 2734),
+		("FIXES #2734", "FIXES", None, 2734),
+		("Closes: #100", "Closes", None, 100),
+		("Resolves owner/repo#42", "Resolves", "owner/repo", 42),
+		("fixed #1", "fixed", None, 1),
+		("resolves #999999", "resolves", None, 999999),
 		# `Close #N` with no plural / no separator is the GitHub-supported
 		# minimal form and must still match.
-		("Close #5", "Close", 5),
+		("Close #5", "Close", None, 5),
 	]
-	for text, keyword, issue in cases:
+	for text, keyword, referenced_repo, issue in cases:
 		matches = mod._scan_text("test", text)
 		assert len(matches) == 1, (
 			f"regex failed to match canonical case {text!r}; got {matches!r}"
 		)
-		_, _, kw, iss = matches[0]
+		_, _, kw, repo_ref, iss = matches[0]
 		assert kw.lower() == keyword.lower()
+		assert repo_ref == referenced_repo
 		assert iss == issue
 
 
@@ -98,20 +99,21 @@ def test_regex_matches_github_url_issue_form():
 	# See https://docs.github.com/articles/closing-issues-using-keywords.
 	mod = _import_lint_module()
 	cases = [
-		("Closes https://github.com/owner/repo/issues/2734", "Closes", 2734),
-		("Fixes https://github.com/owner/repo/issues/100", "Fixes", 100),
-		("Resolves: https://github.com/owner/repo/issues/9", "Resolves", 9),
+		("Closes https://github.com/owner/repo/issues/2734", "Closes", "owner/repo", 2734),
+		("Fixes https://github.com/owner/repo/issues/100", "Fixes", "owner/repo", 100),
+		("Resolves: https://github.com/owner/repo/issues/9", "Resolves", "owner/repo", 9),
 		# Lowercase + http (no s) — GitHub treats both the same.
-		("fixes http://github.com/owner/repo/issues/1", "fixes", 1),
+		("fixes http://github.com/owner/repo/issues/1", "fixes", "owner/repo", 1),
 	]
-	for text, keyword, issue in cases:
+	for text, keyword, referenced_repo, issue in cases:
 		matches = mod._scan_text("test", text)
 		assert len(matches) == 1, (
 			f"regex failed to match URL-form case {text!r}; got {matches!r}. "
 			f"GitHub auto-closes on this form too, so the lint must catch it."
 		)
-		_, _, kw, iss = matches[0]
+		_, _, kw, repo_ref, iss = matches[0]
 		assert kw.lower() == keyword.lower()
+		assert repo_ref == referenced_repo
 		assert iss == issue
 
 
@@ -147,7 +149,31 @@ def test_markdown_code_examples_in_pr_body_are_ignored():
 	)
 	matches = mod._scan_text("PR body", text, markdown=True)
 	assert len(matches) == 1, f"expected only the non-code-span directive to match, got {matches!r}"
-	assert matches[0][3] == 99
+	assert matches[0][4] == 99
+
+
+def test_cross_repo_reference_looks_up_referenced_repo_not_current_repo():
+	mod = _import_lint_module()
+	lookups: list[tuple[str, int]] = []
+
+	def fake_lookup(repo: str, issue: int) -> list[str]:
+		lookups.append((repo, issue))
+		if (repo, issue) == ("other/repo", 2734):
+			return ["ai:orchestrator-tracking"]
+		return []
+
+	violations, errors = mod.lint(
+		pr_body="Fixes other/repo#2734\n",
+		commit_messages=[],
+		repo="owner/current",
+		fail_open_on_lookup_error=False,
+		label_lookup=fake_lookup,
+	)
+	assert errors == []
+	assert lookups == [("other/repo", 2734)]
+	assert len(violations) == 1
+	assert violations[0].issue == 2734
+	assert violations[0].issue_repo == "other/repo"
 
 
 def test_tracking_labeled_issue_produces_violation():

--- a/tests/test_lint_pr_body_auto_close.py
+++ b/tests/test_lint_pr_body_auto_close.py
@@ -89,6 +89,32 @@ def test_regex_matches_canonical_cases():
 		assert iss == issue
 
 
+def test_regex_matches_github_url_issue_form():
+	# GitHub's auto-close logic fires equally on the URL form
+	# (https://github.com/owner/repo/issues/N) and the short-form (#N).
+	# The implement.yml flow uses URL form in its hardcoded PR body
+	# ("Automated implementation. Closes ${ISSUE_URL}"), and the lint
+	# must catch URL-form keyword references against tracking issues.
+	# See https://docs.github.com/articles/closing-issues-using-keywords.
+	mod = _import_lint_module()
+	cases = [
+		("Closes https://github.com/owner/repo/issues/2734", "Closes", 2734),
+		("Fixes https://github.com/owner/repo/issues/100", "Fixes", 100),
+		("Resolves: https://github.com/owner/repo/issues/9", "Resolves", 9),
+		# Lowercase + http (no s) — GitHub treats both the same.
+		("fixes http://github.com/owner/repo/issues/1", "fixes", 1),
+	]
+	for text, keyword, issue in cases:
+		matches = mod._scan_text("test", text)
+		assert len(matches) == 1, (
+			f"regex failed to match URL-form case {text!r}; got {matches!r}. "
+			f"GitHub auto-closes on this form too, so the lint must catch it."
+		)
+		_, _, kw, iss = matches[0]
+		assert kw.lower() == keyword.lower()
+		assert iss == issue
+
+
 def test_regex_does_not_match_substring_or_unrelated_words():
 	mod = _import_lint_module()
 	false_positives = [

--- a/tests/test_lint_pr_body_auto_close.py
+++ b/tests/test_lint_pr_body_auto_close.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lint_pr_body_auto_close.py — the enforcement check for
+CLAUDE.md §19 / unattended_system_instructions.md §19 (the rule that
+forbids auto-close keywords against ai:orchestrator-tracking issues).
+
+The lint script is the executable counterpart to the prose rule; without
+the test suite a future docs edit that silently widens the keyword list
+(or a regex change that misses a keyword) would let the project-#2734
+auto-close failure mode recur. Each test pins one of the script's
+contract guarantees:
+
+  1. The keyword list covers every variant GitHub auto-closes on.
+  2. The regex catches the cross-product (case, separator, owner/repo).
+  3. The regex does NOT catch substring matches (e.g. 'prefixes #1').
+  4. A tracking-labeled issue triggers a violation (exit 1).
+  5. A non-tracking issue triggers no violation (exit 0).
+  6. Lookup failure with --fail-open is treated as no violation.
+  7. Lookup failure without --fail-open is exit 2.
+  8. Commit messages are scanned in addition to the PR body.
+  9. Cache: repeated references to the same issue make one lookup, not N.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "lint_pr_body_auto_close.py"
+
+
+def _import_lint_module():
+	# Import the script as a module so we can call its functions directly
+	# (subprocess-based testing would also work, but direct calls are 1000x
+	# faster and let us inject a mock label_lookup without spinning up gh).
+	spec = importlib.util.spec_from_file_location("lint_pr_body_auto_close", SCRIPT_PATH)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	sys.modules["lint_pr_body_auto_close"] = module
+	spec.loader.exec_module(module)
+	return module
+
+
+def test_keyword_list_covers_all_github_auto_close_variants():
+	# GitHub's auto-close keyword list per
+	# https://docs.github.com/articles/closing-issues-using-keywords —
+	# the exhaustive set as of writing this lint. The script's list MUST
+	# include every entry; if GitHub adds a new keyword the lint becomes
+	# silently weaker until this test is updated.
+	expected_minimum = {
+		"close", "closes", "closed",
+		"fix", "fixes", "fixed",
+		"resolve", "resolves", "resolved",
+	}
+	mod = _import_lint_module()
+	actual = set(k.lower() for k in mod.AUTO_CLOSE_KEYWORDS)
+	missing = expected_minimum - actual
+	assert not missing, (
+		f"AUTO_CLOSE_KEYWORDS is missing GitHub auto-close keyword(s): {sorted(missing)}. "
+		f"GitHub will still auto-close issues referenced by these keywords on merge to "
+		f"the default branch, so without them in the list the lint cannot prevent the "
+		f"project-#2734 failure mode."
+	)
+
+
+def test_regex_matches_canonical_cases():
+	mod = _import_lint_module()
+	cases = [
+		("Fixes #2734", "Fixes", 2734),
+		("fixes #2734", "fixes", 2734),
+		("FIXES #2734", "FIXES", 2734),
+		("Closes: #100", "Closes", 100),
+		("Resolves owner/repo#42", "Resolves", 42),
+		("fixed #1", "fixed", 1),
+		("resolves #999999", "resolves", 999999),
+		# `Close #N` with no plural / no separator is the GitHub-supported
+		# minimal form and must still match.
+		("Close #5", "Close", 5),
+	]
+	for text, keyword, issue in cases:
+		matches = mod._scan_text("test", text)
+		assert len(matches) == 1, (
+			f"regex failed to match canonical case {text!r}; got {matches!r}"
+		)
+		_, _, kw, iss = matches[0]
+		assert kw.lower() == keyword.lower()
+		assert iss == issue
+
+
+def test_regex_does_not_match_substring_or_unrelated_words():
+	mod = _import_lint_module()
+	false_positives = [
+		"prefixes #1",        # substring of 'fixes' but not a word-boundary match
+		"affixed #1",          # ends with 'fixed' but not a word boundary
+		"reclose #1",          # prefix-glued
+		"foreclose #1",        # contains 'close' but not a standalone keyword
+		"some text #2734",     # no keyword
+		"see issue #2734",     # 'see' is not an auto-close keyword
+		"link to #2734",       # no keyword
+		"Refs #2734",          # the recommended replacement — must NOT be flagged
+		"Related to #2734",    # also the recommended replacement
+	]
+	for text in false_positives:
+		matches = mod._scan_text("test", text)
+		assert matches == [], (
+			f"regex falsely matched {text!r}; got {matches!r}. "
+			f"This would create noise for legitimate PR bodies and erode trust in the lint."
+		)
+
+
+def test_tracking_labeled_issue_produces_violation():
+	mod = _import_lint_module()
+	def fake_lookup(repo: str, issue: int) -> list[str]:
+		assert repo == "owner/repo"
+		return ["ai:orchestrator-tracking", "ai:merged"] if issue == 2734 else []
+	violations, errors = mod.lint(
+		pr_body="Some description.\n\nFixes #2734\n",
+		commit_messages=[],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		label_lookup=fake_lookup,
+	)
+	assert errors == []
+	assert len(violations) == 1
+	v = violations[0]
+	assert v.issue == 2734
+	assert v.keyword.lower() == "fixes"
+	# The formatted message must reference §19 + the postmortem so the
+	# developer knows where to look for the rule.
+	formatted = v.format()
+	assert "§19" in formatted
+	assert "postmortem" in formatted.lower() or "2026-05-18" in formatted
+	assert "Refs #" in formatted  # recommended replacement
+
+
+def test_non_tracking_issue_produces_no_violation():
+	mod = _import_lint_module()
+	def fake_lookup(repo: str, issue: int) -> list[str]:
+		# Issue exists, has labels, but NOT the tracking label.
+		return ["bug", "good first issue"]
+	violations, errors = mod.lint(
+		pr_body="Fixes #100\n",
+		commit_messages=[],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		label_lookup=fake_lookup,
+	)
+	assert errors == []
+	assert violations == []
+
+
+def test_lookup_failure_with_fail_open_is_silent_pass():
+	mod = _import_lint_module()
+	def fake_lookup(repo: str, issue: int) -> list[str] | None:
+		return None  # simulate gh failure
+	violations, errors = mod.lint(
+		pr_body="Fixes #2734\n",
+		commit_messages=[],
+		repo="owner/repo",
+		fail_open_on_lookup_error=True,
+		label_lookup=fake_lookup,
+	)
+	assert violations == []
+	# Errors are still recorded (operator visibility) but the lint
+	# does not block the PR.
+	assert len(errors) == 1
+	assert "could not fetch labels" in errors[0]
+
+
+def test_lookup_failure_without_fail_open_reports_error_for_exit_2():
+	mod = _import_lint_module()
+	def fake_lookup(repo: str, issue: int) -> list[str] | None:
+		return None
+	violations, errors = mod.lint(
+		pr_body="Fixes #2734\n",
+		commit_messages=[],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		label_lookup=fake_lookup,
+	)
+	# No violations (we can't prove the issue IS tracking-labeled) but
+	# errors are populated so main() returns exit 2.
+	assert violations == []
+	assert len(errors) == 1
+
+
+def test_commit_messages_are_scanned_in_addition_to_pr_body():
+	mod = _import_lint_module()
+	def fake_lookup(repo: str, issue: int) -> list[str]:
+		return ["ai:orchestrator-tracking"] if issue == 2734 else []
+	# PR body is clean; the violation is hidden in a commit message
+	# (GitHub squash-merge would still use the PR body, but plain merge
+	# commits to the default branch would auto-close on the keyword in the
+	# commit message).
+	violations, errors = mod.lint(
+		pr_body="Some clean description with Refs #2734 only.\n",
+		commit_messages=[(1, "fix: thing\n\nFixes #2734\n")],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		label_lookup=fake_lookup,
+	)
+	assert errors == []
+	assert len(violations) == 1
+	assert "commit message" in violations[0].source
+
+
+def test_repeated_references_to_same_issue_cache_the_lookup():
+	mod = _import_lint_module()
+	call_count = {"n": 0}
+	def counting_lookup(repo: str, issue: int) -> list[str]:
+		call_count["n"] += 1
+		return ["ai:orchestrator-tracking"] if issue == 2734 else []
+	body = (
+		"This PR Fixes #2734 and Closes #2734 and Resolves #2734.\n"
+		"Also fixes #999 (not tracking).\n"
+	)
+	violations, errors = mod.lint(
+		pr_body=body,
+		commit_messages=[(1, "Resolves #2734\n")],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		label_lookup=counting_lookup,
+	)
+	# 4 matches against #2734 + 1 against #999 = 2 unique issues = 2 lookups.
+	# Per CLAUDE.md §15 (GitHub API call hygiene), repeated refs to the same
+	# issue must not multiply lookup calls.
+	assert call_count["n"] == 2, (
+		f"label_lookup was called {call_count['n']} times for 2 unique issues — "
+		f"the per-issue cache regressed. CLAUDE.md §15 forbids per-iteration "
+		f"gh calls; this lint must call gh once per unique issue, not once "
+		f"per keyword reference."
+	)
+	# All four #2734 references should produce 4 violations (one per match).
+	assert len([v for v in violations if v.issue == 2734]) == 4
+	assert len([v for v in violations if v.issue == 999]) == 0
+
+
+def test_empty_pr_body_is_silent_pass():
+	mod = _import_lint_module()
+	violations, errors = mod.lint(
+		pr_body="",
+		commit_messages=[],
+		repo="owner/repo",
+		fail_open_on_lookup_error=False,
+		label_lookup=lambda r, i: [],
+	)
+	assert violations == []
+	assert errors == []
+
+
+def test_main_exit_codes():
+	# End-to-end via the script's main() entry point.
+	mod = _import_lint_module()
+	tmp = Path(tempfile.mkdtemp(prefix="lint-pr-body-"))
+	try:
+		body_path = tmp / "body.txt"
+		body_path.write_text("Fixes #2734\n", encoding="utf-8")
+		# Inject a fake label lookup by monkey-patching the module-level
+		# function the script's `lint()` uses by default.
+		original = mod._fetch_issue_labels_gh
+		mod._fetch_issue_labels_gh = lambda repo, issue: (
+			["ai:orchestrator-tracking"] if issue == 2734 else []
+		)
+		try:
+			# Simulate CLI args via sys.argv.
+			old_argv = sys.argv
+			sys.argv = [
+				"lint_pr_body_auto_close.py",
+				"--pr-body-file", str(body_path),
+				"--repo", "owner/repo",
+			]
+			try:
+				rc = mod.main()
+			finally:
+				sys.argv = old_argv
+			assert rc == 1, f"expected exit 1 (violation), got {rc}"
+		finally:
+			mod._fetch_issue_labels_gh = original
+	finally:
+		import shutil
+		shutil.rmtree(tmp, ignore_errors=True)
+
+
+def main() -> int:
+	try:
+		import sys as _sys
+		_sys.stdout.reconfigure(line_buffering=True)
+	except Exception:
+		pass
+	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+	passed = 0
+	failed = 0
+	for func in test_funcs:
+		name = func.__name__
+		try:
+			func()
+			print(f"  PASS  {name}", flush=True)
+			passed += 1
+		except Exception as e:
+			print(f"  FAIL  {name}: {e}", flush=True)
+			failed += 1
+	print(f"\n{passed} passed, {failed} failed, {passed + failed} total", flush=True)
+	return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -8769,6 +8769,16 @@ def test_resolver_tooling_refresh_function_has_3way_merge_fallback():
 		"counter the post-refresh summary cannot distinguish 3-way merges from "
 		"deadlock-breaker checkouts."
 	)
+	assert ': > "${merge_tmpdir}/base"' not in fn_body, (
+		"_refresh_integration_resolver_tooling must not fabricate an empty 3-way "
+		"merge base on `git cat-file` failure. A zero-byte ancestor silently "
+		"degrades the merge and can lose the true merge-base context."
+	)
+	assert "could not materialize one or more 3-way merge inputs" in fn_body, (
+		"_refresh_integration_resolver_tooling must warn and skip when any 3-way "
+		"merge input blob cannot be materialized. Without this guard the function "
+		"can run `git merge-file` with missing or stale tmpfile inputs."
+	)
 	assert "git merge-file" in fn_body, (
 		"_refresh_integration_resolver_tooling must call `git merge-file` to do "
 		"the 3-way merge of integration + main edits when both sides changed "
@@ -8802,6 +8812,11 @@ def test_resolver_tooling_refresh_function_has_3way_merge_fallback():
 	assert "merged_3way_count=$((merged_3way_count + 1))" in fn_body, (
 		"successful 3-way merge must increment merged_3way_count so the "
 		"post-refresh summary and commit-message body can report it."
+	)
+	assert 'git checkout -- "${f}"' in fn_body, (
+		"the 3-way merge path must revert the worktree copy when `git add` fails. "
+		"Without the revert, a staging failure leaves the poller worktree dirty and "
+		"out of sync with the refresh commit."
 	)
 	# Conflict path must fall through to `skipped_count` (matching the
 	# existing skip semantics from PR #2760) — never stage a file with

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -8818,6 +8818,14 @@ def test_resolver_tooling_refresh_function_has_3way_merge_fallback():
 		"Without the revert, a staging failure leaves the poller worktree dirty and "
 		"out of sync with the refresh commit."
 	)
+	cp_fail_re = re.compile(
+		r'if\s+cp\s+"\$\{merge_tmpdir\}/int"\s+"\$\{f\}"[\s\S]{0,800}?\belse\b[\s\S]{0,200}?git\s+checkout\s+--\s+"\$\{f\}"'
+	)
+	assert cp_fail_re.search(fn_body), (
+		"the 3-way merge path must revert the worktree copy when copying the merged "
+		"tmpfile back into `${f}` fails. Without the revert, a partial copy can leave "
+		"the poller worktree dirty even though the file was excluded from the refresh commit."
+	)
 	# Conflict path must fall through to `skipped_count` (matching the
 	# existing skip semantics from PR #2760) — never stage a file with
 	# conflict markers. The conflict path is reached when `git merge-file`

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -3134,6 +3134,106 @@ def test_external_finalize_detect_preempts_sync_branch_missing_failure():
 	assert not any("Integration branch missing" in body for body in tracking_bodies)
 
 
+def test_external_finalize_refuses_complete_when_subissues_never_created():
+	# Behavioural regression test for project #2734 (postmortem layer 6).
+	# State models the actual incident: a multi-wave project where Wave 1
+	# sub-issues were merged but Waves 2-7 were never dispatched — their
+	# entries are present in the state with status="not_created" and
+	# github_issue=null because the orchestrator never created them.  An
+	# operator (or self-heal pipeline) squash-merges the integration PR
+	# externally.  The external-finalize block sees a merged final PR and
+	# would, pre-fix, mark the project complete and broadcast "✅ Project
+	# complete" via Telegram while 7 of 9 sub-issues had shipped no code.
+	#
+	# Post-fix the gate must:
+	#   - leave status as in_progress (NOT transition to complete)
+	#   - leave final_merge_status as pending (NOT transition to merged)
+	#   - NOT apply the ai:merged label
+	#   - emit a [external-finalize-partial] warning to stdout/stderr
+	#   - persist external_finalize_partial_alert_sig on the state file
+	#     so the Telegram alert deduplicates on subsequent ticks
+	state = _base_state(status="in_progress")
+	state["integration_branch"] = "orchestrator/project-192"
+	state["final_merge_pr"] = 2750
+	state["final_merge_status"] = "pending"
+	# Replace the default 1-issue Wave 1 with a 2-wave project: Wave 1
+	# merged, Wave 2 never created (status="not_created", github_issue=null).
+	# This mirrors project #2734's actual `.waves[]` shape from comment #38.
+	state["total_issues"] = 2
+	state["total_waves"] = 2
+	state["waves"] = [
+		{
+			"wave": 1,
+			"issues": [
+				{"id": "phase1-verifier-baseline-delta", "github_issue": 10, "status": "merged"},
+			],
+		},
+		{
+			"wave": 2,
+			"issues": [
+				{"id": "phase1-resolver-bootstrap-wiring", "github_issue": None, "status": "not_created"},
+			],
+		},
+	]
+	state["issue_number_map"] = {"phase1-verifier-baseline-delta": 10}
+	prs = [
+		{
+			"number": 2750,
+			"state": "closed",
+			"merged": True,
+			"baseRefName": "main",
+			"headRefName": "orchestrator/project-192",
+			"mergeable": None,
+			"mergeable_state": "unknown",
+		},
+	]
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		issue_labels={10: ["ai:merged"]},
+		prs=prs,
+		existing_branches=["main", "orchestrator/project-192"],
+	)
+	# The gate must refuse to transition state.
+	assert result["latest_state"]["status"] != "complete", (
+		"completeness gate failed: status transitioned to `complete` despite "
+		"Wave 2's sub-issue still being `not_created` — this is the exact "
+		"failure mode the gate is meant to prevent (project #2734 scenario)."
+	)
+	assert result["latest_state"]["final_merge_status"] != "merged", (
+		"completeness gate failed: final_merge_status transitioned to `merged` "
+		"despite incomplete sub-issues."
+	)
+	# The ai:merged label must NOT be applied while sub-issues remain
+	# uncreated; the label is the orchestrator's primary downstream signal
+	# for release callbacks and label-repair sweeps.
+	assert "ai:merged" not in result["tracking_labels"], (
+		"completeness gate failed: ai:merged label was applied to tracking "
+		"issue despite Wave 2 sub-issue never being created. Downstream "
+		"automation would treat this project as done and skip remediation."
+	)
+	# The warning marker must surface so log-analysis tooling can detect
+	# this failure mode in workflow runs.
+	combined_log = result.get("stdout", "") + "\n" + result.get("stderr", "")
+	assert "[external-finalize-partial]" in combined_log, (
+		"completeness gate failed: `[external-finalize-partial]` warning "
+		"marker missing from poller stdout/stderr — without it, log-analysis "
+		"tooling cannot detect this failure mode at scale."
+	)
+	# Note: the alert-dedup signature
+	# (`external_finalize_partial_alert_sig` on the state file) is verified
+	# by the companion static guard test
+	# `test_external_finalize_gates_on_subissue_completeness_before_marking_complete`,
+	# which pins both the persistence and the dedup condition.  This
+	# behavioural test does not re-verify it because `_run_poller` only
+	# exposes state via the comment trail, and the gate intentionally does
+	# NOT post_state_comment (the project is genuinely still in_progress
+	# from the orchestrator's POV — posting a state comment on every gate
+	# fire would re-introduce the alert-fatigue failure mode at the
+	# tracking-issue level).
+
+
 def test_standalone_conflict_sweep_skips_integration_base_prs():
 	state = _base_state(status="complete")
 	prs = [
@@ -8352,6 +8452,125 @@ def test_external_finalize_detect_marks_project_complete_when_final_pr_already_m
 		"`PROJECT_STATUS=complete`; without the `continue`, the same tick falls "
 		"through to the terminal-state skip block and logs a misleading "
 		"`Project already complete, skipping.` line."
+	)
+
+
+def test_external_finalize_gates_on_subissue_completeness_before_marking_complete():
+	# Regression guard for the project #2734 false-completion broadcast
+	# (docs/postmortems/2026-05-18-project-2734-stall.md, layer 6).  The
+	# external-finalize block added by PR #2777 transitioned status=complete
+	# whenever the pinned integration PR was closed+merged, without checking
+	# whether the sub-issues in `.waves[].issues[]` had actually shipped.
+	# Project #2734's integration PR (#2750) was squash-merged externally
+	# with only Wave 1 (2 of 9 sub-issues) merged; on the next poll tick
+	# the unconditional transition broadcast "✅ Project complete" with 7
+	# sub-issues never created.
+	#
+	# The fix: before mutating state, count sub-issues whose status is not
+	# in {merged, closed, skipped}. If any are non-terminal, emit a
+	# structured `[external-finalize-partial]` warning, fire one Telegram
+	# alert per distinct missing-issue set (dedup via sha256 of the
+	# missing set, persisted on the state file as
+	# `external_finalize_partial_alert_sig`), and `continue` to skip the
+	# rest of this tick's processing for this project.  No state mutation.
+	#
+	# This test pins the placement (inside the elif-closed-and-merged arm,
+	# BEFORE the jq state mutation), the gate condition (filter shape
+	# matching the established `status != merged/closed/skipped` pattern
+	# used elsewhere in the script), the dedup mechanism (sha256 signature
+	# of the missing set), the early-exit (`continue` before any state
+	# mutation runs), and the side-effect surface (the
+	# `[external-finalize-partial]` warning marker and the WARNING-level
+	# tg_notify so the operator can take action).
+	poller_body = POLLER_SCRIPT.read_text(encoding="utf-8")
+	# Anchor the window on the existing landmarks from
+	# test_external_finalize_detect_marks_project_complete_when_final_pr_already_merged
+	# so a refactor that moves the block also has to update both tests in
+	# lockstep — preventing one test from regressing silently.
+	elif_marker = (
+		'elif [ "${_orch_extfin_pr_state}" = "closed" ] && '
+		'[ "${_orch_extfin_pr_merged}" = "true" ]; then'
+	)
+	elif_idx = poller_body.find(elif_marker)
+	assert elif_idx != -1, (
+		"external-finalize elif (closed+merged) marker is missing from "
+		"scripts/orchestrate_poll_process.sh; the completeness gate must "
+		"live inside that arm, so the elif itself is required."
+	)
+	mutation_marker = "'.final_merge_pr = $final_pr"
+	mutation_idx = poller_body.find(mutation_marker, elif_idx)
+	assert mutation_idx != -1, (
+		"external-finalize state mutation (jq `.final_merge_pr = $final_pr` "
+		"line) is missing after the closed+merged elif; the completeness gate "
+		"must precede that mutation."
+	)
+	gate_window = poller_body[elif_idx:mutation_idx]
+	# Gate condition: must enumerate non-terminal sub-issues using the same
+	# filter shape the rest of the script already uses for terminal-success
+	# detection.  If a future refactor switches to a different filter shape
+	# (e.g. flips the negation or drops `skipped`), this assertion catches
+	# it before the gate starts mis-classifying skipped issues as missing.
+	for needle, why in (
+		(
+			'.waves[]?.issues[]?',
+			"completeness gate no longer iterates `.waves[]?.issues[]?`; without it the gate cannot inspect sub-issue states and would always treat the project as complete.",
+		),
+		(
+			'select(.status == "not_created")',
+			"completeness gate no longer filters on `status == \"not_created\"`; the gate must catch sub-issues that were never dispatched (the project #2734 failure mode) without false-positive-firing on sub-issues that have a github_issue and are merely behind the per-tick label reconciliation. Widening the filter without also reconciling sub-issue status from labels first would break the legitimate external-finalize tests that pass with a `pending` sub-issue whose linked PR is already merged.",
+		),
+		(
+			'_orch_extfin_incomplete_count',
+			"completeness gate no longer computes `_orch_extfin_incomplete_count`; without the count variable the `-gt 0` guard cannot fire and the partial-merge case is silently complete.",
+		),
+		(
+			'-gt 0',
+			"completeness gate no longer gates on `_orch_extfin_incomplete_count -gt 0`; without this guard either every project is treated as incomplete (false positive) or none are (false negative).",
+		),
+		(
+			'[external-finalize-partial]',
+			"completeness gate no longer emits the `[external-finalize-partial]` marker; downstream log-analysis tooling and the postmortem (docs/postmortems/2026-05-18-project-2734-stall.md) anchor on this exact marker.",
+		),
+		(
+			'external_finalize_partial_alert_sig',
+			"completeness gate no longer persists `external_finalize_partial_alert_sig` on the state file; without this dedup key the gate would fire a Telegram alert every poll tick (~12/hour) until the project is completed or de-scoped — alert fatigue is the exact failure mode the postmortem's layer 5 calls out.",
+		),
+		(
+			'tg_notify',
+			"completeness gate no longer fires `tg_notify` on first-detection of an incomplete external-finalize; without the alert the operator has no way to learn the project is stuck except by reading workflow logs.",
+		),
+		(
+			'"WARNING"',
+			"completeness gate no longer escalates the Telegram alert to WARNING level; without the WARNING tag the alert blends into INFO chatter and is easily missed.",
+		),
+		(
+			'continue',
+			"completeness gate no longer short-circuits with `continue` on incomplete detection; without it the gate would warn and then fall through to the state-mutation block, producing the exact false-completion broadcast the gate is meant to prevent.",
+		),
+	):
+		assert needle in gate_window, (
+			"external-finalize completeness gate in scripts/orchestrate_poll_process.sh "
+			f"no longer contains `{needle}` between the closed+merged elif and the "
+			f"state-mutation jq call — {why}"
+		)
+	# Hard requirement: no jq mutation that sets `.status = "complete"`
+	# may appear inside the gate window itself.  The gate's only mutation
+	# is the alert-dedup signature persist; any other state change would
+	# bypass the wave-by-wave finalize path that owns project-status
+	# transitions.
+	# A subtlety: jq operations on `.external_finalize_partial_alert_sig`
+	# are fine; what matters is that `.status = "complete"` (or
+	# `.final_merge_status = "merged"`) does not land before the
+	# `continue`.  Verify the gate window does NOT contain those terminal
+	# transitions.
+	assert '.status = "complete"' not in gate_window, (
+		"external-finalize completeness gate must NOT transition `.status` to `complete` "
+		"itself; that mutation belongs to the post-gate fall-through path which only "
+		"runs when every sub-issue is terminal-success."
+	)
+	assert '.final_merge_status = "merged"' not in gate_window, (
+		"external-finalize completeness gate must NOT mark `.final_merge_status = merged` "
+		"itself; that mutation belongs to the post-gate fall-through path."
 	)
 
 

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -8742,6 +8742,82 @@ def test_resolver_tooling_refresh_function_has_merge_base_divergence_guard():
 	)
 
 
+def test_resolver_tooling_refresh_function_has_3way_merge_fallback():
+	# Static contract for P5 (docs/postmortems/2026-05-18-project-2734-stall.md).
+	# When BOTH the integration branch and main have changed an
+	# allowlisted file since the merge-base, PR #2760's divergence
+	# guard skipped the refresh — preserving the sub-issue PR change
+	# but losing the main-side toolchain fix. P5 layers a 3-way merge
+	# fallback alongside the guard: if both sides changed but the
+	# changes don't conflict, combine them; only fall back to skip on
+	# real conflicts.
+	#
+	# This test pins:
+	#   - presence of the merged_3way_count counter,
+	#   - the `git merge-file` invocation,
+	#   - the conditional that distinguishes "main unchanged" (skip)
+	#     from "both changed" (try 3-way merge),
+	#   - that the 3-way path stages via `git add` (so it lands in the
+	#     refresh commit alongside the deadlock-breaker checkout path),
+	#   - the conflict fallback (skip on non-zero `git merge-file` exit).
+	poller_body = POLLER_SCRIPT.read_text(encoding="utf-8")
+	fn_body = _extract_refresh_function_body(poller_body)
+
+	assert "merged_3way_count=0" in fn_body, (
+		"_refresh_integration_resolver_tooling must initialize merged_3way_count "
+		"alongside refreshed_count / skipped_count / drifted_count. Without the "
+		"counter the post-refresh summary cannot distinguish 3-way merges from "
+		"deadlock-breaker checkouts."
+	)
+	assert "git merge-file" in fn_body, (
+		"_refresh_integration_resolver_tooling must call `git merge-file` to do "
+		"the 3-way merge of integration + main edits when both sides changed "
+		"since the merge-base. Without this the function falls back to PR #2760's "
+		"skip behavior and the toolchain fix never reaches the integration branch."
+	)
+	# The skip sub-case (main unchanged) must come BEFORE the 3-way
+	# merge sub-case so the cheap test runs first.
+	skip_subcase_re = re.compile(
+		r'if\s+\[\s+-z\s+"\$\{base_hash\}"\s+\]\s+\|\|\s+\[\s+"\$\{main_hash\}"\s+=\s+"\$\{base_hash\}"\s+\]\s*;\s*then'
+	)
+	assert skip_subcase_re.search(fn_body), (
+		"3-way merge logic must short-circuit when main is unchanged from "
+		"merge-base (no work to do) BEFORE attempting the merge. Without this "
+		"short-circuit, the function would 3-way merge an unchanged main into "
+		"the integration version, wasting work and adding noise to the refresh."
+	)
+	# The merge must use the standard base/int/main triple in the
+	# correct argument order: `git merge-file <current> <base> <other>`
+	# — `<current>` is the integration version, `<base>` the merge-base,
+	# `<other>` the main version. Swapping any of these would silently
+	# produce the wrong merge or pick the wrong side on conflict.
+	assert '"${merge_tmpdir}/int" "${merge_tmpdir}/base" "${merge_tmpdir}/main"' in fn_body, (
+		"git merge-file argument order must be `int base main` (current, base, "
+		"other). Swapping the order would silently corrupt the merge — the "
+		"integration version is the file we want to update in place, the "
+		"merge-base is the common ancestor, main is the new content to merge in."
+	)
+	# Successful 3-way merge must increment merged_3way_count AND stage
+	# the merged content via git add so it lands in the refresh commit.
+	assert "merged_3way_count=$((merged_3way_count + 1))" in fn_body, (
+		"successful 3-way merge must increment merged_3way_count so the "
+		"post-refresh summary and commit-message body can report it."
+	)
+	# Conflict path must fall through to `skipped_count` (matching the
+	# existing skip semantics from PR #2760) — never stage a file with
+	# conflict markers. The conflict path is reached when `git merge-file`
+	# returns non-zero (1+ for conflicts, 255 for binary/error).
+	skip_re = re.compile(
+		r'git\s+merge-file[\s\S]{0,1500}?\belse\b[\s\S]{0,500}?skipped_count=\$\(\(skipped_count\s*\+\s*1\)\)'
+	)
+	assert skip_re.search(fn_body), (
+		"3-way merge must fall back to `skipped_count += 1` when "
+		"`git merge-file` returns non-zero (conflict or binary file). "
+		"Without this fallback the function would either lose conflict "
+		"information silently or stage a file with conflict markers."
+	)
+
+
 def test_resolver_tooling_refresh_does_not_clobber_files_changed_on_integration_branch():
 	# Behavioural regression for issue #2734: run the real
 	# _refresh_integration_resolver_tooling function against a
@@ -8876,6 +8952,303 @@ def test_resolver_tooling_refresh_does_not_clobber_files_changed_on_integration_
 			"_refresh_integration_resolver_tooling did not log the "
 			"expected skip-on-divergence message for the protected file.\n"
 			f"stdout:\n{result.stdout}\n---\nstderr:\n{result.stderr}\n"
+		)
+	finally:
+		shutil.rmtree(tmp_root, ignore_errors=True)
+
+
+def test_resolver_tooling_refresh_3way_merges_disjoint_edits_from_both_branches():
+	# Behavioural test for P5 (docs/postmortems/2026-05-18-project-2734-stall.md).
+	# When BOTH the integration branch and main have edited an allowlisted
+	# file since the merge-base, AND the edits are in non-overlapping
+	# regions, the 3-way merge fallback must combine them so neither
+	# side's intent is lost.
+	#
+	# This is the case PR #2760's divergence guard could not handle:
+	# the guard correctly preserves the sub-issue PR change but loses
+	# the toolchain fix that main shipped to the same file. The P5
+	# layer fills the gap by trying `git merge-file` before skipping.
+	#
+	# Fixture layout:
+	#   bare.git           — origin
+	#   work/              — single clone with main + integration branches
+	#     scripts/check_resolver_diff.sh   — allowlisted, 5-line file
+	#
+	# Timeline:
+	#   1. main has 5 lines of content with `MAIN_LINE_1` at top.
+	#   2. orchestrator/project-99 branched off, edited only the LAST
+	#      line ("SUB_ISSUE_FOOTER").
+	#   3. main edited only the FIRST line ("MAIN_LINE_1_FIXED").
+	#   4. Run the real refresh function. The clean 3-way merge must
+	#      yield BOTH "MAIN_LINE_1_FIXED" at top AND "SUB_ISSUE_FOOTER"
+	#      at bottom on the integration branch.
+	tmp_root = Path(tempfile.mkdtemp(prefix="refresh-3way-"))
+	try:
+		bare = tmp_root / "bare.git"
+		work = tmp_root / "work"
+		subprocess.run(
+			["git", "init", "--bare", "--quiet", str(bare)],
+			check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+		)
+		subprocess.run(
+			["git", "init", "--quiet", str(work)],
+			check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+		)
+		for k, v in [
+			("user.name", "test"),
+			("user.email", "t@example.com"),
+			("commit.gpgsign", "false"),
+			("commit.gpgSign", "false"),
+		]:
+			subprocess.run(
+				["git", "-C", str(work), "config", k, v],
+				check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+			)
+		(work / "scripts").mkdir()
+		refresh_target = work / "scripts" / "check_resolver_diff.sh"
+		refresh_target.write_text(
+			"MAIN_LINE_1\n"
+			"MAIN_LINE_2\n"
+			"MAIN_LINE_3\n"
+			"MAIN_LINE_4\n"
+			"MAIN_LINE_5\n",
+			encoding="utf-8",
+		)
+
+		def _git(*args: str) -> None:
+			subprocess.run(
+				["git", "-C", str(work), *args],
+				check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+			)
+
+		_git("checkout", "-B", "main")
+		_git("add", "-A")
+		_git("commit", "-m", "initial main", "--quiet")
+		_git("remote", "add", "origin", str(bare))
+		_git("push", "-u", "origin", "main", "--quiet")
+
+		# Integration branches off main and edits only line 5 (the
+		# footer). This simulates a merged sub-issue PR adding a comment
+		# at the bottom of a toolchain script.
+		_git("checkout", "-B", "orchestrator/project-99")
+		refresh_target.write_text(
+			"MAIN_LINE_1\n"
+			"MAIN_LINE_2\n"
+			"MAIN_LINE_3\n"
+			"MAIN_LINE_4\n"
+			"SUB_ISSUE_FOOTER\n",
+			encoding="utf-8",
+		)
+		_git("add", "-A")
+		_git("commit", "-m", "merged sub-issue: add footer", "--quiet")
+		_git("push", "-u", "origin", "orchestrator/project-99", "--quiet")
+
+		# Main edits only line 1 (the header). Simulates the toolchain
+		# fix the orchestrator wants to propagate to the integration
+		# branch.
+		_git("checkout", "main")
+		refresh_target.write_text(
+			"MAIN_LINE_1_FIXED\n"
+			"MAIN_LINE_2\n"
+			"MAIN_LINE_3\n"
+			"MAIN_LINE_4\n"
+			"MAIN_LINE_5\n",
+			encoding="utf-8",
+		)
+		_git("add", "-A")
+		_git("commit", "-m", "toolchain fix", "--quiet")
+		_git("push", "origin", "main", "--quiet")
+
+		poller_body = POLLER_SCRIPT.read_text(encoding="utf-8")
+		fn_body = _extract_refresh_function_body(poller_body)
+
+		runtime_dir = tmp_root / "runtime"
+		runtime_dir.mkdir(parents=True, exist_ok=True)
+		runner = tmp_root / "run.sh"
+		runner.write_text(
+			"#!/usr/bin/env bash\n"
+			"set -uo pipefail\n"
+			f"{fn_body}\n"
+			f"cd {str(work)!r}\n"
+			f"export RUNTIME_DIR={str(runtime_dir)!r}\n"
+			"_refresh_integration_resolver_tooling orchestrator/project-99 main\n",
+			encoding="utf-8",
+		)
+		runner.chmod(0o755)
+		result = subprocess.run(
+			["bash", str(runner)],
+			capture_output=True, text=True, timeout=60,
+		)
+		assert result.returncode == 0, (
+			"_refresh_integration_resolver_tooling 3-way merge fixture run "
+			"failed before the merge-result assertions could validate.\n"
+			f"stdout:\n{result.stdout}\n---\nstderr:\n{result.stderr}\n"
+		)
+		subprocess.run(
+			["git", "-C", str(work), "fetch", "origin", "--quiet"],
+			check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+		)
+		actual = subprocess.run(
+			["git", "-C", str(work), "show",
+			 "origin/orchestrator/project-99:scripts/check_resolver_diff.sh"],
+			capture_output=True, text=True, check=True,
+		).stdout
+		# After the 3-way merge, the integration branch's file must
+		# contain BOTH the main-side fix (line 1) AND the sub-issue
+		# footer (line 5). Losing either side defeats the whole point of
+		# the merge.
+		assert "MAIN_LINE_1_FIXED" in actual, (
+			"3-way merge lost the main-side toolchain fix.\n"
+			f"file contents:\n{actual}\n---\n"
+			f"refresh stdout:\n{result.stdout}\n"
+			f"---\nrefresh stderr:\n{result.stderr}\n"
+		)
+		assert "SUB_ISSUE_FOOTER" in actual, (
+			"3-way merge lost the sub-issue footer — the exact regression "
+			"PR #2760's divergence guard prevented and that P5 must "
+			"continue to prevent. If the 3-way merge ever clobbers the "
+			"integration-branch change, the project-#2734 failure mode "
+			"recurs.\n"
+			f"file contents:\n{actual}\n---\n"
+			f"refresh stdout:\n{result.stdout}\n"
+			f"---\nrefresh stderr:\n{result.stderr}\n"
+		)
+		# Conflict markers must not appear — those would mean the merge
+		# fell back to the skip path but staged the file anyway, which
+		# would trip the post-resolve verifier.
+		assert "<<<<<<<" not in actual and ">>>>>>>" not in actual, (
+			"3-way merge result contains conflict markers — the merge "
+			"must EITHER produce a clean result OR fall through to the "
+			"skip path. Staging a file with conflict markers would trip "
+			"the fingerprint verifier and reproduce the wave-dispatch "
+			"deadlock that P5 is meant to break.\n"
+			f"file contents:\n{actual}\n"
+		)
+		# The log line for 3-way merges must surface so an operator
+		# auditing the refresh commit can see this file was merged
+		# rather than clobbered.
+		assert "3-way merged scripts/check_resolver_diff.sh" in result.stdout, (
+			"_refresh_integration_resolver_tooling did not log the "
+			"expected `3-way merged` line for the merged file. Without "
+			"this log line, operators reviewing the orchestrator log "
+			"have no way to tell that this file came from a 3-way merge "
+			"vs the deadlock-breaker checkout path.\n"
+			f"stdout:\n{result.stdout}\n---\nstderr:\n{result.stderr}\n"
+		)
+	finally:
+		shutil.rmtree(tmp_root, ignore_errors=True)
+
+
+def test_resolver_tooling_refresh_3way_merge_falls_back_to_skip_on_conflict():
+	# Behavioural test for the P5 conflict fallback. When the 3-way
+	# merge would produce conflict markers (because main and the
+	# integration branch edited the SAME region of the file in
+	# incompatible ways), the function must NOT stage the conflict-
+	# markered file — it must fall back to the existing skip behavior
+	# so the normal main->integration sync can surface the conflict
+	# under operator review.
+	tmp_root = Path(tempfile.mkdtemp(prefix="refresh-3way-conflict-"))
+	try:
+		bare = tmp_root / "bare.git"
+		work = tmp_root / "work"
+		subprocess.run(
+			["git", "init", "--bare", "--quiet", str(bare)],
+			check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+		)
+		subprocess.run(
+			["git", "init", "--quiet", str(work)],
+			check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+		)
+		for k, v in [
+			("user.name", "test"),
+			("user.email", "t@example.com"),
+			("commit.gpgsign", "false"),
+			("commit.gpgSign", "false"),
+		]:
+			subprocess.run(
+				["git", "-C", str(work), "config", k, v],
+				check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+			)
+		(work / "scripts").mkdir()
+		refresh_target = work / "scripts" / "check_resolver_diff.sh"
+		refresh_target.write_text("LINE_1\nLINE_2\nLINE_3\n", encoding="utf-8")
+
+		def _git(*args: str) -> None:
+			subprocess.run(
+				["git", "-C", str(work), *args],
+				check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+			)
+
+		_git("checkout", "-B", "main")
+		_git("add", "-A")
+		_git("commit", "-m", "initial", "--quiet")
+		_git("remote", "add", "origin", str(bare))
+		_git("push", "-u", "origin", "main", "--quiet")
+
+		# Both branches edit the SAME line in incompatible ways — must
+		# produce a conflict that git merge-file cannot auto-resolve.
+		_git("checkout", "-B", "orchestrator/project-99")
+		refresh_target.write_text("LINE_1\nSUB_ISSUE_CHANGE\nLINE_3\n", encoding="utf-8")
+		_git("add", "-A")
+		_git("commit", "-m", "sub-issue edit on line 2", "--quiet")
+		_git("push", "-u", "origin", "orchestrator/project-99", "--quiet")
+
+		_git("checkout", "main")
+		refresh_target.write_text("LINE_1\nMAIN_CHANGE\nLINE_3\n", encoding="utf-8")
+		_git("add", "-A")
+		_git("commit", "-m", "main edit on line 2", "--quiet")
+		_git("push", "origin", "main", "--quiet")
+
+		poller_body = POLLER_SCRIPT.read_text(encoding="utf-8")
+		fn_body = _extract_refresh_function_body(poller_body)
+
+		runtime_dir = tmp_root / "runtime"
+		runtime_dir.mkdir(parents=True, exist_ok=True)
+		runner = tmp_root / "run.sh"
+		runner.write_text(
+			"#!/usr/bin/env bash\n"
+			"set -uo pipefail\n"
+			f"{fn_body}\n"
+			f"cd {str(work)!r}\n"
+			f"export RUNTIME_DIR={str(runtime_dir)!r}\n"
+			"_refresh_integration_resolver_tooling orchestrator/project-99 main\n",
+			encoding="utf-8",
+		)
+		runner.chmod(0o755)
+		result = subprocess.run(
+			["bash", str(runner)],
+			capture_output=True, text=True, timeout=60,
+		)
+		assert result.returncode == 0, (
+			f"refresh exited non-zero\nstdout:{result.stdout}\nstderr:{result.stderr}"
+		)
+		subprocess.run(
+			["git", "-C", str(work), "fetch", "origin", "--quiet"],
+			check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+		)
+		actual = subprocess.run(
+			["git", "-C", str(work), "show",
+			 "origin/orchestrator/project-99:scripts/check_resolver_diff.sh"],
+			capture_output=True, text=True, check=True,
+		).stdout
+		# On conflict the function must SKIP — integration-branch content
+		# must be unchanged from the sub-issue version.
+		assert actual == "LINE_1\nSUB_ISSUE_CHANGE\nLINE_3\n", (
+			"3-way merge with conflict did NOT fall back to skip — the "
+			"integration branch was modified despite an unresolvable "
+			"merge. This is the exact failure mode P5's conflict-fallback "
+			"branch is meant to prevent: staging conflict markers (or "
+			"silently picking one side) would trip the fingerprint "
+			"verifier and re-introduce the wave-dispatch deadlock.\n"
+			f"file contents:\n{actual}\n---\n"
+			f"refresh stdout:\n{result.stdout}\n"
+			f"---\nrefresh stderr:\n{result.stderr}\n"
+		)
+		# The log line must surface the skip-on-conflict so operators
+		# know the file needs a manual resolve via normal sync.
+		assert "skip scripts/check_resolver_diff.sh" in result.stdout, (
+			"3-way merge conflict path did not log the expected skip line."
+			f"\nstdout:\n{result.stdout}\n---\nstderr:\n{result.stderr}\n"
 		)
 	finally:
 		shutil.rmtree(tmp_root, ignore_errors=True)

--- a/tests/test_stall_recovery_pr_lookup.py
+++ b/tests/test_stall_recovery_pr_lookup.py
@@ -806,6 +806,13 @@ def _run_create_pr_recovery(
 
 	runtime_dir = tmp / "runtime"
 	runtime_dir.mkdir(parents=True, exist_ok=True)
+	issue_url = f"https://github.com/owner/repo/issues/{issue_number}"
+	pr_body_dir = runtime_dir / "pr-body-lint"
+	pr_body_dir.mkdir(parents=True, exist_ok=True)
+	(pr_body_dir / "body.txt").write_text(
+		f"Automated implementation. Closes {issue_url}\n",
+		encoding="utf-8",
+	)
 	github_output = tmp / "github_output"
 	github_output.write_text("", encoding="utf-8")
 
@@ -813,7 +820,7 @@ def _run_create_pr_recovery(
 	env["PYTHONDONTWRITEBYTECODE"] = "1"
 	env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
 	env["ISSUE_NUMBER"] = issue_number
-	env["ISSUE_URL"] = f"https://github.com/owner/repo/issues/{issue_number}"
+	env["ISSUE_URL"] = issue_url
 	env["TARGET_BRANCH"] = f"ai/issue-{issue_number}"
 	env["PR_BASE_BRANCH"] = "main"
 	env["IS_SMOKE_TEST"] = "false"
@@ -831,6 +838,10 @@ def _run_create_pr_recovery(
 		capture_output=True,
 		text=True,
 		timeout=30,
+	)
+	assert "PR creation failed." in proc.stdout, (
+		"create-PR recovery helper did not reach the gh pr create recovery path; "
+		f"stderr: {proc.stderr}\nstdout: {proc.stdout}"
 	)
 	gh_out = github_output.read_text(encoding="utf-8")
 	return proc, gh_out

--- a/tests/test_stall_recovery_pr_lookup.py
+++ b/tests/test_stall_recovery_pr_lookup.py
@@ -809,6 +809,10 @@ def _run_create_pr_recovery(
 	issue_url = f"https://github.com/owner/repo/issues/{issue_number}"
 	pr_body_dir = runtime_dir / "pr-body-lint"
 	pr_body_dir.mkdir(parents=True, exist_ok=True)
+	(pr_body_dir / "title.txt").write_text(
+		f"AI implementation for issue #{issue_number}\n",
+		encoding="utf-8",
+	)
 	(pr_body_dir / "body.txt").write_text(
 		f"Automated implementation. Closes {issue_url}\n",
 		encoding="utf-8",

--- a/tests/test_workflow_checkout_integration_ref_audit.py
+++ b/tests/test_workflow_checkout_integration_ref_audit.py
@@ -21,7 +21,10 @@ REQUIRED_RESOLVER_WORKFLOWS = {
 # orchestrator-managed issue execution paths.
 ALLOWLIST_EXCEPTIONS = {
 	"ci.yml": "PR CI validation has no orchestrator issue metadata.",
+	"integration-pr-readiness.yml": "Integration-PR readiness check runs on pull_request refs and posts commit status metadata, not orchestrator issue-phase checkout.",
 	"issue_pr_status.yml": "Issue/PR status utility workflow does not execute orchestrator issue phases.",
+	"lint-plan-archival.yml": "Plan-archival lint validates pull_request body/diff state rather than orchestrator issue-phase integration refs.",
+	"lint-pr-body-auto-close.yml": "PR-body auto-close lint validates pull_request metadata rather than orchestrator issue-phase checkout.",
 	"mark-stable.yml": "Release promotion workflow operates on repo refs, not tracking-issue metadata.",
 	"memory_maintenance.yml": "Maintenance workflow has no issue-comment or tracking-issue context.",
 	"orchestrate.yml": "Project bootstrap workflow has no integration-branch metadata at checkout time.",

--- a/unattended_system_instructions.md
+++ b/unattended_system_instructions.md
@@ -494,3 +494,45 @@ trail.
 If a script is renamed or extended, update its entry (path, trigger,
 preflight checks) in the same PR — §10 (naming immutability) still
 applies in this file's numbering.
+
+---
+
+## §21. PR Body Auto-Close Keyword Discipline
+
+GitHub auto-closes issues referenced with `Fixes #N`, `Closes #N`, or
+`Resolves #N` (case-insensitive) in a PR body, PR title, or commit
+message when the PR merges into the default branch. For orchestrator
+tracking issues — any issue carrying the `ai:orchestrator-tracking`
+label — this silently kills the orchestrator's state machine: once the
+tracking issue closes, the poller treats the project as done and stops
+dispatching the remaining waves.
+
+Rules for every PR body, title, and commit message composed by an
+unattended pipeline (implement, implement-repair, review autofix,
+conflict resolver, validate, judge, orchestrate):
+
+- **NEVER** use auto-close keywords (`close`, `closes`, `closed`, `fix`,
+  `fixes`, `fixed`, `resolve`, `resolves`, `resolved`, case-insensitive)
+  followed by a reference to an `ai:orchestrator-tracking` issue.
+- Use `Refs #N` or `Related to #N` for semantic linkage to tracking
+  issues instead.
+- Auto-close keywords against **sub-issues** (issues carrying
+  `ai:orchestrator-managed` but NOT `ai:orchestrator-tracking`) remain
+  the correct convention — those issues are supposed to close on the
+  sub-issue PR's merge.
+- Before any phase invokes `gh pr create --body` (or its equivalent),
+  it MUST run `scripts/lint_pr_body_auto_close.py` against the
+  composed body. The lint exits non-zero (and surfaces a structured
+  `::error::[lint_pr_body_auto_close]` line) when any keyword
+  reference resolves to a tracking-labeled issue. Treat a non-zero
+  exit as `BLOCKED:` per §16 — do not submit the PR.
+
+Historical incident: PR #2760 used `Fixes #2734` in its body.  `#2734`
+was an `ai:orchestrator-tracking` issue for the integration-sync
+resolver self-heal project. On merge, GitHub auto-closed `#2734` and
+the orchestrator stopped dispatching waves 2-7; the bulk of the
+project's planned phases never shipped (see
+`docs/postmortems/2026-05-18-project-2734-stall.md`). The §19 entry in
+CLAUDE.md and this §21 entry both exist to forbid this pattern; the
+script `scripts/lint_pr_body_auto_close.py` is the executable
+enforcement vehicle for both.


### PR DESCRIPTION
## Summary

Seven preventive fixes addressing the project #2734 stall and false "✅ Project complete" broadcast. Investigation lives in `docs/postmortems/2026-05-18-project-2734-stall.md`; this PR ships the code changes that prevent recurrence.

The incident, in one sentence: a refresh-tooling clobber stalled the orchestrator, the fix PR used an auto-close keyword against the tracking issue (stopping wave dispatch), the integration PR was externally squash-merged with only Wave 1 content, and a later self-heal patch broadcast project completion without verifying that the wave-by-wave sub-issues had actually shipped. Tracking issue is `Refs #2734`; integration PR `Refs #2750`; auto-close violator `Refs #2760`; partial self-heal `Refs #2777`.

## Fixes in this PR

Ordered by causal-chain layer:

- **P1** — CI workflow `.github/workflows/lint-pr-body-auto-close.yml` + `scripts/lint_pr_body_auto_close.py`. Required check on every PR; fails when any PR body / commit message contains `Fixes/Closes/Resolves #N` (case-insensitive, short form OR GitHub URL form) where #N carries `ai:orchestrator-tracking`. Turns the prose §19 rule into enforced policy. 12 unit tests.
- **P4** — Generator-side pre-flight: new step in `.github/workflows/implement.yml` runs the same lint against the about-to-be-submitted PR body BEFORE `gh pr create`. New §21 in `unattended_system_instructions.md` mirrors CLAUDE.md §19 for unattended pipelines. Cross-reference added to CLAUDE.md §19 documenting both enforcement layers.
- **P2** — Completeness gate inside `scripts/orchestrate_poll_process.sh:8478-8527`'s `[external-finalize]` block. Before transitioning `status=complete`, counts sub-issues with `status="not_created"`; if any are found, emits `::warning::[external-finalize-partial]`, fires one Telegram alert (deduped by sha256 of the missing-issue set), and `continue`s without mutating state. Filter is intentionally narrow (`not_created` only) so the legitimate post-merge-label-reconciliation lag path still works — covered by 2 new tests + the 5 existing external-finalize tests.
- **P3** — Integration-PR readiness commit status. New workflow `.github/workflows/integration-pr-readiness.yml` + `scripts/check_integration_pr_readiness.py`. On every PR whose head ref matches `orchestrator/project-*`, posts a commit status `orchestrator/integration-pr-not-ready` that's `failure` while tracking-issue checkboxes are unticked, `success` with all ticked, and `success` with the auditable escape-valve label `ai:override-incomplete-merge`. Should be added to branch protection as a required check (not changeable from a workflow). 5 unit tests.
- **P6** — Plan-archival pre-condition. New workflow `.github/workflows/lint-plan-archival.yml` + `scripts/lint_plan_archival_completeness.py`. On PRs adding files under `docs/completed/`, requires that for every `Refs #N`-style reference to an `ai:orchestrator-tracking` issue, EITHER all tracking-issue checkboxes are ticked OR the PR body contains an explicit `## De-scoped phases` heading. 8 unit tests.
- **P5** — 3-way merge fallback in `_refresh_integration_resolver_tooling`. PR #2760's divergence guard preserves sub-issue PR content but loses any toolchain fix on the same file. P5 layers `git merge-file` (with the standard current/base/other argument order) alongside the guard: when both branches edited the same file in non-overlapping ways the merge cleanly combines them; only real conflicts fall back to the existing skip. New `merged_3way_count` counter surfaces in the per-tick log + commit-message body. 3 new tests (static guard + behavioural-clean-merge + behavioural-conflict-fallback) + the 4 existing tooling-refresh tests still pass.
- **P8** — Forensic postmortem at `docs/postmortems/2026-05-18-project-2734-stall.md` documenting the full timeline, six-layer causal chain, lessons, and each preventive fix.

## Scope deferred (per pre-PR clarification)

- **P7** (alert-fatigue ladder / Phase 2 of the original plan) — skipped per user direction; P2 + P3 indirectly close the same operator-silences-alerts pathway.
- **Reviving Phases 2-5** of the integration-sync resolver self-heal plan — out of scope. If revived, open a fresh tracking issue rather than reopening #2734.

## Test plan

All unit tests pass locally:

- [x] `python3 tests/test_orchestrate_poll_process.py` — 7 external-finalize tests (2 new for P2) + 7 tooling-refresh tests (3 new for P5) all pass.
- [x] `python3 tests/test_lint_pr_body_auto_close.py` — 12 / 12 (P1).
- [x] `python3 tests/test_lint_plan_archival_completeness.py` — 8 / 8 (P6).
- [x] `python3 tests/test_check_integration_pr_readiness.py` — 5 / 5 (P3).
- [x] `bash -n scripts/orchestrate_poll_process.sh` clean.
- [x] YAML lint clean on the 4 changed/new workflow files.
- [x] Sanity: P3 script dry-run on this branch correctly no-ops (head ref isn't `orchestrator/project-*`).
- [x] Sanity: P1 lint correctly identifies `Fixes #2734` in the historical-incident quote within the postmortem doc — confirming the regex matches; that's a quote in a markdown file, not a PR body, so it doesn't gate any PR.

## Operational notes for the merger

After this PR merges, to fully activate P3's gate:

1. Add `orchestrator/integration-pr-not-ready` as a required status check on the `main` branch protection rule. Without that, the status appears but does not block merge.
2. Pre-create the `ai:override-incomplete-merge` label (the escape-valve label P3 references) via the existing label-precreation contract, so applying it works on first try.

Both steps are repo-settings / label-catalog changes, not code, so they're out of scope for this PR.

Refs #2734
Refs #2750
Refs #2760
Refs #2776
Refs #2777

https://claude.ai/code/session_01VUyGRbNSW6p2PzehvyNEKb

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUyGRbNSW6p2PzehvyNEKb)_