### PR TITLE
Stop noop-suspicious PRs from stalling: poller retry+force-merge + tighter editor prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
         run: |
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_poll_process.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_poll_noop_suspicious_recovery.py
 
       - name: Merge probe unit tests
         run: |
@@ -206,6 +207,8 @@ jobs:
         run: |
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_autofix_review_pipeline_contract.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_autofix_editor_noop_cascade_contract.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_validate_editor_audit.py
 
       - name: Review consolidator reject-verifier contract test
         run: |

--- a/.github/workflows/mark-stable.yml
+++ b/.github/workflows/mark-stable.yml
@@ -214,10 +214,13 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_lib.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_poll_process.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_poll_noop_suspicious_recovery.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_mark_stable_release_tag_refspec_contract.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_targeted_file_context.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_detect_editor_changes_lost.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_autofix_review_pipeline_contract.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_autofix_editor_noop_cascade_contract.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_validate_editor_audit.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_reject_verify.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_stall_recovery_pr_lookup.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_stall_loop_and_churn_fixes.py

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -954,7 +954,7 @@ jobs:
             echo "SUPPORT_AGENTS_FILE=${SUPPORT_ROOT_DIR}/agents.md"
           } >> "$GITHUB_ENV"
 
-          REQUIRED_BOOTSTRAP_SCRIPTS="gh_helpers.sh git_ref_health_check.sh generate_symbol_diff_summary.py render_prompt.sh tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py review_run_reviewers.sh review_apply_fixes.sh review_reject_verify.sh review_rb_judge.sh review_run_judge_interim.sh review_synthesise_smoke.sh review_commit_changes.sh review_conflict_prepare.sh review_conflict_resolve.sh check_workflow_script_refs.py check_resolver_diff.sh summarize_reviewer_consensus.sh check_external_branch_advance.sh post_review_comment.sh targeted_file_context.py write_codex_config.sh detect_editor_changes_lost.sh"
+          REQUIRED_BOOTSTRAP_SCRIPTS="gh_helpers.sh git_ref_health_check.sh generate_symbol_diff_summary.py render_prompt.sh tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py review_run_reviewers.sh review_apply_fixes.sh review_reject_verify.sh review_rb_judge.sh review_run_judge_interim.sh review_synthesise_smoke.sh review_commit_changes.sh review_conflict_prepare.sh review_conflict_resolve.sh check_workflow_script_refs.py check_resolver_diff.sh summarize_reviewer_consensus.sh check_external_branch_advance.sh post_review_comment.sh targeted_file_context.py write_codex_config.sh detect_editor_changes_lost.sh validate_editor_audit.sh"
           # Optional bootstrap scripts: allowed to be missing from both
           # refs.  The bootstrap emits a warning and continues — callers
           # that depend on these must themselves tolerate absence.  Keep
@@ -4019,48 +4019,24 @@ jobs:
             # ── Check 2: Reviewer audit sanity ──
             # When reviewer execution succeeded (REVIEWERS_SUCCESSFUL > 0)
             # but the editor claims no changes, verify the audit section has
-            # real entries and the arithmetic adds up.
+            # real entries and the arithmetic adds up. The check itself
+            # lives in scripts/validate_editor_audit.sh so the orchestrator
+            # poll's noop-suspicious recovery sweep can call the exact
+            # same regex/arithmetic logic when deciding whether a
+            # force-merge fallback is safe — keeping the two paths in
+            # lockstep prevents drift between "what the workflow flagged
+            # as noop-suspicious" and "what the poller considers an
+            # audit-healthy fallback candidate".
             if [ "${EDITOR_NOOP_SUSPICIOUS}" = "false" ] && [ "${REVIEWERS_SUCCESSFUL:-0}" -gt 0 ]; then
-              audit_section="$(awk '
-                /^[[:space:]]*Review file issue audit:/ { in_s=1; next }
-                in_s && /^[[:space:]]*[A-Za-z][A-Za-z ()-]*:[[:space:]]*$/ { exit }
-                in_s { print }
-              ' "${EDITOR_SUMMARY_FILE}")"
-
-              real_audit="$(printf '%s\n' "${audit_section}" \
-                | grep -vE '^[[:space:]]*$' \
-                | grep -viE '^[[:space:]]*-[[:space:]]*none([[:space:][:punct:]]|$)' \
-                | grep -viE 'editor failed' \
-                || true)"
-
-              if [ -z "${real_audit}" ]; then
-                echo "::warning::${REVIEWERS_SUCCESSFUL:-0} reviewer(s) succeeded but editor audit section is empty or contains only fallback text."
+              # shellcheck disable=SC1091
+              source "${SUPPORT_SCRIPTS_DIR}/validate_editor_audit.sh"
+              _vea_rc=0
+              validate_editor_audit_arithmetic \
+                "${EDITOR_SUMMARY_FILE}" \
+                "${REVIEWERS_SUCCESSFUL:-0}" \
+                || _vea_rc=$?
+              if [ "${_vea_rc}" -ne 0 ]; then
                 EDITOR_NOOP_SUSPICIOUS="true"
-              else
-                # Parse each audit entry and verify total == applied + already_applied + ignored.
-                mismatch_found=false
-                while IFS= read -r line; do
-                  [ -n "${line}" ] || continue
-                  t="$(printf '%s' "${line}" | grep -ioP 'total issues listed[^0-9]*\K[0-9]+' || echo "")"
-                  a="$(printf '%s' "${line}" | grep -ioP '(?<!already )issues applied[^0-9]*\K[0-9]+' || echo "")"
-                  aa="$(printf '%s' "${line}" | grep -ioP 'issues already applied[^0-9]*\K[0-9]+' || echo "")"
-                  ig="$(printf '%s' "${line}" | grep -ioP 'issues ignored[^0-9]*\K[0-9]+' || echo "")"
-
-                  # Skip entries that don't have parseable counts (not audit lines)
-                  [ -n "${t}" ] || continue
-
-                  t="${t:-0}"; a="${a:-0}"; aa="${aa:-0}"; ig="${ig:-0}"
-                  sum=$((a + aa + ig))
-
-                  if [ "${t}" -gt 0 ] && [ "${sum}" -ne "${t}" ]; then
-                    echo "::warning::Audit entry arithmetic mismatch: total=${t} but applied(${a})+already_applied(${aa})+ignored(${ig})=${sum}"
-                    mismatch_found=true
-                  fi
-                done <<< "${real_audit}"
-
-                if [ "${mismatch_found}" = true ]; then
-                  EDITOR_NOOP_SUSPICIOUS="true"
-                fi
               fi
             fi
           fi

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3230,10 +3230,13 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_lib.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_poll_process.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_poll_noop_suspicious_recovery.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_mark_stable_release_tag_refspec_contract.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_targeted_file_context.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_detect_editor_changes_lost.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_autofix_review_pipeline_contract.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_autofix_editor_noop_cascade_contract.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_validate_editor_audit.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_reject_verify.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_stall_recovery_pr_lookup.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_stall_loop_and_churn_fixes.py

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -12722,3 +12722,328 @@ for (( sidx=0; sidx<STANDALONE_COUNT; sidx++ )); do
 done
 
 echo "Standalone conflict sweep complete. Fixed: ${CONFLICT_SWEEP_FIXED}."
+
+# ---------------------------------------------------------------
+# Standalone PR noop-suspicious recovery sweep
+# ---------------------------------------------------------------
+# When `.github/workflows/review_autofix.yml`'s "Validate editor no-op
+# disposition" step (the `EDITOR_NOOP_SUSPICIOUS=true` branch) decides
+# an editor run is noop-suspicious, the "Enable auto-merge" step is
+# gated off and the PR stalls forever. Issue-linked PRs may eventually
+# recover via the generic standalone-stall recovery path (around line
+# 5780), but PRs on `claude/**` branches without a linked issue never
+# do — they sit indefinitely until a human re-dispatches by hand. The
+# original incident was PR
+# `shubhodeep1/tele-funtoken-msg-scoring#3053`: 9 productive autofix
+# commits landed, the 10th converged, and the PR was stuck.
+#
+# This sweep closes that gap. For each open PR with one or more
+# `⚠️ **Editor no-op suspicious**` warning comments posted after the
+# PR's most recent [ai-autofix] / [judge-fix] commit:
+#   - If the warning has been emitted < NOOP_MAX_RETRIES times since
+#     the last productive commit: re-dispatch review_autofix.yml via
+#     workflow_dispatch (reuses _dispatch_review_for_conflicts, which
+#     carries the cycle-local _CONFLICT_DISPATCH_TRACKER guard, so a
+#     conflict-sweep dispatch already this tick will not be
+#     duplicated). Telegram WARNING.
+#   - If the count is >= NOOP_MAX_RETRIES: enter the force-merge
+#     fallback. Force-merge fails CLOSED — every precondition is
+#     audited individually, and any single gate failure aborts with an
+#     ERROR alert (the PR stays open for human review). Gates:
+#       A) PR is open, not draft, mergeable=true, mergeable_state is
+#          neither dirty nor unknown, and does NOT carry
+#          `e2e-smoke-test` or `force-review` labels (operator
+#          opt-out).
+#       B) The latest "AI autofix editor summary" PR comment passes
+#          the reviewer audit arithmetic check
+#          (`scripts/validate_editor_audit.sh` — same code
+#          review_autofix.yml uses, so the two paths cannot drift).
+#       C) At least one prior `[ai-autofix]` / `[judge-fix]` commit
+#          exists on the PR (a brand-new editor that has never
+#          produced work is not eligible for force-merge).
+#       D) All completed required checks on the head SHA are
+#          conclusion=success / neutral / skipped — any failure /
+#          cancelled / timed_out / action_required aborts the gate.
+#     If every gate passes: `gh pr merge --squash --auto`, Telegram
+#     WARNING, and one audit-trail comment posted to the PR so the
+#     decision is visible on the thread (not only in Telegram).
+#
+# Retry counter design. The count of noop-suspicious warning comments
+# newer than the latest [ai-autofix] / [judge-fix] commit IS the
+# retry counter — no new per-PR state JSON is introduced.
+#   - Reset on new head SHA: when a productive commit lands, the count
+#     of noop-warnings-after-that-commit drops to 0, satisfying the
+#     "new SHA invalidates prior noop history" requirement.
+#   - Works for both issue-linked AND linked-issue-less PRs uniformly.
+#     The standalone-state JSON helpers at line 5346 are keyed by
+#     issue number and cannot represent linked-issue-less PRs at all,
+#     so adding a counter field there would only solve half the gap.
+#   - Robust to poller restarts (state lives in GitHub, not on disk
+#     or in memory).
+#
+# API-call hygiene (§15). The sweep reuses `STANDALONE_PRS` from the
+# conflict sweep above — no second `gh pr list`. A pre-filter
+# Issues-comments call is needed per PR because no existing call in
+# the poll cycle returns PR conversation comments:
+#   - _fetch_candidate_issue_details_graphql fetches issue (not PR)
+#     comments, and only for issue-linked candidates.
+#   - The conflict sweep's `pulls/{n}` REST call returns PR metadata
+#     but not comments.
+# The common case (PR with no noop warnings) costs just 1 comments
+# call and exits. A noop-suspicious PR additionally costs 1 commits
+# call, 1 pulls call (force-merge gate), and 1 check-runs call (force-
+# merge gate D) — gated so they only fire when the retry threshold has
+# been reached.
+# ---------------------------------------------------------------
+echo ""
+echo "========================================"
+echo "Standalone PR noop-suspicious recovery sweep"
+echo "========================================"
+
+NOOP_WARNING_LITERAL="⚠️ **Editor no-op suspicious**"
+NOOP_RECOVERY_DISPATCHED=0
+NOOP_FORCE_MERGED=0
+NOOP_RECOVERY_BLOCKED=0
+NOOP_MAX_RETRIES=3
+# Operator-facing opt-outs. `e2e-smoke-test` mirrors the workflow's
+# own auto-merge suppression so the smoke-test bait-removal race
+# stays sealed; `force-review` lets a human pin a stuck PR for manual
+# review without having to disable auto-merge separately.
+NOOP_FORCE_MERGE_SKIP_LABELS="e2e-smoke-test force-review"
+
+# Source the shared audit helper once, outside the loop.
+if [ -f scripts/validate_editor_audit.sh ]; then
+	# shellcheck source=scripts/validate_editor_audit.sh disable=SC1091
+	source scripts/validate_editor_audit.sh
+fi
+
+for (( nidx=0; nidx<STANDALONE_COUNT; nidx++ )); do
+	N_PR="$(echo "${STANDALONE_PRS}" | jq -r ".[${nidx}].number")"
+	N_HEAD="$(echo "${STANDALONE_PRS}" | jq -r ".[${nidx}].headRefName")"
+	N_BASE="$(echo "${STANDALONE_PRS}" | jq -r ".[${nidx}].baseRefName")"
+
+	if [ -z "${N_PR}" ] || [ "${N_PR}" = "null" ]; then
+		continue
+	fi
+	if [ -z "${N_HEAD}" ] || [ "${N_HEAD}" = "null" ]; then
+		continue
+	fi
+	# Skip integration / orchestrator-managed branches — those have
+	# their own merge cadence and should not be force-merged by this
+	# sweep.
+	if [[ "${N_BASE}" == orchestrator/project-* ]]; then
+		continue
+	fi
+
+	# ── Step 1: pre-filter via comments scan ──
+	# Fetch up to 100 most-recent comments. Noop-suspicious warnings
+	# are posted by the workflow itself so they always appear in the
+	# issue-comments stream for the PR.
+	N_COMMENTS_JSON="$(gh_retry gh api --paginate \
+		"repos/${GITHUB_REPOSITORY}/issues/${N_PR}/comments?per_page=100" \
+		| jq -s 'add // []' 2>/dev/null || echo '[]')"
+	[ -n "${N_COMMENTS_JSON}" ] || N_COMMENTS_JSON='[]'
+
+	N_NOOP_LATEST_TS="$(echo "${N_COMMENTS_JSON}" | jq -r \
+		--arg lit "${NOOP_WARNING_LITERAL}" \
+		'[.[] | select((.body // "") | contains($lit))] | max_by(.created_at // "") | .created_at // empty' \
+		2>/dev/null || echo "")"
+
+	if [ -z "${N_NOOP_LATEST_TS}" ]; then
+		# No noop-suspicious warning ever posted → not a candidate.
+		continue
+	fi
+
+	# ── Step 2: find latest productive commit timestamp ──
+	# Only [ai-autofix] / [judge-fix] commits count as "productive
+	# autofix output" — these are the prefixes review_autofix.yml /
+	# review_commit_changes.sh emit when the editor or judge writes
+	# real source-file changes. Manual commits, merge commits, and
+	# bot-housekeeping commits do NOT reset the noop counter.
+	N_COMMITS_JSON="$(gh_retry gh api --paginate \
+		"repos/${GITHUB_REPOSITORY}/pulls/${N_PR}/commits?per_page=100" \
+		| jq -s 'add // []' 2>/dev/null || echo '[]')"
+	[ -n "${N_COMMITS_JSON}" ] || N_COMMITS_JSON='[]'
+
+	N_LATEST_PROD_TS="$(echo "${N_COMMITS_JSON}" | jq -r \
+		'[.[] | select((.commit.message // "") | test("\\[ai-autofix\\]|\\[judge-fix\\]"))] | max_by(.commit.committer.date // "") | .commit.committer.date // empty' \
+		2>/dev/null || echo "")"
+
+	# Stale-warning check: if the latest noop warning predates the
+	# latest productive commit, the PR has already moved on. This is
+	# the equivalent of "reset on new head SHA" from the design spec.
+	if [ -n "${N_LATEST_PROD_TS}" ] && [[ "${N_NOOP_LATEST_TS}" < "${N_LATEST_PROD_TS}" ]]; then
+		echo "  PR #${N_PR}: latest noop warning (${N_NOOP_LATEST_TS}) is older than latest productive commit (${N_LATEST_PROD_TS}); stale, skipping."
+		continue
+	fi
+
+	# Count noop warnings newer than the latest productive commit
+	# (or all noop warnings when there is no productive commit yet —
+	# treated as the worst case for the retry counter).
+	if [ -n "${N_LATEST_PROD_TS}" ]; then
+		N_NOOP_COUNT="$(echo "${N_COMMENTS_JSON}" | jq -r \
+			--arg lit "${NOOP_WARNING_LITERAL}" \
+			--arg since "${N_LATEST_PROD_TS}" \
+			'[.[] | select((.body // "") | contains($lit)) | select((.created_at // "") > $since)] | length' \
+			2>/dev/null || echo "0")"
+	else
+		N_NOOP_COUNT="$(echo "${N_COMMENTS_JSON}" | jq -r \
+			--arg lit "${NOOP_WARNING_LITERAL}" \
+			'[.[] | select((.body // "") | contains($lit))] | length' \
+			2>/dev/null || echo "0")"
+	fi
+	[[ "${N_NOOP_COUNT}" =~ ^[0-9]+$ ]] || N_NOOP_COUNT=0
+
+	echo "  PR #${N_PR} (${N_HEAD}) noop-suspicious count since last productive commit: ${N_NOOP_COUNT}/${NOOP_MAX_RETRIES}"
+
+	# ── Step 3a: under threshold → re-dispatch ──
+	if [ "${N_NOOP_COUNT}" -lt "${NOOP_MAX_RETRIES}" ]; then
+		_noop_dispatch_rc=0
+		_dispatch_review_for_conflicts "${N_PR}" "${N_HEAD}" || _noop_dispatch_rc=$?
+		if [ "${_noop_dispatch_rc}" -eq 0 ]; then
+			tg_send_msg "Noop-suspicious recovery: re-dispatched review_autofix for PR #${N_PR} (retry $((N_NOOP_COUNT + 1))/${NOOP_MAX_RETRIES})."$'\n'"PR: $(_gh_url "pull/${N_PR}")" "WARNING" >/dev/null 2>&1 || true
+			NOOP_RECOVERY_DISPATCHED=$((NOOP_RECOVERY_DISPATCHED + 1))
+		elif [ "${_noop_dispatch_rc}" -eq 2 ]; then
+			echo "  PR #${N_PR}: autofix already active / dispatched this cycle; skipping."
+		else
+			echo "::warning::PR #${N_PR}: noop-suspicious redispatch failed (rc=${_noop_dispatch_rc})."
+		fi
+		continue
+	fi
+
+	# ── Step 3b: at threshold → force-merge gate ──
+	echo "  PR #${N_PR} hit ${NOOP_MAX_RETRIES}-retry cap. Evaluating force-merge fallback..."
+
+	# Gate A: PR mergeability + opt-out labels.
+	N_PR_JSON="$(gh_retry _safe_gh_jq "repos/${GITHUB_REPOSITORY}/pulls/${N_PR}" || echo '{}')"
+	[ -n "${N_PR_JSON}" ] || N_PR_JSON='{}'
+
+	N_STATE="$(echo "${N_PR_JSON}" | jq -r '.state // ""')"
+	N_DRAFT="$(echo "${N_PR_JSON}" | jq -r '.draft // false')"
+	N_MERGEABLE="$(echo "${N_PR_JSON}" | jq -r '.mergeable // null')"
+	N_MERGEABLE_STATE="$(echo "${N_PR_JSON}" | jq -r '.mergeable_state // ""')"
+	N_HEAD_SHA="$(echo "${N_PR_JSON}" | jq -r '.head.sha // ""')"
+
+	if [ "${N_STATE}" != "open" ] || [ "${N_DRAFT}" = "true" ]; then
+		tg_send_msg "Noop-suspicious force-merge gate A failed for PR #${N_PR}: state=${N_STATE} draft=${N_DRAFT}. Leaving PR for human review."$'\n'"PR: $(_gh_url "pull/${N_PR}")" "ERROR" >/dev/null 2>&1 || true
+		NOOP_RECOVERY_BLOCKED=$((NOOP_RECOVERY_BLOCKED + 1))
+		continue
+	fi
+
+	if [ "${N_MERGEABLE}" != "true" ] || [ "${N_MERGEABLE_STATE}" = "dirty" ] || [ "${N_MERGEABLE_STATE}" = "unknown" ] || [ -z "${N_MERGEABLE_STATE}" ]; then
+		tg_send_msg "Noop-suspicious force-merge gate A failed for PR #${N_PR}: mergeable=${N_MERGEABLE} mergeable_state=${N_MERGEABLE_STATE:-empty}. Leaving PR for human review."$'\n'"PR: $(_gh_url "pull/${N_PR}")" "ERROR" >/dev/null 2>&1 || true
+		NOOP_RECOVERY_BLOCKED=$((NOOP_RECOVERY_BLOCKED + 1))
+		continue
+	fi
+
+	N_LABELS_JSON="$(echo "${N_PR_JSON}" | jq -c '[.labels[]?.name // empty]' 2>/dev/null || echo '[]')"
+	_noop_skip_label=""
+	for _lbl in ${NOOP_FORCE_MERGE_SKIP_LABELS}; do
+		if echo "${N_LABELS_JSON}" | jq -e --arg l "${_lbl}" 'any(.[]; . == $l)' >/dev/null 2>&1; then
+			_noop_skip_label="${_lbl}"
+			break
+		fi
+	done
+	if [ -n "${_noop_skip_label}" ]; then
+		tg_send_msg "Noop-suspicious force-merge gate A failed for PR #${N_PR}: carries '${_noop_skip_label}' label (operator opt-out). Leaving PR for human review."$'\n'"PR: $(_gh_url "pull/${N_PR}")" "ERROR" >/dev/null 2>&1 || true
+		NOOP_RECOVERY_BLOCKED=$((NOOP_RECOVERY_BLOCKED + 1))
+		continue
+	fi
+
+	# Gate B: reviewer audit health.  Validate against the latest
+	# editor summary PR comment using the shared helper — this is the
+	# exact same regex/arithmetic logic that review_autofix.yml's
+	# "Validate editor no-op disposition" step uses, so a PR the
+	# workflow flagged as noop-suspicious-but-audit-healthy here will
+	# stay flagged-but-audit-healthy in the helper too.
+	N_LATEST_EDITOR_SUMMARY="$(echo "${N_COMMENTS_JSON}" | jq -r \
+		'[.[] | select((.body // "") | startswith("AI autofix editor summary"))] | max_by(.created_at // "") | .body // empty' \
+		2>/dev/null || echo "")"
+
+	if [ -z "${N_LATEST_EDITOR_SUMMARY}" ]; then
+		tg_send_msg "Noop-suspicious force-merge gate B failed for PR #${N_PR}: no editor summary comment found. Leaving PR for human review."$'\n'"PR: $(_gh_url "pull/${N_PR}")" "ERROR" >/dev/null 2>&1 || true
+		NOOP_RECOVERY_BLOCKED=$((NOOP_RECOVERY_BLOCKED + 1))
+		continue
+	fi
+
+	_noop_tmp_summary="$(mktemp "${TMPDIR:-/tmp}/noop_audit.XXXXXX" 2>/dev/null || echo "/tmp/noop_audit_$$_${N_PR}")"
+	printf '%s' "${N_LATEST_EDITOR_SUMMARY}" > "${_noop_tmp_summary}"
+
+	_noop_audit_rc=0
+	if type validate_editor_audit_arithmetic >/dev/null 2>&1; then
+		validate_editor_audit_arithmetic "${_noop_tmp_summary}" || _noop_audit_rc=$?
+	else
+		# Helper missing — fail closed.
+		_noop_audit_rc=3
+		echo "::warning::PR #${N_PR}: validate_editor_audit_arithmetic helper not loaded; failing force-merge gate B closed."
+	fi
+	rm -f "${_noop_tmp_summary}" 2>/dev/null || true
+
+	if [ "${_noop_audit_rc}" -ne 0 ]; then
+		tg_send_msg "Noop-suspicious force-merge gate B failed for PR #${N_PR}: reviewer audit unhealthy (helper rc=${_noop_audit_rc}). Leaving PR for human review."$'\n'"PR: $(_gh_url "pull/${N_PR}")" "ERROR" >/dev/null 2>&1 || true
+		NOOP_RECOVERY_BLOCKED=$((NOOP_RECOVERY_BLOCKED + 1))
+		continue
+	fi
+
+	# Gate C: at least one [ai-autofix] / [judge-fix] commit must
+	# exist. This guards against an editor that was broken from the
+	# very first invocation (no productive work, nothing to validate
+	# against).
+	if [ -z "${N_LATEST_PROD_TS}" ]; then
+		tg_send_msg "Noop-suspicious force-merge gate C failed for PR #${N_PR}: no prior [ai-autofix] / [judge-fix] commit found. Leaving PR for human review."$'\n'"PR: $(_gh_url "pull/${N_PR}")" "ERROR" >/dev/null 2>&1 || true
+		NOOP_RECOVERY_BLOCKED=$((NOOP_RECOVERY_BLOCKED + 1))
+		continue
+	fi
+
+	# Gate D: required checks must not be failing.
+	if [ -z "${N_HEAD_SHA}" ]; then
+		tg_send_msg "Noop-suspicious force-merge gate D failed for PR #${N_PR}: head SHA missing. Leaving PR for human review."$'\n'"PR: $(_gh_url "pull/${N_PR}")" "ERROR" >/dev/null 2>&1 || true
+		NOOP_RECOVERY_BLOCKED=$((NOOP_RECOVERY_BLOCKED + 1))
+		continue
+	fi
+
+	N_CHECKS_JSON="$(gh_retry gh api --paginate \
+		"repos/${GITHUB_REPOSITORY}/commits/${N_HEAD_SHA}/check-runs?per_page=100" \
+		--jq '[.check_runs[]? | {name, conclusion, status}]' \
+		2>/dev/null | jq -s 'add // []' 2>/dev/null || echo '[]')"
+	[ -n "${N_CHECKS_JSON}" ] || N_CHECKS_JSON='[]'
+
+	_failing_check="$(echo "${N_CHECKS_JSON}" | jq -r '
+		[.[] | select(.status == "completed" and (
+			.conclusion == "failure" or .conclusion == "cancelled" or
+			.conclusion == "timed_out" or .conclusion == "action_required"
+		)) | .name] | .[0] // empty' \
+		2>/dev/null || echo "")"
+
+	if [ -n "${_failing_check}" ]; then
+		tg_send_msg "Noop-suspicious force-merge gate D failed for PR #${N_PR}: check '${_failing_check}' is failing/cancelled. Leaving PR for human review."$'\n'"PR: $(_gh_url "pull/${N_PR}")" "ERROR" >/dev/null 2>&1 || true
+		NOOP_RECOVERY_BLOCKED=$((NOOP_RECOVERY_BLOCKED + 1))
+		continue
+	fi
+
+	# All gates passed → force-merge.
+	echo "  PR #${N_PR}: all force-merge gates passed. Enabling auto-merge via 'gh pr merge --auto'..."
+	if gh_retry gh pr merge "${N_PR}" --repo "${GITHUB_REPOSITORY}" --squash --auto >/dev/null 2>&1; then
+		NOOP_FORCE_MERGED=$((NOOP_FORCE_MERGED + 1))
+		tg_send_msg "Force-merging PR #${N_PR} after ${NOOP_MAX_RETRIES} noop-suspicious retries; reviewer audit was healthy."$'\n'"PR: $(_gh_url "pull/${N_PR}")" "WARNING" >/dev/null 2>&1 || true
+
+		# Audit-trail PR comment.  One per force-merge decision so the
+		# rationale is on the PR thread (not only in Telegram).
+		_force_merge_body="🤖 **Auto-merge enabled after ${NOOP_MAX_RETRIES} noop-suspicious retries**
+
+The editor converged ${NOOP_MAX_RETRIES} times in a row (every reviewer suggestion was either already-applied or correctly ignored), but \`EDITOR_NOOP_SUSPICIOUS=true\` blocked the normal auto-merge step. The orchestrator-poll force-merge fallback engaged because:
+
+- Reviewer audit arithmetic balanced (validated via \`scripts/validate_editor_audit.sh\` against the latest editor summary).
+- No required checks are failing on \`${N_HEAD_SHA}\`.
+- ${N_NOOP_COUNT} noop-suspicious warning(s) post the latest \`[ai-autofix]\` / \`[judge-fix]\` commit.
+
+To pause this behavior for manual review, add the \`force-review\` label."
+		gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${N_PR}/comments" \
+			-f body="${_force_merge_body}" >/dev/null 2>&1 || true
+	else
+		echo "::warning::PR #${N_PR}: gh pr merge --auto failed; will retry next cycle."
+		tg_send_msg "Noop-suspicious force-merge attempted but 'gh pr merge --auto' failed for PR #${N_PR}. Will retry next cycle."$'\n'"PR: $(_gh_url "pull/${N_PR}")" "ERROR" >/dev/null 2>&1 || true
+	fi
+done
+
+echo "Noop-suspicious recovery complete. Dispatched: ${NOOP_RECOVERY_DISPATCHED}, force-merged: ${NOOP_FORCE_MERGED}, blocked: ${NOOP_RECOVERY_BLOCKED}."

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -13077,7 +13077,7 @@ The editor converged ${NOOP_MAX_RETRIES} times in a row (every reviewer suggesti
 
 - Reviewer audit arithmetic balanced (validated via \`scripts/validate_editor_audit.sh\` against the latest editor summary).
 - No required checks are failing on \`${N_HEAD_SHA}\`.
-- ${N_NOOP_COUNT} noop-suspicious warning(s) post the latest \`[ai-autofix]\` / \`[judge-fix]\` commit.
+- ${N_NOOP_COUNT} noop-suspicious warning(s) since the latest \`[ai-autofix]\` / \`[judge-fix]\` commit.
 
 To pause this behavior for manual review, add the \`force-review\` label."
 		gh_retry gh api "repos/${GITHUB_REPOSITORY}/issues/${N_PR}/comments" \

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -12808,8 +12808,9 @@ NOOP_MAX_RETRIES=3
 # Operator-facing opt-outs. `e2e-smoke-test` mirrors the workflow's
 # own auto-merge suppression so the smoke-test bait-removal race
 # stays sealed; `force-review` lets a human pin a stuck PR for manual
-# review without having to disable auto-merge separately.
-NOOP_FORCE_MERGE_SKIP_LABELS="e2e-smoke-test force-review"
+# review without having to disable auto-merge separately. Store the
+# list one label per line so labels with spaces stay intact.
+NOOP_FORCE_MERGE_SKIP_LABELS=$'e2e-smoke-test\nforce-review'
 
 # Source the shared audit helper once, outside the loop.
 if [ -f scripts/validate_editor_audit.sh ]; then
@@ -12870,8 +12871,10 @@ for (( nidx=0; nidx<STANDALONE_COUNT; nidx++ )); do
 		2>/dev/null || echo "")"
 
 	# Stale-warning check: if the latest noop warning predates the
-	# latest productive commit, the PR has already moved on. This is
-	# the equivalent of "reset on new head SHA" from the design spec.
+	# latest productive commit, the PR has already moved on. GitHub API
+	# timestamps are ISO 8601 UTC, so bash's lexical < comparison is
+	# chronology-safe here. This is the equivalent of "reset on new
+	# head SHA" from the design spec.
 	if [ -n "${N_LATEST_PROD_TS}" ] && [[ "${N_NOOP_LATEST_TS}" < "${N_LATEST_PROD_TS}" ]]; then
 		echo "  PR #${N_PR}: latest noop warning (${N_NOOP_LATEST_TS}) is older than latest productive commit (${N_LATEST_PROD_TS}); stale, skipping."
 		continue
@@ -12938,16 +12941,27 @@ for (( nidx=0; nidx<STANDALONE_COUNT; nidx++ )); do
 
 	N_LABELS_JSON="$(echo "${N_PR_JSON}" | jq -c '[.labels[]?.name // empty]' 2>/dev/null || echo '[]')"
 	_noop_skip_label=""
-	for _lbl in ${NOOP_FORCE_MERGE_SKIP_LABELS}; do
+	while IFS= read -r _lbl; do
+		[ -n "${_lbl}" ] || continue
 		if echo "${N_LABELS_JSON}" | jq -e --arg l "${_lbl}" 'any(.[]; . == $l)' >/dev/null 2>&1; then
 			_noop_skip_label="${_lbl}"
 			break
 		fi
-	done
+	done <<< "${NOOP_FORCE_MERGE_SKIP_LABELS}"
 	if [ -n "${_noop_skip_label}" ]; then
 		tg_send_msg "Noop-suspicious force-merge gate A failed for PR #${N_PR}: carries '${_noop_skip_label}' label (operator opt-out). Leaving PR for human review."$'\n'"PR: $(_gh_url "pull/${N_PR}")" "ERROR" >/dev/null 2>&1 || true
 		NOOP_RECOVERY_BLOCKED=$((NOOP_RECOVERY_BLOCKED + 1))
 		continue
+	fi
+
+	# Refresh the comments snapshot on the threshold path so Gate B
+	# validates the latest editor summary when a new noop warning or
+	# summary comment lands mid-tick.
+	N_FRESH_COMMENTS_JSON="$(gh_retry gh api --paginate \
+		"repos/${GITHUB_REPOSITORY}/issues/${N_PR}/comments?per_page=100" \
+		| jq -s 'add // []' 2>/dev/null || true)"
+	if [ -n "${N_FRESH_COMMENTS_JSON}" ]; then
+		N_COMMENTS_JSON="${N_FRESH_COMMENTS_JSON}"
 	fi
 
 	# Gate B: reviewer audit health.  Validate against the latest
@@ -12966,11 +12980,15 @@ for (( nidx=0; nidx<STANDALONE_COUNT; nidx++ )); do
 		continue
 	fi
 
-	_noop_tmp_summary="$(mktemp "${TMPDIR:-/tmp}/noop_audit.XXXXXX" 2>/dev/null || echo "/tmp/noop_audit_$$_${N_PR}")"
-	printf '%s' "${N_LATEST_EDITOR_SUMMARY}" > "${_noop_tmp_summary}"
-
 	_noop_audit_rc=0
-	if type validate_editor_audit_arithmetic >/dev/null 2>&1; then
+	_noop_tmp_summary="$(mktemp "${TMPDIR:-/tmp}/noop_audit.XXXXXX" 2>/dev/null || true)"
+	if [ -z "${_noop_tmp_summary}" ]; then
+		_noop_audit_rc=3
+		echo "::warning::PR #${N_PR}: could not allocate temp file for editor summary; failing force-merge gate B closed."
+	elif ! printf '%s' "${N_LATEST_EDITOR_SUMMARY}" > "${_noop_tmp_summary}"; then
+		_noop_audit_rc=3
+		echo "::warning::PR #${N_PR}: could not write editor summary to temp file; failing force-merge gate B closed."
+	elif type validate_editor_audit_arithmetic >/dev/null 2>&1; then
 		validate_editor_audit_arithmetic "${_noop_tmp_summary}" || _noop_audit_rc=$?
 	else
 		# Helper missing — fail closed.
@@ -13002,18 +13020,42 @@ for (( nidx=0; nidx<STANDALONE_COUNT; nidx++ )); do
 		continue
 	fi
 
-	N_CHECKS_JSON="$(gh_retry gh api --paginate \
+	N_CHECKS_JSON="$(gh_retry _safe_gh_jq --paginate --slurp \
 		"repos/${GITHUB_REPOSITORY}/commits/${N_HEAD_SHA}/check-runs?per_page=100" \
-		--jq '[.check_runs[]? | {name, conclusion, status}]' \
-		2>/dev/null | jq -s 'add // []' 2>/dev/null || echo '[]')"
-	[ -n "${N_CHECKS_JSON}" ] || N_CHECKS_JSON='[]'
+		2>/dev/null || echo '{}')"
 
-	_failing_check="$(echo "${N_CHECKS_JSON}" | jq -r '
-		[.[] | select(.status == "completed" and (
+	_failing_check_count="$(printf '%s' "${N_CHECKS_JSON}" | jq -r '
+		def _is_blocking: .status == "completed" and (
 			.conclusion == "failure" or .conclusion == "cancelled" or
 			.conclusion == "timed_out" or .conclusion == "action_required"
-		)) | .name] | .[0] // empty' \
-		2>/dev/null || echo "")"
+		);
+		if (type == "array") then
+			[.[]? | (.check_runs // [])[] | select(_is_blocking)] | length
+		elif (type == "object" and (.check_runs | type == "array")) then
+			[.check_runs[] | select(_is_blocking)] | length
+		else
+			empty
+		end
+	' 2>/dev/null | tail -n1)"
+	if ! [[ "${_failing_check_count}" =~ ^[0-9]+$ ]]; then
+		tg_send_msg "Noop-suspicious force-merge gate D failed for PR #${N_PR}: could not query check-runs for head SHA ${N_HEAD_SHA}. Leaving PR for human review."$'\n'"PR: $(_gh_url "pull/${N_PR}")" "ERROR" >/dev/null 2>&1 || true
+		NOOP_RECOVERY_BLOCKED=$((NOOP_RECOVERY_BLOCKED + 1))
+		continue
+	fi
+
+	_failing_check="$(printf '%s' "${N_CHECKS_JSON}" | jq -r '
+		def _is_blocking: .status == "completed" and (
+			.conclusion == "failure" or .conclusion == "cancelled" or
+			.conclusion == "timed_out" or .conclusion == "action_required"
+		);
+		if (type == "array") then
+			([.[]? | (.check_runs // [])[] | select(_is_blocking) | .name] | .[0]) // empty
+		elif (type == "object" and (.check_runs | type == "array")) then
+			([.check_runs[] | select(_is_blocking) | .name] | .[0]) // empty
+		else
+			empty
+		end
+	' 2>/dev/null | tail -n1)"
 
 	if [ -n "${_failing_check}" ]; then
 		tg_send_msg "Noop-suspicious force-merge gate D failed for PR #${N_PR}: check '${_failing_check}' is failing/cancelled. Leaving PR for human review."$'\n'"PR: $(_gh_url "pull/${N_PR}")" "ERROR" >/dev/null 2>&1 || true

--- a/scripts/review_apply_fixes.sh
+++ b/scripts/review_apply_fixes.sh
@@ -1014,6 +1014,59 @@ no-modification statements (optionally with informational sub-bullets
 for validation runs, assumptions, or missing-context notes), emit
 "- not-edited". Do NOT put any other text, qualifier, or sub-bullet
 under this section — exactly one of those two values, on its own line.
+
+Convergence is a first-class valid outcome.
+If, after carefully evaluating every reviewer-panel issue and every PR
+comment, you find that ALL of them are either "already satisfied" by
+the worktree as you found it, OR correctly classified as ignored
+(out-of-scope / stylistic / etc.), AND you did NOT perform any
+apply_patch / write tool calls in this invocation, the correct final
+response is:
+  Changes made:
+  - none
+  Change status:
+  - not-edited
+Do NOT invent or restate edits to make "Changes made:" look populated.
+Information about what was already correct on HEAD belongs under
+"Already satisfied (suggested but already present):"; information
+about what you chose not to apply belongs under "Ignored suggestions
+(with short reason):". A genuinely-converged run is the SUCCESS path,
+not a failure — the downstream review_autofix workflow gates on
+clean editor output combined with a clean worktree.
+
+Claimed edits MUST correspond to writes you actually performed in
+THIS run.
+Every bullet under "Changes made:" MUST trace to a successful
+apply_patch / write tool call you executed during this invocation.
+Do NOT include bullets that describe edits already present on HEAD
+before you started, even if you considered them and decided they
+were already correct — those belong under "Already satisfied
+(suggested but already present):". The downstream worktree-vs-HEAD
+validator (scripts/review_apply_fixes.sh, the "Editor claimed
+changes but git shows no substantive diff from HEAD" check) WILL
+fail validation if "Changes made:" is non-empty but \`git diff HEAD\`
+is empty, and the workflow will treat the run as noop-suspicious.
+
+No fabricated edits to satisfy the format.
+Do NOT add a whitespace-only edit, a no-op rename, an empty-line
+shuffle, or any other insubstantive change purely to make the
+structured-format check "pass". A clean "Changes made:\\n- none" with
+"Change status:\\n- not-edited" always beats a fabricated change —
+the validator pipeline (scripts/review_apply_fixes.sh and
+review_autofix.yml's "Validate editor no-op disposition" step) is
+explicitly designed to accept the converged shape as healthy.
+
+Self-check before emitting your final response.
+Mentally walk through \`git status\` / \`git diff HEAD\` immediately
+before you write the response. If the worktree is clean (no staged
+and no unstaged changes you produced this run), your "Changes made:"
+MUST be exactly "- none" and your "Change status:" MUST be exactly
+"- not-edited" — do not append clarifying sub-bullets to "Changes
+made:" in that case. If the worktree is non-empty, every bullet
+under "Changes made:" must correspond to one or more files visible
+in the diff; do not list files you considered but did not actually
+modify.
+
 Under Regression fingerprint: and Runtime failure path:
 - ALWAYS emit both sections, even when no previously changed hunk was
   touched. Each section must contain at least one bullet. The commit

--- a/scripts/validate_editor_audit.sh
+++ b/scripts/validate_editor_audit.sh
@@ -130,7 +130,7 @@ validate_editor_audit_arithmetic()
 
 		sum=$((a + aa + ig))
 
-		if [ "${t}" -gt 0 ] && [ "${sum}" -ne "${t}" ]; then
+		if [ "${sum}" -ne "${t}" ]; then
 			echo "::warning::Audit entry arithmetic mismatch: total=${t} but applied(${a})+already_applied(${aa})+ignored(${ig})=${sum}" >&2
 			mismatch_found=true
 		fi

--- a/scripts/validate_editor_audit.sh
+++ b/scripts/validate_editor_audit.sh
@@ -98,22 +98,36 @@ validate_editor_audit_arithmetic()
 	fi
 
 	local mismatch_found=false
-	local line line_lower t a aa ig sum
+	local line line_lower line_without_already t a aa ig sum
 	while IFS= read -r line; do
 		[ -n "${line}" ] || continue
 		line_lower="$(printf '%s' "${line}" | tr '[:upper:]' '[:lower:]')"
-		if [[ "${line_lower}" =~ ^[[:space:]]*-[[:space:]]*.*total[[:space:]]+issues[[:space:]]+listed[^0-9]*([0-9]+),[[:space:]]*issues[[:space:]]+applied[^0-9]*([0-9]+),[[:space:]]*issues[[:space:]]+already[[:space:]]+applied[^0-9]*([0-9]+),[[:space:]]*issues[[:space:]]+ignored[^0-9]*([0-9]+)[[:space:][:punct:]]*$ ]]; then
+		t=""
+		a=""
+		aa=""
+		ig=""
+		line_without_already="${line_lower}"
+
+		if [[ "${line_lower}" =~ total[[:space:]]+issues[[:space:]]+listed[^0-9]*([0-9]+) ]]; then
 			t="${BASH_REMATCH[1]}"
-			a="${BASH_REMATCH[2]}"
-			aa="${BASH_REMATCH[3]}"
-			ig="${BASH_REMATCH[4]}"
-		else
+		fi
+		if [[ "${line_lower}" =~ issues[[:space:]]+already[[:space:]]+applied[^0-9]*([0-9]+) ]]; then
+			aa="${BASH_REMATCH[1]}"
+			line_without_already="${line_lower/${BASH_REMATCH[0]}/}"
+		fi
+		if [[ "${line_without_already}" =~ issues[[:space:]]+applied[^0-9]*([0-9]+) ]]; then
+			a="${BASH_REMATCH[1]}"
+		fi
+		if [[ "${line_lower}" =~ issues[[:space:]]+ignored[^0-9]*([0-9]+) ]]; then
+			ig="${BASH_REMATCH[1]}"
+		fi
+
+		if [ -z "${t}" ] || [ -z "${a}" ] || [ -z "${aa}" ] || [ -z "${ig}" ]; then
 			echo "::warning::Audit entry arithmetic mismatch: unparseable audit line: ${line}" >&2
 			mismatch_found=true
 			continue
 		fi
 
-		t="${t:-0}"; a="${a:-0}"; aa="${aa:-0}"; ig="${ig:-0}"
 		sum=$((a + aa + ig))
 
 		if [ "${t}" -gt 0 ] && [ "${sum}" -ne "${t}" ]; then

--- a/scripts/validate_editor_audit.sh
+++ b/scripts/validate_editor_audit.sh
@@ -46,8 +46,10 @@
 #       Audit healthy.
 #   1 — audit section is empty or contains only fallback text. The
 #       reviewer panel produced no usable audit.
-#   2 — at least one audit entry has an arithmetic mismatch. The editor
-#       claimed disposition counts that don't add up to the total.
+#   2 — at least one audit entry has an arithmetic mismatch OR is
+#       malformed/unparseable. The editor claimed disposition counts
+#       that don't add up to the total, or emitted a line that the
+#       validator cannot safely interpret.
 #   3 — usage error (missing/unreadable summary file).
 #
 # Warning lines emitted to stderr match the legacy inline block in
@@ -70,7 +72,7 @@ validate_editor_audit_arithmetic()
 	local audit_section
 	audit_section="$(awk '
 		/^[[:space:]]*Review file issue audit:/ { in_s=1; next }
-		in_s && /^[[:space:]]*[A-Za-z][A-Za-z ()-]*:[[:space:]]*$/ { exit }
+		in_s && /^[[:space:]]*PR comment audit:/ { exit }
 		in_s { print }
 	' "${summary_file}")"
 
@@ -87,7 +89,7 @@ validate_editor_audit_arithmetic()
 		# The poller path passes "" and gets a generic warning instead;
 		# both still grep-match "Editor audit section is empty or
 		# contains only fallback text" for operator searches.
-		if [ -n "${reviewers_successful}" ]; then
+		if [[ "${reviewers_successful}" =~ ^[0-9]+$ ]]; then
 			echo "::warning::${reviewers_successful} reviewer(s) succeeded but editor audit section is empty or contains only fallback text." >&2
 		else
 			echo "::warning::Editor audit section is empty or contains only fallback text." >&2
@@ -96,15 +98,20 @@ validate_editor_audit_arithmetic()
 	fi
 
 	local mismatch_found=false
-	local line t a aa ig sum
+	local line line_lower t a aa ig sum
 	while IFS= read -r line; do
 		[ -n "${line}" ] || continue
-		t="$(printf '%s' "${line}" | grep -ioP 'total issues listed[^0-9]*\K[0-9]+' || echo "")"
-		a="$(printf '%s' "${line}" | grep -ioP '(?<!already )issues applied[^0-9]*\K[0-9]+' || echo "")"
-		aa="$(printf '%s' "${line}" | grep -ioP 'issues already applied[^0-9]*\K[0-9]+' || echo "")"
-		ig="$(printf '%s' "${line}" | grep -ioP 'issues ignored[^0-9]*\K[0-9]+' || echo "")"
-
-		[ -n "${t}" ] || continue
+		line_lower="$(printf '%s' "${line}" | tr '[:upper:]' '[:lower:]')"
+		if [[ "${line_lower}" =~ ^[[:space:]]*-[[:space:]]*.*total[[:space:]]+issues[[:space:]]+listed[^0-9]*([0-9]+),[[:space:]]*issues[[:space:]]+applied[^0-9]*([0-9]+),[[:space:]]*issues[[:space:]]+already[[:space:]]+applied[^0-9]*([0-9]+),[[:space:]]*issues[[:space:]]+ignored[^0-9]*([0-9]+)[[:space:][:punct:]]*$ ]]; then
+			t="${BASH_REMATCH[1]}"
+			a="${BASH_REMATCH[2]}"
+			aa="${BASH_REMATCH[3]}"
+			ig="${BASH_REMATCH[4]}"
+		else
+			echo "::warning::Audit entry arithmetic mismatch: unparseable audit line: ${line}" >&2
+			mismatch_found=true
+			continue
+		fi
 
 		t="${t:-0}"; a="${a:-0}"; aa="${aa:-0}"; ig="${ig:-0}"
 		sum=$((a + aa + ig))

--- a/scripts/validate_editor_audit.sh
+++ b/scripts/validate_editor_audit.sh
@@ -80,7 +80,7 @@ validate_editor_audit_arithmetic()
 	real_audit="$(printf '%s\n' "${audit_section}" \
 		| grep -vE '^[[:space:]]*$' \
 		| grep -viE '^[[:space:]]*-[[:space:]]*none([[:space:][:punct:]]|$)' \
-		| grep -viE 'editor failed' \
+		| grep -viE '^[[:space:]]*-[[:space:]]*editor failed([[:space:][:punct:]]|$)' \
 		|| true)"
 
 	if [ -z "${real_audit}" ]; then

--- a/scripts/validate_editor_audit.sh
+++ b/scripts/validate_editor_audit.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# validate_editor_audit.sh — Shared validator for the "Review file issue
+# audit:" section of an editor summary, consumed by:
+#
+#   1. .github/workflows/review_autofix.yml — "Validate editor no-op
+#      disposition" step ("Check 2: Reviewer audit sanity"). Replaces the
+#      previously-inlined arithmetic block. Sets EDITOR_NOOP_SUSPICIOUS=true
+#      when the helper exits non-zero (caller-side).
+#
+#   2. scripts/orchestrate_poll_process.sh — noop-suspicious recovery
+#      sweep. The poller calls this helper against the latest editor
+#      summary PR comment to decide whether a force-merge fallback is
+#      safe (audit healthy → fallback eligible; audit not healthy →
+#      ERROR alert + leave PR open).
+#
+# Keeping a single implementation prevents the two callers from
+# disagreeing about what "audit healthy" means (per the task spec for
+# Fix B in this PR).
+#
+# Usage as a library (preferred — avoids subshell overhead):
+#   source scripts/validate_editor_audit.sh
+#   rc=0
+#   validate_editor_audit_arithmetic "${EDITOR_SUMMARY_FILE}" \
+#     "${REVIEWERS_SUCCESSFUL:-}" || rc=$?
+#
+# Usage as a script:
+#   bash scripts/validate_editor_audit.sh <summary-file> [reviewers_successful]
+#
+# Arguments:
+#   $1 (summary-file)         Path to the editor summary text file. Must
+#                             contain a "Review file issue audit:" section.
+#                             For the poller, write the latest editor
+#                             summary PR comment body to a tempfile and
+#                             pass that.
+#   $2 (reviewers_successful) Optional integer. When passed and present
+#                             in the empty-audit warning, the message is
+#                             prefixed with the reviewer count so the
+#                             workflow's existing operator alert wording
+#                             is preserved byte-for-byte. Omit (or pass
+#                             "") for the poller path, which has no
+#                             REVIEWERS_SUCCESSFUL env var.
+#
+# Exit codes:
+#   0 — audit section is non-fallback AND every parseable entry's
+#       arithmetic balances (total == applied + already_applied + ignored).
+#       Audit healthy.
+#   1 — audit section is empty or contains only fallback text. The
+#       reviewer panel produced no usable audit.
+#   2 — at least one audit entry has an arithmetic mismatch. The editor
+#       claimed disposition counts that don't add up to the total.
+#   3 — usage error (missing/unreadable summary file).
+#
+# Warning lines emitted to stderr match the legacy inline block in
+# review_autofix.yml byte-for-byte so existing cross-workflow grep
+# contracts (test_review_autofix_editor_noop_cascade_contract.py and the
+# e2e poller in test-and-mark-stable.yml) keep passing.
+
+# Function body: parse summary file's audit section, return per the
+# exit-code contract above.
+validate_editor_audit_arithmetic()
+{
+	local summary_file="${1:-}"
+	local reviewers_successful="${2:-}"
+
+	if [ -z "${summary_file}" ] || [ ! -f "${summary_file}" ]; then
+		echo "::warning::validate_editor_audit_arithmetic: summary file '${summary_file}' missing or unreadable." >&2
+		return 3
+	fi
+
+	local audit_section
+	audit_section="$(awk '
+		/^[[:space:]]*Review file issue audit:/ { in_s=1; next }
+		in_s && /^[[:space:]]*[A-Za-z][A-Za-z ()-]*:[[:space:]]*$/ { exit }
+		in_s { print }
+	' "${summary_file}")"
+
+	local real_audit
+	real_audit="$(printf '%s\n' "${audit_section}" \
+		| grep -vE '^[[:space:]]*$' \
+		| grep -viE '^[[:space:]]*-[[:space:]]*none([[:space:][:punct:]]|$)' \
+		| grep -viE 'editor failed' \
+		|| true)"
+
+	if [ -z "${real_audit}" ]; then
+		# Preserve the workflow's existing warning literal byte-for-byte
+		# when called from the workflow (reviewers_successful supplied).
+		# The poller path passes "" and gets a generic warning instead;
+		# both still grep-match "Editor audit section is empty or
+		# contains only fallback text" for operator searches.
+		if [ -n "${reviewers_successful}" ]; then
+			echo "::warning::${reviewers_successful} reviewer(s) succeeded but editor audit section is empty or contains only fallback text." >&2
+		else
+			echo "::warning::Editor audit section is empty or contains only fallback text." >&2
+		fi
+		return 1
+	fi
+
+	local mismatch_found=false
+	local line t a aa ig sum
+	while IFS= read -r line; do
+		[ -n "${line}" ] || continue
+		t="$(printf '%s' "${line}" | grep -ioP 'total issues listed[^0-9]*\K[0-9]+' || echo "")"
+		a="$(printf '%s' "${line}" | grep -ioP '(?<!already )issues applied[^0-9]*\K[0-9]+' || echo "")"
+		aa="$(printf '%s' "${line}" | grep -ioP 'issues already applied[^0-9]*\K[0-9]+' || echo "")"
+		ig="$(printf '%s' "${line}" | grep -ioP 'issues ignored[^0-9]*\K[0-9]+' || echo "")"
+
+		[ -n "${t}" ] || continue
+
+		t="${t:-0}"; a="${a:-0}"; aa="${aa:-0}"; ig="${ig:-0}"
+		sum=$((a + aa + ig))
+
+		if [ "${t}" -gt 0 ] && [ "${sum}" -ne "${t}" ]; then
+			echo "::warning::Audit entry arithmetic mismatch: total=${t} but applied(${a})+already_applied(${aa})+ignored(${ig})=${sum}" >&2
+			mismatch_found=true
+		fi
+	done <<< "${real_audit}"
+
+	if [ "${mismatch_found}" = true ]; then
+		return 2
+	fi
+
+	return 0
+}
+
+# When executed directly (not sourced), dispatch to the function with
+# the caller's arguments and exit with its return code. Sourcing the
+# file is a pure function-definition side-effect; no work runs.
+if [ "${BASH_SOURCE[0]:-$0}" = "${0}" ]; then
+	validate_editor_audit_arithmetic "$@"
+	exit $?
+fi

--- a/tests/test_orchestrate_poll_noop_suspicious_recovery.py
+++ b/tests/test_orchestrate_poll_noop_suspicious_recovery.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Contract tests for the noop-suspicious recovery sweep in
+`scripts/orchestrate_poll_process.sh`.
+
+The sweep recovers PRs that hit
+`EDITOR_NOOP_SUSPICIOUS=true` in `.github/workflows/review_autofix.yml`
+and would otherwise stall forever (the workflow's "Enable auto-merge"
+step is gated off). Issue-linked PRs eventually recover via the
+generic standalone-stall recovery path, but linked-issue-less PRs
+(branches like `claude/**`) never do — the original incident was
+shubhodeep1/tele-funtoken-msg-scoring#3053.
+
+These tests are grep-based contracts on the sweep's invariants:
+detection, retry counter shape, dispatch path, force-merge gates,
+shared-helper reuse, and Telegram alert levels. They are deliberately
+NOT behavioural — the existing `tests/test_orchestrate_poll_process.py`
+infrastructure for sandboxed poller runs is heavy enough that adding
+behavioural fixtures for this sweep would dwarf the sweep itself. The
+contracts cover the failure modes that matter:
+
+  1. The sweep section header and its core invariants survive future
+     edits.
+  2. The retry threshold matches the design spec (3).
+  3. Detection uses the exact warning literal the workflow emits
+     (`⚠️ **Editor no-op suspicious**`) — drift between the two
+     would break the recovery silently.
+  4. The force-merge gate consults the shared audit helper, not a
+     local re-implementation that could drift from review_autofix.yml.
+  5. Force-merge fails CLOSED on every individual precondition.
+  6. The sweep reuses the conflict sweep's `STANDALONE_PRS` cache
+     (no second `gh pr list` per cycle, per CLAUDE.md §15).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+POLLER = REPO_ROOT / "scripts" / "orchestrate_poll_process.sh"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "review_autofix.yml"
+HELPER = REPO_ROOT / "scripts" / "validate_editor_audit.sh"
+
+SWEEP_HEADER = "Standalone PR noop-suspicious recovery sweep"
+NOOP_WARNING_LITERAL = "⚠️ **Editor no-op suspicious**"
+
+
+def _poller_text() -> str:
+	return POLLER.read_text(encoding="utf-8")
+
+
+def _workflow_text() -> str:
+	return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _sweep_block() -> str:
+	"""Return the source slice from the sweep section header to EOF.
+
+	The sweep is the final block of the poller; all contract checks
+	below restrict their search to this block so an accidental match
+	on unrelated code elsewhere can't falsely satisfy a contract."""
+	text = _poller_text()
+	start = text.find(SWEEP_HEADER)
+	assert start != -1, f"Noop-suspicious recovery sweep section is missing — expected header {SWEEP_HEADER!r}"
+	return text[start:]
+
+
+def test_sweep_section_exists():
+	"""The sweep is present. The header appears in two intentional
+	places: the documentation comment block and the runtime banner
+	echo. Anything other than exactly 2 indicates either the sweep is
+	missing (0/1) or the block was accidentally duplicated (4+)."""
+	text = _poller_text()
+	occurrences = text.count(SWEEP_HEADER)
+	assert occurrences == 2, (
+		f"Expected exactly 2 occurrences of the sweep header (1 in "
+		f"docs comment, 1 in echo banner); found {occurrences}. If "
+		f"this jumped to >2 the sweep block was likely pasted twice."
+	)
+
+
+def test_sweep_uses_exact_workflow_warning_literal():
+	"""Detection must use the exact warning literal that
+	`review_autofix.yml` emits — a drift here would break recovery
+	silently. The literal appears in both files."""
+	wf = _workflow_text()
+	assert NOOP_WARNING_LITERAL in wf, "Workflow must still emit the noop-suspicious warning literal"
+	sweep = _sweep_block()
+	assert NOOP_WARNING_LITERAL in sweep, "Poller sweep must grep for the exact workflow literal"
+	# And it must be assigned to a named constant (so a future renamer
+	# updating one site is forced to update the other too, via the
+	# test failure here if they don't).
+	assert 'NOOP_WARNING_LITERAL=' in sweep
+
+
+def test_retry_threshold_is_three():
+	"""The design spec is 3 retries before force-merge. Pinning the
+	constant guards against accidental bumps."""
+	sweep = _sweep_block()
+	assert "NOOP_MAX_RETRIES=3" in sweep
+
+
+def test_sweep_uses_shared_audit_helper():
+	"""The force-merge gate B (reviewer audit health) MUST call the
+	shared helper, not a local re-implementation. Otherwise the poller
+	and the workflow can disagree about what "audit healthy" means."""
+	sweep = _sweep_block()
+	assert "source scripts/validate_editor_audit.sh" in sweep, (
+		"Sweep must source scripts/validate_editor_audit.sh — "
+		"never re-implement the arithmetic check inline."
+	)
+	assert "validate_editor_audit_arithmetic" in sweep, (
+		"Sweep must invoke the shared function validate_editor_audit_arithmetic."
+	)
+
+
+def _strip_shell_comments(text: str) -> str:
+	"""Remove lines that are pure comments (start with `#` after
+	whitespace). Lets contract tests check for forbidden tokens like
+	`gh pr list` in actual executable code without false-matching on
+	the documentation comments that explain why those tokens are
+	absent."""
+	out = []
+	for line in text.splitlines():
+		stripped = line.lstrip()
+		if stripped.startswith("#"):
+			continue
+		out.append(line)
+	return "\n".join(out)
+
+
+def test_sweep_reuses_standalone_prs_cache():
+	"""Per CLAUDE.md §15, the sweep MUST reuse the conflict sweep's
+	`STANDALONE_PRS` cache rather than running a second `gh pr list`.
+	A new `gh pr list` inside the sweep block is a regression."""
+	sweep_code = _strip_shell_comments(_sweep_block())
+	assert "STANDALONE_PRS" in sweep_code, "Sweep must reference STANDALONE_PRS"
+	assert "gh pr list" not in sweep_code, (
+		"Sweep must NOT call `gh pr list` again — it should reuse the "
+		"STANDALONE_PRS cache populated by the conflict sweep above."
+	)
+
+
+def test_sweep_uses_dispatch_helper_not_raw_workflow_run():
+	"""Re-dispatches must go through `_dispatch_review_for_conflicts`
+	so the cycle-local `_CONFLICT_DISPATCH_TRACKER` and active-run
+	guard fire. A raw `gh workflow run` would bypass both."""
+	sweep = _sweep_block()
+	assert "_dispatch_review_for_conflicts" in sweep
+	# Permit `gh pr merge --squash --auto` (force-merge path) but
+	# forbid `gh workflow run` (would race the existing guards).
+	assert "gh workflow run" not in sweep
+
+
+def test_force_merge_call_uses_squash_and_auto():
+	"""The actual force-merge invocation must use `--squash --auto` to
+	mirror the workflow's auto-merge step
+	(`.github/workflows/review_autofix.yml:5073`).
+
+	Restricted to executable code (comments and Telegram message
+	strings are stripped) so error-message strings like
+	"'gh pr merge --auto' failed" don't false-fail."""
+	sweep_code = _strip_shell_comments(_sweep_block())
+	# Match only invocations that look like commands (lines that
+	# include `gh pr merge` not wrapped in single quotes from a
+	# message string). The simplest heuristic: look for at least one
+	# line that has both --squash and --auto on the same gh-pr-merge
+	# line.
+	for line in sweep_code.splitlines():
+		if "gh pr merge" in line and "--squash" in line and "--auto" in line:
+			return  # found a valid invocation
+	raise AssertionError(
+		"Sweep must contain at least one `gh pr merge ... --squash --auto` "
+		"invocation in executable code (not in a comment or string)."
+	)
+
+
+def test_force_merge_skip_labels_include_force_review_and_e2e():
+	"""Operator opt-outs: `force-review` lets a human pin a PR for
+	manual review; `e2e-smoke-test` mirrors the workflow's existing
+	auto-merge suppression for smoke-test PRs."""
+	sweep = _sweep_block()
+	assert "e2e-smoke-test" in sweep
+	assert "force-review" in sweep
+
+
+def test_force_merge_gate_distinguishes_warning_and_error_levels():
+	"""Re-dispatches alert at WARNING (expected operational chatter).
+	Force-merge gate failures alert at ERROR (action needed —
+	something genuinely broken). This distinction is part of the
+	operator contract."""
+	sweep = _sweep_block()
+	# Match `tg_send_msg <args...> "WARNING"` / `"ERROR"` on a single
+	# line — the calls use bash quote-concatenation for multi-segment
+	# bodies but the level token is always the last quoted argument
+	# on its own line.
+	warning_lines = [
+		line for line in sweep.splitlines()
+		if "tg_send_msg" in line and '"WARNING"' in line
+	]
+	assert warning_lines, (
+		"Sweep must emit at least one Telegram WARNING (the re-dispatch / "
+		"successful-force-merge path)."
+	)
+	error_lines = [
+		line for line in sweep.splitlines()
+		if "tg_send_msg" in line and '"ERROR"' in line
+	]
+	assert error_lines, (
+		"Sweep must emit Telegram ERROR alerts whenever a force-merge "
+		"precondition fails — operators rely on the ERROR level to "
+		"distinguish 'stuck PR genuinely broken' from routine chatter."
+	)
+
+
+def test_force_merge_each_gate_has_distinct_failure_branch():
+	"""Gates A/B/C/D must each have an explicit failure branch that
+	calls `continue` (so a downstream gate cannot accidentally fire
+	on a PR that already failed an earlier gate). The contract is the
+	individual gate identifiers showing up in alert text — operators
+	debugging an ERROR alert need to see which gate tripped."""
+	sweep = _sweep_block()
+	for gate_id in ("gate A", "gate B", "gate C", "gate D"):
+		assert gate_id in sweep, (
+			f"Force-merge {gate_id} must have a labeled failure branch "
+			"so operators reading the ERROR alert know which precondition failed."
+		)
+
+
+def test_force_merge_records_audit_trail_comment():
+	"""Successful force-merges MUST post a PR comment alongside the
+	Telegram alert. The audit trail on the PR thread is the durable
+	record; Telegram is ephemeral."""
+	sweep = _sweep_block()
+	assert "Auto-merge enabled after" in sweep, (
+		"Force-merge success path must post a PR comment explaining "
+		"the override; the body is the audit trail."
+	)
+	assert "comments" in sweep, "Sweep must POST to issues/${PR}/comments"
+
+
+def test_sweep_force_merge_gate_skips_when_no_productive_commit():
+	"""Gate C: at least one `[ai-autofix]` / `[judge-fix]` commit must
+	exist before force-merge fires. A PR whose editor was broken from
+	the very first invocation is NOT force-merge eligible — the
+	whole point of force-merge is "the editor produced N productive
+	rounds and is now stuck in convergence."
+	"""
+	sweep = _sweep_block()
+	# The detection block already filters for productive-commit
+	# timestamp; we confirm the force-merge path explicitly references
+	# the absence-of-productive-commit case.
+	assert "no prior [ai-autofix] / [judge-fix] commit" in sweep
+
+
+def test_sweep_force_merge_gate_d_checks_required_checks():
+	"""Gate D blocks force-merge when any completed required check is
+	failure/cancelled/timed_out/action_required. Mirrors the workflow's
+	own auto-merge safety (it would not auto-merge a PR with failing
+	checks either)."""
+	sweep = _sweep_block()
+	for conclusion in ("failure", "cancelled", "timed_out", "action_required"):
+		assert conclusion in sweep, (
+			f"Gate D must treat conclusion={conclusion} as a blocker."
+		)
+
+
+def test_sweep_skips_orchestrator_project_branches():
+	"""Integration / orchestrator-managed branches have their own
+	merge cadence; this sweep must NOT touch them."""
+	sweep = _sweep_block()
+	assert "orchestrator/project-" in sweep, (
+		"Sweep must explicitly skip PRs targeting orchestrator/project-* base branches."
+	)
+
+
+def test_sweep_counts_only_post_productive_warnings():
+	"""The retry counter is "noop warnings newer than latest
+	[ai-autofix] / [judge-fix] commit". This is the implicit reset on
+	new head SHA — a new productive commit drops the count to 0.
+	"""
+	sweep = _sweep_block()
+	# The jq filter must compare comment created_at against the
+	# productive commit timestamp.
+	assert "N_LATEST_PROD_TS" in sweep
+	assert "[ai-autofix]" in sweep
+	assert "[judge-fix]" in sweep
+
+
+def test_sweep_appears_after_conflict_sweep():
+	"""Ordering matters: the conflict sweep must run first so a
+	dirty PR gets routed to the conflict resolver rather than the
+	noop-suspicious force-merge (which would refuse it anyway via
+	mergeable_state=dirty, but doing conflict resolution first is
+	cheaper and avoids spurious ERROR alerts)."""
+	text = _poller_text()
+	conflict_idx = text.find("Standalone PR conflict sweep")
+	noop_idx = text.find(SWEEP_HEADER)
+	assert conflict_idx != -1 and noop_idx != -1
+	assert conflict_idx < noop_idx, (
+		"Conflict sweep must precede the noop-suspicious sweep in the script."
+	)
+
+
+def test_sweep_emits_summary_line():
+	"""Every poll cycle must log how many PRs were dispatched /
+	force-merged / blocked so operators can grep `Noop-suspicious
+	recovery complete` in the orchestrator log."""
+	sweep = _sweep_block()
+	assert "Noop-suspicious recovery complete" in sweep

--- a/tests/test_orchestrate_poll_noop_suspicious_recovery.py
+++ b/tests/test_orchestrate_poll_noop_suspicious_recovery.py
@@ -309,3 +309,32 @@ def test_sweep_emits_summary_line():
 	recovery complete` in the orchestrator log."""
 	sweep = _sweep_block()
 	assert "Noop-suspicious recovery complete" in sweep
+
+
+def main() -> int:
+	# Direct `python3 tests/<file>.py` entrypoint — the repo's CI runs
+	# tests via that pattern rather than pytest discovery, so without
+	# this block the contract assertions never execute under CI.
+	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+	passed = 0
+	failed = 0
+
+	for func in test_funcs:
+		name = func.__name__
+		try:
+			func()
+			print(f"  PASS  {name}")
+			passed += 1
+		except AssertionError as e:
+			print(f"  FAIL  {name}: {e}")
+			failed += 1
+		except Exception as e:
+			print(f"  ERROR {name}: {type(e).__name__}: {e}")
+			failed += 1
+
+	print(f"\n{passed} passed, {failed} failed, {passed + failed} total")
+	return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_review_autofix_editor_noop_cascade_contract.py
+++ b/tests/test_review_autofix_editor_noop_cascade_contract.py
@@ -33,6 +33,7 @@ prompt copies, and success-path cleanup of the per-attempt prompt file.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
@@ -410,6 +411,262 @@ def test_refusal_contract_literals_stay_in_lockstep_across_files() -> None:
 		)
 
 
+# ---------------------------------------------------------------
+# Editor-prompt false-claim-convergence guards (Fix C of the noop-
+# suspicious recovery PR).
+#
+# The prompt was tightened to teach the editor model that convergence
+# (every reviewer comment is already-satisfied or correctly ignored) is
+# a first-class valid outcome. Without this language the model emits a
+# "Changes made: …" narrative on every attempt even when the worktree
+# is clean, which the downstream validator at
+# `scripts/review_apply_fixes.sh:1453` then rejects — triggering the
+# very EDITOR_NOOP_SUSPICIOUS path Fix B exists to recover from.
+#
+# The grep-based contracts below pin the four pieces of language the
+# task spec mandates, plus a regression guard that the existing
+# section headings the validators downstream depend on were NOT
+# renamed (CLAUDE.md §6: naming immutability).
+# ---------------------------------------------------------------
+
+
+EDITOR_PROMPT_HEREDOC_OPEN = "cat <<__EDITOR_PROMPT__"
+EDITOR_PROMPT_HEREDOC_CLOSE = "__EDITOR_PROMPT__"
+
+# Existing heading literals downstream tools grep for. Renaming any of
+# these is forbidden by CLAUDE.md §6 (naming immutability) — both
+# scripts/review_apply_fixes.sh (validator block at ~1390-1480) and
+# scripts/review_commit_changes.sh grep for these exact strings.
+PROTECTED_PROMPT_HEADINGS = (
+	"Changes made:",
+	"Change status:",
+	"Already satisfied (suggested but already present):",
+	"Ignored suggestions (with short reason):",
+	"Reviewer files processed:",
+	"Review file issue audit:",
+	"PR comment audit:",
+	"Regression fingerprint:",
+	"Runtime failure path:",
+)
+
+
+def _editor_prompt_heredoc() -> str:
+	"""Extract the slice of review_apply_fixes.sh between the editor
+	prompt's `cat <<__EDITOR_PROMPT__` opener and its closer. Pinning
+	the contract tests to this slice prevents accidental cross-talk
+	with unrelated code (e.g. the validator block that also mentions
+	these heading literals)."""
+	text = REVIEW_APPLY_FIXES.read_text(encoding="utf-8")
+	open_idx = text.find(EDITOR_PROMPT_HEREDOC_OPEN)
+	assert open_idx != -1, f"Editor prompt heredoc opener {EDITOR_PROMPT_HEREDOC_OPEN!r} not found"
+	# The closer is the literal line `__EDITOR_PROMPT__` AFTER the opener.
+	close_idx = text.find("\n" + EDITOR_PROMPT_HEREDOC_CLOSE, open_idx + len(EDITOR_PROMPT_HEREDOC_OPEN))
+	assert close_idx != -1, f"Editor prompt heredoc closer not found after opener"
+	return text[open_idx:close_idx]
+
+
+def test_editor_prompt_documents_convergence_outcome() -> None:
+	"""The prompt must explicitly tell the model that a converged
+	run (every reviewer comment is already-satisfied / ignored, no
+	apply_patch calls performed) is a valid SUCCESS outcome with the
+	`- none` / `- not-edited` shape — not a failure to be papered
+	over with a fabricated narrative."""
+	prompt = _editor_prompt_heredoc()
+	assert "Convergence is a first-class valid outcome" in prompt, (
+		"Prompt must contain the convergence-is-valid header line so "
+		"the model recognizes the converged path as a SUCCESS shape."
+	)
+	# Must reference the exact two-bullet contract the validator
+	# accepts.
+	assert "- none" in prompt
+	assert "- not-edited" in prompt
+
+
+def test_editor_prompt_requires_changes_match_this_run_writes() -> None:
+	"""Each bullet under `Changes made:` must correspond to an
+	apply_patch / write the model actually performed THIS run — not
+	to edits already on HEAD that the model considered."""
+	prompt = _editor_prompt_heredoc()
+	assert "Claimed edits MUST correspond to writes you actually performed in" in prompt
+	assert "THIS run" in prompt
+	# The hard rule must reference apply_patch (the editor's primary
+	# write tool) so the model can't argue it via a different
+	# write-tool reading.
+	assert "apply_patch" in prompt
+	# The downstream validator citation makes the failure mode
+	# concrete: the model can't talk itself out of the rule.
+	assert "git diff HEAD" in prompt
+
+
+def test_editor_prompt_forbids_fabricated_edits() -> None:
+	"""The prompt must explicitly forbid whitespace-only / no-op
+	edits added purely to make the structured-format check pass —
+	the failure mode the validator catches via the "no substantive
+	diff from HEAD" branch."""
+	prompt = _editor_prompt_heredoc()
+	assert "No fabricated edits to satisfy the format" in prompt
+	# Concrete forbidden examples — whitespace-only, no-op rename,
+	# empty-line shuffle — make the rule unmistakable.
+	assert "whitespace-only" in prompt
+
+
+def test_editor_prompt_requires_self_check_before_emitting() -> None:
+	"""Before emitting the final response, the model must mentally
+	walk through git status / git diff HEAD and reconcile its
+	"Changes made:" bullets against the actual diff. A clean worktree
+	must emit the two-bullet converged shape; a non-empty worktree
+	must list only files visible in the diff."""
+	prompt = _editor_prompt_heredoc()
+	assert "Self-check before emitting" in prompt
+	# Both git tools the self-check inspects must be named — the
+	# model is more likely to actually perform the check when the
+	# commands are explicit.
+	assert "git status" in prompt
+	assert "git diff HEAD" in prompt
+
+
+def test_editor_prompt_section_headings_unchanged() -> None:
+	"""CLAUDE.md §6 (naming immutability): the existing section
+	heading literals MUST appear in the prompt exactly as before.
+	scripts/review_apply_fixes.sh's validator block at lines
+	1390-1480 and scripts/review_commit_changes.sh grep for these
+	literals — any rename here silently breaks both."""
+	prompt = _editor_prompt_heredoc()
+	for heading in PROTECTED_PROMPT_HEADINGS:
+		assert heading in prompt, (
+			f"Protected prompt heading {heading!r} is no longer present "
+			f"in the editor prompt heredoc. Renames here are forbidden "
+			f"by CLAUDE.md §6 and silently break the downstream "
+			f"validators that grep for the literal."
+		)
+
+
+# ---------------------------------------------------------------
+# Shared audit-helper integration (Fix B of the same PR).
+#
+# The "Reviewer audit sanity" arithmetic check (Check 2 of the
+# "Validate editor no-op disposition" step) was extracted from
+# `.github/workflows/review_autofix.yml` into
+# `scripts/validate_editor_audit.sh` so the orchestrator-poll
+# noop-suspicious recovery sweep can call the exact same logic when
+# deciding whether a force-merge fallback is safe. Drift between the
+# two callers is precisely the bug we are avoiding — these tests pin
+# the integration so the inline block can never be re-introduced.
+# ---------------------------------------------------------------
+
+
+def test_workflow_sources_shared_audit_helper() -> None:
+	"""The validator step must `source` scripts/validate_editor_audit.sh
+	and call validate_editor_audit_arithmetic — never re-implement the
+	arithmetic check inline."""
+	text = _review_autofix_text()
+	disposition = _step_block(text, "Validate editor no-op disposition")
+	assert "validate_editor_audit.sh" in disposition, (
+		"Validate editor no-op disposition step must source the shared "
+		"audit helper."
+	)
+	assert "validate_editor_audit_arithmetic" in disposition, (
+		"Workflow must call validate_editor_audit_arithmetic (the "
+		"shared function) — never re-implement the check inline."
+	)
+
+
+def test_workflow_no_longer_contains_inline_audit_arithmetic_regex() -> None:
+	"""The inline `total issues listed` / `issues applied` / `issues
+	already applied` / `issues ignored` regex block must have moved
+	OUT of the workflow and INTO the shared helper. Catches a
+	regression where someone re-inlines the block under the same
+	step but forgets to delete the helper-source call."""
+	text = _review_autofix_text()
+	disposition = _step_block(text, "Validate editor no-op disposition")
+	# The unique-to-the-arithmetic-block regex fragments must NOT
+	# appear inside the workflow step any more.
+	forbidden_in_workflow = [
+		"total issues listed[^0-9]*\\K",
+		"(?<!already )issues applied[^0-9]*\\K",
+		"issues already applied[^0-9]*\\K",
+		"issues ignored[^0-9]*\\K",
+	]
+	for needle in forbidden_in_workflow:
+		assert needle not in disposition, (
+			f"Inline audit-arithmetic regex {needle!r} re-appeared in "
+			f"the workflow step. It must live ONLY in "
+			f"scripts/validate_editor_audit.sh so the workflow and the "
+			f"poller cannot drift."
+		)
+	# And the helper must still own the regex.
+	helper_text = (REPO_ROOT / "scripts" / "validate_editor_audit.sh").read_text(encoding="utf-8")
+	for needle in forbidden_in_workflow:
+		assert needle in helper_text, (
+			f"The shared helper must own the audit-arithmetic regex "
+			f"{needle!r}; if it moved elsewhere, the contract is broken."
+		)
+
+
+def test_workflow_warning_literals_preserved_in_helper() -> None:
+	"""The validator step previously emitted two distinctive
+	`::warning::` literals that downstream operator searches and the
+	e2e poller grep contracts depend on. The shared helper MUST emit
+	the same literals."""
+	helper_text = (REPO_ROOT / "scripts" / "validate_editor_audit.sh").read_text(encoding="utf-8")
+	# The empty-audit warning has the form
+	# "::warning::N reviewer(s) succeeded but editor audit section is empty or contains only fallback text."
+	# (lowercase `editor` because it appears mid-sentence). The poller
+	# path also emits a sentence-start variant that starts uppercase.
+	assert "reviewer(s) succeeded but editor audit section is empty or contains only fallback text" in helper_text
+	# Per-line arithmetic mismatch literal stays byte-for-byte:
+	assert "Audit entry arithmetic mismatch: total=" in helper_text
+
+
+def test_required_bootstrap_scripts_includes_audit_helper() -> None:
+	"""For consumer repos, the workflow stages scripts into
+	${SUPPORT_SCRIPTS_DIR} via REQUIRED_BOOTSTRAP_SCRIPTS. The new
+	helper MUST appear in that list or `source
+	${SUPPORT_SCRIPTS_DIR}/validate_editor_audit.sh` will fail with
+	"No such file" on every consumer-repo run."""
+	text = _review_autofix_text()
+	# Find the REQUIRED_BOOTSTRAP_SCRIPTS assignment.
+	bootstrap_match = re.search(r'REQUIRED_BOOTSTRAP_SCRIPTS="([^"]+)"', text)
+	assert bootstrap_match is not None, (
+		"REQUIRED_BOOTSTRAP_SCRIPTS list not found — workflow bootstrap "
+		"shape changed without test update."
+	)
+	bootstrap_list = bootstrap_match.group(1)
+	assert "validate_editor_audit.sh" in bootstrap_list, (
+		"validate_editor_audit.sh must be listed in "
+		"REQUIRED_BOOTSTRAP_SCRIPTS or consumer-repo runs will fail "
+		"to find the helper at ${SUPPORT_SCRIPTS_DIR}."
+	)
+
+
+# ---------------------------------------------------------------
+# Cross-file: the noop-suspicious warning literal that the workflow
+# emits and the poller greps for must stay in lockstep — drift here
+# is the exact bug Fix B's recovery sweep was added to avoid.
+# ---------------------------------------------------------------
+
+
+NOOP_WARNING_LITERAL = "⚠️ **Editor no-op suspicious**"
+
+
+def test_noop_warning_literal_present_in_workflow() -> None:
+	text = _review_autofix_text()
+	assert NOOP_WARNING_LITERAL in text, (
+		"review_autofix.yml must still post a body comment containing "
+		"the noop-suspicious warning literal — the orchestrator-poll "
+		"sweep greps for this exact substring."
+	)
+
+
+def test_noop_warning_literal_present_in_poller() -> None:
+	poller = (REPO_ROOT / "scripts" / "orchestrate_poll_process.sh").read_text(encoding="utf-8")
+	assert NOOP_WARNING_LITERAL in poller, (
+		"scripts/orchestrate_poll_process.sh must reference the exact "
+		"same noop-suspicious warning literal — otherwise the recovery "
+		"sweep will fail to detect any noop-suspicious PRs."
+	)
+
+
 if __name__ == "__main__":
 	test_merge_conflict_chain_gates_on_editor_noop_suspicious()
 	test_validator_emits_exact_grep_literal()
@@ -426,4 +683,15 @@ if __name__ == "__main__":
 	test_review_apply_fixes_fallback_distinguishes_refusal()
 	test_review_apply_fixes_centralizes_refusal_regex()
 	test_refusal_contract_literals_stay_in_lockstep_across_files()
+	test_editor_prompt_documents_convergence_outcome()
+	test_editor_prompt_requires_changes_match_this_run_writes()
+	test_editor_prompt_forbids_fabricated_edits()
+	test_editor_prompt_requires_self_check_before_emitting()
+	test_editor_prompt_section_headings_unchanged()
+	test_workflow_sources_shared_audit_helper()
+	test_workflow_no_longer_contains_inline_audit_arithmetic_regex()
+	test_workflow_warning_literals_preserved_in_helper()
+	test_required_bootstrap_scripts_includes_audit_helper()
+	test_noop_warning_literal_present_in_workflow()
+	test_noop_warning_literal_present_in_poller()
 	print("All EDITOR_NOOP_SUSPICIOUS cascade-guard contract tests passed.")

--- a/tests/test_review_autofix_editor_noop_cascade_contract.py
+++ b/tests/test_review_autofix_editor_noop_cascade_contract.py
@@ -594,13 +594,22 @@ def test_workflow_no_longer_contains_inline_audit_arithmetic_regex() -> None:
 			f"scripts/validate_editor_audit.sh so the workflow and the "
 			f"poller cannot drift."
 		)
-	# And the helper must still own the regex.
+	# And the helper must still own the arithmetic parser. The
+	# implementation is allowed to evolve away from the original grep -P
+	# fragments as long as the parsing logic remains centralized there.
 	helper_text = (REPO_ROOT / "scripts" / "validate_editor_audit.sh").read_text(encoding="utf-8")
-	for needle in forbidden_in_workflow:
-		assert needle in helper_text, (
-			f"The shared helper must own the audit-arithmetic regex "
-			f"{needle!r}; if it moved elsewhere, the contract is broken."
-		)
+	assert (
+		"total issues listed[^0-9]*\\K" in helper_text
+		or "total[[:space:]]+issues[[:space:]]+listed" in helper_text
+	), (
+		"The shared helper must still own the audit-arithmetic parser; "
+		"if neither the legacy grep -P fragment nor the bash-regex "
+		"replacement is present, the parser likely moved elsewhere."
+	)
+	assert "Audit entry arithmetic mismatch" in helper_text, (
+		"The shared helper must still emit the arithmetic-mismatch warning; "
+		"if that literal moved elsewhere, the contract is broken."
+	)
 
 
 def test_workflow_warning_literals_preserved_in_helper() -> None:

--- a/tests/test_validate_editor_audit.py
+++ b/tests/test_validate_editor_audit.py
@@ -22,7 +22,9 @@ poller in test-and-mark-stable.yml) keep passing.
 
 from __future__ import annotations
 
+import inspect
 import subprocess
+import tempfile
 import textwrap
 from pathlib import Path
 
@@ -35,7 +37,7 @@ def _run(summary_text: str, reviewers_successful: str | None = None, tmp_path: P
 	"""Write `summary_text` to a tempfile and invoke the helper against
 	it. Returns the completed process so callers can inspect rc + stderr.
 	"""
-	assert tmp_path is not None, "Caller must pass pytest's tmp_path fixture"
+	assert tmp_path is not None, "Caller must pass a temporary Path"
 	summary = tmp_path / "summary.txt"
 	summary.write_text(summary_text, encoding="utf-8")
 	cmd = ["bash", str(HELPER), str(summary)]
@@ -222,6 +224,23 @@ def test_unparseable_audit_line_fails_closed(tmp_path):
 	assert "Audit entry arithmetic mismatch: unparseable audit line" in result.stderr
 
 
+def test_legitimate_audit_line_containing_editor_failed_phrase_is_not_filtered(tmp_path):
+	"""The helper must strip only the fallback bullet shape, not any
+	otherwise-valid audit line whose filename/prose happens to contain
+	`editor failed`. Regression guard for the anchored grep filter."""
+	summary = textwrap.dedent(
+		"""\
+		Review file issue audit:
+		- review editor failed case.md: total issues listed 1, issues applied 1, issues already applied 0, issues ignored 0
+
+		PR comment audit:
+		- none
+		"""
+	)
+	result = _run(summary, "1", tmp_path=tmp_path)
+	assert result.returncode == 0, result.stderr
+
+
 def test_helper_handles_audit_section_followed_by_pr_comment_audit(tmp_path):
 	"""The extractor stops at the explicit `PR comment audit:` heading.
 	A `Review file issue audit:` section followed immediately by `PR
@@ -240,3 +259,39 @@ def test_helper_handles_audit_section_followed_by_pr_comment_audit(tmp_path):
 	result = _run(summary, "1", tmp_path=tmp_path)
 	# review_a.md's arithmetic balances (1 == 1 + 0 + 0), so rc=0.
 	assert result.returncode == 0
+
+
+def main() -> int:
+	# Direct `python3 tests/<file>.py` entrypoint — the repo's CI runs
+	# tests via that pattern rather than pytest discovery, so this file
+	# needs its own runner for the assertions to execute under CI.
+	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+	passed = 0
+	failed = 0
+
+	for func in test_funcs:
+		name = func.__name__
+		try:
+			params = list(inspect.signature(func).parameters)
+			if not params:
+				func()
+			elif params == ["tmp_path"]:
+				with tempfile.TemporaryDirectory(prefix="validate-editor-audit-") as td:
+					func(Path(td))
+			else:
+				raise TypeError(f"unsupported test signature for {name}: {params}")
+			print(f"  PASS  {name}")
+			passed += 1
+		except AssertionError as e:
+			print(f"  FAIL  {name}: {e}")
+			failed += 1
+		except Exception as e:
+			print(f"  ERROR {name}: {type(e).__name__}: {e}")
+			failed += 1
+
+	print(f"\n{passed} passed, {failed} failed, {passed + failed} total")
+	return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_validate_editor_audit.py
+++ b/tests/test_validate_editor_audit.py
@@ -185,6 +185,34 @@ def test_balanced_arithmetic_with_zero_totals_passes(tmp_path):
 	assert result.returncode == 0
 
 
+def test_existing_colon_separated_fixture_format_passes(tmp_path):
+	"""Existing editor-summary fixtures use colon/space separators rather
+	than the comma-delimited shape from the helper's first draft. The
+	helper must continue accepting the historical fixture format so the
+	workflow and poller stay aligned with summaries already in-repo."""
+	summary = (REPO_ROOT / "tests" / "fixtures" / "editor_summaries" / "narrative_none_status_edited.txt").read_text(encoding="utf-8")
+	result = _run(summary, "1", tmp_path=tmp_path)
+	assert result.returncode == 0, result.stderr
+
+
+def test_trailing_annotation_after_ignored_count_passes(tmp_path):
+	"""The legacy per-field extractor tolerated extra prose after the
+	ignored-count field. Keep that behavior so convergence notes or other
+	harmless trailing annotations do not spuriously flip the audit to
+	unhealthy."""
+	summary = textwrap.dedent(
+		"""\
+		Review file issue audit:
+		- review_a.md: total issues listed: 3 issues applied: 0 issues already applied: 3 issues ignored: 0 (converged on current HEAD)
+
+		PR comment audit:
+		- none
+		"""
+	)
+	result = _run(summary, "1", tmp_path=tmp_path)
+	assert result.returncode == 0, result.stderr
+
+
 def test_helper_is_sourceable_as_library(tmp_path):
 	"""Sourcing the helper file defines `validate_editor_audit_arithmetic`
 	but performs no work — the workflow and poller both source it and

--- a/tests/test_validate_editor_audit.py
+++ b/tests/test_validate_editor_audit.py
@@ -172,8 +172,8 @@ def test_non_numeric_reviewer_count_falls_back_to_generic_warning(tmp_path):
 
 
 def test_balanced_arithmetic_with_zero_totals_passes(tmp_path):
-	"""Entries with total=0 are skipped by the arithmetic check (they
-	cannot mismatch). A summary with only zero-total entries passes."""
+	"""Entries with total=0 still pass when their summed counts are also
+	zero."""
 	summary = textwrap.dedent(
 		"""\
 		Review file issue audit:
@@ -183,6 +183,19 @@ def test_balanced_arithmetic_with_zero_totals_passes(tmp_path):
 	)
 	result = _run(summary, "2", tmp_path=tmp_path)
 	assert result.returncode == 0
+
+
+def test_zero_total_with_non_zero_sum_fails_closed(tmp_path):
+	"""Zero-total entries must still balance; non-zero applied counts are malformed."""
+	summary = textwrap.dedent(
+		"""\
+		Review file issue audit:
+		- review_bad.md: total issues listed 0, issues applied 1, issues already applied 0, issues ignored 0
+		"""
+	)
+	result = _run(summary, "1", tmp_path=tmp_path)
+	assert result.returncode == 2
+	assert "Audit entry arithmetic mismatch: total=0 but applied(1)+already_applied(0)+ignored(0)=1" in result.stderr
 
 
 def test_existing_colon_separated_fixture_format_passes(tmp_path):

--- a/tests/test_validate_editor_audit.py
+++ b/tests/test_validate_editor_audit.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Unit tests for `scripts/validate_editor_audit.sh`.
+
+The helper extracts the "Reviewer audit sanity" arithmetic check that
+was previously inlined inside `.github/workflows/review_autofix.yml`'s
+"Validate editor no-op disposition" step (the
+`EDITOR_NOOP_SUSPICIOUS=true` branch). It now backs both:
+
+  1. The workflow's noop-suspicious detection (the inline block at
+     ~line 4019 is now a `source` + function call).
+  2. `scripts/orchestrate_poll_process.sh`'s noop-suspicious recovery
+     sweep — specifically the force-merge fallback's "reviewer audit
+     healthy?" gate. Force-merging a PR whose audit arithmetic does not
+     balance would defeat the safety contract, so the two paths MUST
+     consult the same regex/arithmetic logic.
+
+These tests pin the helper's exit-code contract and warning literals
+so the workflow's existing cross-workflow grep contracts
+(test_review_autofix_editor_noop_cascade_contract.py and the e2e
+poller in test-and-mark-stable.yml) keep passing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HELPER = REPO_ROOT / "scripts" / "validate_editor_audit.sh"
+
+
+def _run(summary_text: str, reviewers_successful: str | None = None, tmp_path: Path | None = None) -> subprocess.CompletedProcess:
+	"""Write `summary_text` to a tempfile and invoke the helper against
+	it. Returns the completed process so callers can inspect rc + stderr.
+	"""
+	assert tmp_path is not None, "Caller must pass pytest's tmp_path fixture"
+	summary = tmp_path / "summary.txt"
+	summary.write_text(summary_text, encoding="utf-8")
+	cmd = ["bash", str(HELPER), str(summary)]
+	if reviewers_successful is not None:
+		cmd.append(reviewers_successful)
+	return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def test_helper_script_exists_and_is_executable():
+	assert HELPER.exists(), f"Shared audit helper not found at {HELPER}"
+	assert HELPER.stat().st_mode & 0o111, "validate_editor_audit.sh must be executable"
+
+
+def test_exit_zero_when_audit_balances(tmp_path):
+	"""A canonical healthy audit (every entry has total == applied +
+	already_applied + ignored) returns rc=0."""
+	summary = textwrap.dedent(
+		"""\
+		Changes made:
+		- none
+
+		Review file issue audit:
+		- review_a.md: total issues listed 3, issues applied 1, issues already applied 1, issues ignored 1
+		- review_b.md: total issues listed 2, issues applied 0, issues already applied 2, issues ignored 0
+
+		PR comment audit:
+		- none
+		"""
+	)
+	result = _run(summary, "3", tmp_path=tmp_path)
+	assert result.returncode == 0, f"Expected rc=0 for healthy audit, got {result.returncode}; stderr={result.stderr!r}"
+
+
+def test_exit_one_when_audit_section_is_only_none(tmp_path):
+	"""Audit section contains only `- none` → treated as empty/fallback,
+	rc=1. This mirrors the workflow's "audit section is empty or contains
+	only fallback text" branch — and the workflow's literal is preserved
+	byte-for-byte (lowercase `editor` because it appears mid-sentence
+	after `but`)."""
+	summary = textwrap.dedent(
+		"""\
+		Review file issue audit:
+		- none
+
+		PR comment audit:
+		- none
+		"""
+	)
+	result = _run(summary, "3", tmp_path=tmp_path)
+	assert result.returncode == 1
+	# Workflow-path message preserves the exact pre-extraction literal:
+	# "::warning::N reviewer(s) succeeded but editor audit section ..."
+	assert "3 reviewer(s) succeeded but editor audit section is empty or contains only fallback text" in result.stderr
+
+
+def test_exit_one_when_audit_section_contains_only_editor_failed_fallback(tmp_path):
+	"""The `editor failed` substring is the other fallback marker
+	stripped by `grep -viE 'editor failed'`. A section with only this
+	must still be classified as empty/fallback."""
+	summary = textwrap.dedent(
+		"""\
+		Review file issue audit:
+		- editor failed before producing a validated summary
+
+		PR comment audit:
+		- none
+		"""
+	)
+	result = _run(summary, "2", tmp_path=tmp_path)
+	assert result.returncode == 1
+
+
+def test_exit_two_when_arithmetic_mismatch(tmp_path):
+	"""One entry's total != applied + already_applied + ignored → rc=2.
+	The per-line mismatch warning literal is preserved byte-for-byte."""
+	summary = textwrap.dedent(
+		"""\
+		Review file issue audit:
+		- review_a.md: total issues listed 5, issues applied 1, issues already applied 1, issues ignored 1
+
+		PR comment audit:
+		- none
+		"""
+	)
+	result = _run(summary, "1", tmp_path=tmp_path)
+	assert result.returncode == 2
+	assert "Audit entry arithmetic mismatch: total=5 but applied(1)+already_applied(1)+ignored(1)=3" in result.stderr
+
+
+def test_exit_three_when_summary_file_missing(tmp_path):
+	"""A non-existent summary file path is a usage error → rc=3."""
+	cmd = ["bash", str(HELPER), str(tmp_path / "does-not-exist.txt")]
+	result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+	assert result.returncode == 3
+	assert "missing or unreadable" in result.stderr
+
+
+def test_poller_path_omits_reviewer_count_prefix(tmp_path):
+	"""When called WITHOUT a reviewers_successful argument (the poller's
+	path — it has no `REVIEWERS_SUCCESSFUL` env var), the empty-audit
+	warning omits the reviewer count prefix. The literal still contains
+	the grep-friendly substring so operators searching for "editor audit
+	section is empty" find both message variants."""
+	summary = textwrap.dedent(
+		"""\
+		Review file issue audit:
+		- none
+		"""
+	)
+	result = _run(summary, None, tmp_path=tmp_path)
+	assert result.returncode == 1
+	# Poller-path message: starts the sentence with uppercase "Editor"
+	# and omits the reviewer-count prefix.
+	assert "::warning::Editor audit section is empty or contains only fallback text" in result.stderr
+	assert "reviewer(s) succeeded" not in result.stderr
+
+
+def test_balanced_arithmetic_with_zero_totals_passes(tmp_path):
+	"""Entries with total=0 are skipped by the arithmetic check (they
+	cannot mismatch). A summary with only zero-total entries passes."""
+	summary = textwrap.dedent(
+		"""\
+		Review file issue audit:
+		- review_empty.md: total issues listed 0, issues applied 0, issues already applied 0, issues ignored 0
+		- review_a.md: total issues listed 2, issues applied 0, issues already applied 1, issues ignored 1
+		"""
+	)
+	result = _run(summary, "2", tmp_path=tmp_path)
+	assert result.returncode == 0
+
+
+def test_helper_is_sourceable_as_library(tmp_path):
+	"""Sourcing the helper file defines `validate_editor_audit_arithmetic`
+	but performs no work — the workflow and poller both source it and
+	call the function. A sourcing-and-call dry-run must succeed and
+	return the function's exit code via $?."""
+	summary = tmp_path / "summary.txt"
+	summary.write_text("Review file issue audit:\n- none\n", encoding="utf-8")
+	# `set -e` would propagate a non-zero return from the function; we
+	# disable it to capture the rc explicitly.
+	script = textwrap.dedent(
+		f"""\
+		set +e
+		source {HELPER}
+		validate_editor_audit_arithmetic {summary} 2
+		echo "rc=$?"
+		"""
+	)
+	result = subprocess.run(["bash", "-c", script], capture_output=True, text=True, check=False)
+	assert result.returncode == 0, f"Sourcing the helper itself must not fail; stderr={result.stderr!r}"
+	assert "rc=1" in result.stdout, f"Function should return 1 for empty audit; got stdout={result.stdout!r}"
+
+
+def test_helper_handles_audit_section_followed_by_pr_comment_audit(tmp_path):
+	"""The awk extractor stops at the next top-level "Foo:" header. A
+	"Review file issue audit:" section followed immediately by "PR
+	comment audit:" must include only the audit entries, not the PR
+	comment section. Regression guard for the awk boundary regex."""
+	summary = textwrap.dedent(
+		"""\
+		Review file issue audit:
+		- review_a.md: total issues listed 1, issues applied 1, issues already applied 0, issues ignored 0
+		PR comment audit:
+		- bot/foo: applied
+		Regression fingerprint:
+		- n/a
+		"""
+	)
+	result = _run(summary, "1", tmp_path=tmp_path)
+	# review_a.md's arithmetic balances (1 == 1 + 0 + 0), so rc=0.
+	assert result.returncode == 0

--- a/tests/test_validate_editor_audit.py
+++ b/tests/test_validate_editor_audit.py
@@ -153,6 +153,22 @@ def test_poller_path_omits_reviewer_count_prefix(tmp_path):
 	assert "reviewer(s) succeeded" not in result.stderr
 
 
+def test_non_numeric_reviewer_count_falls_back_to_generic_warning(tmp_path):
+	"""A non-numeric reviewers_successful value must not leak into the
+	exact-string workflow warning literal. The helper should fall back to
+	the generic poller-style warning instead."""
+	summary = textwrap.dedent(
+		"""\
+		Review file issue audit:
+		- none
+		"""
+	)
+	result = _run(summary, "N/A", tmp_path=tmp_path)
+	assert result.returncode == 1
+	assert "::warning::Editor audit section is empty or contains only fallback text" in result.stderr
+	assert "N/A reviewer(s) succeeded" not in result.stderr
+
+
 def test_balanced_arithmetic_with_zero_totals_passes(tmp_path):
 	"""Entries with total=0 are skipped by the arithmetic check (they
 	cannot mismatch). A summary with only zero-total entries passes."""
@@ -189,11 +205,28 @@ def test_helper_is_sourceable_as_library(tmp_path):
 	assert "rc=1" in result.stdout, f"Function should return 1 for empty audit; got stdout={result.stdout!r}"
 
 
+def test_unparseable_audit_line_fails_closed(tmp_path):
+	"""A malformed audit line that cannot be fully parsed must return
+	rc=2 rather than being skipped as healthy."""
+	summary = textwrap.dedent(
+		"""\
+		Review file issue audit:
+		- review_a.md: total issues listed 2, issues applied 1
+
+		PR comment audit:
+		- none
+		"""
+	)
+	result = _run(summary, "1", tmp_path=tmp_path)
+	assert result.returncode == 2
+	assert "Audit entry arithmetic mismatch: unparseable audit line" in result.stderr
+
+
 def test_helper_handles_audit_section_followed_by_pr_comment_audit(tmp_path):
-	"""The awk extractor stops at the next top-level "Foo:" header. A
-	"Review file issue audit:" section followed immediately by "PR
-	comment audit:" must include only the audit entries, not the PR
-	comment section. Regression guard for the awk boundary regex."""
+	"""The extractor stops at the explicit `PR comment audit:` heading.
+	A `Review file issue audit:` section followed immediately by `PR
+	comment audit:` must include only the audit entries, not the PR
+	comment section."""
 	summary = textwrap.dedent(
 		"""\
 		Review file issue audit:


### PR DESCRIPTION
## Summary

When `review_autofix.yml`'s validator decides an editor run is "noop-suspicious" (`EDITOR_NOOP_SUSPICIOUS=true`), the auto-merge step is gated off and the PR stalls forever. Issue-linked PRs eventually recover via the generic standalone-stall path, but standalone `claude/**` branch PRs without a linked issue never do. Original incident: `shubhodeep1/tele-funtoken-msg-scoring#3053` — 9 productive autofix commits landed, the 10th editor invocation converged (every reviewer comment was already-satisfied or correctly out-of-scope), the model still emitted a "Changes made:" narrative with concrete file bullets on each of its 3 attempts, the worktree had no diff because the changes were already on HEAD, the validator tripped, and the PR was frozen.

This PR addresses both halves of the gap:

- **Fix B (recovery)**: orchestrator-poll now sweeps for noop-suspicious PRs after the conflict sweep, re-dispatches up to 3 times, then force-merges iff a multi-gate health check passes (audit healthy, no failing required checks, ≥1 prior productive commit, no opt-out labels). Force-merge fails CLOSED — any single gate failure alerts ERROR and leaves the PR open.
- **Fix C (root cause)**: editor prompt now explicitly teaches the model that convergence is a first-class valid SUCCESS shape (`Changes made:\n- none` + `Change status:\n- not-edited`), forbids fabricated edits added to make the format pass, and adds a self-check step requiring the model to walk through `git status` / `git diff HEAD` before emitting its response.

The reviewer-audit arithmetic check that `review_autofix.yml` uses to detect noop-suspicious in the first place is now `scripts/validate_editor_audit.sh`, called from both the workflow validator AND the poller's force-merge gate so the two paths cannot drift.

## Design notes

**Retry counter**: the count of `⚠️ **Editor no-op suspicious**` comments newer than the latest `[ai-autofix]` / `[judge-fix]` commit IS the counter. No new per-PR state JSON is introduced. The task spec suggested adding `editor_noop_retry_count` to the standalone-state JSON at `scripts/orchestrate_poll_process.sh:5346`, but that JSON is keyed by issue number and cannot represent linked-issue-less PRs — which is exactly the case the recovery sweep needs to cover. The comment-count approach works uniformly for both PR types, has implicit reset on new head SHA (a new productive commit drops the post-commit warning count to 0), and is robust to poller restarts (state lives in GitHub).

**API hygiene (§15)**: the sweep reuses the conflict sweep's `STANDALONE_PRS` cache (no second `gh pr list`). Common case (PR with no noop warnings) costs 1 issues-comments call per PR. The per-PR PR-comment fetch is unavoidable because no existing call in the poll cycle returns PR conversation comments — the candidate-details GraphQL batch fetches issue (not PR) comments, only for issue-linked candidates.

**Automation Bias (§18)**: this extends two existing scripts and one workflow that already run from the scheduler. No new manual script, no new long-running supervisor, no `docs/scripts-pending-removal.md` entry needed.

**Naming Immutability (§6)**: no renames. The shared helper is additive; the editor prompt additions sit between existing section blocks without renaming any heading the downstream validator greps for.

## Commits

1. `8c6d8cf` — extract reviewer audit sanity check to shared helper.
2. `eb67e35` — add noop-suspicious recovery sweep with force-merge fallback.
3. `55eb813` — tighten editor prompt against false-claim convergence.
4. `ca5fbc2` — cover audit helper, recovery sweep, and editor prompt invariants in tests.

## Test plan

- [x] `pytest tests/test_validate_editor_audit.py` — 10 new helper unit tests
- [x] `pytest tests/test_orchestrate_poll_noop_suspicious_recovery.py` — 17 new sweep contract tests
- [x] `pytest tests/test_review_autofix_editor_noop_cascade_contract.py` — 26 tests (15 existing + 11 new for editor prompt + workflow refactor)
- [x] `pytest tests/test_review_apply_fixes_smoke_deterministic.py` — 4 existing smoke tests still pass
- [x] `python3 scripts/check_workflow_script_refs.py --files .github/workflows/review_autofix.yml` — workflow refs resolve
- [x] `bash -n` syntax checks on the three modified shell files
- [x] All 57 affected tests pass; one keyword-matched test (`test_implement_post_codex_recovery.py::test_out_of_scope_noop_when_capture_file_missing`) failed identically on `stable` without these changes — pre-existing sandbox `git commit` env issue, unrelated.
- [ ] After merge: bump `v1.13.x` via `scripts/mark-stable.sh` per the task spec so `@stable` consumers pick up both fixes.
- [ ] After promotion: re-dispatching `ai-review.yml` on `shubhodeep1/tele-funtoken-msg-scoring#3053` will exercise both fixes and merge it.

## Out of scope

Per task spec: no widening of the workflow's structured-format / reviewer-manifest validation, no changes to the `EDITOR_NOOP_SUSPICIOUS` env name (§6), no retroactive fix to PR #3053, no changes to gemini-code-assist daily-quota warnings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTzb9pNyQSMsodpmZF7Zwf)_