### PR TITLE
fix(workflow): keep run blocks under 21k expression limit in test-and-mark-stable.yml (stable)

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1200,6 +1200,11 @@ jobs:
           # filter so non-bait runs (no bait was injected this run) are
           # unaffected.
           BAIT_SHA: ${{ steps.inject-bait.outputs.bait_sha }}
+          # Promoted to env so the run: script body contains no ${{ }}
+          # interpolations. With even one inline expression, GitHub Actions
+          # treats the entire script as a single expression and enforces a
+          # 21,000-char limit; this script is ~25k chars and was tripping it.
+          ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
         run: |
           set -euo pipefail
           echo "Waiting for review workflow on PR #${PR_NUMBER}..."
@@ -1262,7 +1267,7 @@ jobs:
             IDLE=$((NOW - LAST_ACTIVITY))
 
             # Find the review workflow run for this PR's head branch
-            PR_BRANCH="ai/issue-${{ steps.create-issue.outputs.issue_number }}"
+            PR_BRANCH="ai/issue-${ISSUE_NUMBER}"
 
             # Look for workflow runs on this branch.
             # When BAIT_SHA is set the filter pins to head_sha == BAIT_SHA
@@ -1688,6 +1693,11 @@ jobs:
           PR_NUMBER: ${{ steps.wait-implement.outputs.pr_number }}
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
           BAIT_SHA: ${{ steps.inject-bait.outputs.bait_sha }}
+          # Promoted to env so the run: script body contains no ${{ }}
+          # interpolations. Same constraint as Phase 4 above: a single
+          # inline expression makes GitHub Actions treat the whole script
+          # as one expression, capped at 21,000 chars; this body is ~21.3k.
+          PRIOR_REVIEW_RUN: ${{ steps.wait-review.outputs.review_run_id }}
         run: |
           set -euo pipefail
           BRANCH="ai/issue-${ISSUE_NUMBER}"
@@ -1974,7 +1984,6 @@ jobs:
           # run ids are always positive) and could pick up the
           # original review run as the "retry run". Fail fast in that
           # case rather than silently misattribute.
-          PRIOR_REVIEW_RUN="${{ steps.wait-review.outputs.review_run_id }}"
           if ! [[ "${PRIOR_REVIEW_RUN}" =~ ^[0-9]+$ ]]; then
             echo "::error::wait-review.outputs.review_run_id is not a positive integer ('${PRIOR_REVIEW_RUN}'); refusing to enter retry poll loop with a no-op exclusion filter"
             echo "status=retry_dispatch_failed" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Mirror of #2796 onto the `stable` branch.

`test-and-mark-stable.yml` is dispatched only from `stable` (Job −1 hard-rejects any other ref), so the parse error must be fixed on this branch before the workflow can be dispatched at all. The same bug exists on stable today (`origin/stable` was tested locally and reproduces "Exceeded max expression length 21000" at line 1203).

This is a cherry-pick of commit `623d62c` from #2796 — the file in this region is structurally identical on `main` and `stable`, so the diff is byte-for-byte the same.

## Background

GitHub Actions caps a single `${{ }}` expression evaluation at 21,000 characters. A `run:` script is only expression-evaluated when it contains at least one `${{ }}` interpolation — and when it does, the whole script body counts toward the cap.

| Step | Body size | Inline `${{ }}` |
|---|---|---|
| Phase 4: `wait-review` | ~25,473 chars | `${{ steps.create-issue.outputs.issue_number }}` |
| Phase 4b: `verify-bait-removed` | ~21,289 chars | `${{ steps.wait-review.outputs.review_run_id }}` |

Both stray interpolations are promoted into the steps' existing `env:` blocks (matching the existing `PR_NUMBER`/`ISSUE_NUMBER`/`BAIT_SHA` pattern). With no `${{ }}` left in the script body, the expression-length cap no longer applies.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test-and-mark-stable.yml'))"` parses cleanly on this branch.
- Re-swept every `run: |` block in the file: no remaining body contains `${{ }}` and exceeds (or comes within ~3k of) the 21,000-char cap.
- No identifiers renamed (§6 preserved); no DB contracts touched (§10 N/A).

## Test plan

- [ ] Dispatch `test-and-mark-stable.yml` on `stable` with `dry_run=true` after merge and confirm it parses + reaches the static-check gate without the "Exceeded max expression length" error.
- [ ] Optionally dispatch with `skip_e2e=false` once a real release window is available, to verify Phase 4 and Phase 4b execute end-to-end now that they parse.

## Related

- #2796 — same fix targeting `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJehVJMreHTvskNimDmyaU)_