### PR TITLE
fix(fingerprints): skip multi-occurrence partial-removal false positives

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -195,6 +195,7 @@ and shipped:
 - `REISSUE_BASELINE_PRESERVED`
 - `REISSUE_BASELINE_DISCARDED`
 - `REISSUE_MODE`
+- `FINGERPRINT_PARTIAL_REMOVAL_FALSE_POSITIVE_V1`
 - `SEMBLE_QUERY`
 - `SEMBLE_FALLBACK`
 - `SERENA_QUERY`
@@ -251,5 +252,5 @@ it is intentionally large.
 
 ## Integration-sync verifier + bootstrap contract
 
-- `scripts/verify_integration_fingerprints.py` supports `--baseline-fingerprints-state <out>` / `--compare-against-baseline <in>` alongside `--ref`; capture mode records ref-accurate `head_sha` metadata, and compare mode emits `PRE_EXISTING_FINGERPRINT_DRIFT_V1` markers for pre-existing drift that should not block the resolver commit.
+- `scripts/verify_integration_fingerprints.py` supports `--baseline-fingerprints-state <out>` / `--compare-against-baseline <in>` alongside `--ref`; capture mode records ref-accurate `head_sha` metadata, compare mode emits `PRE_EXISTING_FINGERPRINT_DRIFT_V1` markers for pre-existing drift that should not block the resolver commit, and the partial-removal guard emits `FINGERPRINT_PARTIAL_REMOVAL_FALSE_POSITIVE_V1` when it excises a legacy capture-side false positive.
 - `.github/workflows/review_autofix.yml` stages `verify_integration_fingerprints.py`, `review_conflict_prepare.sh`, and `review_conflict_resolve.sh` through `MAIN_PRIMARY_BOOTSTRAP_SCRIPTS` (main snapshot first, branch fallback). `OPTIONAL_BOOTSTRAP_SCRIPTS` is reserved for genuinely optional helpers only.

--- a/agents.md
+++ b/agents.md
@@ -252,5 +252,5 @@ it is intentionally large.
 
 ## Integration-sync verifier + bootstrap contract
 
-- `scripts/verify_integration_fingerprints.py` supports `--baseline-fingerprints-state <out>` / `--compare-against-baseline <in>` alongside `--ref`; capture mode records ref-accurate `head_sha` metadata, compare mode emits `PRE_EXISTING_FINGERPRINT_DRIFT_V1` markers for pre-existing drift that should not block the resolver commit, and the partial-removal guard emits `FINGERPRINT_PARTIAL_REMOVAL_FALSE_POSITIVE_V1` when it excises a legacy capture-side false positive.
+- `scripts/verify_integration_fingerprints.py` supports `--baseline-fingerprints-state <out>` / `--compare-against-baseline <in>` alongside `--ref`; capture mode records ref-accurate `head_sha` metadata, compare mode emits `PRE_EXISTING_FINGERPRINT_DRIFT_V1` markers for pre-existing drift that should not block the resolver commit, and the verifier-side partial-removal defense emits `FINGERPRINT_PARTIAL_REMOVAL_FALSE_POSITIVE_V1` when it suppresses a legacy capture-side false positive.
 - `.github/workflows/review_autofix.yml` stages `verify_integration_fingerprints.py`, `review_conflict_prepare.sh`, and `review_conflict_resolve.sh` through `MAIN_PRIMARY_BOOTSTRAP_SCRIPTS` (main snapshot first, branch fallback). `OPTIONAL_BOOTSTRAP_SCRIPTS` is reserved for genuinely optional helpers only.

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -3051,11 +3051,33 @@ capture_intent_fingerprints_for_merged_subissue() {
     return 0
   fi
 
+  # Resolve the integration branch ref so the post-merge presence filter
+  # inside the python heredoc can read the post-merge file content via
+  # ``git show``. Fingerprint capture runs after the orchestrator detects
+  # the sub-issue PR has merged onto the integration branch, so the
+  # remote tip already reflects the post-merge state. Best-effort fetch
+  # — fail-open: if the fetch fails or the branch is unknown, the python
+  # heredoc skips the post-merge filter (the existing net-change /
+  # substring-overlap filters still apply, and the verifier-side
+  # partial-removal defense catches the remaining false positives).
+  local integration_branch_for_capture integration_ref_for_capture=""
+  integration_branch_for_capture="$(jq -r '.integration_branch // empty' "${STATE_FILE}" 2>/dev/null || echo "")"
+  if [ -n "${integration_branch_for_capture}" ] && [ "${integration_branch_for_capture}" != "null" ]; then
+    if git fetch --no-tags --quiet origin \
+        "refs/heads/${integration_branch_for_capture}:refs/remotes/origin/${integration_branch_for_capture}" \
+        2>/dev/null; then
+      integration_ref_for_capture="refs/remotes/origin/${integration_branch_for_capture}"
+    elif git rev-parse --verify --quiet "refs/remotes/origin/${integration_branch_for_capture}" >/dev/null 2>&1; then
+      integration_ref_for_capture="refs/remotes/origin/${integration_branch_for_capture}"
+    fi
+  fi
+
   local fp_json
   fp_json="$(FINGERPRINT_PER_FILE_CAP="${FINGERPRINT_PER_FILE_CAP}" \
     FINGERPRINT_MIN_PATTERN_CHARS="${FINGERPRINT_MIN_PATTERN_CHARS}" \
+    FINGERPRINT_POST_MERGE_REF="${integration_ref_for_capture}" \
     python3 - "${diff_file}" <<'PY' 2>/dev/null || true
-import json, os, re, sys
+import json, os, re, subprocess, sys
 from collections import Counter
 
 cap = int(os.environ.get("FINGERPRINT_PER_FILE_CAP", "12"))
@@ -3249,6 +3271,56 @@ for p in removed_paths:
         continue
     seen_removed_paths.add(p)
     removed_paths_unique.append(p)
+
+# Post-merge presence filter: drop any removed line whose stripped
+# text still appears in the post-merge file content. This catches
+# the multi-occurrence partial-removal case: a PR that removes line
+# X from one position while leaving X at other positions in the same
+# file. The unified-diff parser only sees the per-position removal,
+# so X ends up in must_not_contain even though it survives in the
+# post-merge tree. Without this filter the verifier later re-detects
+# X (because re.search hits an unchanged occurrence) and reports a
+# fake regression. The post-merge ref is the integration branch tip
+# at capture time — capture runs after the orchestrator observes the
+# sub-issue PR as merged, so the integration branch already reflects
+# the merge. Fail-open: any git failure (no ref, file absent, decode
+# error) leaves the candidate line in place; the verifier-side
+# partial-removal defense in scripts/verify_integration_fingerprints.py
+# provides the second line of defense for those leftover false
+# positives.
+post_merge_ref = (os.environ.get("FINGERPRINT_POST_MERGE_REF") or "").strip()
+if post_merge_ref and per_file_removed:
+    for path in list(per_file_removed.keys()):
+        try:
+            git_result = subprocess.run(
+                ["git", "show", f"{post_merge_ref}:{path}"],
+                capture_output=True,
+                check=False,
+                timeout=15,
+            )
+        except Exception:
+            continue
+        if git_result.returncode != 0:
+            continue
+        try:
+            post_merge_content = git_result.stdout.decode("utf-8", errors="replace")
+        except Exception:
+            continue
+        kept_lines: list[str] = []
+        for raw in per_file_removed[path]:
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            try:
+                if re.search(re.escape(stripped), post_merge_content):
+                    continue
+            except re.error:
+                pass
+            kept_lines.append(raw)
+        if kept_lines:
+            per_file_removed[path] = kept_lines
+        else:
+            del per_file_removed[path]
 
 result = {
     "must_contain": to_patterns(per_file_added),

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -3060,13 +3060,22 @@ capture_intent_fingerprints_for_merged_subissue() {
   # filter rather than reading a potentially stale local ref (the existing
   # net-change / substring-overlap filters still apply, and the verifier-
   # side partial-removal defense catches the remaining false positives).
-  local integration_branch_for_capture integration_ref_for_capture=""
+  local integration_branch_for_capture integration_ref_for_capture="" integration_fetch_timeout_secs="${GIT_COMMAND_TIMEOUT_SECS:-30}"
+  case "${integration_fetch_timeout_secs}" in
+    ''|*[!0-9]*) integration_fetch_timeout_secs=30 ;;
+  esac
+  if [ "${integration_fetch_timeout_secs}" -le 0 ]; then
+    integration_fetch_timeout_secs=30
+  fi
   integration_branch_for_capture="$(jq -r '.integration_branch // empty' "${STATE_FILE}" 2>/dev/null || echo "")"
   if [ -n "${integration_branch_for_capture}" ] && [ "${integration_branch_for_capture}" != "null" ]; then
     if git check-ref-format "refs/heads/${integration_branch_for_capture}" >/dev/null 2>&1 \
       && git remote get-url origin >/dev/null 2>&1 \
-      && git fetch --no-tags --quiet origin "${integration_branch_for_capture}" >/dev/null 2>&1; then
+      && env GIT_TERMINAL_PROMPT=0 timeout "${integration_fetch_timeout_secs}s" \
+        git fetch --no-tags --quiet origin "${integration_branch_for_capture}" >/dev/null 2>&1; then
       integration_ref_for_capture="$(git rev-parse --verify FETCH_HEAD 2>/dev/null || echo "")"
+    else
+      echo "::notice::capture_intent_fingerprints_for_merged_subissue: skipping post-merge presence filter for '${integration_branch_for_capture}' because integration ref refresh failed or timed out after ${integration_fetch_timeout_secs}s." >&2
     fi
   fi
 

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -3056,8 +3056,9 @@ capture_intent_fingerprints_for_merged_subissue() {
   # orchestrator detects the sub-issue PR has merged onto the integration
   # branch, so a successful fetch's FETCH_HEAD already reflects the
   # post-merge state. Fail-open: if the branch name is invalid, origin is
-  # unavailable, or the fetch fails, the heredoc skips the post-merge
-  # filter rather than reading a potentially stale local ref (the existing
+  # unavailable, the timeout wrapper is missing, or the fetch fails, the
+  # heredoc skips the post-merge filter rather than reading a potentially
+  # stale local ref (the existing
   # net-change / substring-overlap filters still apply, and the verifier-
   # side partial-removal defense catches the remaining false positives).
   local integration_branch_for_capture integration_ref_for_capture="" integration_fetch_timeout_secs="${GIT_COMMAND_TIMEOUT_SECS:-30}"
@@ -3069,7 +3070,9 @@ capture_intent_fingerprints_for_merged_subissue() {
   fi
   integration_branch_for_capture="$(jq -r '.integration_branch // empty' "${STATE_FILE}" 2>/dev/null || echo "")"
   if [ -n "${integration_branch_for_capture}" ] && [ "${integration_branch_for_capture}" != "null" ]; then
-    if git check-ref-format "refs/heads/${integration_branch_for_capture}" >/dev/null 2>&1 \
+    if ! command -v timeout >/dev/null 2>&1; then
+      echo "::notice::capture_intent_fingerprints_for_merged_subissue: skipping post-merge presence filter for '${integration_branch_for_capture}' because 'timeout' is not available on this runner." >&2
+    elif git check-ref-format "refs/heads/${integration_branch_for_capture}" >/dev/null 2>&1 \
       && git remote get-url origin >/dev/null 2>&1 \
       && env GIT_TERMINAL_PROMPT=0 timeout "${integration_fetch_timeout_secs}s" \
         git fetch --no-tags --quiet origin "${integration_branch_for_capture}" >/dev/null 2>&1; then

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -3051,24 +3051,22 @@ capture_intent_fingerprints_for_merged_subissue() {
     return 0
   fi
 
-  # Resolve the integration branch ref so the post-merge presence filter
-  # inside the python heredoc can read the post-merge file content via
-  # ``git show``. Fingerprint capture runs after the orchestrator detects
-  # the sub-issue PR has merged onto the integration branch, so the
-  # remote tip already reflects the post-merge state. Best-effort fetch
-  # — fail-open: if the fetch fails or the branch is unknown, the python
-  # heredoc skips the post-merge filter (the existing net-change /
-  # substring-overlap filters still apply, and the verifier-side
-  # partial-removal defense catches the remaining false positives).
+  # Resolve a fresh integration-branch commit for the post-merge presence
+  # filter inside the python heredoc. Fingerprint capture runs after the
+  # orchestrator detects the sub-issue PR has merged onto the integration
+  # branch, so a successful fetch's FETCH_HEAD already reflects the
+  # post-merge state. Fail-open: if the branch name is invalid, origin is
+  # unavailable, or the fetch fails, the heredoc skips the post-merge
+  # filter rather than reading a potentially stale local ref (the existing
+  # net-change / substring-overlap filters still apply, and the verifier-
+  # side partial-removal defense catches the remaining false positives).
   local integration_branch_for_capture integration_ref_for_capture=""
   integration_branch_for_capture="$(jq -r '.integration_branch // empty' "${STATE_FILE}" 2>/dev/null || echo "")"
   if [ -n "${integration_branch_for_capture}" ] && [ "${integration_branch_for_capture}" != "null" ]; then
-    if git fetch --no-tags --quiet origin \
-        "refs/heads/${integration_branch_for_capture}:refs/remotes/origin/${integration_branch_for_capture}" \
-        2>/dev/null; then
-      integration_ref_for_capture="refs/remotes/origin/${integration_branch_for_capture}"
-    elif git rev-parse --verify --quiet "refs/remotes/origin/${integration_branch_for_capture}" >/dev/null 2>&1; then
-      integration_ref_for_capture="refs/remotes/origin/${integration_branch_for_capture}"
+    if git check-ref-format "refs/heads/${integration_branch_for_capture}" >/dev/null 2>&1 \
+      && git remote get-url origin >/dev/null 2>&1 \
+      && git fetch --no-tags --quiet origin "${integration_branch_for_capture}" >/dev/null 2>&1; then
+      integration_ref_for_capture="$(git rev-parse --verify FETCH_HEAD 2>/dev/null || echo "")"
     fi
   fi
 
@@ -3082,6 +3080,7 @@ from collections import Counter
 
 cap = int(os.environ.get("FINGERPRINT_PER_FILE_CAP", "12"))
 minlen = int(os.environ.get("FINGERPRINT_MIN_PATTERN_CHARS", "12"))
+git_timeout_secs = int(os.environ.get("GIT_COMMAND_TIMEOUT_SECS", "30"))
 
 ALLOWED_PREFIXES = (
     ".github/", "scripts/", "prompts/", "ai-memory/",
@@ -3296,7 +3295,7 @@ if post_merge_ref and per_file_removed:
                 ["git", "show", f"{post_merge_ref}:{path}"],
                 capture_output=True,
                 check=False,
-                timeout=15,
+                timeout=git_timeout_secs,
             )
         except Exception:
             continue

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -3085,6 +3085,7 @@ capture_intent_fingerprints_for_merged_subissue() {
   local fp_json
   fp_json="$(FINGERPRINT_PER_FILE_CAP="${FINGERPRINT_PER_FILE_CAP}" \
     FINGERPRINT_MIN_PATTERN_CHARS="${FINGERPRINT_MIN_PATTERN_CHARS}" \
+    GIT_COMMAND_TIMEOUT_SECS="${integration_fetch_timeout_secs}" \
     FINGERPRINT_POST_MERGE_REF="${integration_ref_for_capture}" \
     python3 - "${diff_file}" <<'PY' 2>/dev/null || true
 import json, os, re, subprocess, sys

--- a/scripts/verify_integration_fingerprints.py
+++ b/scripts/verify_integration_fingerprints.py
@@ -304,10 +304,11 @@ def _find_pr_merge_commit_for_path(ref: str | None, pr_num: Any, path: str) -> s
 
 	Used by the must_not_contain partial-removal false-positive defense
 	to look up the file's post-merge state at the captured PR's merge
-	commit. Walks the integration branch history with
-	``git log -n 1 --format=%H --grep="#<pr_num>" <ref> -- <path>``
-	(default GitHub squash-merge commit subjects include the PR number
-	in the form ``(#1234)``, which is what this grep targets).
+	commit. Walks the integration branch history oldest-first and picks
+	the first commit whose *subject* ends with the GitHub squash-merge
+	marker ``(#<pr_num>)``. This avoids selecting a later follow-up
+	commit that merely mentions the PR number while touching the same
+	path.
 
 	Args:
 		ref: git ref to walk; if None, falls back to ``HEAD``.
@@ -339,8 +340,8 @@ def _find_pr_merge_commit_for_path(ref: str | None, pr_num: Any, path: str) -> s
 		git_result = subprocess.run(
 			[
 				"git", "log",
-				"-n", "1",
-				"--format=%H",
+				"--reverse",
+				"--format=%H%x00%s",
 				f"--grep=#{pr_str}\\b",
 				"-E",
 				effective_ref,
@@ -357,8 +358,15 @@ def _find_pr_merge_commit_for_path(ref: str | None, pr_num: Any, path: str) -> s
 	if git_result.returncode != 0:
 		_PR_MERGE_COMMIT_CACHE[cache_key] = None
 		return None
-	sha = git_result.stdout.decode("utf-8", errors="replace").strip()
-	resolved = sha if sha else None
+	merge_suffix = f"(#{pr_str})"
+	resolved = None
+	for raw_line in git_result.stdout.decode("utf-8", errors="replace").splitlines():
+		sha, _sep, subject = raw_line.partition("\x00")
+		if not sha or not subject:
+			continue
+		if subject.rstrip().endswith(merge_suffix):
+			resolved = sha.strip() or None
+			break
 	_PR_MERGE_COMMIT_CACHE[cache_key] = resolved
 	return resolved
 

--- a/scripts/verify_integration_fingerprints.py
+++ b/scripts/verify_integration_fingerprints.py
@@ -286,6 +286,166 @@ def _path_exists(path: str, exists_cache: dict[str, tuple[bool, str | None]], re
 	return exists
 
 
+# Cache for _find_pr_merge_commit_for_path keyed on (ref, pr_num, normalized_path).
+# Populated lazily during verify; bounded by the number of distinct
+# (issue, path) pairs in the fingerprint state, which is small.
+_PR_MERGE_COMMIT_CACHE: dict[tuple[str, str, str], str | None] = {}
+
+# Cache for file content at a specific ref/path used by the partial-removal
+# false-positive defense. Distinct from _read_file_result's cache because
+# the defense reads at the PR's merge commit (a different ref than the
+# verifier's current ref) and we want to avoid re-shelling out git show
+# for the same (merge_commit, path) pair across issues / patterns.
+_PARTIAL_REMOVAL_POST_MERGE_CACHE: dict[tuple[str, str], str | None] = {}
+
+
+def _find_pr_merge_commit_for_path(ref: str | None, pr_num: Any, path: str) -> str | None:
+	"""Find the commit on ``ref`` (or HEAD) that merged PR #pr_num and touched ``path``.
+
+	Used by the must_not_contain partial-removal false-positive defense
+	to look up the file's post-merge state at the captured PR's merge
+	commit. Walks the integration branch history with
+	``git log -n 1 --format=%H --grep="#<pr_num>" <ref> -- <path>``
+	(default GitHub squash-merge commit subjects include the PR number
+	in the form ``(#1234)``, which is what this grep targets).
+
+	Args:
+		ref: git ref to walk; if None, falls back to ``HEAD``.
+		pr_num: the PR number captured in the fingerprint entry.
+		path: the file path the fingerprint pattern targets.
+
+	Returns:
+		The merge commit SHA on success; None when the PR can't be
+		identified, the git plumbing fails, or the inputs are invalid.
+		Callers MUST treat None as "defense check inconclusive" and
+		fall through to the original violation.
+
+	API call count: zero (uses ``git`` locally). Cached per
+	(ref, pr_num, normalized_path) so repeated fingerprint patterns
+	on the same file share a single ``git log`` invocation. Fail-open
+	on any subprocess / encoding error.
+	"""
+	pr_str = str(pr_num).strip() if pr_num is not None else ""
+	if not pr_str.isdigit():
+		return None
+	normalized_path, path_error = _normalize_repo_path(path)
+	if path_error is not None or normalized_path is None:
+		return None
+	effective_ref = _normalize_ref(ref) or "HEAD"
+	cache_key = (effective_ref, pr_str, normalized_path)
+	if cache_key in _PR_MERGE_COMMIT_CACHE:
+		return _PR_MERGE_COMMIT_CACHE[cache_key]
+	try:
+		git_result = subprocess.run(
+			[
+				"git", "log",
+				"-n", "1",
+				"--format=%H",
+				f"--grep=#{pr_str}\\b",
+				"-E",
+				effective_ref,
+				"--",
+				normalized_path,
+			],
+			capture_output=True,
+			check=False,
+			timeout=GIT_COMMAND_TIMEOUT_SECS,
+		)
+	except Exception:  # noqa: BLE001 — defense check must stay fail-open
+		_PR_MERGE_COMMIT_CACHE[cache_key] = None
+		return None
+	if git_result.returncode != 0:
+		_PR_MERGE_COMMIT_CACHE[cache_key] = None
+		return None
+	sha = git_result.stdout.decode("utf-8", errors="replace").strip()
+	resolved = sha if sha else None
+	_PR_MERGE_COMMIT_CACHE[cache_key] = resolved
+	return resolved
+
+
+def _read_file_at_merge_commit(merge_commit: str, path: str) -> str | None:
+	"""Read file content from a specific git commit.
+
+	Used by the must_not_contain partial-removal false-positive defense
+	to inspect the file's state at the captured PR's merge commit.
+	Cached per (merge_commit, normalized_path) so repeated lookups
+	don't re-shell out.
+
+	Returns None on any failure (file absent at that commit, git error,
+	encoding error). Callers MUST treat None as "defense check
+	inconclusive".
+	"""
+	if not merge_commit:
+		return None
+	normalized_path, path_error = _normalize_repo_path(path)
+	if path_error is not None or normalized_path is None:
+		return None
+	cache_key = (merge_commit, normalized_path)
+	if cache_key in _PARTIAL_REMOVAL_POST_MERGE_CACHE:
+		return _PARTIAL_REMOVAL_POST_MERGE_CACHE[cache_key]
+	try:
+		git_result = subprocess.run(
+			["git", "show", f"{merge_commit}:{normalized_path}"],
+			capture_output=True,
+			check=False,
+			timeout=GIT_COMMAND_TIMEOUT_SECS,
+		)
+	except Exception:  # noqa: BLE001 — defense check must stay fail-open
+		_PARTIAL_REMOVAL_POST_MERGE_CACHE[cache_key] = None
+		return None
+	if git_result.returncode != 0:
+		_PARTIAL_REMOVAL_POST_MERGE_CACHE[cache_key] = None
+		return None
+	try:
+		content = git_result.stdout.decode("utf-8", errors="replace")
+	except Exception:  # noqa: BLE001 — defense check must stay fail-open
+		_PARTIAL_REMOVAL_POST_MERGE_CACHE[cache_key] = None
+		return None
+	_PARTIAL_REMOVAL_POST_MERGE_CACHE[cache_key] = content
+	return content
+
+
+def _is_must_not_contain_partial_removal_false_positive(
+	ref: str | None,
+	pr_num: Any,
+	path: str,
+	pattern: "re.Pattern[str]",
+) -> str | None:
+	"""Detect must_not_contain capture false positives (multi-occurrence partial removal).
+
+	Capture emits a must_not_contain pattern for every PR-removed line
+	that survives the existing net-change / substring-overlap filters
+	in ``capture_intent_fingerprints_for_merged_subissue``. Neither
+	filter catches the case where a line existed at N>1 distinct
+	positions in the file pre-PR and the PR only removed K<N of them:
+	the line still exists in the post-merge file, but capture records
+	a must_not_contain anyway and verify later trips on the unchanged
+	occurrences as a fake "reappeared" violation.
+
+	This defense detects the case by re-reading the file at the
+	captured PR's merge commit: if the pattern still matches there,
+	then the PR did not fully delete the line and the captured
+	must_not_contain entry is a false positive that should be skipped
+	(with a warning marker so the bug is observable).
+
+	Returns the merge commit SHA when the pattern is confirmed as a
+	false positive (caller should skip the violation); None otherwise
+	(caller should surface the original violation). Fail-open on any
+	plumbing error so genuine regressions still fail the gate.
+	"""
+	merge_commit = _find_pr_merge_commit_for_path(ref, pr_num, path)
+	if not merge_commit:
+		return None
+	post_merge_content = _read_file_at_merge_commit(merge_commit, path)
+	if post_merge_content is None:
+		return None
+	try:
+		matched = bool(pattern.search(post_merge_content))
+	except Exception:  # noqa: BLE001 — defense check must stay fail-open
+		return None
+	return merge_commit if matched else None
+
+
 def _fp_key(fp: Any) -> tuple[str, str] | None:
 	if not isinstance(fp, dict):
 		return None
@@ -654,6 +814,34 @@ def _evaluate_fp_state(
 			"violation": None,
 		}
 	if pattern.search(content):
+		false_positive_merge_commit = _is_must_not_contain_partial_removal_false_positive(
+			ref, pr_num, path, pattern,
+		)
+		if false_positive_merge_commit:
+			print(
+				f"::warning::FINGERPRINT_PARTIAL_REMOVAL_FALSE_POSITIVE_V1 "
+				f"issue=#{issue_num} pr=#{pr_num} file={path} "
+				f"merge_commit={false_positive_merge_commit[:12]} "
+				f"reason=must_not_contain_pattern_still_present_at_pr_merge_commit",
+				flush=True,
+			)
+			print(
+				f"::warning::issue #{issue_num} (PR #{pr_num}): must_not_contain pattern in '{path}' "
+				"classified as capture-side false positive (line was already present in the "
+				"file at the captured PR's merge commit — capture should have dropped the "
+				"pattern under the multi-occurrence partial-removal filter). "
+				f"Skipping violation. Pattern (first 200 chars): {regex_src[:200]}",
+				flush=True,
+			)
+			return {
+				"kind": kind,
+				"path": path,
+				"regex": regex_src,
+				"fp_key": fp_key,
+				"satisfied": True,
+				"check_error": None,
+				"violation": None,
+			}
 		return {
 			"kind": kind,
 			"path": path,

--- a/scripts/verify_integration_fingerprints.py
+++ b/scripts/verify_integration_fingerprints.py
@@ -927,6 +927,8 @@ def list_violated_files(fingerprints: dict[str, Any], ref: str | None = None) ->
 	for issue_key, entry in fingerprints.items():
 		if not isinstance(entry, dict):
 			continue
+		issue_num = entry.get("issue", issue_key)
+		pr_num = entry.get("pr", "?")
 		# Cross-dedup: stay silent in list-violated-files mode — the stdout
 		# contract is "file paths ONLY" and the verify path already emits the
 		# operator-visible warnings.
@@ -938,7 +940,7 @@ def list_violated_files(fingerprints: dict[str, Any], ref: str | None = None) ->
 		must_not_exist = entry.get("must_not_exist", []) or []
 
 		for fp in must_contain:
-			state = _evaluate_fp_state(fp, "must_contain", issue_num="?", pr_num="?", file_cache=file_cache, exists_cache=exists_cache, ref=ref)
+			state = _evaluate_fp_state(fp, "must_contain", issue_num=issue_num, pr_num=pr_num, file_cache=file_cache, exists_cache=exists_cache, ref=ref)
 			if state is None:
 				continue
 			if state["check_error"] is not None:
@@ -947,7 +949,7 @@ def list_violated_files(fingerprints: dict[str, Any], ref: str | None = None) ->
 				violated.add(state["path"])
 
 		for fp in must_not_contain:
-			state = _evaluate_fp_state(fp, "must_not_contain", issue_num="?", pr_num="?", file_cache=file_cache, exists_cache=exists_cache, ref=ref)
+			state = _evaluate_fp_state(fp, "must_not_contain", issue_num=issue_num, pr_num=pr_num, file_cache=file_cache, exists_cache=exists_cache, ref=ref)
 			if state is None:
 				continue
 			if state["check_error"] is not None:
@@ -956,7 +958,7 @@ def list_violated_files(fingerprints: dict[str, Any], ref: str | None = None) ->
 				violated.add(state["path"])
 
 		for fp in must_not_exist:
-			state = _evaluate_fp_state(fp, "must_not_exist", issue_num="?", pr_num="?", file_cache=file_cache, exists_cache=exists_cache, ref=ref)
+			state = _evaluate_fp_state(fp, "must_not_exist", issue_num=issue_num, pr_num=pr_num, file_cache=file_cache, exists_cache=exists_cache, ref=ref)
 			if state is None:
 				continue
 			if state["check_error"] is not None:

--- a/scripts/verify_integration_fingerprints.py
+++ b/scripts/verify_integration_fingerprints.py
@@ -333,6 +333,7 @@ def _find_pr_merge_commit_for_path(ref: str | None, pr_num: Any, path: str) -> s
 	if path_error is not None or normalized_path is None:
 		return None
 	effective_ref = _normalize_ref(ref) or "HEAD"
+	merge_suffix = f"(#{pr_str})"
 	cache_key = (effective_ref, pr_str, normalized_path)
 	if cache_key in _PR_MERGE_COMMIT_CACHE:
 		return _PR_MERGE_COMMIT_CACHE[cache_key]
@@ -342,8 +343,7 @@ def _find_pr_merge_commit_for_path(ref: str | None, pr_num: Any, path: str) -> s
 				"git", "log",
 				"--reverse",
 				"--format=%H%x00%s",
-				f"--grep=#{pr_str}\\b",
-				"-E",
+				f"--grep={merge_suffix}",
 				effective_ref,
 				"--",
 				normalized_path,
@@ -358,7 +358,6 @@ def _find_pr_merge_commit_for_path(ref: str | None, pr_num: Any, path: str) -> s
 	if git_result.returncode != 0:
 		_PR_MERGE_COMMIT_CACHE[cache_key] = None
 		return None
-	merge_suffix = f"(#{pr_str})"
 	resolved = None
 	for raw_line in git_result.stdout.decode("utf-8", errors="replace").splitlines():
 		sha, _sep, subject = raw_line.partition("\x00")
@@ -832,6 +831,7 @@ def _evaluate_fp_state(
 				f"merge_commit={false_positive_merge_commit[:12]} "
 				f"reason=must_not_contain_pattern_still_present_at_pr_merge_commit",
 				flush=True,
+				file=sys.stderr,
 			)
 			print(
 				f"::warning::issue #{issue_num} (PR #{pr_num}): must_not_contain pattern in '{path}' "
@@ -840,6 +840,7 @@ def _evaluate_fp_state(
 				"pattern under the multi-occurrence partial-removal filter). "
 				f"Skipping violation. Pattern (first 200 chars): {regex_src[:200]}",
 				flush=True,
+				file=sys.stderr,
 			)
 			return {
 				"kind": kind,

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -7140,6 +7140,9 @@ def test_capture_intent_fingerprints_helper_is_defined_and_idempotent():
 	assert "capture_intent_fingerprints_for_merged_subissue()" in script
 	assert "FINGERPRINT_PER_FILE_CAP" in script
 	assert "FINGERPRINT_MIN_PATTERN_CHARS" in script
+	assert "FINGERPRINT_POST_MERGE_REF" in script
+	assert "git rev-parse --verify FETCH_HEAD" in script
+	assert 'elif git rev-parse --verify --quiet "refs/remotes/origin/${integration_branch_for_capture}"' not in script
 	# Idempotency guard — must short-circuit when fingerprints are
 	# already recorded for that issue.
 	assert ".merged_issue_fingerprints[$k]" in script

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -7142,6 +7142,7 @@ def test_capture_intent_fingerprints_helper_is_defined_and_idempotent():
 	assert "FINGERPRINT_MIN_PATTERN_CHARS" in script
 	assert "FINGERPRINT_POST_MERGE_REF" in script
 	assert "git rev-parse --verify FETCH_HEAD" in script
+	assert "command -v timeout >/dev/null 2>&1" in script
 	assert 'GIT_TERMINAL_PROMPT=0 timeout "${integration_fetch_timeout_secs}s"' in script
 	assert "skipping post-merge presence filter" in script
 	assert 'elif git rev-parse --verify --quiet "refs/remotes/origin/${integration_branch_for_capture}"' not in script

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -7142,6 +7142,8 @@ def test_capture_intent_fingerprints_helper_is_defined_and_idempotent():
 	assert "FINGERPRINT_MIN_PATTERN_CHARS" in script
 	assert "FINGERPRINT_POST_MERGE_REF" in script
 	assert "git rev-parse --verify FETCH_HEAD" in script
+	assert 'GIT_TERMINAL_PROMPT=0 timeout "${integration_fetch_timeout_secs}s"' in script
+	assert "skipping post-merge presence filter" in script
 	assert 'elif git rev-parse --verify --quiet "refs/remotes/origin/${integration_branch_for_capture}"' not in script
 	# Idempotency guard — must short-circuit when fingerprints are
 	# already recorded for that issue.

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -7143,6 +7143,7 @@ def test_capture_intent_fingerprints_helper_is_defined_and_idempotent():
 	assert "FINGERPRINT_POST_MERGE_REF" in script
 	assert "git rev-parse --verify FETCH_HEAD" in script
 	assert "command -v timeout >/dev/null 2>&1" in script
+	assert 'GIT_COMMAND_TIMEOUT_SECS="${integration_fetch_timeout_secs}"' in script
 	assert 'GIT_TERMINAL_PROMPT=0 timeout "${integration_fetch_timeout_secs}s"' in script
 	assert "skipping post-merge presence filter" in script
 	assert 'elif git rev-parse --verify --quiet "refs/remotes/origin/${integration_branch_for_capture}"' not in script

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -7225,6 +7225,24 @@ def test_verify_integration_fingerprints_baseline_regressions():
 			value()
 
 
+def test_verify_integration_fingerprints_partial_removal_regressions():
+	# CI/release workflows run explicit `python3 tests/<file>.py` allowlists,
+	# so execute the dedicated partial-removal verifier suite from this
+	# already-allowlisted harness too.
+	import importlib.util
+
+	spec = importlib.util.spec_from_file_location(
+		"test_verify_integration_fingerprints_partial_removal",
+		REPO_ROOT / "tests" / "test_verify_integration_fingerprints_partial_removal.py",
+	)
+	assert spec is not None and spec.loader is not None
+	mod = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(mod)
+	for name, value in sorted(vars(mod).items()):
+		if name.startswith("test_") and callable(value):
+			value()
+
+
 def test_verify_integration_fingerprints_passes_when_intent_preserved():
 	mod = _verifier_module()
 	files = {

--- a/tests/test_verify_integration_fingerprints_partial_removal.py
+++ b/tests/test_verify_integration_fingerprints_partial_removal.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+"""Regression coverage for the must_not_contain partial-removal false-positive defense.
+
+When a sub-issue PR removes ONE occurrence of a line that recurs at
+multiple positions in the same file, the pre-existing capture filters
+(net-change, substring-overlap) still emit a ``must_not_contain``
+fingerprint for that line. At verify time the unchanged occurrences
+trip ``re.search`` and the verifier reports a fake "reappeared"
+violation that blocks the next wave's dispatch.
+
+This test sets up a small git repo that reproduces exactly that case
+(based on the project #2836 wave 3 incident on
+``orchestrator/project-2836`` — PR #2840 changed one of three
+``previous_state["consecutive_failure_count"] = 4`` occurrences in
+``tests/test_review_conflict_resolve_retry_state.py`` to ``= 7`` and
+left the other two intact) and asserts that:
+
+  * the verifier's ``_is_must_not_contain_partial_removal_false_positive``
+    helper classifies the captured fingerprint as a false positive
+    (returns the merge commit SHA, not None);
+  * end-to-end ``main([fingerprints.json])`` exits 0 (the violation is
+    skipped) and emits the ``FINGERPRINT_PARTIAL_REMOVAL_FALSE_POSITIVE_V1``
+    marker plus a human-readable warning;
+  * the defense is conservative — when the pattern is truly absent
+    from the file at the PR's merge commit (a real regression
+    introduced after the merge), the verifier still fails the gate.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterator
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _verifier_module():
+	spec = importlib.util.spec_from_file_location(
+		"verify_integration_fingerprints",
+		REPO_ROOT / "scripts" / "verify_integration_fingerprints.py",
+	)
+	assert spec is not None and spec.loader is not None
+	mod = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(mod)
+	return mod
+
+
+def _run_git(cwd: Path, *args: str, env_overrides: dict[str, str] | None = None) -> str:
+	env = os.environ.copy()
+	env.update({
+		"GIT_AUTHOR_NAME": "Test Bot",
+		"GIT_AUTHOR_EMAIL": "test@example.invalid",
+		"GIT_COMMITTER_NAME": "Test Bot",
+		"GIT_COMMITTER_EMAIL": "test@example.invalid",
+	})
+	if env_overrides:
+		env.update(env_overrides)
+	result = subprocess.run(
+		["git", *args],
+		cwd=str(cwd),
+		capture_output=True,
+		check=True,
+		env=env,
+	)
+	return result.stdout.decode("utf-8", errors="replace")
+
+
+def _run_verifier(mod, argv: list[str], cwd: Path) -> tuple[int, str, str]:
+	out_buf = io.StringIO()
+	err_buf = io.StringIO()
+	prev_cwd = os.getcwd()
+	try:
+		os.chdir(cwd)
+		with contextlib.redirect_stdout(out_buf), contextlib.redirect_stderr(err_buf):
+			rc = mod.main(argv)
+	finally:
+		os.chdir(prev_cwd)
+	return rc, out_buf.getvalue(), err_buf.getvalue()
+
+
+def _clear_verifier_caches(mod) -> None:
+	"""Defensive: each test must observe a fresh git-lookup state.
+
+	The defense helpers cache merge-commit lookups and file content
+	keyed on ``(ref, pr_num, path)`` to avoid duplicate git shells
+	across the many patterns / issues a single verify run inspects.
+	Tests construct fresh sandbox repos that reuse those keys, so the
+	caches must be cleared between tests to keep coverage isolated.
+	"""
+	mod._PR_MERGE_COMMIT_CACHE.clear()
+	mod._PARTIAL_REMOVAL_POST_MERGE_CACHE.clear()
+
+
+@contextlib.contextmanager
+def _sandbox_repo() -> Iterator[Path]:
+	td = Path(tempfile.mkdtemp(prefix="verifier-partial-removal-test-"))
+	try:
+		_run_git(td, "init", "--quiet", "--initial-branch=main")
+		# Disable commit signing inside the sandbox so the test stays
+		# hermetic on developer machines that have global gpg / ssh
+		# signing configured. The test only cares about commit subjects
+		# and tree contents, not authorship trust.
+		_run_git(td, "config", "commit.gpgsign", "false")
+		_run_git(td, "config", "tag.gpgsign", "false")
+		_run_git(td, "config", "gpg.format", "openpgp")
+		yield td
+	finally:
+		shutil.rmtree(td, ignore_errors=True)
+
+
+# Mirrors the project #2836 incident: the same line appears at three
+# distinct positions in the file. The "PR" rewrites one occurrence and
+# leaves the other two untouched — capture's per-line removal scan
+# emits a must_not_contain entry for the line even though the line
+# still exists post-merge.
+_RECURRING_LINE = '\tprevious_state["consecutive_failure_count"] = 4'
+_PRE_PR_FILE_CONTENT = "\n".join([
+	"def test_a():",
+	_RECURRING_LINE,
+	"\tassert True",
+	"",
+	"def test_b():",
+	_RECURRING_LINE,
+	"\tassert True",
+	"",
+	"def test_c():",
+	_RECURRING_LINE,
+	"\tassert True",
+	"",
+])
+_POST_PR_FILE_CONTENT = "\n".join([
+	"def test_a():",
+	_RECURRING_LINE,
+	"\tassert True",
+	"",
+	"def test_b():",
+	_RECURRING_LINE,
+	"\tassert True",
+	"",
+	"def test_c():",
+	'\tprevious_state["consecutive_failure_count"] = 7',
+	"\tassert True",
+	"",
+])
+_REGRESSED_FILE_CONTENT = "\n".join([
+	"def test_a():",
+	"\t# all occurrences truly removed by the PR",
+	"\tassert True",
+	"",
+	"def test_b():",
+	"\t# all occurrences truly removed by the PR",
+	"\tassert True",
+	"",
+	"def test_c():",
+	"\t# but the resolver later re-inserted one — this MUST fail",
+	_RECURRING_LINE,
+	"\tassert True",
+	"",
+])
+
+_TARGET_PATH = "tests/sample_retry_state.py"
+
+
+def _fingerprint_state_for_issue(issue: int, pr: int, regex_src: str) -> dict:
+	return {
+		str(issue): {
+			"issue": issue,
+			"pr": pr,
+			"must_contain": [],
+			"must_not_contain": [
+				{"file": _TARGET_PATH, "regex": regex_src},
+			],
+			"must_not_exist": [],
+		}
+	}
+
+
+def _seed_repo_with_partial_removal_merge(repo: Path, pr_num: int) -> str:
+	"""Set up a tiny git history that reproduces the #2836 scenario.
+
+	Returns the merge commit SHA for the simulated PR.
+	"""
+	target = repo / _TARGET_PATH
+	target.parent.mkdir(parents=True, exist_ok=True)
+	target.write_text(_PRE_PR_FILE_CONTENT, encoding="utf-8")
+	_run_git(repo, "add", _TARGET_PATH)
+	_run_git(repo, "commit", "--quiet", "-m", "seed file with three occurrences")
+	target.write_text(_POST_PR_FILE_CONTENT, encoding="utf-8")
+	_run_git(repo, "add", _TARGET_PATH)
+	_run_git(repo, "commit", "--quiet", "-m", f"AI implementation for issue #999 (#{pr_num})")
+	return _run_git(repo, "rev-parse", "HEAD").strip()
+
+
+def _seed_repo_with_genuine_regression_merge(repo: Path, pr_num: int) -> str:
+	"""Set up a history where the PR truly removes ALL occurrences and a later
+	commit re-adds the line — a genuine regression the defense must NOT mask.
+	"""
+	target = repo / _TARGET_PATH
+	target.parent.mkdir(parents=True, exist_ok=True)
+	target.write_text(_PRE_PR_FILE_CONTENT, encoding="utf-8")
+	_run_git(repo, "add", _TARGET_PATH)
+	_run_git(repo, "commit", "--quiet", "-m", "seed file with three occurrences")
+	target.write_text(
+		"\n".join([
+			"def test_a():",
+			"\t# clean removal by the PR",
+			"\tassert True",
+			"",
+			"def test_b():",
+			"\t# clean removal by the PR",
+			"\tassert True",
+			"",
+			"def test_c():",
+			"\t# clean removal by the PR",
+			"\tassert True",
+			"",
+		]),
+		encoding="utf-8",
+	)
+	_run_git(repo, "add", _TARGET_PATH)
+	merge_msg = f"AI implementation for issue #999 (#{pr_num})"
+	_run_git(repo, "commit", "--quiet", "-m", merge_msg)
+	merge_commit = _run_git(repo, "rev-parse", "HEAD").strip()
+	target.write_text(_REGRESSED_FILE_CONTENT, encoding="utf-8")
+	_run_git(repo, "add", _TARGET_PATH)
+	_run_git(repo, "commit", "--quiet", "-m", "[ai-merge-resolve] regression sneaks the line back in")
+	return merge_commit
+
+
+def test_partial_removal_helper_returns_merge_commit_when_line_still_present_post_merge():
+	mod = _verifier_module()
+	with _sandbox_repo() as repo:
+		_clear_verifier_caches(mod)
+		merge_sha = _seed_repo_with_partial_removal_merge(repo, pr_num=2840)
+		prev_cwd = os.getcwd()
+		try:
+			os.chdir(repo)
+			pattern = re.compile(re.escape(_RECURRING_LINE))
+			result = mod._is_must_not_contain_partial_removal_false_positive(
+				ref=None, pr_num=2840, path=_TARGET_PATH, pattern=pattern,
+			)
+		finally:
+			os.chdir(prev_cwd)
+	assert result == merge_sha, (
+		"defense should return the PR's merge commit when the pattern is "
+		"still present in the post-merge file (partial removal); got "
+		f"{result!r}, expected {merge_sha!r}"
+	)
+
+
+def test_partial_removal_helper_returns_none_when_pattern_truly_removed_at_merge_commit():
+	mod = _verifier_module()
+	with _sandbox_repo() as repo:
+		_clear_verifier_caches(mod)
+		_seed_repo_with_genuine_regression_merge(repo, pr_num=2841)
+		prev_cwd = os.getcwd()
+		try:
+			os.chdir(repo)
+			pattern = re.compile(re.escape(_RECURRING_LINE))
+			result = mod._is_must_not_contain_partial_removal_false_positive(
+				ref=None, pr_num=2841, path=_TARGET_PATH, pattern=pattern,
+			)
+		finally:
+			os.chdir(prev_cwd)
+	assert result is None, (
+		"defense must NOT classify the violation as a false positive when "
+		"the PR truly deleted every occurrence (the post-merge file is "
+		"clean and the leftover match is a real regression). Got "
+		f"{result!r}, expected None"
+	)
+
+
+def test_partial_removal_helper_fails_open_on_missing_pr_number():
+	mod = _verifier_module()
+	with _sandbox_repo() as repo:
+		_clear_verifier_caches(mod)
+		_seed_repo_with_partial_removal_merge(repo, pr_num=2840)
+		prev_cwd = os.getcwd()
+		try:
+			os.chdir(repo)
+			pattern = re.compile(re.escape(_RECURRING_LINE))
+			# Non-numeric / sentinel pr_num values must short-circuit to None
+			# so the original violation surfaces rather than being silently
+			# masked.
+			assert mod._is_must_not_contain_partial_removal_false_positive(
+				ref=None, pr_num="?", path=_TARGET_PATH, pattern=pattern,
+			) is None
+			assert mod._is_must_not_contain_partial_removal_false_positive(
+				ref=None, pr_num="", path=_TARGET_PATH, pattern=pattern,
+			) is None
+			assert mod._is_must_not_contain_partial_removal_false_positive(
+				ref=None, pr_num=None, path=_TARGET_PATH, pattern=pattern,
+			) is None
+		finally:
+			os.chdir(prev_cwd)
+
+
+def test_partial_removal_helper_fails_open_when_merge_commit_not_found():
+	mod = _verifier_module()
+	with _sandbox_repo() as repo:
+		_clear_verifier_caches(mod)
+		# Seed the repo but use a PR number that doesn't appear in any
+		# commit message — _find_pr_merge_commit_for_path returns None,
+		# defense must fail open.
+		_seed_repo_with_partial_removal_merge(repo, pr_num=2840)
+		prev_cwd = os.getcwd()
+		try:
+			os.chdir(repo)
+			pattern = re.compile(re.escape(_RECURRING_LINE))
+			result = mod._is_must_not_contain_partial_removal_false_positive(
+				ref=None, pr_num=9999, path=_TARGET_PATH, pattern=pattern,
+			)
+		finally:
+			os.chdir(prev_cwd)
+	assert result is None
+
+
+def test_verifier_main_skips_must_not_contain_false_positive_with_marker():
+	mod = _verifier_module()
+	with _sandbox_repo() as repo:
+		_clear_verifier_caches(mod)
+		_seed_repo_with_partial_removal_merge(repo, pr_num=2840)
+		fingerprints = _fingerprint_state_for_issue(
+			issue=2839, pr=2840, regex_src=re.escape(_RECURRING_LINE),
+		)
+		fp_path = repo / "fingerprints.json"
+		fp_path.write_text(json.dumps(fingerprints), encoding="utf-8")
+		rc, out, _err = _run_verifier(mod, [str(fp_path)], repo)
+	# False positive — verify must succeed (exit 0) and emit the
+	# machine-readable marker so the operator audit can find it.
+	assert rc == 0, f"expected verifier to skip the false positive (exit 0); got rc={rc}, stdout=\n{out}"
+	assert "FINGERPRINT_PARTIAL_REMOVAL_FALSE_POSITIVE_V1" in out, (
+		"verifier must emit the FINGERPRINT_PARTIAL_REMOVAL_FALSE_POSITIVE_V1 "
+		"marker when it skips a partial-removal false positive so the "
+		"capture-side bug stays observable in CI logs; stdout was:\n" + out
+	)
+	assert "issue=#2839" in out and "pr=#2840" in out and f"file={_TARGET_PATH}" in out
+	assert "classified as capture-side false positive" in out
+	assert "Integration fingerprint verification FAILED" not in out
+
+
+def test_verifier_main_still_fails_on_genuine_regression_after_clean_merge():
+	mod = _verifier_module()
+	with _sandbox_repo() as repo:
+		_clear_verifier_caches(mod)
+		_seed_repo_with_genuine_regression_merge(repo, pr_num=2841)
+		fingerprints = _fingerprint_state_for_issue(
+			issue=2841, pr=2841, regex_src=re.escape(_RECURRING_LINE),
+		)
+		fp_path = repo / "fingerprints.json"
+		fp_path.write_text(json.dumps(fingerprints), encoding="utf-8")
+		rc, out, _err = _run_verifier(mod, [str(fp_path)], repo)
+	assert rc == 1, (
+		"verifier must STILL fail on a genuine regression (the PR truly "
+		"removed every occurrence; a later resolver commit re-inserted the "
+		f"line). Got rc={rc}, stdout=\n{out}"
+	)
+	assert "FINGERPRINT_PARTIAL_REMOVAL_FALSE_POSITIVE_V1" not in out, (
+		"defense must not mask the real regression with the partial-removal "
+		"marker; stdout was:\n" + out
+	)
+	assert "must_not_contain pattern reappeared" in out
+
+
+_CAPTURE_FUNCTION_SCRIPT = (REPO_ROOT / "scripts" / "orchestrate_poll_process.sh").read_text(encoding="utf-8")
+
+
+def _extract_capture_heredoc() -> str:
+	"""Extract the python heredoc embedded in capture_intent_fingerprints_for_merged_subissue.
+
+	The shell function passes the heredoc to python3 with `python3 - "${diff_file}"`.
+	For test coverage we reuse the exact same script body so the test
+	pins capture's filter behaviour against the live source.
+	"""
+	body = _CAPTURE_FUNCTION_SCRIPT
+	marker_start = body.index("capture_intent_fingerprints_for_merged_subissue()")
+	heredoc_open = body.index("python3 - \"${diff_file}\" <<'PY'", marker_start)
+	heredoc_body_start = body.index("\n", heredoc_open) + 1
+	heredoc_close = body.index("\nPY\n", heredoc_body_start)
+	return body[heredoc_body_start:heredoc_close]
+
+
+def _run_capture_heredoc(
+	*,
+	diff_text: str,
+	post_merge_ref: str,
+	cwd: Path,
+) -> dict:
+	heredoc = _extract_capture_heredoc()
+	diff_path = cwd / "pr.diff"
+	diff_path.write_text(diff_text, encoding="utf-8")
+	env = os.environ.copy()
+	env.update({
+		"FINGERPRINT_PER_FILE_CAP": "12",
+		"FINGERPRINT_MIN_PATTERN_CHARS": "12",
+		"FINGERPRINT_POST_MERGE_REF": post_merge_ref,
+		"PYTHONDONTWRITEBYTECODE": "1",
+	})
+	result = subprocess.run(
+		[sys.executable, "-c", heredoc, str(diff_path)],
+		cwd=str(cwd),
+		capture_output=True,
+		check=True,
+		env=env,
+	)
+	stdout = result.stdout.decode("utf-8", errors="replace").strip()
+	assert stdout, (
+		"capture heredoc returned empty stdout; stderr was:\n"
+		+ result.stderr.decode("utf-8", errors="replace")
+	)
+	return json.loads(stdout)
+
+
+_PARTIAL_REMOVAL_DIFF = """\
+diff --git a/tests/sample_retry_state.py b/tests/sample_retry_state.py
+index 1111111..2222222 100644
+--- a/tests/sample_retry_state.py
++++ b/tests/sample_retry_state.py
+@@ -8,5 +8,5 @@ def test_b():
+ def test_c():
+-\tprevious_state["consecutive_failure_count"] = 4
++\tprevious_state["consecutive_failure_count"] = 7
+ \tassert True
+"""
+
+
+def test_capture_post_merge_filter_drops_partial_removal_false_positive():
+	"""Capture-side prevention: a removed line that still appears in the
+	post-merge file content MUST NOT land in must_not_contain.
+	"""
+	with _sandbox_repo() as repo:
+		_seed_repo_with_partial_removal_merge(repo, pr_num=2840)
+		result = _run_capture_heredoc(
+			diff_text=_PARTIAL_REMOVAL_DIFF,
+			post_merge_ref="HEAD",
+			cwd=repo,
+		)
+	must_not_contain = result.get("must_not_contain") or []
+	# Capture's to_patterns() strips leading whitespace before applying
+	# re.escape, so compare against the stripped form.
+	regex_src = re.escape(_RECURRING_LINE.strip())
+	matches = [
+		entry for entry in must_not_contain
+		if entry.get("file") == _TARGET_PATH and entry.get("regex") == regex_src
+	]
+	assert matches == [], (
+		"capture must drop must_not_contain entries whose stripped text "
+		"still appears in the post-merge file (multi-occurrence partial "
+		f"removal). Got must_not_contain={must_not_contain!r}"
+	)
+
+
+def test_capture_post_merge_filter_keeps_must_not_contain_when_line_truly_removed():
+	"""Capture-side defense must not over-trigger: when the post-merge
+	file genuinely does not contain the removed line, the entry MUST
+	survive into must_not_contain (so the verifier still catches a
+	later resolver-introduced regression).
+	"""
+	with _sandbox_repo() as repo:
+		_seed_repo_with_genuine_regression_merge(repo, pr_num=2841)
+		merge_commit = _run_git(repo, "rev-parse", "HEAD~1").strip()
+		result = _run_capture_heredoc(
+			diff_text=_PARTIAL_REMOVAL_DIFF,
+			post_merge_ref=merge_commit,
+			cwd=repo,
+		)
+	must_not_contain = result.get("must_not_contain") or []
+	# Capture's to_patterns() strips leading whitespace before applying
+	# re.escape, so compare against the stripped form.
+	regex_src = re.escape(_RECURRING_LINE.strip())
+	matches = [
+		entry for entry in must_not_contain
+		if entry.get("file") == _TARGET_PATH and entry.get("regex") == regex_src
+	]
+	assert matches, (
+		"capture must keep must_not_contain entries when the line is truly "
+		"gone from the post-merge file — otherwise a later resolver "
+		f"regression would silently pass verify. Got must_not_contain={must_not_contain!r}"
+	)
+
+
+def test_capture_post_merge_filter_fails_open_when_ref_is_unresolvable():
+	"""If the post-merge ref can't be read (env var empty, branch
+	unknown), the filter must leave the candidate must_not_contain
+	entries in place so the existing capture invariants stay intact.
+	The verifier-side defense will catch any leftover false positives.
+	"""
+	with _sandbox_repo() as repo:
+		_seed_repo_with_partial_removal_merge(repo, pr_num=2840)
+		result = _run_capture_heredoc(
+			diff_text=_PARTIAL_REMOVAL_DIFF,
+			post_merge_ref="",  # unresolvable — skip the filter
+			cwd=repo,
+		)
+	must_not_contain = result.get("must_not_contain") or []
+	# Capture's to_patterns() strips leading whitespace before applying
+	# re.escape, so compare against the stripped form.
+	regex_src = re.escape(_RECURRING_LINE.strip())
+	matches = [
+		entry for entry in must_not_contain
+		if entry.get("file") == _TARGET_PATH and entry.get("regex") == regex_src
+	]
+	assert matches, (
+		"capture must fail open when the post-merge ref is empty so the "
+		"verifier-side defense can still inspect the entry; "
+		f"got must_not_contain={must_not_contain!r}"
+	)
+
+
+def main() -> int:
+	# Surface helpful diagnostics if the verifier module fails to import
+	# (e.g. syntax errors in the script under test). The standalone test
+	# runner pattern matches scripts/test_verify_integration_fingerprints_baseline.py.
+	failures: list[str] = []
+	for name, value in sorted(globals().items()):
+		if not name.startswith("test_") or not callable(value):
+			continue
+		try:
+			value()
+		except AssertionError as exc:
+			failures.append(f"{name}: {exc}")
+		except Exception as exc:  # noqa: BLE001 — surface unexpected errors verbatim
+			failures.append(f"{name}: {type(exc).__name__}: {exc}")
+	if failures:
+		print("FAIL")
+		for line in failures:
+			print(f"  {line}")
+		return 1
+	print("PASS")
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_verify_integration_fingerprints_partial_removal.py
+++ b/tests/test_verify_integration_fingerprints_partial_removal.py
@@ -357,17 +357,17 @@ def test_verifier_main_skips_must_not_contain_false_positive_with_marker():
 		)
 		fp_path = repo / "fingerprints.json"
 		fp_path.write_text(json.dumps(fingerprints), encoding="utf-8")
-		rc, out, _err = _run_verifier(mod, [str(fp_path)], repo)
+		rc, out, err = _run_verifier(mod, [str(fp_path)], repo)
 	# False positive — verify must succeed (exit 0) and emit the
 	# machine-readable marker so the operator audit can find it.
 	assert rc == 0, f"expected verifier to skip the false positive (exit 0); got rc={rc}, stdout=\n{out}"
-	assert "FINGERPRINT_PARTIAL_REMOVAL_FALSE_POSITIVE_V1" in out, (
+	assert "FINGERPRINT_PARTIAL_REMOVAL_FALSE_POSITIVE_V1" in err, (
 		"verifier must emit the FINGERPRINT_PARTIAL_REMOVAL_FALSE_POSITIVE_V1 "
 		"marker when it skips a partial-removal false positive so the "
-		"capture-side bug stays observable in CI logs; stdout was:\n" + out
+		"capture-side bug stays observable in CI logs; stderr was:\n" + err
 	)
-	assert "issue=#2839" in out and "pr=#2840" in out and f"file={_TARGET_PATH}" in out
-	assert "classified as capture-side false positive" in out
+	assert "issue=#2839" in err and "pr=#2840" in err and f"file={_TARGET_PATH}" in err
+	assert "classified as capture-side false positive" in err
 	assert "Integration fingerprint verification FAILED" not in out
 
 

--- a/tests/test_verify_integration_fingerprints_partial_removal.py
+++ b/tests/test_verify_integration_fingerprints_partial_removal.py
@@ -371,6 +371,28 @@ def test_verifier_main_skips_must_not_contain_false_positive_with_marker():
 	assert "Integration fingerprint verification FAILED" not in out
 
 
+def test_verifier_list_mode_skips_must_not_contain_false_positive():
+	mod = _verifier_module()
+	with _sandbox_repo() as repo:
+		_clear_verifier_caches(mod)
+		_seed_repo_with_partial_removal_merge(repo, pr_num=2840)
+		fingerprints = _fingerprint_state_for_issue(
+			issue=2839, pr=2840, regex_src=re.escape(_RECURRING_LINE),
+		)
+		fp_path = repo / "fingerprints.json"
+		fp_path.write_text(json.dumps(fingerprints), encoding="utf-8")
+		rc, out, err = _run_verifier(mod, ["--list-violated-files", str(fp_path)], repo)
+	assert rc == 0, f"expected list mode to stay soft-success (rc=0); got rc={rc}, stdout=\n{out}"
+	assert out.strip() == "", (
+		"list mode should not report a file path for a partial-removal false positive; "
+		f"stdout was:\n{out}"
+	)
+	assert "FINGERPRINT_PARTIAL_REMOVAL_FALSE_POSITIVE_V1" in err, (
+		"list mode must still run the partial-removal defense when a numeric PR number is "
+		"present in the fingerprint entry; stderr was:\n" + err
+	)
+
+
 def test_verifier_main_still_fails_on_genuine_regression_after_clean_merge():
 	mod = _verifier_module()
 	with _sandbox_repo() as repo:

--- a/tests/test_verify_integration_fingerprints_partial_removal.py
+++ b/tests/test_verify_integration_fingerprints_partial_removal.py
@@ -326,6 +326,27 @@ def test_partial_removal_helper_fails_open_when_merge_commit_not_found():
 	assert result is None
 
 
+def test_find_pr_merge_commit_ignores_later_same_path_followup_mentions():
+	mod = _verifier_module()
+	with _sandbox_repo() as repo:
+		_clear_verifier_caches(mod)
+		merge_sha = _seed_repo_with_partial_removal_merge(repo, pr_num=2840)
+		target = repo / _TARGET_PATH
+		target.write_text(_POST_PR_FILE_CONTENT + "# later follow-up\n", encoding="utf-8")
+		_run_git(repo, "add", _TARGET_PATH)
+		_run_git(repo, "commit", "--quiet", "-m", "follow-up for #2840")
+		prev_cwd = os.getcwd()
+		try:
+			os.chdir(repo)
+			result = mod._find_pr_merge_commit_for_path(None, 2840, _TARGET_PATH)
+		finally:
+			os.chdir(prev_cwd)
+	assert result == merge_sha, (
+		"merge-commit lookup must ignore later same-path commits that merely mention "
+		f"the PR number; got {result!r}, expected original merge {merge_sha!r}"
+	)
+
+
 def test_verifier_main_skips_must_not_contain_false_positive_with_marker():
 	mod = _verifier_module()
 	with _sandbox_repo() as repo:


### PR DESCRIPTION
## Summary

`scripts/orchestrate_poll_process.sh`'s `capture_intent_fingerprints_for_merged_subissue` recorded a `must_not_contain` pattern for every line removed in a sub-issue PR's unified diff. The existing net-change and substring-overlap filters don't catch the **multi-occurrence partial-removal** case: when a PR removes ONE occurrence of a line that recurs at multiple positions in the same file, the unchanged occurrences trip `re.search` at verify time and the verifier reports a fake "reappeared" violation that blocks the next wave's dispatch.

Project #2836 wave 3 hit exactly this case on run [26190348904](https://github.com/shubhodeep1/coding-workflows/actions/runs/26190348904) — PR #2840 changed one of three `previous_state["consecutive_failure_count"] = 4` lines in `tests/test_review_conflict_resolve_retry_state.py` to `= 7` and left the other two intact. Capture stored the bogus must_not_contain, the verifier tripped on the unchanged occurrences, and the orchestrator refused to dispatch wave 3.

## Fix — two layers of defense

- **Capture-side prevention** (`scripts/orchestrate_poll_process.sh`): after the existing filters, drop any `must_not_contain` candidate whose stripped text still appears in the integration branch tip after the PR's merge. New `FINGERPRINT_POST_MERGE_REF` env var passes the integration ref into the python heredoc; the filter `git show <ref>:<path>` and skips the entry if `re.search` matches. Fail-open on missing/unresolvable ref so the existing invariants stay intact.
- **Verifier-side defense** (`scripts/verify_integration_fingerprints.py`): when a `must_not_contain` pattern matches in the post-resolve tree, look up the PR's merge commit on the integration ref (`git log --grep="#<pr>" -E -- <path>`) and re-check the pattern against the file at that commit. If the pattern was still present immediately after the merge, classify the violation as a capture-side false positive, emit a `FINGERPRINT_PARTIAL_REMOVAL_FALSE_POSITIVE_V1` marker + a human-readable warning, and skip. The defense unblocks the existing bad fingerprint for #2839 in #2836's state with no operator state-edit and stays conservative — when the PR truly removed every occurrence and a later commit reintroduced the line, the violation still fails the gate.

Both helpers use only local git (zero new GitHub API calls per §15), cache lookups per `(ref, pr_num, path)`, and fail-open on any subprocess / encoding error.

## Verification

Confirmed against the live broken state on `orchestrator/project-2836`: patched verifier exits 0 and emits `::warning::FINGERPRINT_PARTIAL_REMOVAL_FALSE_POSITIVE_V1 issue=#2839 pr=#2840 file=tests/test_review_conflict_resolve_retry_state.py merge_commit=019d913d7096 reason=must_not_contain_pattern_still_present_at_pr_merge_commit` (matches PR #2840's actual squash commit `019d913`).

## Test plan

- [x] `tests/test_verify_integration_fingerprints_partial_removal.py` (new, 9 tests):
  - Helper returns merge commit SHA when the pattern still appears at the PR's merge commit (partial removal).
  - Helper returns None when the PR truly deleted every occurrence (post-merge file clean) — defense must NOT mask a genuine resolver-introduced regression.
  - Helper fail-open paths (`pr_num` is non-numeric, merge commit not found).
  - End-to-end `main()` exits 0 with the marker + human warning when the captured pattern is a false positive.
  - End-to-end `main()` STILL exits 1 + emits the original "reappeared" violation when the PR genuinely removed every occurrence and a later commit re-inserted the line.
  - Capture heredoc drops the must_not_contain entry when the line survives at the post-merge ref.
  - Capture heredoc preserves the must_not_contain entry when the line is truly gone (so verify still catches later regressions).
  - Capture heredoc fails open when `FINGERPRINT_POST_MERGE_REF` is empty.
- [x] Existing `test_capture_intent_fingerprints_*` (9 tests in `tests/test_orchestrate_poll_process.py`) still pass against the modified capture function.
- [x] `bash -n scripts/orchestrate_poll_process.sh` clean; `verify_integration_fingerprints.py` imports cleanly.
- [ ] Next orchestrator poll tick on `orchestrator/project-2836` should classify the existing #2839 fingerprint as a false positive, emit the marker, and advance wave 3 dispatch.

Refs #2836

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvD7TL3CR14PYL3urAwFS9)_