### PR TITLE
orchestrate_poll_process: log cache provenance when active issue set is empty

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -11575,6 +11575,25 @@ fi
       ACTIVE_WORKFLOW_ISSUES="$(build_active_issue_set)"
       if [ -n "${ACTIVE_WORKFLOW_ISSUES}" ]; then
         echo "Issues with active workflow runs: $(echo "${ACTIVE_WORKFLOW_ISSUES}" | tr '\n' ' ')"
+      else
+        # Diagnostic: when one or more issues stalled but the active set
+        # came back empty, emit cache provenance so a stall recovery
+        # that fires over an actually in_progress workflow can be traced
+        # back to cache state (304-reuse of empty cached_runs, fresh
+        # cache hit on empty data, head_branch=null on workflow_dispatch
+        # extraction, or API-failure fallback in _load_actions_runs_cached).
+        # Reads from the per-tick memoised cache populated by the call
+        # above, so this adds zero API calls (§15).  Fails open on jq
+        # errors: counts fall back to "?" and the diagnostic still
+        # prints.  The retrigger_review defense-in-depth guard at
+        # scripts/orchestrate_poll_process.sh:5829 still protects the
+        # empty-commit push if the cache misses a live review run; this
+        # logging just makes the cache state observable next time.
+        _diag_blob="$(_load_actions_runs_cached 2>/dev/null || echo '{"workflow_runs":[]}')"
+        _diag_total="$(printf '%s' "${_diag_blob}" | jq -r '.workflow_runs | length' 2>/dev/null || echo "?")"
+        _diag_in_progress="$(printf '%s' "${_diag_blob}" | jq -r '[.workflow_runs[]? | select((.status // "") == "in_progress")] | length' 2>/dev/null || echo "?")"
+        _diag_queued="$(printf '%s' "${_diag_blob}" | jq -r '[.workflow_runs[]? | select((.status // "") == "queued")] | length' 2>/dev/null || echo "?")"
+        echo "Active issue set is empty (cache: total=${_diag_total}, in_progress=${_diag_in_progress}, queued=${_diag_queued})."
       fi
 
       # Prefetch linked-PR state for every stalled issue in batched

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -11582,18 +11582,32 @@ fi
         # back to cache state (304-reuse of empty cached_runs, fresh
         # cache hit on empty data, head_branch=null on workflow_dispatch
         # extraction, or API-failure fallback in _load_actions_runs_cached).
-        # Reads from the per-tick memoised cache populated by the call
-        # above, so this adds zero API calls (§15).  Fails open on jq
-        # errors: counts fall back to "?" and the diagnostic still
-        # prints.  The retrigger_review defense-in-depth guard at
+        # Reads directly from the per-tick memoised
+        # _ACTIONS_RUNS_BLOB_CACHE populated by the call above, so
+        # this adds zero API calls (§15).  Fails open on jq errors:
+        # counts fall back to "?" and the diagnostic still prints,
+        # but parse_error=true keeps that path distinguishable from a
+        # genuinely empty cache.  The retrigger_review defense-in-depth
+        # guard at
         # scripts/orchestrate_poll_process.sh:5829 still protects the
         # empty-commit push if the cache misses a live review run; this
         # logging just makes the cache state observable next time.
-        _diag_blob="$(_load_actions_runs_cached 2>/dev/null || echo '{"workflow_runs":[]}')"
-        _diag_total="$(printf '%s' "${_diag_blob}" | jq -r '.workflow_runs | length' 2>/dev/null || echo "?")"
-        _diag_in_progress="$(printf '%s' "${_diag_blob}" | jq -r '[.workflow_runs[]? | select((.status // "") == "in_progress")] | length' 2>/dev/null || echo "?")"
-        _diag_queued="$(printf '%s' "${_diag_blob}" | jq -r '[.workflow_runs[]? | select((.status // "") == "queued")] | length' 2>/dev/null || echo "?")"
-        echo "Active issue set is empty (cache: total=${_diag_total}, in_progress=${_diag_in_progress}, queued=${_diag_queued})."
+        (
+          _diag_blob="${_ACTIONS_RUNS_BLOB_CACHE}"
+          _diag_parse_error="false"
+          if [ -z "${_diag_blob}" ]; then
+            _diag_blob='{"workflow_runs":[]}'
+            _diag_parse_error="true"
+          fi
+          _diag_total="$(printf '%s' "${_diag_blob}" | jq -r 'if (.workflow_runs | type) == "array" then (.workflow_runs | length) else error("workflow_runs_missing_or_not_array") end' 2>/dev/null)" || { _diag_total="?"; _diag_parse_error="true"; }
+          _diag_in_progress="$(printf '%s' "${_diag_blob}" | jq -r 'if (.workflow_runs | type) == "array" then [.workflow_runs[] | select((.status // "") == "in_progress")] | length else error("workflow_runs_missing_or_not_array") end' 2>/dev/null)" || { _diag_in_progress="?"; _diag_parse_error="true"; }
+          _diag_queued="$(printf '%s' "${_diag_blob}" | jq -r 'if (.workflow_runs | type) == "array" then [.workflow_runs[] | select((.status // "") == "queued")] | length else error("workflow_runs_missing_or_not_array") end' 2>/dev/null)" || { _diag_queued="?"; _diag_parse_error="true"; }
+          if [ "${_diag_parse_error}" = "true" ]; then
+            echo "Active issue set is empty (cache: total=${_diag_total}, in_progress=${_diag_in_progress}, queued=${_diag_queued}, parse_error=true)."
+          else
+            echo "Active issue set is empty (cache: total=${_diag_total}, in_progress=${_diag_in_progress}, queued=${_diag_queued})."
+          fi
+        )
       fi
 
       # Prefetch linked-PR state for every stalled issue in batched

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -11570,8 +11570,14 @@ fi
     if [ "${STALL_COUNT}" -gt 0 ]; then
       echo "Detected ${STALL_COUNT} stalled issue(s). Checking for active workflow runs..."
 
-      # Build the set of issues with active workflows (one API call batch,
-      # reused across all stalled issues to avoid per-issue API calls).
+      # Prime the shared actions-runs blob in the parent shell before the
+      # command-substitution call below; otherwise the loader's global cache
+      # assignments stay trapped in the subshell and the diagnostic branch
+      # cannot inspect the same payload.
+      _load_actions_runs_cached >/dev/null || true
+
+      # Build the set of issues with active workflows (reusing the one API
+      # call batch primed above to avoid per-issue API calls).
       ACTIVE_WORKFLOW_ISSUES="$(build_active_issue_set)"
       if [ -n "${ACTIVE_WORKFLOW_ISSUES}" ]; then
         echo "Issues with active workflow runs: $(echo "${ACTIVE_WORKFLOW_ISSUES}" | tr '\n' ' ')"
@@ -11583,7 +11589,7 @@ fi
         # cache hit on empty data, head_branch=null on workflow_dispatch
         # extraction, or API-failure fallback in _load_actions_runs_cached).
         # Reads directly from the per-tick memoised
-        # _ACTIONS_RUNS_BLOB_CACHE populated by the call above, so
+        # _ACTIONS_RUNS_BLOB_CACHE primed just above, so
         # this adds zero API calls (§15).  Fails open on jq errors:
         # counts fall back to "?" and the diagnostic still prints,
         # but parse_error=true keeps that path distinguishable from a


### PR DESCRIPTION
## Summary

- Adds a diagnostic log line when `build_active_issue_set` returns empty *and* stalled issues were detected, surfacing the underlying `_load_actions_runs_cached` blob counts (`total` / `in_progress` / `queued` `workflow_runs`).
- Companion to the defense-in-depth guard added in #2790: that guard prevents the duplicate empty-commit push when the cache misses a live review run, but the cache state itself was previously invisible from the poll log.
- Zero new API calls — reads from the per-tick memoised `_ACTIONS_RUNS_BLOB_CACHE` populated by the existing `build_active_issue_set` call (§15).

## Motivation

A `bitsafe.io` investigation surfaced a `retrigger_review` stall recovery that fired over an actually in-progress AI Review run. The active-workflow guard at `scripts/orchestrate_poll_process.sh:7887` (`issue_has_active_workflow` → `build_active_issue_set`) failed open because the cached `_load_actions_runs_cached` blob did not contain the in-flight run.

#2790 added the targeted in-flight guard that bails out right before the empty-commit push — but it does not make the underlying cache state observable. Today, `_load_actions_runs_cached`'s three quiet failure branches (304-reuse of empty `cached_runs`, fresh-cache hit on empty data, API-failure fallback at `:4899-4903`) plus the `head_branch=null on workflow_dispatch` extraction pathway in `build_active_issue_set` all collapse into the same outcome — empty `ACTIVE_WORKFLOW_ISSUES` — with no log line distinguishing them.

This commit emits a single positive line so the next investigation can tell `total=0` (genuinely nothing running) apart from `total>0, in_progress>0` (cache populated but the head_branch regex / sha matcher dropped it) without re-investigating from cold.

## Behaviour

Only fires when stalled issues were detected **and** the active set is empty — i.e. the previously silent branch. No new log lines on the common happy path.

```
Detected 1 stalled issue(s). Checking for active workflow runs...
Active issue set is empty (cache: total=3, in_progress=1, queued=0).
```

Fails open: jq errors fall back to `"?"` and the diagnostic still prints.

## Test plan

- [x] `bash -n scripts/orchestrate_poll_process.sh` — syntax clean.
- [x] `pytest tests/test_orchestrate_poll_process.py -k "retrigger_review or build_active or active_workflow"` — 11 passed.
- [ ] Manual verification in a real poll cycle on the next deploy: confirm the new line appears on a tick that detects a stalled issue while the cache is empty, and is absent on ticks where `ACTIVE_WORKFLOW_ISSUES` is non-empty.

## Out of scope

- The cache itself is not changed — this PR only makes its state observable.
- Behavioural fixes for the stall recovery race already landed in #2790.

https://claude.ai/code/session_0156qa8EJZjso7aYFw6yDG6P

---
_Generated by [Claude Code](https://claude.ai/code/session_0156qa8EJZjso7aYFw6yDG6P)_