### PR TITLE
feat(orchestrate): pinned completion-status comment + defensive validate-dispatch gate

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -139,7 +139,7 @@ dashboard without producing a fresh comment per tick.
 | Marker | Helper | Purpose |
 |---|---|---|
 | `<!-- ORCH_STATE_V2_… -->` (chunked chain) | `post_state_comment` / `_post_state_comment_v2_chunk` | Canonical machine-readable orchestrator state snapshot. Multi-chunk so it can carry state blobs >65 KiB. Reader: `extract_latest_valid_orchestrator_state`. Reader falls back to the legacy V1 marker `<!-- ORCHESTRATOR_STATE_V1 -->` for issues that have not yet been re-written. |
-| `<!-- orchestrator:completion-status -->` | `update_completion_status_comment` | Human-readable "what is blocking completion" summary. Second-line tag `<!-- status:<token> -->` exposes the canonical status token (`in-progress` \| `waiting` \| `ready` \| `validated` \| `failed`) for grep-friendly downstream parsing. Idempotent — skips the API call when the rendered body matches the previously written hash. |
+| `<!-- orchestrator:completion-status -->` | `update_completion_status_comment` | Human-readable "what is blocking completion" summary. Second-line tag `<!-- status:<token> -->` exposes the canonical status token (`in-progress` \| `waiting` \| `ready` \| `validated` \| `failed`) for grep-friendly downstream parsing. Idempotent — skips the API call when the rendered body already matches, and persists `.completion_status_comment_id` + `.completion_status_comment_body_hash` in the state file so edit-in-place fallback survives the next cron invocation. |
 
 The completion-status comment is updated from three call sites:
 
@@ -147,7 +147,9 @@ The completion-status comment is updated from three call sites:
    `in-progress` / `waiting` / `ready` / `failed` from the
    `check-wave-status` JSON, and fires a once-per-project `tg_notify`
    CRITICAL on the first `any_failed=true` observation, guarded by
-   `.completion_status_failure_alert_sent` in the state file).
+   `.completion_status_failure_alert_sent` in the state file; compare-API
+   failures surface as an explicit "integration status is unknown"
+   line instead of silently omitting the integration gate state).
 2. `mark_validation_complete` — final transition to `validated`.
 3. `mark_validation_failed` (both terminal branches: the deterministic-
    class short-circuit and the recovery-budget-exhausted path) — final

--- a/agents.md
+++ b/agents.md
@@ -138,7 +138,7 @@ dashboard without producing a fresh comment per tick.
 
 | Marker | Helper | Purpose |
 |---|---|---|
-| `<!-- ORCH_STATE_V2_… -->` (chunked chain) | `post_state_comment` / `_post_state_comment_v2_chunk` | Canonical machine-readable orchestrator state snapshot. Multi-chunk so it can carry state blobs >65 KiB. Reader: `extract_latest_valid_orchestrator_state`. Reader falls back to the legacy V1 marker `<!-- ORCHESTRATOR_STATE_V1 -->` for issues that have not yet been re-written. |
+| `<!-- ORCHESTRATOR_STATE_V2 part=N/N manifest=<sha> -->` … `<!-- ORCHESTRATOR_STATE_V2 -->` | `post_state_comment` / `_post_state_comment_v2_chunk` | Canonical machine-readable orchestrator state snapshot. Multi-chunk so it can carry state blobs >65 KiB. Reader: `extract_latest_valid_orchestrator_state`. Reader falls back to the legacy V1 marker `<!-- ORCHESTRATOR_STATE_V1 -->` for issues that have not yet been re-written. |
 | `<!-- orchestrator:completion-status -->` | `update_completion_status_comment` | Human-readable "what is blocking completion" summary. Second-line tag `<!-- status:<token> -->` exposes the canonical status token (`in-progress` \| `waiting` \| `ready` \| `validated` \| `failed`) for grep-friendly downstream parsing. Idempotent — skips the API call when the rendered body already matches, and persists `.completion_status_comment_id` + `.completion_status_comment_body_hash` in the state file so edit-in-place fallback survives the next cron invocation. |
 
 The completion-status comment is updated from three call sites:

--- a/agents.md
+++ b/agents.md
@@ -145,15 +145,17 @@ The completion-status comment is updated from three call sites:
 
 1. The cycle-level wave-status decision block (every poll tick — derives
    `in-progress` / `waiting` / `ready` / `failed` from the
-   `check-wave-status` JSON, and fires a once-per-project `tg_notify`
-   CRITICAL on the first `any_failed=true` observation, guarded by
+   `check-wave-status` JSON plus the live validation-recovery state,
+   and fires a once-per-project `tg_notify` CRITICAL on the first
+   `any_failed=true` observation, guarded by
    `.completion_status_failure_alert_sent` in the state file; compare-API
    failures surface as an explicit "integration status is unknown"
    line instead of silently omitting the integration gate state).
 2. `mark_validation_complete` — final transition to `validated`.
-3. `mark_validation_failed` (both terminal branches: the deterministic-
-   class short-circuit and the recovery-budget-exhausted path) — final
-   transition to `failed`.
+3. `mark_validation_failed` — transitions to `in-progress` during
+   validation recovery, and to `failed` on both terminal branches (the
+   deterministic-class short-circuit and the recovery-budget-exhausted
+   path).
 
 The same change also adds a defensive preflight inside
 `dispatch_validation_if_needed`: when `PROJECT_COMPLETE != "true"` at

--- a/agents.md
+++ b/agents.md
@@ -132,7 +132,7 @@ Cycle-local caches that must not be re-fetched per iteration:
 ## Orchestrator tracking-issue comment markers
 
 The orchestrator poller (`scripts/orchestrate_poll_process.sh`) maintains
-two distinct pinned-comment families on each tracking issue. Both edit
+two distinct marker-keyed comment families on each tracking issue. Both edit
 in place every poll cycle so the tracking issue stays a live status
 dashboard without producing a fresh comment per tick.
 
@@ -164,7 +164,11 @@ that transitioned back from merged), the dispatch is skipped this
 cycle so the runtime-validation workflow is not burned on a state
 that cannot pass. The judge-side override at the `JUDGE_STATUS=complete`
 branch remains the primary gate; the dispatch-side check is belt and
-suspenders. Re-entry on the next 5-minute poll tick converges the
+suspenders. When the validating / `/revalidate` paths reach the helper
+before the loop's main wave-status block has populated the scratch
+`PROJECT_COMPLETE` variable, the helper recomputes live wave status
+first and still fails closed on `project_complete=false`. Re-entry on
+the next 5-minute poll tick converges the
 project once wave PRs and the integration→default merge land.
 
 ---

--- a/agents.md
+++ b/agents.md
@@ -129,6 +129,42 @@ Cycle-local caches that must not be re-fetched per iteration:
 
 ---
 
+## Orchestrator tracking-issue comment markers
+
+The orchestrator poller (`scripts/orchestrate_poll_process.sh`) maintains
+two distinct pinned-comment families on each tracking issue. Both edit
+in place every poll cycle so the tracking issue stays a live status
+dashboard without producing a fresh comment per tick.
+
+| Marker | Helper | Purpose |
+|---|---|---|
+| `<!-- ORCH_STATE_V2_… -->` (chunked chain) | `post_state_comment` / `_post_state_comment_v2_chunk` | Canonical machine-readable orchestrator state snapshot. Multi-chunk so it can carry state blobs >65 KiB. Reader: `extract_latest_valid_orchestrator_state`. Reader falls back to the legacy V1 marker `<!-- ORCHESTRATOR_STATE_V1 -->` for issues that have not yet been re-written. |
+| `<!-- orchestrator:completion-status -->` | `update_completion_status_comment` | Human-readable "what is blocking completion" summary. Second-line tag `<!-- status:<token> -->` exposes the canonical status token (`in-progress` \| `waiting` \| `ready` \| `validated` \| `failed`) for grep-friendly downstream parsing. Idempotent — skips the API call when the rendered body matches the previously written hash. |
+
+The completion-status comment is updated from three call sites:
+
+1. The cycle-level wave-status decision block (every poll tick — derives
+   `in-progress` / `waiting` / `ready` / `failed` from the
+   `check-wave-status` JSON, and fires a once-per-project `tg_notify`
+   CRITICAL on the first `any_failed=true` observation, guarded by
+   `.completion_status_failure_alert_sent` in the state file).
+2. `mark_validation_complete` — final transition to `validated`.
+3. `mark_validation_failed` (both terminal branches: the deterministic-
+   class short-circuit and the recovery-budget-exhausted path) — final
+   transition to `failed`.
+
+The same change also adds a defensive preflight inside
+`dispatch_validation_if_needed`: when `PROJECT_COMPLETE != "true"` at
+dispatch time (rare race against label-reconciliation, or a wave PR
+that transitioned back from merged), the dispatch is skipped this
+cycle so the runtime-validation workflow is not burned on a state
+that cannot pass. The judge-side override at the `JUDGE_STATUS=complete`
+branch remains the primary gate; the dispatch-side check is belt and
+suspenders. Re-entry on the next 5-minute poll tick converges the
+project once wave PRs and the integration→default merge land.
+
+---
+
 ## Stable log prefixes (contractual)
 
 Workflow-log-analysis and API-hygiene reporting depend on these stable log

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1272,6 +1272,29 @@ _post_state_comment_v2_chunk() {
   return 0
 }
 
+persist_completion_status_comment_state() {
+  local comment_id="$1"
+  local body_hash="$2"
+  local state_tmp
+
+  [ -n "${STATE_FILE:-}" ] && [ -f "${STATE_FILE}" ] || return 0
+  [[ "${comment_id}" =~ ^[0-9]+$ ]] || return 0
+  [ -n "${body_hash}" ] || return 0
+
+  state_tmp="${STATE_FILE}.tmp"
+  if jq --arg hash "${body_hash}" --argjson comment_id "${comment_id}" '
+      .completion_status_comment_body_hash = $hash
+      | .completion_status_comment_id = $comment_id' \
+      "${STATE_FILE}" > "${state_tmp}" && mv "${state_tmp}" "${STATE_FILE}"; then
+    COMPLETION_STATUS_STATE_CHANGED="true"
+    return 0
+  fi
+
+  rm -f "${state_tmp}" || true
+  echo "::warning::[completion-status] failed to persist comment metadata for issue #${TRACKING_NUM:-?}; cross-cycle idempotency may retry next tick." >&2
+  return 1
+}
+
 # update_completion_status_comment — maintain a single pinned "what is
 # blocking completion" comment on the tracking issue, edit-in-place.
 #
@@ -1291,8 +1314,9 @@ _post_state_comment_v2_chunk() {
 #        prepended by the helper)
 #
 # Idempotency: hashes the rendered body and skips the API call when the
-# hash matches the last successfully written value for this project.
-# Safe to call every poll cycle.
+# comment already matches. Successful writes persist the body hash +
+# comment ID into STATE_FILE so the edit-in-place fallback survives the
+# next cron invocation even though ${TMPDIR:-/tmp} does not.
 #
 # API hygiene (§15): when COMMENTS is set (paginated comments fetched
 # earlier in the same cycle), the existing-comment lookup is satisfied
@@ -1302,7 +1326,8 @@ update_completion_status_comment() {
   local status="$1"
   local body_markdown="$2"
   local marker="<!-- orchestrator:completion-status -->"
-  local full_body body_hash cache_file existing_id payload_file
+  local full_body body_hash existing_id existing_body payload_file response_file
+  local response_id state_hash state_comment_id existing_hash comments_fetch_ok
 
   if [ -z "${TRACKING_NUM:-}" ] || [ "${TRACKING_NUM}" = "0" ]; then
     return 0
@@ -1310,18 +1335,39 @@ update_completion_status_comment() {
 
   full_body="${marker}"$'\n'"<!-- status:${status} -->"$'\n'"${body_markdown}"
   body_hash="$(printf '%s' "${full_body}" | sha256sum | awk '{print $1}')"
-  cache_file="${TMPDIR:-/tmp}/orchestrate_completion_status_${TRACKING_NUM}.sha256"
+  state_hash=""
+  state_comment_id=""
+  comments_fetch_ok="${COMMENTS_FETCH_OK:-false}"
 
-  if [ -f "${cache_file}" ] && [ "$(cat "${cache_file}" 2>/dev/null)" = "${body_hash}" ]; then
-    return 0
+  if [ -f "${STATE_FILE:-/dev/null}" ]; then
+    state_hash="$(jq -r '.completion_status_comment_body_hash // empty' "${STATE_FILE}" 2>/dev/null || echo "")"
+    state_comment_id="$(jq -r '.completion_status_comment_id // empty' "${STATE_FILE}" 2>/dev/null || echo "")"
   fi
 
   existing_id=""
-  if [ -n "${COMMENTS:-}" ] && [ "${COMMENTS}" != "[]" ]; then
+  existing_body=""
+  if [ "${comments_fetch_ok}" = "true" ] && [ -n "${COMMENTS:-}" ] && [ "${COMMENTS}" != "[]" ]; then
     existing_id="$(printf '%s' "${COMMENTS}" \
       | jq -r --arg marker "${marker}" '
           [.[] | select((.body // "") | contains($marker))]
           | first | .id // empty' 2>/dev/null || echo "")"
+    existing_body="$(printf '%s' "${COMMENTS}" \
+      | jq -r --arg marker "${marker}" '
+          [.[] | select((.body // "") | contains($marker))]
+          | first | .body // empty' 2>/dev/null || echo "")"
+    if [ -n "${existing_body}" ]; then
+      existing_hash="$(printf '%s' "${existing_body}" | sha256sum | awk '{print $1}')"
+      if [ "${existing_hash}" = "${body_hash}" ]; then
+        persist_completion_status_comment_state "${existing_id}" "${body_hash}" || true
+        return 0
+      fi
+    fi
+  elif [ "${comments_fetch_ok}" != "true" ] && [ -n "${state_hash}" ] && [ "${state_hash}" = "${body_hash}" ]; then
+    return 0
+  fi
+
+  if [ -z "${existing_id}" ] && [ "${comments_fetch_ok}" != "true" ] && [[ "${state_comment_id}" =~ ^[0-9]+$ ]]; then
+    existing_id="${state_comment_id}"
   fi
 
   payload_file="$(mktemp "${TMPDIR:-/tmp}/completion_status_payload.XXXXXX")"
@@ -1330,16 +1376,37 @@ update_completion_status_comment() {
     return 1
   fi
 
+  response_file="$(mktemp "${TMPDIR:-/tmp}/completion_status_response.XXXXXX")"
+
   if [ -n "${existing_id}" ] && [[ "${existing_id}" =~ ^[0-9]+$ ]]; then
-    gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" \
-      --method PATCH --input "${payload_file}" >/dev/null 2>&1 || true
+    if ! gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" \
+      --method PATCH --input "${payload_file}" > "${response_file}" 2>&1; then
+      rm -f "${payload_file}"
+      echo "::warning::[completion-status] failed to PATCH comment ${existing_id} for issue #${TRACKING_NUM:-?}; will retry on a later cycle." >&2
+      head -c 4096 "${response_file}" >&2 || true
+      echo >&2
+      rm -f "${response_file}"
+      return 1
+    fi
   else
-    gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
-      --method POST --input "${payload_file}" >/dev/null 2>&1 || true
+    if ! gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
+      --method POST --input "${payload_file}" > "${response_file}" 2>&1; then
+      rm -f "${payload_file}"
+      echo "::warning::[completion-status] failed to POST comment for issue #${TRACKING_NUM:-?}; will retry on a later cycle." >&2
+      head -c 4096 "${response_file}" >&2 || true
+      echo >&2
+      rm -f "${response_file}"
+      return 1
+    fi
   fi
   rm -f "${payload_file}"
 
-  printf '%s' "${body_hash}" > "${cache_file}" 2>/dev/null || true
+  response_id="$(jq -r '.id // empty' "${response_file}" 2>/dev/null || echo "")"
+  rm -f "${response_file}"
+  if [ -z "${response_id}" ]; then
+    response_id="${existing_id}"
+  fi
+  persist_completion_status_comment_state "${response_id}" "${body_hash}" || true
   return 0
 }
 
@@ -8824,6 +8891,7 @@ for ((tidx=0; tidx<COUNT; tidx++)); do
   # produce "Unfinished string at EOF" errors when the response is truncated
   # due to network interruptions.
   _comments_raw="$(mktemp "${TMPDIR:-/tmp}/comments_raw.XXXXXX")"
+  COMMENTS_FETCH_OK="false"
   COMMENTS='[]'
   if gh_retry_to_file "${_comments_raw}" gh api --paginate \
     "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments?per_page=100"; then
@@ -8831,6 +8899,7 @@ for ((tidx=0; tidx<COUNT; tidx++)); do
     if jq -s 'add // []' "${_comments_raw}" > "${_comments_merged}" 2>/dev/null \
       && jq -e 'type == "array"' "${_comments_merged}" >/dev/null 2>&1; then
       COMMENTS="$(cat "${_comments_merged}")"
+      COMMENTS_FETCH_OK="true"
     else
       echo "::warning::Comments JSON for issue #${TRACKING_NUM} failed validation; proceeding with empty list" >&2
       echo "::group::Raw comments response (first 50 lines)" >&2
@@ -9986,6 +10055,7 @@ These issues will enter the AI pipeline (clarify → plan → implement → revi
   # call every tick. See update_completion_status_comment for the
   # marker contract and API hygiene notes.
   # ---------------------------------------------------------------
+  COMPLETION_STATUS_STATE_CHANGED="false"
   _completion_status_text="in-progress"
   if [ "${ANY_FAILED}" = "true" ]; then
     _completion_status_text="failed"
@@ -10004,7 +10074,7 @@ These issues will enter the AI pipeline (clarify → plan → implement → revi
   _csc_current_wave="$(echo "${WAVE_STATUS}" | jq -r '.wave // 0')"
   _csc_pending_lines="$(echo "${WAVE_STATUS}" | jq -r '
     [.issues[]
-      | select(.status != "merged" and .status != "closed" and .status != "skipped")
+      | select(.status != "merged" and .status != "closed" and .status != "skipped" and .status != "implementation-failed")
       | "- #\(.github_issue // "?"): \(.status)"]
     | join("\n")')"
   _csc_failed_lines="$(echo "${WAVE_STATUS}" | jq -r '
@@ -10025,6 +10095,8 @@ These issues will enter the AI pipeline (clarify → plan → implement → revi
     _csc_body+=$'\n'"Integration branch is contained in default — integration→default merge has landed."$'\n'
   elif [ -n "${_csc_integration_ahead_by}" ] && [ "${_csc_integration_ahead_by}" != "0" ]; then
     _csc_body+=$'\n'"Integration branch is ahead of default by **${_csc_integration_ahead_by}** commit(s). The integration→default merge has not landed yet (autofix may still be running on the integration PR)."$'\n'
+  else
+    _csc_body+=$'\n'"Integration status is unknown this cycle (compare API unavailable). Project completion remains gated until the next successful poll re-check."$'\n'
   fi
   if [ -n "${_csc_failed_lines}" ]; then
     _csc_body+=$'\n'"**Wave issues closed without merge / implementation-failed:**"$'\n'"${_csc_failed_lines}"$'\n'
@@ -10045,8 +10117,13 @@ These issues will enter the AI pipeline (clarify → plan → implement → revi
     _csc_alert_sent="$(jq -r '.completion_status_failure_alert_sent // false' "${STATE_FILE}" 2>/dev/null || echo false)"
     if [ "${_csc_alert_sent}" != "true" ]; then
       tg_notify "Project #${TRACKING_NUM}: one or more wave PR(s) closed without merge — see the pinned 'Completion status' comment on the tracking issue for the full list. The project cannot complete until these are resolved." "CRITICAL"
-      jq '.completion_status_failure_alert_sent = true' "${STATE_FILE}" > "${STATE_FILE}.tmp" \
-        && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
+      if jq '.completion_status_failure_alert_sent = true' "${STATE_FILE}" > "${STATE_FILE}.tmp" \
+        && mv "${STATE_FILE}.tmp" "${STATE_FILE}"; then
+        :
+      else
+        rm -f "${STATE_FILE}.tmp" || true
+        echo "::warning::[completion-status] failed to persist completion_status_failure_alert_sent for issue #${TRACKING_NUM:-?}; the once-per-project alert may repeat on a later tick."
+      fi
     fi
     unset _csc_alert_sent
   fi
@@ -12117,7 +12194,7 @@ with open('${STATE_FILE}', 'w') as f:
       fi
     fi
 
-    if [ "${STALL_STATE_CHANGED}" = "true" ] || [ "${STALL_HEALING_CHANGED}" = "true" ] || [ "${TIMESTAMP_STATE_CHANGED}" = "true" ] || [ "${RECONCILE_STATE_CHANGED}" = "true" ] || [ "${RECONCILE_LABELS_CHANGED}" = "true" ]; then
+    if [ "${STALL_STATE_CHANGED}" = "true" ] || [ "${STALL_HEALING_CHANGED}" = "true" ] || [ "${TIMESTAMP_STATE_CHANGED}" = "true" ] || [ "${RECONCILE_STATE_CHANGED}" = "true" ] || [ "${RECONCILE_LABELS_CHANGED}" = "true" ] || [ "${COMPLETION_STATUS_STATE_CHANGED:-false}" = "true" ]; then
       post_state_comment || true
     fi
     if [ "${RECONCILE_LABELS_CHANGED}" = "true" ] || [ "${RECONCILE_STATE_CHANGED}" = "true" ] || [ "${STALL_HEALING_CHANGED}" = "true" ]; then

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1272,6 +1272,77 @@ _post_state_comment_v2_chunk() {
   return 0
 }
 
+# update_completion_status_comment — maintain a single pinned "what is
+# blocking completion" comment on the tracking issue, edit-in-place.
+#
+# The V2 state chain written by post_state_comment is the canonical
+# machine-readable state record. This comment is a separate, human-
+# facing summary keyed to a unique marker so it can be edited in place
+# every cycle as wave PRs land and the project converges on completion
+# — without producing a fresh comment per poll tick.
+#
+# Marker: <!-- orchestrator:completion-status -->
+# Status tag (grep-friendly second-line marker):
+#   <!-- status:in-progress|waiting|ready|validated|failed -->
+#
+# Args:
+#   $1 = status token (in-progress | waiting | ready | validated | failed)
+#   $2 = rendered markdown body (the marker and status-tag lines are
+#        prepended by the helper)
+#
+# Idempotency: hashes the rendered body and skips the API call when the
+# hash matches the last successfully written value for this project.
+# Safe to call every poll cycle.
+#
+# API hygiene (§15): when COMMENTS is set (paginated comments fetched
+# earlier in the same cycle), the existing-comment lookup is satisfied
+# from that cache. The helper never issues a per-cycle list call on
+# its own.
+update_completion_status_comment() {
+  local status="$1"
+  local body_markdown="$2"
+  local marker="<!-- orchestrator:completion-status -->"
+  local full_body body_hash cache_file existing_id payload_file
+
+  if [ -z "${TRACKING_NUM:-}" ] || [ "${TRACKING_NUM}" = "0" ]; then
+    return 0
+  fi
+
+  full_body="${marker}"$'\n'"<!-- status:${status} -->"$'\n'"${body_markdown}"
+  body_hash="$(printf '%s' "${full_body}" | sha256sum | awk '{print $1}')"
+  cache_file="${TMPDIR:-/tmp}/orchestrate_completion_status_${TRACKING_NUM}.sha256"
+
+  if [ -f "${cache_file}" ] && [ "$(cat "${cache_file}" 2>/dev/null)" = "${body_hash}" ]; then
+    return 0
+  fi
+
+  existing_id=""
+  if [ -n "${COMMENTS:-}" ] && [ "${COMMENTS}" != "[]" ]; then
+    existing_id="$(printf '%s' "${COMMENTS}" \
+      | jq -r --arg marker "${marker}" '
+          [.[] | select((.body // "") | contains($marker))]
+          | first | .id // empty' 2>/dev/null || echo "")"
+  fi
+
+  payload_file="$(mktemp "${TMPDIR:-/tmp}/completion_status_payload.XXXXXX")"
+  if ! printf '%s' "${full_body}" | jq -Rs '{body: .}' > "${payload_file}" 2>/dev/null; then
+    rm -f "${payload_file}"
+    return 1
+  fi
+
+  if [ -n "${existing_id}" ] && [[ "${existing_id}" =~ ^[0-9]+$ ]]; then
+    gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" \
+      --method PATCH --input "${payload_file}" >/dev/null 2>&1 || true
+  else
+    gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
+      --method POST --input "${payload_file}" >/dev/null 2>&1 || true
+  fi
+  rm -f "${payload_file}"
+
+  printf '%s' "${body_hash}" > "${cache_file}" 2>/dev/null || true
+  return 0
+}
+
 extract_orchestrator_state_payload() {
   local comment_body="$1"
   printf '%s' "${comment_body}" | sed -n '/^<!-- ORCHESTRATOR_STATE_V1$/,/^ORCHESTRATOR_STATE_V1 -->$/p' | sed '1d;$d'
@@ -4636,6 +4707,23 @@ dispatch_validation_if_needed() {
   local now_epoch
   local stale_threshold_secs=3600  # 1 hour: if no label appears after dispatch, allow redispatch
 
+  # Defensive preflight: refuse to dispatch validate while wave PRs are
+  # unmerged or the integration→default merge has not landed. The judge
+  # override at the JUDGE_STATUS=complete branch already gates the
+  # transition to status=validating on PROJECT_COMPLETE=true, so this
+  # branch is belt-and-suspenders against the rare case where a wave PR
+  # transitions from merged back to a non-terminal state between the
+  # judge call and the dispatch (e.g. a consumer-side revert or
+  # label-reconciliation race). When that happens we skip dispatch this
+  # cycle and let the next poll tick re-evaluate once wave PR state
+  # settles. PROJECT_COMPLETE is set in the wave-status decision block
+  # above; an unset value (poller started mid-flow) is treated as "not
+  # gated" so we never block dispatch on absent state.
+  if [ -n "${PROJECT_COMPLETE+set}" ] && [ "${PROJECT_COMPLETE}" != "true" ]; then
+    echo "Preflight: PROJECT_COMPLETE=${PROJECT_COMPLETE:-unset}; deferring validate dispatch this cycle (wave PRs unmerged or integration→default merge pending)."
+    return 0
+  fi
+
   last_dispatch_cycle="$(jq -r '.validation_last_dispatch_cycle // 0' "${STATE_FILE}")"
   if [ "${last_dispatch_cycle}" = "${validation_cycle}" ]; then
     # Check for staleness: if dispatched but no label change for >1h, allow redispatch
@@ -4723,6 +4811,9 @@ mark_validation_failed() {
 ${reason}
 
 Failure class \`${_deterministic_class}\` is environment-deterministic; retrying this workflow on the same runner image will not help. Skipping the recovery budget. Manual intervention required."
+    update_completion_status_comment "failed" \
+      "## Completion status"$'\n\n'"**State:** \`failed\`"$'\n\n'"Runtime validation failed deterministically (class \`${_deterministic_class}\`). Manual intervention required. See the \"❌ Runtime validation failed (deterministic)\" comment for the diagnostic detail." \
+      || true
     tg_notify "Project #${TRACKING_NUM} validation failed deterministically (class=${_deterministic_class}). Manual intervention required." "CRITICAL"
     return 0
   fi
@@ -4765,6 +4856,9 @@ Transitioning back to judge for re-evaluation."
 ${reason}
 
 Validation recovery exhausted (${val_recovery_count}/${MAX_VALIDATION_RECOVERY_ATTEMPTS}). Manual intervention required."
+  update_completion_status_comment "failed" \
+    "## Completion status"$'\n\n'"**State:** \`failed\`"$'\n\n'"Runtime validation failed after ${val_recovery_count}/${MAX_VALIDATION_RECOVERY_ATTEMPTS} recovery attempt(s). Manual intervention required. See the \"❌ Runtime validation failed\" comment for the diagnostic detail." \
+    || true
   tg_notify "Project #${TRACKING_NUM} validation failed after ${val_recovery_count} recovery attempt(s). Manual intervention required." "CRITICAL"
 }
 
@@ -4848,6 +4942,12 @@ Manual intervention required: resolve the blocking condition on the final PR (me
   _tracking_labels="$(get_issue_labels_json "${TRACKING_NUM}")"
   handle_comprehensive_release_callback_if_needed "complete" "${_tracking_labels}" "${COMMENTS:-[]}"
   set_tracking_phase_label "ai:validated"
+  # Final transition for the pinned completion-status comment: project
+  # is validated, all wave PRs are merged, and the integration squash
+  # merge has landed in default.
+  update_completion_status_comment "validated" \
+    "## Completion status"$'\n\n'"**State:** \`validated\`"$'\n\n'"All wave PRs merged. Integration branch squash-merged into default. Runtime validation passed (cycle ${validation_cycle}). Tracking issue kept open for manual review." \
+    || true
   post_tracking_comment "Project completed successfully after runtime validation passed (cycle ${validation_cycle}). Issue kept open for manual review."
   tg_cleanup_msgs "${TRACKING_NUM}"
   MSG="Project #${TRACKING_NUM} completed after validation pass (cycle ${validation_cycle})."
@@ -9875,6 +9975,84 @@ These issues will enter the AI pipeline (clarify → plan → implement → revi
   WAVE_COMPLETE="$(echo "${WAVE_STATUS}" | jq -r '.wave_complete')"
   ANY_FAILED="$(echo "${WAVE_STATUS}" | jq -r '.any_failed')"
   PROJECT_COMPLETE="$(echo "${WAVE_STATUS}" | jq -r '.project_complete')"
+
+  # ---------------------------------------------------------------
+  # Maintain the pinned "completion status" comment on the tracking
+  # issue every cycle. The V2 state comment chain (post_state_comment)
+  # remains the canonical state record; this comment is a separate,
+  # human-readable summary the operator can read at a glance to see
+  # which wave PRs and integration→default merge are still blocking
+  # completion. Idempotent via body-hash cache so this is cheap to
+  # call every tick. See update_completion_status_comment for the
+  # marker contract and API hygiene notes.
+  # ---------------------------------------------------------------
+  _completion_status_text="in-progress"
+  if [ "${ANY_FAILED}" = "true" ]; then
+    _completion_status_text="failed"
+  elif [ "${PROJECT_COMPLETE}" = "true" ]; then
+    _completion_status_text="ready"
+  elif [ "${WAVE_COMPLETE}" = "true" ]; then
+    # Final-wave PRs merged into the integration branch but the
+    # integration→default squash merge has not landed yet (autofix may
+    # still be running on the integration PR).
+    _completion_status_text="waiting"
+  fi
+
+  _csc_integration_ahead_by="$(echo "${WAVE_STATUS}" | jq -r '.integration_ahead_by // ""')"
+  _csc_integration_contained="$(echo "${WAVE_STATUS}" | jq -r '.integration_contained_in_default // false')"
+  _csc_total_waves="$(jq -r '.total_waves // 0' "${STATE_FILE}" 2>/dev/null || echo 0)"
+  _csc_current_wave="$(echo "${WAVE_STATUS}" | jq -r '.wave // 0')"
+  _csc_pending_lines="$(echo "${WAVE_STATUS}" | jq -r '
+    [.issues[]
+      | select(.status != "merged" and .status != "closed" and .status != "skipped")
+      | "- #\(.github_issue // "?"): \(.status)"]
+    | join("\n")')"
+  _csc_failed_lines="$(echo "${WAVE_STATUS}" | jq -r '
+    [.issues[]
+      | select(.status == "closed" or .status == "implementation-failed")
+      | "- #\(.github_issue // "?"): \(.status) (\(.decision_source // "unknown"))"]
+    | join("\n")')"
+
+  _csc_body="## Completion status"$'\n\n'
+  _csc_body+="**State:** \`${_completion_status_text}\`"$'\n'
+  _csc_body+="**Wave:** ${_csc_current_wave}/${_csc_total_waves}"$'\n'
+  if [ -n "${_csc_pending_lines}" ]; then
+    _csc_body+=$'\n'"**Wave issues still pending merge:**"$'\n'"${_csc_pending_lines}"$'\n'
+  else
+    _csc_body+=$'\n'"All wave issues in this wave have merged or are accounted for."$'\n'
+  fi
+  if [ "${_csc_integration_contained}" = "true" ]; then
+    _csc_body+=$'\n'"Integration branch is contained in default — integration→default merge has landed."$'\n'
+  elif [ -n "${_csc_integration_ahead_by}" ] && [ "${_csc_integration_ahead_by}" != "0" ]; then
+    _csc_body+=$'\n'"Integration branch is ahead of default by **${_csc_integration_ahead_by}** commit(s). The integration→default merge has not landed yet (autofix may still be running on the integration PR)."$'\n'
+  fi
+  if [ -n "${_csc_failed_lines}" ]; then
+    _csc_body+=$'\n'"**Wave issues closed without merge / implementation-failed:**"$'\n'"${_csc_failed_lines}"$'\n'
+    _csc_body+=$'\n'"Project cannot complete until these are resolved (re-open, re-merge, or skip)."$'\n'
+  fi
+  _csc_body+=$'\n'"_The orchestrator poller updates this comment every cycle (~5 min) until the project completes. Marker: \`<!-- orchestrator:completion-status -->\`._"
+
+  update_completion_status_comment "${_completion_status_text}" "${_csc_body}" || true
+
+  # Once-per-project Telegram escalation when a wave PR has been closed
+  # without merging (or implementation-failed). The stall/review-blocked
+  # paths further down also surface their own alerts on specific
+  # failures, but this is the earliest deterministic signal — fire here
+  # so the operator sees the alert as soon as ANY_FAILED first goes
+  # true. Guarded by a state-file flag so we never alert more than once
+  # per project for the same condition.
+  if [ "${ANY_FAILED}" = "true" ]; then
+    _csc_alert_sent="$(jq -r '.completion_status_failure_alert_sent // false' "${STATE_FILE}" 2>/dev/null || echo false)"
+    if [ "${_csc_alert_sent}" != "true" ]; then
+      tg_notify "Project #${TRACKING_NUM}: one or more wave PR(s) closed without merge — see the pinned 'Completion status' comment on the tracking issue for the full list. The project cannot complete until these are resolved." "CRITICAL"
+      jq '.completion_status_failure_alert_sent = true' "${STATE_FILE}" > "${STATE_FILE}.tmp" \
+        && mv "${STATE_FILE}.tmp" "${STATE_FILE}"
+    fi
+    unset _csc_alert_sent
+  fi
+
+  unset _completion_status_text _csc_integration_ahead_by _csc_integration_contained
+  unset _csc_total_waves _csc_current_wave _csc_pending_lines _csc_failed_lines _csc_body
 
   # Persist reconciled status decisions every cycle (not only narrow branches).
   RECONCILE_STATE_CHANGED=false

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1320,11 +1320,18 @@ persist_completion_status_comment_state() {
 recover_completion_status_comment_id_from_live_comments() {
   local full_body="$1"
   local marker="$2"
-  local comments_json recovered_id
+  local comments_json recovered_id comments_raw
 
-  if ! comments_json="$(gh_retry gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments?per_page=100" | jq -s 'add // []' 2>/dev/null)"; then
+  comments_raw="$(mktemp "${TMPDIR:-/tmp}/completion_status_comments.XXXXXX")" || return 1
+  if ! gh_retry_to_file "${comments_raw}" gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments?per_page=100"; then
+    rm -f "${comments_raw}"
     return 1
   fi
+  if ! comments_json="$(jq -s 'add // []' "${comments_raw}" 2>/dev/null)"; then
+    rm -f "${comments_raw}"
+    return 1
+  fi
+  rm -f "${comments_raw}"
 
   recovered_id="$(printf '%s' "${comments_json}" | jq -r --arg body "${full_body}" '
     [.[] | select((.body // "") == $body)]
@@ -1434,8 +1441,8 @@ update_completion_status_comment() {
   response_file="$(mktemp "${TMPDIR:-/tmp}/completion_status_response.XXXXXX")"
 
   if [ -n "${existing_id}" ] && [[ "${existing_id}" =~ ^[0-9]+$ ]]; then
-    if ! gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" \
-      -X PATCH -f body="${full_body}" > "${response_file}"; then
+    if ! gh_retry_to_file "${response_file}" gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" \
+      -X PATCH -f body="${full_body}"; then
       echo "::warning::[completion-status] failed to PATCH comment ${existing_id} for issue #${TRACKING_NUM:-?}; will retry on a later cycle." >&2
       head -c 4096 "${response_file}" >&2 || true
       echo >&2
@@ -1443,8 +1450,8 @@ update_completion_status_comment() {
       return 1
     fi
   else
-    if ! gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
-      -X POST -f body="${full_body}" > "${response_file}"; then
+    if ! gh_retry_to_file "${response_file}" gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
+      -X POST -f body="${full_body}"; then
       echo "::warning::[completion-status] failed to POST comment for issue #${TRACKING_NUM:-?}; will retry on a later cycle." >&2
       head -c 4096 "${response_file}" >&2 || true
       echo >&2

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1275,11 +1275,29 @@ _post_state_comment_v2_chunk() {
 persist_completion_status_comment_state() {
   local comment_id="$1"
   local body_hash="$2"
-  local state_tmp
+  local state_tmp old_hash old_comment_id
 
-  [ -n "${STATE_FILE:-}" ] && [ -f "${STATE_FILE}" ] || return 0
-  [[ "${comment_id}" =~ ^[0-9]+$ ]] || return 0
-  [ -n "${body_hash}" ] || return 0
+  if [ -z "${STATE_FILE:-}" ] || [ ! -f "${STATE_FILE}" ]; then
+    echo "::warning::[completion-status] cannot persist comment metadata for issue #${TRACKING_NUM:-?}: STATE_FILE is missing." >&2
+    return 1
+  fi
+  if ! [[ "${comment_id}" =~ ^[0-9]+$ ]]; then
+    echo "::warning::[completion-status] cannot persist comment metadata for issue #${TRACKING_NUM:-?}: invalid comment id '${comment_id:-<empty>}'" >&2
+    return 1
+  fi
+  if ! [[ "${body_hash}" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "::warning::[completion-status] cannot persist comment metadata for issue #${TRACKING_NUM:-?}: invalid body hash." >&2
+    return 1
+  fi
+
+  old_hash="$(jq -r '.completion_status_comment_body_hash // empty' "${STATE_FILE}" 2>/dev/null || echo "")"
+  [[ "${old_hash}" =~ ^[0-9a-f]{64}$ ]] || old_hash=""
+  old_comment_id="$(jq -r '.completion_status_comment_id // empty' "${STATE_FILE}" 2>/dev/null || echo "")"
+  [[ "${old_comment_id}" =~ ^[0-9]+$ ]] || old_comment_id=""
+
+  if [ "${old_hash}" = "${body_hash}" ] && [ "${old_comment_id}" = "${comment_id}" ]; then
+    return 0
+  fi
 
   state_tmp="${STATE_FILE}.tmp"
   if jq --arg hash "${body_hash}" --argjson comment_id "${comment_id}" '
@@ -1326,12 +1344,20 @@ update_completion_status_comment() {
   local status="$1"
   local body_markdown="$2"
   local marker="<!-- orchestrator:completion-status -->"
-  local full_body body_hash existing_id existing_body payload_file response_file
+  local full_body body_hash existing_id existing_body response_file
   local response_id state_hash state_comment_id existing_hash comments_fetch_ok
 
   if [ -z "${TRACKING_NUM:-}" ] || [ "${TRACKING_NUM}" = "0" ]; then
     return 0
   fi
+
+  case "${status}" in
+    in-progress|waiting|ready|validated|failed) ;;
+    *)
+      echo "::warning::[completion-status] invalid status token '${status}' for issue #${TRACKING_NUM:-?}; skipping comment update." >&2
+      return 1
+      ;;
+  esac
 
   full_body="${marker}"$'\n'"<!-- status:${status} -->"$'\n'"${body_markdown}"
   body_hash="$(printf '%s' "${full_body}" | sha256sum | awk '{print $1}')"
@@ -1342,6 +1368,8 @@ update_completion_status_comment() {
   if [ -f "${STATE_FILE:-/dev/null}" ]; then
     state_hash="$(jq -r '.completion_status_comment_body_hash // empty' "${STATE_FILE}" 2>/dev/null || echo "")"
     state_comment_id="$(jq -r '.completion_status_comment_id // empty' "${STATE_FILE}" 2>/dev/null || echo "")"
+    [[ "${state_hash}" =~ ^[0-9a-f]{64}$ ]] || state_hash=""
+    [[ "${state_comment_id}" =~ ^[0-9]+$ ]] || state_comment_id=""
   fi
 
   existing_id=""
@@ -1358,8 +1386,8 @@ update_completion_status_comment() {
     if [ -n "${existing_body}" ]; then
       existing_hash="$(printf '%s' "${existing_body}" | sha256sum | awk '{print $1}')"
       if [ "${existing_hash}" = "${body_hash}" ]; then
-        persist_completion_status_comment_state "${existing_id}" "${body_hash}" || true
-        return 0
+        persist_completion_status_comment_state "${existing_id}" "${body_hash}"
+        return $?
       fi
     fi
   elif [ "${comments_fetch_ok}" != "true" ] && [ -n "${state_hash}" ] && [ "${state_hash}" = "${body_hash}" ]; then
@@ -1370,18 +1398,11 @@ update_completion_status_comment() {
     existing_id="${state_comment_id}"
   fi
 
-  payload_file="$(mktemp "${TMPDIR:-/tmp}/completion_status_payload.XXXXXX")"
-  if ! printf '%s' "${full_body}" | jq -Rs '{body: .}' > "${payload_file}" 2>/dev/null; then
-    rm -f "${payload_file}"
-    return 1
-  fi
-
   response_file="$(mktemp "${TMPDIR:-/tmp}/completion_status_response.XXXXXX")"
 
   if [ -n "${existing_id}" ] && [[ "${existing_id}" =~ ^[0-9]+$ ]]; then
     if ! gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" \
-      --method PATCH --input "${payload_file}" > "${response_file}" 2>&1; then
-      rm -f "${payload_file}"
+      -X PATCH -f body="${full_body}" > "${response_file}" 2>&1; then
       echo "::warning::[completion-status] failed to PATCH comment ${existing_id} for issue #${TRACKING_NUM:-?}; will retry on a later cycle." >&2
       head -c 4096 "${response_file}" >&2 || true
       echo >&2
@@ -1390,8 +1411,7 @@ update_completion_status_comment() {
     fi
   else
     if ! gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
-      --method POST --input "${payload_file}" > "${response_file}" 2>&1; then
-      rm -f "${payload_file}"
+      -X POST -f body="${full_body}" > "${response_file}" 2>&1; then
       echo "::warning::[completion-status] failed to POST comment for issue #${TRACKING_NUM:-?}; will retry on a later cycle." >&2
       head -c 4096 "${response_file}" >&2 || true
       echo >&2
@@ -1399,15 +1419,18 @@ update_completion_status_comment() {
       return 1
     fi
   fi
-  rm -f "${payload_file}"
 
   response_id="$(jq -r '.id // empty' "${response_file}" 2>/dev/null || echo "")"
   rm -f "${response_file}"
-  if [ -z "${response_id}" ]; then
-    response_id="${existing_id}"
+  if ! [[ "${response_id}" =~ ^[0-9]+$ ]]; then
+    if [ -n "${existing_id}" ] && [[ "${existing_id}" =~ ^[0-9]+$ ]]; then
+      response_id="${existing_id}"
+    else
+      echo "::warning::[completion-status] GitHub comment update succeeded but no numeric comment id was returned for issue #${TRACKING_NUM:-?}; will retry metadata persistence on a later cycle." >&2
+      return 1
+    fi
   fi
-  persist_completion_status_comment_state "${response_id}" "${body_hash}" || true
-  return 0
+  persist_completion_status_comment_state "${response_id}" "${body_hash}"
 }
 
 extract_orchestrator_state_payload() {
@@ -4878,9 +4901,13 @@ mark_validation_failed() {
 ${reason}
 
 Failure class \`${_deterministic_class}\` is environment-deterministic; retrying this workflow on the same runner image will not help. Skipping the recovery budget. Manual intervention required."
+    COMPLETION_STATUS_STATE_CHANGED="false"
     update_completion_status_comment "failed" \
       "## Completion status"$'\n\n'"**State:** \`failed\`"$'\n\n'"Runtime validation failed deterministically (class \`${_deterministic_class}\`). Manual intervention required. See the \"❌ Runtime validation failed (deterministic)\" comment for the diagnostic detail." \
       || true
+    if [ "${COMPLETION_STATUS_STATE_CHANGED:-false}" = "true" ]; then
+      post_state_comment || true
+    fi
     tg_notify "Project #${TRACKING_NUM} validation failed deterministically (class=${_deterministic_class}). Manual intervention required." "CRITICAL"
     return 0
   fi
@@ -4906,6 +4933,13 @@ Failure class \`${_deterministic_class}\` is environment-deterministic; retrying
 ${reason}
 
 Transitioning back to judge for re-evaluation."
+    COMPLETION_STATUS_STATE_CHANGED="false"
+    update_completion_status_comment "in-progress" \
+      "## Completion status"$'\n\n'"**State:** \`in-progress\`"$'\n\n'"Runtime validation failed and recovery attempt $((val_recovery_count + 1))/${MAX_VALIDATION_RECOVERY_ATTEMPTS} is in progress. Waiting for judge re-evaluation before validation can resume." \
+      || true
+    if [ "${COMPLETION_STATUS_STATE_CHANGED:-false}" = "true" ]; then
+      post_state_comment || true
+    fi
     tg_notify "Validation recovery ($((val_recovery_count + 1))/${MAX_VALIDATION_RECOVERY_ATTEMPTS}) for #${TRACKING_NUM}: transitioning back to judge." "WARNING"
     return 0
   fi
@@ -4923,9 +4957,13 @@ Transitioning back to judge for re-evaluation."
 ${reason}
 
 Validation recovery exhausted (${val_recovery_count}/${MAX_VALIDATION_RECOVERY_ATTEMPTS}). Manual intervention required."
+  COMPLETION_STATUS_STATE_CHANGED="false"
   update_completion_status_comment "failed" \
     "## Completion status"$'\n\n'"**State:** \`failed\`"$'\n\n'"Runtime validation failed after ${val_recovery_count}/${MAX_VALIDATION_RECOVERY_ATTEMPTS} recovery attempt(s). Manual intervention required. See the \"❌ Runtime validation failed\" comment for the diagnostic detail." \
     || true
+  if [ "${COMPLETION_STATUS_STATE_CHANGED:-false}" = "true" ]; then
+    post_state_comment || true
+  fi
   tg_notify "Project #${TRACKING_NUM} validation failed after ${val_recovery_count} recovery attempt(s). Manual intervention required." "CRITICAL"
 }
 
@@ -5012,9 +5050,13 @@ Manual intervention required: resolve the blocking condition on the final PR (me
   # Final transition for the pinned completion-status comment: project
   # is validated, all wave PRs are merged, and the integration squash
   # merge has landed in default.
+  COMPLETION_STATUS_STATE_CHANGED="false"
   update_completion_status_comment "validated" \
     "## Completion status"$'\n\n'"**State:** \`validated\`"$'\n\n'"All wave PRs merged. Integration branch squash-merged into default. Runtime validation passed (cycle ${validation_cycle}). Tracking issue kept open for manual review." \
     || true
+  if [ "${COMPLETION_STATUS_STATE_CHANGED:-false}" = "true" ]; then
+    post_state_comment || true
+  fi
   post_tracking_comment "Project completed successfully after runtime validation passed (cycle ${validation_cycle}). Issue kept open for manual review."
   tg_cleanup_msgs "${TRACKING_NUM}"
   MSG="Project #${TRACKING_NUM} completed after validation pass (cycle ${validation_cycle})."
@@ -8994,6 +9036,8 @@ for ((tidx=0; tidx<COUNT; tidx++)); do
   fi
 
   echo "${STATE_JSON}" > "${STATE_FILE}"
+  unset PROJECT_COMPLETE WAVE_COMPLETE ANY_FAILED
+  COMPLETION_STATUS_STATE_CHANGED="false"
   PROJECT_STATUS="$(jq -r '.status' "${STATE_FILE}")"
   TRACKING_LABELS="$(get_issue_labels_json "${TRACKING_NUM}")"
 
@@ -10056,9 +10100,15 @@ These issues will enter the AI pipeline (clarify → plan → implement → revi
   # marker contract and API hygiene notes.
   # ---------------------------------------------------------------
   COMPLETION_STATUS_STATE_CHANGED="false"
+  _csc_validation_recovery_count="$(jq -r '.validation_recovery_count // 0' "${STATE_FILE}" 2>/dev/null || echo 0)"
+  if ! [[ "${_csc_validation_recovery_count}" =~ ^[0-9]+$ ]]; then
+    _csc_validation_recovery_count=0
+  fi
   _completion_status_text="in-progress"
   if [ "${ANY_FAILED}" = "true" ]; then
     _completion_status_text="failed"
+  elif [ "${PROJECT_STATUS:-}" = "in_progress" ] && [ "${_csc_validation_recovery_count}" -gt 0 ]; then
+    _completion_status_text="in-progress"
   elif [ "${PROJECT_COMPLETE}" = "true" ]; then
     _completion_status_text="ready"
   elif [ "${WAVE_COMPLETE}" = "true" ]; then
@@ -10091,6 +10141,9 @@ These issues will enter the AI pipeline (clarify → plan → implement → revi
   else
     _csc_body+=$'\n'"All wave issues in this wave have merged or are accounted for."$'\n'
   fi
+  if [ "${PROJECT_STATUS:-}" = "in_progress" ] && [ "${_csc_validation_recovery_count}" -gt 0 ]; then
+    _csc_body+=$'\n'"Runtime validation is in recovery attempt ${_csc_validation_recovery_count}/${MAX_VALIDATION_RECOVERY_ATTEMPTS}; waiting for judge re-evaluation before validation can resume."$'\n'
+  fi
   if [ "${_csc_integration_contained}" = "true" ]; then
     _csc_body+=$'\n'"Integration branch is contained in default — integration→default merge has landed."$'\n'
   elif [ -n "${_csc_integration_ahead_by}" ] && [ "${_csc_integration_ahead_by}" != "0" ]; then
@@ -10119,7 +10172,7 @@ These issues will enter the AI pipeline (clarify → plan → implement → revi
       tg_notify "Project #${TRACKING_NUM}: one or more wave PR(s) closed without merge — see the pinned 'Completion status' comment on the tracking issue for the full list. The project cannot complete until these are resolved." "CRITICAL"
       if jq '.completion_status_failure_alert_sent = true' "${STATE_FILE}" > "${STATE_FILE}.tmp" \
         && mv "${STATE_FILE}.tmp" "${STATE_FILE}"; then
-        :
+        COMPLETION_STATUS_STATE_CHANGED="true"
       else
         rm -f "${STATE_FILE}.tmp" || true
         echo "::warning::[completion-status] failed to persist completion_status_failure_alert_sent for issue #${TRACKING_NUM:-?}; the once-per-project alert may repeat on a later tick."
@@ -10129,7 +10182,7 @@ These issues will enter the AI pipeline (clarify → plan → implement → revi
   fi
 
   unset _completion_status_text _csc_integration_ahead_by _csc_integration_contained
-  unset _csc_total_waves _csc_current_wave _csc_pending_lines _csc_failed_lines _csc_body
+  unset _csc_total_waves _csc_current_wave _csc_pending_lines _csc_failed_lines _csc_body _csc_validation_recovery_count
 
   # Persist reconciled status decisions every cycle (not only narrow branches).
   RECONCILE_STATE_CHANGED=false

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1368,8 +1368,8 @@ recover_completion_status_comment_id_from_live_comments() {
 #
 # API hygiene (§15): when COMMENTS is set (paginated comments fetched
 # earlier in the same cycle), the existing-comment lookup is satisfied
-# from that cache. The helper never issues a per-cycle list call on
-# its own.
+# from that cache. Only the malformed-response recovery path re-lists
+# comments, and only when the POST/PATCH response omitted a numeric id.
 update_completion_status_comment() {
   local status="$1"
   local body_markdown="$2"
@@ -1435,7 +1435,7 @@ update_completion_status_comment() {
 
   if [ -n "${existing_id}" ] && [[ "${existing_id}" =~ ^[0-9]+$ ]]; then
     if ! gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" \
-      -X PATCH -f body="${full_body}" > "${response_file}" 2>&1; then
+      -X PATCH -f body="${full_body}" > "${response_file}"; then
       echo "::warning::[completion-status] failed to PATCH comment ${existing_id} for issue #${TRACKING_NUM:-?}; will retry on a later cycle." >&2
       head -c 4096 "${response_file}" >&2 || true
       echo >&2
@@ -1444,7 +1444,7 @@ update_completion_status_comment() {
     fi
   else
     if ! gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments" \
-      -X POST -f body="${full_body}" > "${response_file}" 2>&1; then
+      -X POST -f body="${full_body}" > "${response_file}"; then
       echo "::warning::[completion-status] failed to POST comment for issue #${TRACKING_NUM:-?}; will retry on a later cycle." >&2
       head -c 4096 "${response_file}" >&2 || true
       echo >&2

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -1313,6 +1313,36 @@ persist_completion_status_comment_state() {
   return 1
 }
 
+# recover_completion_status_comment_id_from_live_comments — rare-path repair
+# for GitHub comment updates that succeeded but returned a malformed body
+# without a numeric `.id`. The cycle-local COMMENTS cache predates a POST,
+# so only this recovery path is allowed to re-list comments.
+recover_completion_status_comment_id_from_live_comments() {
+  local full_body="$1"
+  local marker="$2"
+  local comments_json recovered_id
+
+  if ! comments_json="$(gh_retry gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${TRACKING_NUM}/comments?per_page=100" | jq -s 'add // []' 2>/dev/null)"; then
+    return 1
+  fi
+
+  recovered_id="$(printf '%s' "${comments_json}" | jq -r --arg body "${full_body}" '
+    [.[] | select((.body // "") == $body)]
+    | max_by([(.created_at // ""), ((.id // 0) | tonumber? // 0)])
+    | .id // empty
+  ' 2>/dev/null || echo "")"
+  if ! [[ "${recovered_id}" =~ ^[0-9]+$ ]]; then
+    recovered_id="$(printf '%s' "${comments_json}" | jq -r --arg marker "${marker}" '
+      [.[] | select((.body // "") | contains($marker))]
+      | max_by([(.created_at // ""), ((.id // 0) | tonumber? // 0)])
+      | .id // empty
+    ' 2>/dev/null || echo "")"
+  fi
+
+  [[ "${recovered_id}" =~ ^[0-9]+$ ]] || return 1
+  printf '%s' "${recovered_id}"
+}
+
 # update_completion_status_comment — maintain a single pinned "what is
 # blocking completion" comment on the tracking issue, edit-in-place.
 #
@@ -1386,6 +1416,9 @@ update_completion_status_comment() {
     if [ -n "${existing_body}" ]; then
       existing_hash="$(printf '%s' "${existing_body}" | sha256sum | awk '{print $1}')"
       if [ "${existing_hash}" = "${body_hash}" ]; then
+        if ! [[ "${existing_id}" =~ ^[0-9]+$ ]] && [[ "${state_comment_id}" =~ ^[0-9]+$ ]]; then
+          existing_id="${state_comment_id}"
+        fi
         persist_completion_status_comment_state "${existing_id}" "${body_hash}"
         return $?
       fi
@@ -1425,12 +1458,74 @@ update_completion_status_comment() {
   if ! [[ "${response_id}" =~ ^[0-9]+$ ]]; then
     if [ -n "${existing_id}" ] && [[ "${existing_id}" =~ ^[0-9]+$ ]]; then
       response_id="${existing_id}"
+    elif response_id="$(recover_completion_status_comment_id_from_live_comments "${full_body}" "${marker}" 2>/dev/null || echo "")" \
+      && [[ "${response_id}" =~ ^[0-9]+$ ]]; then
+      :
     else
       echo "::warning::[completion-status] GitHub comment update succeeded but no numeric comment id was returned for issue #${TRACKING_NUM:-?}; will retry metadata persistence on a later cycle." >&2
       return 1
     fi
   fi
   persist_completion_status_comment_state "${response_id}" "${body_hash}"
+}
+
+refresh_validation_dispatch_wave_gate() {
+  local wave_issue_nums_json candidate_details_json labels_json issue_states_json pr_states_json
+  local integration_branch default_branch ahead_by wave_status
+
+  wave_issue_nums_json="$(jq -c '[.waves[((.current_wave // 1) - 1)].issues[]?.github_issue | select(. != null) | tonumber?]' "${STATE_FILE}" 2>/dev/null || echo '[]')"
+  if ! printf '%s' "${wave_issue_nums_json}" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    wave_issue_nums_json='[]'
+  fi
+
+  candidate_details_json="$(_fetch_candidate_issue_details_graphql "${wave_issue_nums_json}")"
+  if ! printf '%s' "${candidate_details_json}" | jq -e 'type == "object"' >/dev/null 2>&1; then
+    candidate_details_json='{}'
+  fi
+
+  labels_json="$(printf '%s' "${candidate_details_json}" | jq -c 'with_entries(.value = (.value.labels // []))' 2>/dev/null || echo '{}')"
+  issue_states_json="$(printf '%s' "${candidate_details_json}" | jq -c 'with_entries(.value = (((.value.state // "OPEN") | ascii_downcase) | if . == "closed" then "closed" else "open" end))' 2>/dev/null || echo '{}')"
+  pr_states_json="$(printf '%s' "${candidate_details_json}" | jq -c '
+    with_entries(.value = (
+      if (.value.linked_pr // null) == null then {state: "unknown", merged: false}
+      else {
+        state: (
+          if (.value.linked_pr.merged // false) == true then "closed"
+          else ((.value.linked_pr.state // "") | ascii_downcase | if . == "open" or . == "closed" then . else "unknown" end)
+          end
+        ),
+        merged: ((.value.linked_pr.merged // false) == true)
+      }
+      end
+    ))
+  ' 2>/dev/null || echo '{}')"
+
+  integration_branch="$(jq -r '.integration_branch // ""' "${STATE_FILE}" 2>/dev/null || echo "")"
+  [ "${integration_branch}" = "null" ] && integration_branch=""
+  if [ -n "${integration_branch}" ]; then
+    default_branch="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}" --jq '.default_branch' || echo "")"
+    if [ -z "${default_branch}" ]; then
+      ahead_by=""
+    elif ahead_by="$(_integration_branch_ahead_of_default "${integration_branch}" "${default_branch}")"; then
+      :
+    else
+      ahead_by=""
+    fi
+  else
+    ahead_by="0"
+  fi
+
+  wave_status="$(python3 scripts/orchestrate_lib.py check-wave-status \
+    --state-file "${STATE_FILE}" \
+    --labels-json "${labels_json}" \
+    --issue-states-json "${issue_states_json}" \
+    --pr-states-json "${pr_states_json}" \
+    --integration-ahead-by "${ahead_by}" 2>/dev/null || echo '')"
+  [ -n "${wave_status}" ] || return 1
+
+  WAVE_COMPLETE="$(echo "${wave_status}" | jq -r '.wave_complete // false' 2>/dev/null || echo false)"
+  ANY_FAILED="$(echo "${wave_status}" | jq -r '.any_failed // false' 2>/dev/null || echo false)"
+  PROJECT_COMPLETE="$(echo "${wave_status}" | jq -r '.project_complete // false' 2>/dev/null || echo false)"
 }
 
 extract_orchestrator_state_payload() {
@@ -4806,10 +4901,17 @@ dispatch_validation_if_needed() {
   # judge call and the dispatch (e.g. a consumer-side revert or
   # label-reconciliation race). When that happens we skip dispatch this
   # cycle and let the next poll tick re-evaluate once wave PR state
-  # settles. PROJECT_COMPLETE is set in the wave-status decision block
-  # above; an unset value (poller started mid-flow) is treated as "not
-  # gated" so we never block dispatch on absent state.
-  if [ -n "${PROJECT_COMPLETE+set}" ] && [ "${PROJECT_COMPLETE}" != "true" ]; then
+  # settles. The judge-complete path reaches this helper after the main
+  # wave-status block has already set PROJECT_COMPLETE; validating /
+  # revalidate paths hit it earlier in the loop, so recompute the live
+  # gate on demand there and fail closed if the probe itself cannot run.
+  if [ -z "${PROJECT_COMPLETE+set}" ]; then
+    if ! refresh_validation_dispatch_wave_gate; then
+      echo "::warning::[validation-dispatch] unable to recompute project completion for issue #${TRACKING_NUM:-?}; deferring validate dispatch this cycle." >&2
+      return 0
+    fi
+  fi
+  if [ "${PROJECT_COMPLETE}" != "true" ]; then
     echo "Preflight: PROJECT_COMPLETE=${PROJECT_COMPLETE:-unset}; deferring validate dispatch this cycle (wave PRs unmerged or integration→default merge pending)."
     return 0
   fi
@@ -10122,6 +10224,11 @@ These issues will enter the AI pipeline (clarify → plan → implement → revi
   _csc_integration_contained="$(echo "${WAVE_STATUS}" | jq -r '.integration_contained_in_default // false')"
   _csc_total_waves="$(jq -r '.total_waves // 0' "${STATE_FILE}" 2>/dev/null || echo 0)"
   _csc_current_wave="$(echo "${WAVE_STATUS}" | jq -r '.wave // 0')"
+  _csc_skipped_lines="$(echo "${WAVE_STATUS}" | jq -r '
+    [.issues[]
+      | select(.status == "skipped")
+      | "- #\(.github_issue // "?"): \(.status) (\(.decision_source // "unknown"))"]
+    | join("\n")')"
   _csc_pending_lines="$(echo "${WAVE_STATUS}" | jq -r '
     [.issues[]
       | select(.status != "merged" and .status != "closed" and .status != "skipped" and .status != "implementation-failed")
@@ -10155,6 +10262,10 @@ These issues will enter the AI pipeline (clarify → plan → implement → revi
     _csc_body+=$'\n'"**Wave issues closed without merge / implementation-failed:**"$'\n'"${_csc_failed_lines}"$'\n'
     _csc_body+=$'\n'"Project cannot complete until these are resolved (re-open, re-merge, or skip)."$'\n'
   fi
+  if [ -n "${_csc_skipped_lines}" ]; then
+    _csc_body+=$'\n'"**Wave issues skipped:**"$'\n'"${_csc_skipped_lines}"$'\n'
+    _csc_body+=$'\n'"Skipped issues are already accounted for and do not block completion."$'\n'
+  fi
   _csc_body+=$'\n'"_The orchestrator poller updates this comment every cycle (~5 min) until the project completes. Marker: \`<!-- orchestrator:completion-status -->\`._"
 
   update_completion_status_comment "${_completion_status_text}" "${_csc_body}" || true
@@ -10182,7 +10293,7 @@ These issues will enter the AI pipeline (clarify → plan → implement → revi
   fi
 
   unset _completion_status_text _csc_integration_ahead_by _csc_integration_contained
-  unset _csc_total_waves _csc_current_wave _csc_pending_lines _csc_failed_lines _csc_body _csc_validation_recovery_count
+  unset _csc_total_waves _csc_current_wave _csc_pending_lines _csc_failed_lines _csc_skipped_lines _csc_body _csc_validation_recovery_count
 
   # Persist reconciled status decisions every cycle (not only narrow branches).
   RECONCILE_STATE_CHANGED=false


### PR DESCRIPTION
## Summary

Makes the "are all orchestrator branches merged before declaring complete?" gate **visible** on the tracking issue and **defensive** at the validate-dispatch boundary, without making any workflow block on the wait.

- **New pinned comment** on every tracking issue, edited in place every poll tick — shows the live "what is blocking completion" picture (pending wave PRs, integration→default ahead-by, any closed-without-merge wave PRs). Marker: `<!-- orchestrator:completion-status -->`. Status token (`in-progress | waiting | ready | validated | failed`) carried in a grep-friendly second-line tag so downstream readers can parse it without rendering markdown.
- **Defensive dispatch gate** inside `dispatch_validation_if_needed`: skip the validate dispatch this cycle when `PROJECT_COMPLETE != "true"`. The judge-side `JUDGE_STATUS=complete` override remains the primary gate; this is belt-and-suspenders against label-reconciliation races where a wave PR transitions back from merged between the judge call and the dispatch. Re-entry on the next 5-min poll tick converges.
- **Once-per-project escalation:** the first time the cycle-level decision block observes `any_failed=true` (closed-without-merge wave PR), fire a CRITICAL `tg_notify` — guarded by `.completion_status_failure_alert_sent` in the state file so we never repeat the alert.

The deterministic merge gate itself (`scripts/orchestrate_lib.py:cmd_check_wave_status` — `all_merged AND last_wave AND integration_contained_in_default`) was already in place; this change makes the operator-facing surface of that gate observable from the tracking issue alone, and adds the defensive preflight at the dispatch boundary.

## Design choices

- **Poller-side gate, not validate-side.** A `validate.yml`-side preflight was the original sketch but had two real problems: replicating wave-PR state-extraction in a Bash step duplicates the orchestrator state machine; and a coarse "any PR cross-referencing the tracking issue is unmerged" check would false-positive on the integration→default PR while it is being autofixed. The poller already has `WAVE_STATUS` / `PROJECT_COMPLETE` in scope at the dispatch site, so the gate is six lines with zero state plumbing and no false positives.
- **Idempotent comment write.** The helper hashes the rendered body and skips the API call when the hash matches the last successfully written value for this project — so calling it every 5-minute tick does not produce comment-edit churn.
- **§15-clean.** Existing-comment lookup is satisfied from the cycle-local `COMMENTS` cache that the poller already paginates once per tick — no new per-iteration list calls.
- **Pinned status tag.** The second-line `<!-- status:<token> -->` marker is the canonical machine-readable status so future readers (e.g. validate-success fallback, dashboard tooling) can grep one substring without rendering the markdown body.

## Files

- `scripts/orchestrate_poll_process.sh` — +178 lines:
  - `update_completion_status_comment` helper (after `_post_state_comment_v2_chunk`, ~line 1275).
  - Defensive preflight in `dispatch_validation_if_needed` (~line 4710).
  - Wave-status decision block: completion-status comment build + write + once-per-project Telegram escalation (~line 9978).
  - Final transition calls in `mark_validation_complete` (validated) and both terminal branches of `mark_validation_failed` (failed).
- `agents.md` — +36 lines: new "Orchestrator tracking-issue comment markers" section documenting the two comment families (V2 state chain vs. completion-status) and the three call sites + dispatch-side preflight.

## Test plan

- [x] `bash -n scripts/orchestrate_poll_process.sh` — syntax valid.
- [ ] CI: lint / existing pytest suite (`tests/test_orchestrate_poll_process.py` etc.) green.
- [ ] Smoke on a real orchestrator project: confirm the pinned comment appears on first cycle, edits in place on subsequent ticks, transitions through `in-progress → waiting → ready → validated` as waves complete and validation passes, and is left in `failed` state on terminal mark_validation_failed branches.
- [ ] Confirm the once-per-project Telegram alert fires exactly once when a wave PR transitions to `closed` without merge (and does not re-fire on subsequent ticks).
- [ ] Confirm `dispatch_validation_if_needed` returns 0 without dispatching when `PROJECT_COMPLETE=false`, and that the next poll tick after wave completion does dispatch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PtGxnf33Mp6YFZMRDMEUs1)_