### PR TITLE
fix(ai-memory): add jittered backoff to memory-branch push retries

### DIFF
--- a/scripts/ai_memory_lib.py
+++ b/scripts/ai_memory_lib.py
@@ -14,11 +14,13 @@ import json
 import logging
 import math
 import os
+import random
 import re
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import urllib.request
 import urllib.error
 import uuid
@@ -1728,6 +1730,10 @@ def persist_memory_operation(
                     raise MemoryGitError(
                         f"Failed to push memory branch after {push_retries} attempts: {push.stderr.strip()}"
                     )
+
+                # Jittered backoff so concurrent memory writers don't retry in lockstep.
+                backoff = min(2 ** (attempt - 1), 16) * (0.5 + random.random())
+                time.sleep(backoff)
 
                 _run_git(
                     clone_dir,


### PR DESCRIPTION
## Summary

`persist_memory_operation()` in `scripts/ai_memory_lib.py` retried the `ai-memory` branch push with **no delay between attempts**. The `ai-memory` branch is a single shared serialization point for every workflow phase, and each push relies on git's atomic compare-and-swap on the ref. When workflow runs are dispatched seconds apart they fetch the same branch tip, rebase onto it, and push simultaneously — losing the CAS race in lockstep, colliding on every one of the 5 attempts, and exhausting retries:

```
AI_MEMORY_ERROR: Failed to push memory branch after 5 attempts
! [remote rejected] HEAD -> ai-memory (cannot lock ref 'refs/heads/ai-memory': is at <x> but expected <y>)
```

`memory_processed_command_claim()` is (by design) the one memory helper without a fail-open wrapper, so the resulting non-zero exit kills the claim step under `set -euo pipefail` and fails the whole workflow phase.

## Change

`scripts/ai_memory_lib.py`:
- Add `import random` and `import time`.
- Insert a jittered exponential backoff — `min(2 ** (attempt - 1), 16) * (0.5 + random.random())` seconds — before the fetch+rebase between push attempts, so concurrent memory writers desynchronize instead of retrying in lockstep.

Single-function change, low blast radius. No behavior change other than timing — retry count, env vars, and the `AI_MEMORY_PUSH_RETRIES` contract are unchanged. Worst-case added latency with 5 retries is ~22s.

Deliberately **not** included: raising the `AI_MEMORY_PUSH_RETRIES` default (5 → 8). With jitter, 5 retries comfortably absorbs the observed burst; raising it should wait for telemetry showing continued exhaustion.

## Base branch

Hotfix cut from and targeting the `stable` branch (`2086b4c5`, v1.13.5), not `main`. Reaching `@stable` consumers still requires the normal release step that re-points the `stable` tag — intentionally out of scope here.

## Test plan

- [x] `python3 -m py_compile scripts/ai_memory_lib.py` passes
- [ ] CI checks on this PR pass
- [ ] Confirm concurrently-dispatched workflow runs no longer fail the claim step with `Failed to push memory branch after 5 attempts`

## Context

Surfaced by AI Plan failures in consumer repo `shubhodeep1/tele-funtoken-msg-scoring`:
- https://github.com/shubhodeep1/tele-funtoken-msg-scoring/issues/3123
- https://github.com/shubhodeep1/tele-funtoken-msg-scoring/issues/3118

https://claude.ai/code/session_01MtgUVisNEM3GBMrZ3rAXdm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtgUVisNEM3GBMrZ3rAXdm)_