### PR TITLE
fix(e2e-smoke): scope Phase 2 plan-poll query to our issue's Plan run

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -743,6 +743,7 @@ jobs:
               PLAN_RUNS_JSON=$(fetch_plan_runs_json || echo "")
               if ! _plan_runs_json_valid "$PLAN_RUNS_JSON"; then
                 echo "  ⏳ Unable to confirm concurrent Plan runs yet — retrying"
+                sleep "$POLL_INTERVAL"
                 continue
               fi
               OTHER_ACTIVE_PLAN_RUNS=0

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -391,6 +391,13 @@ jobs:
           echo "created_after=${TIMESTAMP}" >> "$GITHUB_OUTPUT"
 
           TITLE="[E2E Smoke Test] Update smoke-test canary (run ${RUN_ID})"
+          # Expose TITLE as a step output so Phase 2's plan-poller can scope its
+          # workflow_runs query to this specific issue (via display_title — which
+          # equals the issue title for issue_comment events). Without this scoping,
+          # the poller picks "the latest non-skipped Plan run globally" and is
+          # vulnerable to API per_page truncation when many parallel test workflows
+          # generate >100 workflow runs in the same window.
+          echo "title=${TITLE}" >> "$GITHUB_OUTPUT"
 
           # Single source of truth for the canary spec lives in
           # tests/e2e_smoke_canary_spec.txt with `__RUN_ID__` as the
@@ -581,6 +588,10 @@ jobs:
         id: wait-plan
         env:
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
+          # ISSUE_TITLE scopes the workflow_runs query to OUR Plan run via
+          # display_title (which equals the issue title for issue_comment events).
+          # See create-issue step for rationale.
+          ISSUE_TITLE: ${{ steps.create-issue.outputs.title }}
         run: |
           set -euo pipefail
           echo "Waiting for plan to finish on issue #${ISSUE_NUMBER}..."
@@ -607,7 +618,9 @@ jobs:
           # Robust workflow run-ID capture — retries on empty results to ride out
           # the brief race window where the matching run isn't yet indexed by the
           # API, and widens pagination to per_page=100 in case of high concurrent
-          # workflow run volume on the target repo. Returns the run id on stdout
+          # workflow run volume on the target repo. Filters by display_title so we
+          # only pick up the Plan run that fired for OUR issue (display_title for
+          # issue_comment events is the issue title). Returns the run id on stdout
           # (empty string if all attempts fail).
           capture_run_id() {
             local name_re="$1"
@@ -615,7 +628,7 @@ jobs:
             local _attempt
             for _attempt in 1 2 3 4 5; do
               result=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?per_page=100&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq "[.workflow_runs[] | select(.name | test(\"${name_re}\"; \"i\")) | select(.conclusion != \"skipped\")] | sort_by(.created_at) | last | .id // empty" || echo "")
+                --jq "[.workflow_runs[] | select(.name | test(\"${name_re}\"; \"i\")) | select(.display_title == \"${ISSUE_TITLE}\") | select(.conclusion != \"skipped\")] | sort_by(.created_at) | last | .id // empty" || echo "")
               if [ -n "$result" ] && [ "$result" != "null" ]; then
                 printf '%s' "$result"
                 return 0
@@ -643,9 +656,16 @@ jobs:
             # Track latest comment updated_at so progress comment edits reset the timer
             LATEST_COMMENT_UPDATED=$(echo "${COMMENTS_JSON}" | jq -r '[.[].updated_at] | sort | last // ""' 2>/dev/null || echo "")
 
-            # Also check the plan workflow run status as an activity signal
-            PLAN_RUN_STATUS=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?per_page=50&created=>${{ steps.create-issue.outputs.created_after }}" \
-              --jq '[.workflow_runs[] | select(.name | test("Plan"; "i")) | select(.conclusion != "skipped")] | sort_by(.created_at) | last | .status // "unknown"' || echo "unknown")
+            # Also check the plan workflow run status as an activity signal.
+            # Filter by display_title (== issue title for issue_comment events)
+            # so we pick OUR issue's Plan run, not any concurrent Plan run from
+            # a parallel test job. Bumped per_page from 50 to 100 (the API max)
+            # so the query still surfaces our run when the release window has
+            # high workflow-run volume; v1.13.5's smoke test broke when our
+            # Plan run fell to position 51 in the unfiltered list and was
+            # truncated off the per_page=50 response.
+            PLAN_RUN_STATUS=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?per_page=100&created=>${{ steps.create-issue.outputs.created_after }}" \
+              --jq "[.workflow_runs[] | select(.name | test(\"Plan\"; \"i\")) | select(.display_title == \"${ISSUE_TITLE}\") | select(.conclusion != \"skipped\")] | sort_by(.created_at) | last | .status // \"unknown\"" || echo "unknown")
 
             CUR_STATE="labels=${LABELS};comments=${COMMENT_COUNT};comment_updated=${LATEST_COMMENT_UPDATED};plan_run=${PLAN_RUN_STATUS}"
 
@@ -686,17 +706,21 @@ jobs:
               if echo "$LABELS_RECHECK" | grep -qE 'ai:awaiting-approval|ai:implementing'; then
                 continue
               fi
-              # Check if other Plan runs are still queued or in-progress.
-              # The "completed" run may be a spurious trigger (e.g. non-/answer
-              # comment that caused the job to be skipped) while the real Plan
-              # run is still working.
+              # Check if other Plan runs for OUR issue are still queued or
+              # in-progress. The "completed" run may be a spurious trigger
+              # (e.g. a non-/answer comment that caused the job to be
+              # skipped while the real Plan run is still working). Filter by
+              # display_title (== issue title for issue_comment events) so we
+              # only count Plan runs for OUR issue, and use per_page=100
+              # (the API max) so high concurrent workflow-run volume in the
+              # release window doesn't truncate our run off the response.
               _plan_runs_json_valid() {
                 printf '%s' "$1" \
                   | jq -se 'length == 1 and (.[0] | type == "object" and (.workflow_runs | type == "array"))' \
                   >/dev/null 2>&1
               }
               PLAN_RUNS_JSON='{"workflow_runs":[]}'
-              if _PLAN_RUNS_OUT=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=50&created=>${{ steps.create-issue.outputs.created_after }}" 2>/dev/null); then
+              if _PLAN_RUNS_OUT=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=100&created=>${{ steps.create-issue.outputs.created_after }}" 2>/dev/null); then
                 PLAN_RUNS_JSON="$_PLAN_RUNS_OUT"
               fi
               unset _PLAN_RUNS_OUT
@@ -705,7 +729,7 @@ jobs:
               fi
               OTHER_ACTIVE_PLAN_RUNS=0
               if _OTHER_ACTIVE_PLAN_RUNS=$(printf '%s' "$PLAN_RUNS_JSON" \
-                | jq -r '[.workflow_runs[] | select(.name | test("Plan"; "i")) | select(.status == "in_progress" or .status == "queued")] | length' 2>/dev/null); then
+                | jq -r --arg title "${ISSUE_TITLE}" '[.workflow_runs[] | select(.name | test("Plan"; "i")) | select(.display_title == $title) | select(.status == "in_progress" or .status == "queued")] | length' 2>/dev/null); then
                 OTHER_ACTIVE_PLAN_RUNS="$_OTHER_ACTIVE_PLAN_RUNS"
               fi
               unset _OTHER_ACTIVE_PLAN_RUNS

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -601,6 +601,12 @@ jobs:
           PREV_STATE=""
           RATE_LIMIT_BACKOFF=0
 
+          if [ -z "${ISSUE_TITLE}" ]; then
+            echo "::error::Missing issue title for Plan run scoping"
+            echo "status=plan_failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
           gh_api_safe() {
             local output
             output=$(gh api "$@" 2>/tmp/gh_api_err) && { RATE_LIMIT_BACKOFF=0; echo "$output"; return 0; }
@@ -615,6 +621,20 @@ jobs:
             echo ""; return 1
           }
 
+          fetch_plan_runs_json() {
+            gh_api_safe "repos/${TEST_REPO}/actions/runs?per_page=100&created=>${{ steps.create-issue.outputs.created_after }}"
+          }
+
+          latest_scoped_run_field() {
+            local name_re="$1"
+            local field="$2"
+            local runs_json=""
+            runs_json=$(fetch_plan_runs_json || echo "")
+            [ -n "$runs_json" ] || return 1
+            printf '%s' "$runs_json" \
+              | jq -r --arg name_re "$name_re" --arg title "$ISSUE_TITLE" --arg field "$field" '[.workflow_runs[] | select(.name | test($name_re; "i")) | select(.display_title == $title) | select(.conclusion != "skipped")] | sort_by(.created_at) | last | .[$field] // empty' 2>/dev/null
+          }
+
           # Robust workflow run-ID capture — retries on empty results to ride out
           # the brief race window where the matching run isn't yet indexed by the
           # API, and widens pagination to per_page=100 in case of high concurrent
@@ -627,8 +647,7 @@ jobs:
             local result=""
             local _attempt
             for _attempt in 1 2 3 4 5; do
-              result=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?per_page=100&created=>${{ steps.create-issue.outputs.created_after }}" \
-                --jq "[.workflow_runs[] | select(.name | test(\"${name_re}\"; \"i\")) | select(.display_title == \"${ISSUE_TITLE}\") | select(.conclusion != \"skipped\")] | sort_by(.created_at) | last | .id // empty" || echo "")
+              result=$(latest_scoped_run_field "$name_re" "id" || echo "")
               if [ -n "$result" ] && [ "$result" != "null" ]; then
                 printf '%s' "$result"
                 return 0
@@ -664,8 +683,10 @@ jobs:
             # high workflow-run volume; v1.13.5's smoke test broke when our
             # Plan run fell to position 51 in the unfiltered list and was
             # truncated off the per_page=50 response.
-            PLAN_RUN_STATUS=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?per_page=100&created=>${{ steps.create-issue.outputs.created_after }}" \
-              --jq "[.workflow_runs[] | select(.name | test(\"Plan\"; \"i\")) | select(.display_title == \"${ISSUE_TITLE}\") | select(.conclusion != \"skipped\")] | sort_by(.created_at) | last | .status // \"unknown\"" || echo "unknown")
+            PLAN_RUN_STATUS=$(latest_scoped_run_field "Plan" "status" || echo "")
+            if [ -z "$PLAN_RUN_STATUS" ] || [ "$PLAN_RUN_STATUS" = "null" ]; then
+              PLAN_RUN_STATUS="unknown"
+            fi
 
             CUR_STATE="labels=${LABELS};comments=${COMMENT_COUNT};comment_updated=${LATEST_COMMENT_UPDATED};plan_run=${PLAN_RUN_STATUS}"
 
@@ -719,13 +740,10 @@ jobs:
                   | jq -se 'length == 1 and (.[0] | type == "object" and (.workflow_runs | type == "array"))' \
                   >/dev/null 2>&1
               }
-              PLAN_RUNS_JSON='{"workflow_runs":[]}'
-              if _PLAN_RUNS_OUT=$(gh api "repos/${TEST_REPO}/actions/runs?per_page=100&created=>${{ steps.create-issue.outputs.created_after }}" 2>/dev/null); then
-                PLAN_RUNS_JSON="$_PLAN_RUNS_OUT"
-              fi
-              unset _PLAN_RUNS_OUT
+              PLAN_RUNS_JSON=$(fetch_plan_runs_json || echo "")
               if ! _plan_runs_json_valid "$PLAN_RUNS_JSON"; then
-                PLAN_RUNS_JSON='{"workflow_runs":[]}'
+                echo "  ⏳ Unable to confirm concurrent Plan runs yet — retrying"
+                continue
               fi
               OTHER_ACTIVE_PLAN_RUNS=0
               if _OTHER_ACTIVE_PLAN_RUNS=$(printf '%s' "$PLAN_RUNS_JSON" \

--- a/tests/test_test_and_mark_stable_plan_polling_guard.py
+++ b/tests/test_test_and_mark_stable_plan_polling_guard.py
@@ -23,13 +23,20 @@ def test_other_active_plan_runs_avoids_inline_fallback_substitution() -> None:
 
 def test_plan_runs_payload_is_shape_validated_before_counting() -> None:
 	wf = _read_workflow()
+	retry_guard = 'if ! _plan_runs_json_valid "$PLAN_RUNS_JSON"; then'
+	retry_message = 'echo "  ⏳ Unable to confirm concurrent Plan runs yet — retrying"'
+	sleep_stmt = 'sleep "$POLL_INTERVAL"'
 
 	assert "_plan_runs_json_valid()" in wf
 	assert "jq -se 'length == 1 and (.[0] | type == \"object\" and (.workflow_runs | type == \"array\"))'" in wf
 	assert "PLAN_RUNS_JSON=$(fetch_plan_runs_json || echo \"\")" in wf
 	assert "PLAN_RUNS_JSON='{\"workflow_runs\":[]}'" not in wf
-	assert "if ! _plan_runs_json_valid \"$PLAN_RUNS_JSON\"; then" in wf
-	assert 'echo "  ⏳ Unable to confirm concurrent Plan runs yet — retrying"\n                continue' in wf
+	assert retry_guard in wf
+	retry_guard_idx = wf.index(retry_guard)
+	retry_message_idx = wf.index(retry_message, retry_guard_idx)
+	sleep_idx = wf.index(sleep_stmt, retry_message_idx)
+	continue_idx = wf.index("continue", sleep_idx)
+	assert retry_guard_idx < retry_message_idx < sleep_idx < continue_idx
 	assert "if _OTHER_ACTIVE_PLAN_RUNS=$(printf '%s' \"$PLAN_RUNS_JSON\"" in wf
 
 

--- a/tests/test_test_and_mark_stable_plan_polling_guard.py
+++ b/tests/test_test_and_mark_stable_plan_polling_guard.py
@@ -23,6 +23,7 @@ def test_other_active_plan_runs_avoids_inline_fallback_substitution() -> None:
 
 def test_plan_runs_payload_is_shape_validated_before_counting() -> None:
 	wf = _read_workflow()
+	wf_lines = wf.splitlines()
 	retry_guard = 'if ! _plan_runs_json_valid "$PLAN_RUNS_JSON"; then'
 	retry_message = 'echo "  ⏳ Unable to confirm concurrent Plan runs yet — retrying"'
 	sleep_stmt = 'sleep "$POLL_INTERVAL"'
@@ -32,10 +33,10 @@ def test_plan_runs_payload_is_shape_validated_before_counting() -> None:
 	assert "PLAN_RUNS_JSON=$(fetch_plan_runs_json || echo \"\")" in wf
 	assert "PLAN_RUNS_JSON='{\"workflow_runs\":[]}'" not in wf
 	assert retry_guard in wf
-	retry_guard_idx = wf.index(retry_guard)
-	retry_message_idx = wf.index(retry_message, retry_guard_idx)
-	sleep_idx = wf.index(sleep_stmt, retry_message_idx)
-	continue_idx = wf.index("continue", sleep_idx)
+	retry_guard_idx = next(i for i, line in enumerate(wf_lines) if retry_guard in line)
+	retry_message_idx = next(i for i, line in enumerate(wf_lines) if i > retry_guard_idx and retry_message in line)
+	sleep_idx = next(i for i, line in enumerate(wf_lines) if i > retry_message_idx and sleep_stmt in line)
+	continue_idx = next(i for i, line in enumerate(wf_lines) if i > sleep_idx and line.strip() == "continue")
 	assert retry_guard_idx < retry_message_idx < sleep_idx < continue_idx
 	assert "if _OTHER_ACTIVE_PLAN_RUNS=$(printf '%s' \"$PLAN_RUNS_JSON\"" in wf
 

--- a/tests/test_test_and_mark_stable_plan_polling_guard.py
+++ b/tests/test_test_and_mark_stable_plan_polling_guard.py
@@ -26,8 +26,10 @@ def test_plan_runs_payload_is_shape_validated_before_counting() -> None:
 
 	assert "_plan_runs_json_valid()" in wf
 	assert "jq -se 'length == 1 and (.[0] | type == \"object\" and (.workflow_runs | type == \"array\"))'" in wf
-	assert "PLAN_RUNS_JSON='{\"workflow_runs\":[]}'" in wf
+	assert "PLAN_RUNS_JSON=$(fetch_plan_runs_json || echo \"\")" in wf
+	assert "PLAN_RUNS_JSON='{\"workflow_runs\":[]}'" not in wf
 	assert "if ! _plan_runs_json_valid \"$PLAN_RUNS_JSON\"; then" in wf
+	assert 'echo "  ⏳ Unable to confirm concurrent Plan runs yet — retrying"\n                continue' in wf
 	assert "if _OTHER_ACTIVE_PLAN_RUNS=$(printf '%s' \"$PLAN_RUNS_JSON\"" in wf
 
 


### PR DESCRIPTION
## Summary

Release v1.13.5's `e2e-smoke-test` failed in Phase 2 (`Wait for plan to complete`) with `Plan workflow completed but issue lacks expected labels (current: ai:planning)`. Root cause: the poller picked the wrong Plan workflow run and gave up while OUR run was still working.

The poll query selected "the latest non-skipped Plan run globally" from an API response capped at `per_page=50`:

```
[.workflow_runs[] | select(.name | test("Plan"; "i"))
                 | select(.conclusion != "skipped")]
| sort_by(.created_at) | last | .status
```

In v1.13.5's window, ~80 workflow runs were created across the parallel test jobs (clarify/plan/implement/etc.) before the poller's check. Our Plan run for issue #2829 (run [`26177670206`](https://github.com/shubhodeep1/coding-workflows/actions/runs/26177670206), created at 17:04:06) sat at position 51 in the descending-by-created-at list, so `per_page=50` truncated it off the response. Meanwhile an unrelated concurrent Plan run (`26177702469`, for a different orchestrator-managed issue, completed 17:06:27 as a no-op skip) became "the latest non-skipped Plan run" the query could see. When it transitioned to `completed`, the poller rechecked `#2829`'s labels (still `ai:planning`, because our run was actually still mid-flight), then re-fetched the runs list to count `OTHER_ACTIVE_PLAN_RUNS` — and that query *also* used `per_page=50` and *also* missed our still-running Plan run. The poller exited with `plan_failed` at `17:08:11`; the real Plan run posted the Implementation Plan ~10 seconds later (`17:08:21`).

## Fix

Phase 2 now tracks OUR issue's Plan run specifically:

- **`create-issue`** — expose the issue title as a step output (`title=${TITLE}`).
- **`wait-plan` env** — surface `ISSUE_TITLE` for the polling shell.
- **`capture_run_id`, `PLAN_RUN_STATUS`, `OTHER_ACTIVE_PLAN_RUNS`** — filter by `display_title == ISSUE_TITLE`. For `issue_comment` events, `display_title` defaults to the issue title, which uniquely identifies OUR Plan run.
- Bump `per_page` from 50 to 100 (the GitHub API max) on `PLAN_RUN_STATUS` and `OTHER_ACTIVE_PLAN_RUNS`, matching `capture_run_id` and the other Phase queries, as a defense-in-depth backstop against future traffic spikes.

Phase 1 (Clarify) and Phase 4 (Implement) use the same "latest non-skipped run globally" pattern in their own `capture_run_id` helpers but already query with `per_page=100` and didn't fail this time, so this PR leaves them unchanged. If the same scoping issue surfaces there, fix in a separate change.

## Evidence

- Failing run: https://github.com/shubhodeep1/coding-workflows/actions/runs/26177257854 (job `77011255020`).
- Smoke-test issue: [#2829](https://github.com/shubhodeep1/coding-workflows/issues/2829) — at `17:08:11Z` labels were `ai:planning`; Implementation Plan posted by the real Plan run at `17:08:21Z`; `ai:awaiting-approval` applied at `17:08:38Z`.
- Real Plan run for #2829: [`26177670206`](https://github.com/shubhodeep1/coding-workflows/actions/runs/26177670206) — `display_title="[E2E Smoke Test] Update smoke-test canary (run 26177257854)"`, started `17:04:06`, completed `17:09:40`. Verified by API to be at index 50 (51st) in the descending list of runs created in the polling window.

## Test plan

- [ ] Next stable release run exercises Phase 2 and passes.
- [ ] If a future high-traffic release window pushes our Plan run past the per_page=100 boundary, the `display_title`-scoped filter still surfaces it correctly (the API max is per_page=100, so this is the strongest the filter can get without a different mechanism).

Refs https://github.com/shubhodeep1/coding-workflows/actions/runs/26177257854

https://claude.ai/code/session_01WhmtyKwYXPrM63eENgETTx

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhmtyKwYXPrM63eENgETTx)_