### PR TITLE
fix(stall-recovery): filter cross-repo PRs in _fetch_linked_pr_status_graphql

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -6844,6 +6844,7 @@ _fetch_linked_pr_status_graphql() {
                   __typename
                   ... on PullRequest {
                     number state merged
+                    repository { nameWithOwner }
                     commits(last: 1) { nodes { commit { pushedDate committedDate } } }
                   }
                 }
@@ -6870,7 +6871,7 @@ _fetch_linked_pr_status_graphql() {
       continue
     fi
 
-    batch_transformed="$(printf '%s' "${batch_resp}" | jq -c '
+    batch_transformed="$(printf '%s' "${batch_resp}" | jq -c --arg repo "${owner}/${name}" '
       (.data.repository // {}) | to_entries | map(
         select(.value != null and (.value.number? != null)) | {
           key: (.value.number | tostring),
@@ -6879,6 +6880,7 @@ _fetch_linked_pr_status_graphql() {
               (.value.timelineItems.nodes // [])[]?
               | (.source // null)
               | select(. != null and .__typename == "PullRequest")
+              | select((.repository.nameWithOwner // "") == $repo)
               | {
                   number: .number,
                   state: .state,


### PR DESCRIPTION
## Summary

- `_fetch_linked_pr_status_graphql` accepted `CROSS_REFERENCED_EVENT` sources from **any repository**, so a foreign merged PR that merely cited consumer issue URLs in its body was treated as that issue's linked merged PR.
- This caused the stall-recovery merged-PR guard to stamp `ai:merged` on consumer issues `tele-funtoken-msg-scoring#3118` and `#3123` (via `coding-workflows#2866`), permanently blocking stall recovery — every poll cycle re-detected the false "merged" state, re-applied `ai:merged`, and skipped the real `auto_respond_clarify` recovery.
- The close-merged sweep (`gh_issue_timeline_with_cross_refs` in `gh_helpers.sh:1069-1072`) already had the correct same-repo filter; the stall-recovery prefetch path was missing it.

## Fix

Two-line change in `_fetch_linked_pr_status_graphql` (`scripts/orchestrate_poll_process.sh`):

1. **Line ~6847** — added `repository { nameWithOwner }` to the `... on PullRequest` GraphQL fragment so the repo is available in the response.
2. **Lines ~6874, 6883** — passed `--arg repo "${owner}/${name}"` to the `jq` call and added `| select((.repository.nameWithOwner // "") == $repo)` after the `.__typename == "PullRequest"` filter — mirroring the proven pattern in `gh_helpers.sh:1069-1072`.

A cross-repo PR will now produce no entry in the prefetch cache, causing `_check_merged_pr_guard` to fail open (return 1) and let stall recovery proceed normally.

## Test plan

- [ ] Verify that a consumer issue cross-referenced by a **same-repo** merged PR still triggers the guard (merged entry present in cache).
- [ ] Verify that a consumer issue cross-referenced only by a **foreign-repo** merged PR no longer triggers the guard (no entry / `null` in cache).
- [ ] Confirm `tele-funtoken-msg-scoring#3118` and `#3123` resume normal stall-recovery processing after `@stable` is updated to pick up this release.
- [ ] Confirm the `no_merged_pr_found` warning no longer fires for issues that have only foreign cross-references.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgZJuyw3RRwGat9s2XnbpD)_