### PR TITLE
fix(ai-memory): add jittered backoff to memory-branch push retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,7 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_clarify_loop_guard.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_ai_memory_processed_command_entry.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_ai_memory_push_retry_backoff.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_plan_clarify_blocked_output.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_plan_auto_answer_recommended_parser.py
 

--- a/scripts/ai_memory_lib.py
+++ b/scripts/ai_memory_lib.py
@@ -1839,10 +1839,11 @@ def _push_retry_backoff_seconds(attempt: int) -> float:
     """
     if attempt < 1:
         attempt = 1
-    ceiling = min(
-        _PUSH_RETRY_BACKOFF_CAP_SECONDS,
-        _PUSH_RETRY_BACKOFF_BASE_SECONDS * (2 ** (attempt - 1)),
-    )
+    ceiling = min(_PUSH_RETRY_BACKOFF_BASE_SECONDS, _PUSH_RETRY_BACKOFF_CAP_SECONDS)
+    for _ in range(1, attempt):
+        if ceiling >= _PUSH_RETRY_BACKOFF_CAP_SECONDS:
+            break
+        ceiling = min(_PUSH_RETRY_BACKOFF_CAP_SECONDS, ceiling * 2.0)
     return random.uniform(0.0, ceiling)
 
 
@@ -1922,7 +1923,12 @@ def persist_memory_operation(
                 if _run_git(clone_dir, ["show-ref", "--verify", f"refs/remotes/origin/{memory_branch}"], check=False).returncode == 0:
                     rebase = _run_git(clone_dir, ["rebase", f"refs/remotes/origin/{memory_branch}"], check=False)
                     if rebase.returncode != 0:
-                        _run_git(clone_dir, ["rebase", "--abort"], check=False)
+                        rebase_abort = _run_git(clone_dir, ["rebase", "--abort"], check=False)
+                        if rebase_abort.returncode != 0:
+                            raise MemoryGitError(
+                                "Memory branch rebase failed while retrying push: "
+                                f"{rebase.stderr.strip()} (rebase --abort also failed: {rebase_abort.stderr.strip()})"
+                            )
                         raise MemoryGitError(
                             f"Memory branch rebase failed while retrying push: {rebase.stderr.strip()}"
                         )

--- a/scripts/ai_memory_lib.py
+++ b/scripts/ai_memory_lib.py
@@ -14,11 +14,13 @@ import json
 import logging
 import math
 import os
+import random
 import re
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import urllib.request
 import urllib.error
 import uuid
@@ -1817,6 +1819,33 @@ def _clone_for_memory_branch(repo_root: Path, memory_branch: str) -> Path:
     return temp_dir
 
 
+# Memory-branch push retries all contend on the single shared `ai-memory`
+# ref: every concurrent workflow run pushes there.  Without a randomized
+# delay between attempts the contenders retry in lockstep and keep losing
+# the same server-side ref-lock race ("cannot lock ref ... is at X but
+# expected Y"), exhausting the retry budget.  Full-jitter exponential
+# backoff decorrelates them so a push lands within the budget.
+_PUSH_RETRY_BACKOFF_BASE_SECONDS = 0.5
+_PUSH_RETRY_BACKOFF_CAP_SECONDS = 8.0
+
+
+def _push_retry_backoff_seconds(attempt: int) -> float:
+    """Return a randomized delay (seconds) to wait before the next push retry.
+
+    ``attempt`` is the 1-based number of the push attempt that just failed.
+    Full-jitter exponential backoff: the delay is drawn uniformly from
+    ``[0, min(cap, base * 2 ** (attempt - 1))]`` so concurrent pushers
+    spread across the retry window instead of colliding in lockstep.
+    """
+    if attempt < 1:
+        attempt = 1
+    ceiling = min(
+        _PUSH_RETRY_BACKOFF_CAP_SECONDS,
+        _PUSH_RETRY_BACKOFF_BASE_SECONDS * (2 ** (attempt - 1)),
+    )
+    return random.uniform(0.0, ceiling)
+
+
 def persist_memory_operation(
     repo_root: Path,
     *,
@@ -1877,6 +1906,11 @@ def persist_memory_operation(
                     raise MemoryGitError(
                         f"Failed to push memory branch after {push_retries} attempts: {push.stderr.strip()}"
                     )
+
+                # Wait a jittered, exponentially growing interval before
+                # re-syncing and retrying so concurrent runs stop losing the
+                # ref-lock race against the shared memory branch in lockstep.
+                time.sleep(_push_retry_backoff_seconds(attempt))
 
                 _run_git(
                     clone_dir,

--- a/scripts/ai_memory_lib.py
+++ b/scripts/ai_memory_lib.py
@@ -1912,11 +1912,13 @@ def persist_memory_operation(
                 # ref-lock race against the shared memory branch in lockstep.
                 time.sleep(_push_retry_backoff_seconds(attempt))
 
-                _run_git(
+                fetch = _run_git(
                     clone_dir,
                     ["fetch", "--no-tags", "origin", f"refs/heads/{memory_branch}:refs/remotes/origin/{memory_branch}"],
                     check=False,
                 )
+                if fetch.returncode != 0:
+                    raise MemoryGitError(f"Memory branch fetch failed while retrying push: {fetch.stderr.strip()}")
                 if _run_git(clone_dir, ["show-ref", "--verify", f"refs/remotes/origin/{memory_branch}"], check=False).returncode == 0:
                     rebase = _run_git(clone_dir, ["rebase", f"refs/remotes/origin/{memory_branch}"], check=False)
                     if rebase.returncode != 0:
@@ -1924,8 +1926,6 @@ def persist_memory_operation(
                         raise MemoryGitError(
                             f"Memory branch rebase failed while retrying push: {rebase.stderr.strip()}"
                         )
-
-            raise MemoryGitError("Unexpected push retry flow")
         finally:
             shutil.rmtree(clone_dir, ignore_errors=True)
 

--- a/tests/test_ai_memory_push_retry_backoff.py
+++ b/tests/test_ai_memory_push_retry_backoff.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Tests for memory-branch push retry backoff.
+
+The `ai-memory` branch is a single shared ref every concurrent workflow run
+pushes to.  Without a randomized delay between push retries the contenders
+retry in lockstep and keep losing the same server-side ref-lock race, which
+surfaced as `Failed to push memory branch after N attempts`.  These tests
+lock in the jittered exponential backoff that decorrelates the pushers.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MODULE_PATH = REPO_ROOT / "scripts" / "ai_memory_lib.py"
+
+if str(REPO_ROOT) not in sys.path:
+	sys.path.insert(0, str(REPO_ROOT))
+
+spec = importlib.util.spec_from_file_location("ai_memory_lib", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+ai_memory_lib = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = ai_memory_lib
+spec.loader.exec_module(ai_memory_lib)
+
+
+class _FakeProc:
+	"""Minimal stand-in for subprocess.CompletedProcess used by _run_git."""
+
+	def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+		self.returncode = returncode
+		self.stdout = stdout
+		self.stderr = stderr
+
+
+def test_backoff_stays_within_jittered_exponential_bounds() -> None:
+	base = ai_memory_lib._PUSH_RETRY_BACKOFF_BASE_SECONDS
+	cap = ai_memory_lib._PUSH_RETRY_BACKOFF_CAP_SECONDS
+	for attempt in range(1, 9):
+		ceiling = min(cap, base * (2 ** (attempt - 1)))
+		for _ in range(200):
+			delay = ai_memory_lib._push_retry_backoff_seconds(attempt)
+			assert 0.0 <= delay <= ceiling, (attempt, delay, ceiling)
+
+
+def test_backoff_ceiling_never_exceeds_cap() -> None:
+	base = ai_memory_lib._PUSH_RETRY_BACKOFF_BASE_SECONDS
+	cap = ai_memory_lib._PUSH_RETRY_BACKOFF_CAP_SECONDS
+	assert base > 0.0
+	assert cap >= base
+	# A very large attempt must clamp to the cap, not grow unbounded.
+	for _ in range(200):
+		assert ai_memory_lib._push_retry_backoff_seconds(99) <= cap
+
+
+def test_backoff_clamps_nonpositive_attempt() -> None:
+	# attempt < 1 must not raise or yield a negative ceiling.
+	ceiling = ai_memory_lib._PUSH_RETRY_BACKOFF_BASE_SECONDS
+	for attempt in (0, -1, -50):
+		for _ in range(50):
+			delay = ai_memory_lib._push_retry_backoff_seconds(attempt)
+			assert 0.0 <= delay <= ceiling, (attempt, delay)
+
+
+def test_backoff_is_randomized() -> None:
+	# Jitter must actually vary — a constant delay would not decorrelate
+	# concurrent pushers, which is the whole point of the backoff.
+	samples = {ai_memory_lib._push_retry_backoff_seconds(5) for _ in range(64)}
+	assert len(samples) > 1, "backoff delay is not randomized"
+
+
+def _scripted_run_git(push_codes: list[int]):
+	"""Build a fake _run_git that yields scripted push return codes.
+
+	Every git op other than `push` succeeds; `diff --cached` reports staged
+	changes so the commit/push path is exercised.
+	"""
+
+	push_results = iter(push_codes)
+
+	def fake_run_git(cwd, args, check: bool = True):  # noqa: ANN001 - test stub
+		op = args[0] if args else ""
+		if op == "ls-remote":
+			return _FakeProc(returncode=0, stdout="")
+		if op == "diff":
+			return _FakeProc(returncode=1)  # staged changes present
+		if op == "rev-parse":
+			return _FakeProc(returncode=0, stdout="0123456789abcdef\n")
+		if op == "push":
+			rc = next(push_results)
+			return _FakeProc(
+				returncode=rc,
+				stderr="" if rc == 0 else "! [remote rejected] cannot lock ref",
+			)
+		return _FakeProc(returncode=0)
+
+	return fake_run_git
+
+
+def _run_persist(push_codes: list[int], push_retries: int):
+	"""Drive persist_memory_operation with scripted pushes; return (result, backoff_attempts).
+
+	`_run_git` and `_push_retry_backoff_seconds` are stubbed so the retry loop
+	runs without real git or real sleeps.  Either returns the result dict, or
+	the raised MemoryGitError, alongside the recorded backoff attempt numbers.
+	"""
+
+	work = Path(tempfile.mkdtemp(prefix="ai-memory-retry-test-"))
+	repo_root = work / "repo"
+	repo_root.mkdir(parents=True, exist_ok=True)
+	backoff_attempts: list[int] = []
+
+	def fake_backoff(attempt: int) -> float:
+		backoff_attempts.append(attempt)
+		return 0.0
+
+	original_run_git = ai_memory_lib._run_git
+	original_backoff = ai_memory_lib._push_retry_backoff_seconds
+	ai_memory_lib._run_git = _scripted_run_git(push_codes)
+	ai_memory_lib._push_retry_backoff_seconds = fake_backoff
+
+	def _op(_clone_dir: Path) -> dict:
+		return {"claimed": True}
+
+	try:
+		result = ai_memory_lib.persist_memory_operation(
+			repo_root,
+			memory_branch="ai-memory",
+			memory_root_relative="ai-memory",
+			push_retries=push_retries,
+			commit_message="ai-memory: test claim",
+			operation=_op,
+		)
+		return result, backoff_attempts, None
+	except ai_memory_lib.MemoryGitError as exc:
+		return None, backoff_attempts, exc
+	finally:
+		ai_memory_lib._run_git = original_run_git
+		ai_memory_lib._push_retry_backoff_seconds = original_backoff
+		shutil.rmtree(work, ignore_errors=True)
+
+
+def test_persist_memory_operation_backs_off_then_succeeds_on_retry() -> None:
+	# Two rejected pushes (concurrent ref-lock race) then success: the backoff
+	# must fire once per failed attempt and the push must still land.
+	result, backoff_attempts, exc = _run_persist([1, 1, 0], push_retries=5)
+	assert exc is None, exc
+	assert result is not None
+	assert result["did_push"] is True, result
+	assert result["push_attempts"] == 3, result
+	# One backoff per failed attempt (1 and 2); none after the success.
+	assert backoff_attempts == [1, 2], backoff_attempts
+
+
+def test_persist_memory_operation_backs_off_every_attempt_before_raising() -> None:
+	# All pushes rejected: backoff fires after every non-final attempt and the
+	# loop still raises — claiming is mutual exclusion and is not fail-open.
+	result, backoff_attempts, exc = _run_persist([1, 1, 1, 1], push_retries=4)
+	assert result is None
+	assert isinstance(exc, ai_memory_lib.MemoryGitError), exc
+	# 4 attempts -> backoff after attempts 1, 2, 3 (not after the final one).
+	assert backoff_attempts == [1, 2, 3], backoff_attempts
+
+
+def main() -> int:
+	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+	passed = 0
+	failed = 0
+	for func in test_funcs:
+		name = func.__name__
+		try:
+			func()
+			print(f"  PASS  {name}")
+			passed += 1
+		except Exception as exc:  # noqa: BLE001 - test harness reports all
+			print(f"  FAIL  {name}: {exc}")
+			failed += 1
+
+	print(f"\n{passed} passed, {failed} failed, {passed + failed} total")
+	return 1 if failed else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_ai_memory_push_retry_backoff.py
+++ b/tests/test_ai_memory_push_retry_backoff.py
@@ -180,8 +180,7 @@ def _run_persist(
 		try:
 			work = Path(tempfile.mkdtemp(prefix="ai-memory-retry-test-"))
 		except FileNotFoundError:
-			scratch_root = REPO_ROOT / ".tmp-ai-memory-tests"
-			scratch_root.mkdir(parents=True, exist_ok=True)
+			scratch_root = Path(tempfile.mkdtemp(prefix=".tmp-ai-memory-tests-", dir=REPO_ROOT))
 			tempfile.tempdir = str(scratch_root)
 			work = Path(tempfile.mkdtemp(prefix="ai-memory-retry-test-"))
 		repo_root = work / "repo"

--- a/tests/test_ai_memory_push_retry_backoff.py
+++ b/tests/test_ai_memory_push_retry_backoff.py
@@ -71,8 +71,40 @@ def test_backoff_clamps_nonpositive_attempt() -> None:
 def test_backoff_is_randomized() -> None:
 	# Jitter must actually vary — a constant delay would not decorrelate
 	# concurrent pushers, which is the whole point of the backoff.
-	samples = {ai_memory_lib._push_retry_backoff_seconds(5) for _ in range(64)}
-	assert len(samples) > 1, "backoff delay is not randomized"
+	calls: list[tuple[float, float]] = []
+	returned_delays = iter([0.25, 0.75])
+	original_uniform = ai_memory_lib.random.uniform
+
+	def fake_uniform(low: float, high: float) -> float:
+		calls.append((low, high))
+		return next(returned_delays)
+
+	ai_memory_lib.random.uniform = fake_uniform
+	try:
+		delays = [ai_memory_lib._push_retry_backoff_seconds(5) for _ in range(2)]
+	finally:
+		ai_memory_lib.random.uniform = original_uniform
+
+	assert delays == [0.25, 0.75]
+	assert calls == [(0.0, ai_memory_lib._PUSH_RETRY_BACKOFF_CAP_SECONDS)] * 2
+
+
+def test_backoff_large_attempt_clamps_before_overflow() -> None:
+	calls: list[tuple[float, float]] = []
+	original_uniform = ai_memory_lib.random.uniform
+
+	def fake_uniform(low: float, high: float) -> float:
+		calls.append((low, high))
+		return high
+
+	ai_memory_lib.random.uniform = fake_uniform
+	try:
+		delay = ai_memory_lib._push_retry_backoff_seconds(10_000)
+	finally:
+		ai_memory_lib.random.uniform = original_uniform
+
+	assert delay == ai_memory_lib._PUSH_RETRY_BACKOFF_CAP_SECONDS
+	assert calls == [(0.0, ai_memory_lib._PUSH_RETRY_BACKOFF_CAP_SECONDS)]
 
 
 def _scripted_run_git(
@@ -81,6 +113,7 @@ def _scripted_run_git(
 	fetch_codes: list[int] | None = None,
 	show_ref_codes: list[int] | None = None,
 	rebase_codes: list[int] | None = None,
+	rebase_abort_codes: list[int] | None = None,
 	call_log: list[tuple[str, tuple[str, ...]]] | None = None,
 ):
 	"""Build a fake _run_git with scripted failure points in the retry loop."""
@@ -89,6 +122,7 @@ def _scripted_run_git(
 	fetch_results = iter(fetch_codes or [])
 	show_ref_results = iter(show_ref_codes or [])
 	rebase_results = iter(rebase_codes or [])
+	rebase_abort_results = iter(rebase_abort_codes or [])
 
 	def fake_run_git(cwd, args, check: bool = True):  # noqa: ANN001 - test stub
 		op = args[0] if args else ""
@@ -108,7 +142,8 @@ def _scripted_run_git(
 			return _FakeProc(returncode=rc, stderr="" if rc == 0 else "show-ref missing")
 		if op == "rebase":
 			if len(args) > 1 and args[1] == "--abort":
-				return _FakeProc(returncode=0)
+				rc = next(rebase_abort_results, 0)
+				return _FakeProc(returncode=rc, stderr="" if rc == 0 else "rebase abort failed")
 			rc = next(rebase_results, 0)
 			return _FakeProc(returncode=rc, stderr="" if rc == 0 else "rebase conflict")
 		if op == "push":
@@ -129,6 +164,7 @@ def _run_persist(
 	fetch_codes: list[int] | None = None,
 	show_ref_codes: list[int] | None = None,
 	rebase_codes: list[int] | None = None,
+	rebase_abort_codes: list[int] | None = None,
 ):
 	"""Drive persist_memory_operation; return (result, backoff_attempts, call_log, exc).
 
@@ -154,6 +190,7 @@ def _run_persist(
 		fetch_codes=fetch_codes,
 		show_ref_codes=show_ref_codes,
 		rebase_codes=rebase_codes,
+		rebase_abort_codes=rebase_abort_codes,
 		call_log=call_log,
 	)
 	ai_memory_lib._push_retry_backoff_seconds = fake_backoff
@@ -226,6 +263,21 @@ def test_persist_memory_operation_aborts_rebase_before_raising() -> None:
 	assert result is None
 	assert isinstance(exc, ai_memory_lib.MemoryGitError), exc
 	assert "Memory branch rebase failed while retrying push: rebase conflict" in str(exc)
+	assert backoff_attempts == [1], backoff_attempts
+	assert any(args == ("rebase", "--abort") for _op, args in call_log), call_log
+
+
+def test_persist_memory_operation_surfaces_rebase_abort_failure() -> None:
+	result, backoff_attempts, call_log, exc = _run_persist(
+		[1],
+		push_retries=2,
+		rebase_codes=[1],
+		rebase_abort_codes=[1],
+	)
+	assert result is None
+	assert isinstance(exc, ai_memory_lib.MemoryGitError), exc
+	assert "Memory branch rebase failed while retrying push: rebase conflict" in str(exc)
+	assert "rebase --abort also failed: rebase abort failed" in str(exc)
 	assert backoff_attempts == [1], backoff_attempts
 	assert any(args == ("rebase", "--abort") for _op, args in call_log), call_log
 

--- a/tests/test_ai_memory_push_retry_backoff.py
+++ b/tests/test_ai_memory_push_retry_backoff.py
@@ -75,23 +75,42 @@ def test_backoff_is_randomized() -> None:
 	assert len(samples) > 1, "backoff delay is not randomized"
 
 
-def _scripted_run_git(push_codes: list[int]):
-	"""Build a fake _run_git that yields scripted push return codes.
-
-	Every git op other than `push` succeeds; `diff --cached` reports staged
-	changes so the commit/push path is exercised.
-	"""
+def _scripted_run_git(
+	push_codes: list[int],
+	*,
+	fetch_codes: list[int] | None = None,
+	show_ref_codes: list[int] | None = None,
+	rebase_codes: list[int] | None = None,
+	call_log: list[tuple[str, tuple[str, ...]]] | None = None,
+):
+	"""Build a fake _run_git with scripted failure points in the retry loop."""
 
 	push_results = iter(push_codes)
+	fetch_results = iter(fetch_codes or [])
+	show_ref_results = iter(show_ref_codes or [])
+	rebase_results = iter(rebase_codes or [])
 
 	def fake_run_git(cwd, args, check: bool = True):  # noqa: ANN001 - test stub
 		op = args[0] if args else ""
+		if call_log is not None:
+			call_log.append((op, tuple(args)))
 		if op == "ls-remote":
 			return _FakeProc(returncode=0, stdout="")
 		if op == "diff":
 			return _FakeProc(returncode=1)  # staged changes present
 		if op == "rev-parse":
 			return _FakeProc(returncode=0, stdout="0123456789abcdef\n")
+		if op == "fetch":
+			rc = next(fetch_results, 0)
+			return _FakeProc(returncode=rc, stderr="" if rc == 0 else "fetch failed")
+		if op == "show-ref":
+			rc = next(show_ref_results, 0)
+			return _FakeProc(returncode=rc, stderr="" if rc == 0 else "show-ref missing")
+		if op == "rebase":
+			if len(args) > 1 and args[1] == "--abort":
+				return _FakeProc(returncode=0)
+			rc = next(rebase_results, 0)
+			return _FakeProc(returncode=rc, stderr="" if rc == 0 else "rebase conflict")
 		if op == "push":
 			rc = next(push_results)
 			return _FakeProc(
@@ -103,8 +122,15 @@ def _scripted_run_git(push_codes: list[int]):
 	return fake_run_git
 
 
-def _run_persist(push_codes: list[int], push_retries: int):
-	"""Drive persist_memory_operation with scripted pushes; return (result, backoff_attempts).
+def _run_persist(
+	push_codes: list[int],
+	push_retries: int,
+	*,
+	fetch_codes: list[int] | None = None,
+	show_ref_codes: list[int] | None = None,
+	rebase_codes: list[int] | None = None,
+):
+	"""Drive persist_memory_operation; return (result, backoff_attempts, call_log, exc).
 
 	`_run_git` and `_push_retry_backoff_seconds` are stubbed so the retry loop
 	runs without real git or real sleeps.  Either returns the result dict, or
@@ -115,6 +141,7 @@ def _run_persist(push_codes: list[int], push_retries: int):
 	repo_root = work / "repo"
 	repo_root.mkdir(parents=True, exist_ok=True)
 	backoff_attempts: list[int] = []
+	call_log: list[tuple[str, tuple[str, ...]]] = []
 
 	def fake_backoff(attempt: int) -> float:
 		backoff_attempts.append(attempt)
@@ -122,7 +149,13 @@ def _run_persist(push_codes: list[int], push_retries: int):
 
 	original_run_git = ai_memory_lib._run_git
 	original_backoff = ai_memory_lib._push_retry_backoff_seconds
-	ai_memory_lib._run_git = _scripted_run_git(push_codes)
+	ai_memory_lib._run_git = _scripted_run_git(
+		push_codes,
+		fetch_codes=fetch_codes,
+		show_ref_codes=show_ref_codes,
+		rebase_codes=rebase_codes,
+		call_log=call_log,
+	)
 	ai_memory_lib._push_retry_backoff_seconds = fake_backoff
 
 	def _op(_clone_dir: Path) -> dict:
@@ -137,9 +170,9 @@ def _run_persist(push_codes: list[int], push_retries: int):
 			commit_message="ai-memory: test claim",
 			operation=_op,
 		)
-		return result, backoff_attempts, None
+		return result, backoff_attempts, call_log, None
 	except ai_memory_lib.MemoryGitError as exc:
-		return None, backoff_attempts, exc
+		return None, backoff_attempts, call_log, exc
 	finally:
 		ai_memory_lib._run_git = original_run_git
 		ai_memory_lib._push_retry_backoff_seconds = original_backoff
@@ -149,7 +182,7 @@ def _run_persist(push_codes: list[int], push_retries: int):
 def test_persist_memory_operation_backs_off_then_succeeds_on_retry() -> None:
 	# Two rejected pushes (concurrent ref-lock race) then success: the backoff
 	# must fire once per failed attempt and the push must still land.
-	result, backoff_attempts, exc = _run_persist([1, 1, 0], push_retries=5)
+	result, backoff_attempts, _call_log, exc = _run_persist([1, 1, 0], push_retries=5)
 	assert exc is None, exc
 	assert result is not None
 	assert result["did_push"] is True, result
@@ -161,11 +194,40 @@ def test_persist_memory_operation_backs_off_then_succeeds_on_retry() -> None:
 def test_persist_memory_operation_backs_off_every_attempt_before_raising() -> None:
 	# All pushes rejected: backoff fires after every non-final attempt and the
 	# loop still raises — claiming is mutual exclusion and is not fail-open.
-	result, backoff_attempts, exc = _run_persist([1, 1, 1, 1], push_retries=4)
+	result, backoff_attempts, _call_log, exc = _run_persist([1, 1, 1, 1], push_retries=4)
 	assert result is None
 	assert isinstance(exc, ai_memory_lib.MemoryGitError), exc
+	assert "Failed to push memory branch after 4 attempts" in str(exc)
 	# 4 attempts -> backoff after attempts 1, 2, 3 (not after the final one).
 	assert backoff_attempts == [1, 2, 3], backoff_attempts
+
+
+def test_persist_memory_operation_raises_on_fetch_failure_before_rebase() -> None:
+	result, backoff_attempts, call_log, exc = _run_persist([1], push_retries=2, fetch_codes=[1])
+	assert result is None
+	assert isinstance(exc, ai_memory_lib.MemoryGitError), exc
+	assert "Memory branch fetch failed while retrying push: fetch failed" in str(exc)
+	assert backoff_attempts == [1], backoff_attempts
+	assert not any(op == "show-ref" for op, _args in call_log), call_log
+	assert not any(op == "rebase" for op, _args in call_log), call_log
+
+
+def test_persist_memory_operation_skips_rebase_when_remote_ref_is_missing() -> None:
+	result, backoff_attempts, call_log, exc = _run_persist([1, 0], push_retries=3, show_ref_codes=[1])
+	assert exc is None, exc
+	assert result is not None
+	assert result["did_push"] is True, result
+	assert backoff_attempts == [1], backoff_attempts
+	assert not any(args == ("rebase", "refs/remotes/origin/ai-memory") for _op, args in call_log), call_log
+
+
+def test_persist_memory_operation_aborts_rebase_before_raising() -> None:
+	result, backoff_attempts, call_log, exc = _run_persist([1], push_retries=2, rebase_codes=[1])
+	assert result is None
+	assert isinstance(exc, ai_memory_lib.MemoryGitError), exc
+	assert "Memory branch rebase failed while retrying push: rebase conflict" in str(exc)
+	assert backoff_attempts == [1], backoff_attempts
+	assert any(args == ("rebase", "--abort") for _op, args in call_log), call_log
 
 
 def main() -> int:

--- a/tests/test_ai_memory_push_retry_backoff.py
+++ b/tests/test_ai_memory_push_retry_backoff.py
@@ -173,47 +173,62 @@ def _run_persist(
 	the raised MemoryGitError, alongside the recorded backoff attempt numbers.
 	"""
 
-	work = Path(tempfile.mkdtemp(prefix="ai-memory-retry-test-"))
-	repo_root = work / "repo"
-	repo_root.mkdir(parents=True, exist_ok=True)
-	backoff_attempts: list[int] = []
-	call_log: list[tuple[str, tuple[str, ...]]] = []
-
-	def fake_backoff(attempt: int) -> float:
-		backoff_attempts.append(attempt)
-		return 0.0
-
-	original_run_git = ai_memory_lib._run_git
-	original_backoff = ai_memory_lib._push_retry_backoff_seconds
-	ai_memory_lib._run_git = _scripted_run_git(
-		push_codes,
-		fetch_codes=fetch_codes,
-		show_ref_codes=show_ref_codes,
-		rebase_codes=rebase_codes,
-		rebase_abort_codes=rebase_abort_codes,
-		call_log=call_log,
-	)
-	ai_memory_lib._push_retry_backoff_seconds = fake_backoff
-
-	def _op(_clone_dir: Path) -> dict:
-		return {"claimed": True}
-
+	work_tempdir = tempfile.tempdir
+	scratch_root: Path | None = None
+	work: Path | None = None
 	try:
-		result = ai_memory_lib.persist_memory_operation(
-			repo_root,
-			memory_branch="ai-memory",
-			memory_root_relative="ai-memory",
-			push_retries=push_retries,
-			commit_message="ai-memory: test claim",
-			operation=_op,
+		try:
+			work = Path(tempfile.mkdtemp(prefix="ai-memory-retry-test-"))
+		except FileNotFoundError:
+			scratch_root = REPO_ROOT / ".tmp-ai-memory-tests"
+			scratch_root.mkdir(parents=True, exist_ok=True)
+			tempfile.tempdir = str(scratch_root)
+			work = Path(tempfile.mkdtemp(prefix="ai-memory-retry-test-"))
+		repo_root = work / "repo"
+		repo_root.mkdir(parents=True, exist_ok=True)
+		backoff_attempts: list[int] = []
+		call_log: list[tuple[str, tuple[str, ...]]] = []
+
+		def fake_backoff(attempt: int) -> float:
+			backoff_attempts.append(attempt)
+			return 0.0
+
+		original_run_git = ai_memory_lib._run_git
+		original_backoff = ai_memory_lib._push_retry_backoff_seconds
+		ai_memory_lib._run_git = _scripted_run_git(
+			push_codes,
+			fetch_codes=fetch_codes,
+			show_ref_codes=show_ref_codes,
+			rebase_codes=rebase_codes,
+			rebase_abort_codes=rebase_abort_codes,
+			call_log=call_log,
 		)
-		return result, backoff_attempts, call_log, None
-	except ai_memory_lib.MemoryGitError as exc:
-		return None, backoff_attempts, call_log, exc
+		ai_memory_lib._push_retry_backoff_seconds = fake_backoff
+
+		def _op(_clone_dir: Path) -> dict:
+			return {"claimed": True}
+
+		try:
+			result = ai_memory_lib.persist_memory_operation(
+				repo_root,
+				memory_branch="ai-memory",
+				memory_root_relative="ai-memory",
+				push_retries=push_retries,
+				commit_message="ai-memory: test claim",
+				operation=_op,
+			)
+			return result, backoff_attempts, call_log, None
+		except ai_memory_lib.MemoryGitError as exc:
+			return None, backoff_attempts, call_log, exc
+		finally:
+			ai_memory_lib._run_git = original_run_git
+			ai_memory_lib._push_retry_backoff_seconds = original_backoff
 	finally:
-		ai_memory_lib._run_git = original_run_git
-		ai_memory_lib._push_retry_backoff_seconds = original_backoff
-		shutil.rmtree(work, ignore_errors=True)
+		tempfile.tempdir = work_tempdir
+		if work is not None:
+			shutil.rmtree(work, ignore_errors=True)
+		if scratch_root is not None:
+			shutil.rmtree(scratch_root, ignore_errors=True)
 
 
 def test_persist_memory_operation_backs_off_then_succeeds_on_retry() -> None:


### PR DESCRIPTION
## Summary

The AI Plan run for issue #2872 ([run 26268304639](https://github.com/shubhodeep1/coding-workflows/actions/runs/26268304639)) failed at the **Check and claim /answer command** step with:

```
AI_MEMORY_ERROR: Failed to push memory branch after 5 attempts: To https://github.com/shubhodeep1/coding-workflows
 ! [remote rejected]  HEAD -> ai-memory (cannot lock ref 'refs/heads/ai-memory': is at bc2d754... but expected 7224b2a...)
##[error]Process completed with exit code 2.
```

### Root cause

The `ai-memory` branch is a **single shared git ref** that every concurrent workflow run pushes to (`/answer` claim, `record-run-event`, `record-candidate`, etc.). `persist_memory_operation` (`scripts/ai_memory_lib.py`) retries a failed push with `fetch` + `rebase` between attempts — but with **no delay, backoff, or jitter**.

When the orchestrator dispatches a wave, many runs push to `refs/heads/ai-memory` near-simultaneously. Pushes to one ref are serialized server-side via a compare-and-swap ref lock; losers get `! [remote rejected] ... cannot lock ref`. With no jitter, all contenders retry in **lockstep** at the same git-op cadence and keep colliding. A run that loses the race for all `AI_MEMORY_PUSH_RETRIES` (default 5) attempts raises `MemoryGitError`.

Most memory ops are fail-open (wrapped in `memory_helpers.sh`), but `memory_processed_command_claim` is deliberately **not** fail-open (claiming is mutual exclusion — fail-open would risk double-processing the same `/answer`). The non-zero exit propagated through `set -euo pipefail` and killed the whole AI Plan run before any plan was posted. This is systemic — every repo running the orchestrator with wave dispatch hits the same single-hot-ref contention.

### Fix

Add **full-jitter exponential backoff** between push retry attempts in `persist_memory_operation`. The delay before retry attempt N+1 is drawn uniformly from `[0, min(8s, 0.5s · 2^(N-1))]`, so concurrent pushers decorrelate in time and a push lands within the retry budget instead of failing in lockstep. The retry count and fail-open semantics are unchanged.

## Changes

- `scripts/ai_memory_lib.py`
  - New `_push_retry_backoff_seconds()` helper + `_PUSH_RETRY_BACKOFF_BASE_SECONDS` / `_PUSH_RETRY_BACKOFF_CAP_SECONDS` constants (full-jitter exponential backoff).
  - `persist_memory_operation` push retry loop now sleeps `_push_retry_backoff_seconds(attempt)` before each `fetch`/`rebase`/retry.
  - Added `random` and `time` imports.
- `tests/test_ai_memory_push_retry_backoff.py` (new) — unit tests for the backoff bounds/cap/jitter, plus white-box tests that the retry loop backs off once per failed attempt and still succeeds on rebase-retry / raises after exhausting the budget.
- `.github/workflows/ci.yml` — register the new test in the unit-test step.

## Test plan

- [x] `python3 -m py_compile scripts/ai_memory_lib.py scripts/ai_memory.py`
- [x] `python3 tests/test_ai_memory_push_retry_backoff.py` — 6/6 pass
- [x] `python3 tests/test_ai_memory_processed_command_entry.py` — 7/7 pass (regression)
- [x] `ci.yml` validated as well-formed YAML

Refs #2872

https://claude.ai/code/session_01273uvwdTTimcGG8QNnyBNm

---
_Generated by [Claude Code](https://claude.ai/code/session_01273uvwdTTimcGG8QNnyBNm)_