### PR TITLE
fix(stall-recovery): skip open-PR guard for Refs-only cross-references

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -8116,6 +8116,7 @@ _fetch_linked_pr_status_graphql() {
           timelineItems(last: 50, itemTypes: [CROSS_REFERENCED_EVENT]) {
             nodes {
               ... on CrossReferencedEvent {
+                willCloseTarget
                 source {
                   __typename
                   ... on PullRequest {
@@ -8153,8 +8154,9 @@ _fetch_linked_pr_status_graphql() {
           value: (
             [
               (.value.timelineItems.nodes // [])[]?
-              | (.source // null)
-              | select(. != null and .__typename == "PullRequest")
+              | select(.willCloseTarget == true and (.source // null) != null)
+              | .source
+              | select(.__typename == "PullRequest")
               | {
                   number: .number,
                   state: .state,
@@ -9537,26 +9539,42 @@ recover_stalled_issue() {
         if [[ "${_lpr_num}" =~ ^[0-9]+$ ]]; then
           local _lpr_json=""
           local _lpr_merged=""
+          local _lpr_body=""
           _lpr_json="$(_fetch_pr_json "${_lpr_num}")"
           _lpr_state="$(_jq_field "${_lpr_json}" '.state' 'open|closed')"
           _lpr_merged="$(_jq_field "${_lpr_json}" '.merged_at != null' 'true|false')"
-          # REST-fallback merged-PR sub-guard: catches merged PRs that
-          # the batched GraphQL prefetch missed or failed to fetch
-          # (transient network error, partial batch, issue number that
-          # wasn't in the stalls list, etc.).  Without this, the
-          # merged-PR short-circuit silently regresses on any cache
-          # miss and the /reclarify loop from GH issue #1074 could
-          # recur.  Uses the same _reconcile_merged_pr_issue helper
-          # as the cache-hit path at the top of this guard, and
-          # respects ENABLE_STALL_MERGED_PR_GUARD so disabling the
-          # flag still gives full opt-out.  No extra API calls — the
-          # REST fallback has already fetched the PR payload on the
-          # preceding line.
-          if [ "${ENABLE_STALL_MERGED_PR_GUARD}" = "true" ] && [ "${_lpr_merged}" = "true" ]; then
-            echo "STALL_SKIP issue=${issue_num} reason=merged_linked_pr pr=${_lpr_num} phase=${phase} action=${action} source=rest_fallback"
-            _reconcile_merged_pr_issue "${issue_num}" "${phase}" "${action}" "${_lpr_num}"
-            STALL_HEALING_CHANGED=true
-            return 1  # Signal: no action taken (caller should not increment counter)
+          # Skip reference-only PRs ("Refs #N") — only implementation PRs
+          # that will auto-close the issue must trigger the merged/open guards.
+          # A "Refs #N" cross-reference (e.g. an infrastructure-fix PR that
+          # merely mentions the issue) must not block stall recovery or
+          # cause _reconcile_merged_pr_issue to tag the issue ai:merged.
+          # The GraphQL cache already filters by willCloseTarget; this REST
+          # fallback check mirrors that for the cache-miss path.
+          _lpr_body="$(printf '%s' "${_lpr_json}" | jq -r '.body // ""' 2>/dev/null || echo "")"
+          if ! { printf '%s' "${_lpr_body}" \
+              | grep -qiE "(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]:]+#${issue_num}\b" 2>/dev/null \
+              || printf '%s' "${_lpr_body}" \
+              | grep -qiE "(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]:]+(https?://github\.com/[^[:space:]]*/issues/${issue_num}([^0-9]|\$))" 2>/dev/null; }; then
+            _lpr_num=""
+          else
+            # REST-fallback merged-PR sub-guard: catches merged PRs that
+            # the batched GraphQL prefetch missed or failed to fetch
+            # (transient network error, partial batch, issue number that
+            # wasn't in the stalls list, etc.).  Without this, the
+            # merged-PR short-circuit silently regresses on any cache
+            # miss and the /reclarify loop from GH issue #1074 could
+            # recur.  Uses the same _reconcile_merged_pr_issue helper
+            # as the cache-hit path at the top of this guard, and
+            # respects ENABLE_STALL_MERGED_PR_GUARD so disabling the
+            # flag still gives full opt-out.  No extra API calls — the
+            # REST fallback has already fetched the PR payload on the
+            # preceding line.
+            if [ "${ENABLE_STALL_MERGED_PR_GUARD}" = "true" ] && [ "${_lpr_merged}" = "true" ]; then
+              echo "STALL_SKIP issue=${issue_num} reason=merged_linked_pr pr=${_lpr_num} phase=${phase} action=${action} source=rest_fallback"
+              _reconcile_merged_pr_issue "${issue_num}" "${phase}" "${action}" "${_lpr_num}"
+              STALL_HEALING_CHANGED=true
+              return 1  # Signal: no action taken (caller should not increment counter)
+            fi
           fi
         fi
       fi

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -8220,9 +8220,21 @@ _pr_json_closes_issue() {
       false
     else
       (.body // "") as $body
-      | ($body | test("(?i)(close[sd]?|fix(es|ed)?|resolve[sd]?):?[[:space:]]+#" + $n + "\\b"))
-        or
-        ($body | test("(?i)(close[sd]?|fix(es|ed)?|resolve[sd]?):?[[:space:]]+https?://github\\.com/[^[:space:]]+/[^[:space:]]+/issues/" + $n + "\\b"))
+      # Keep this conservative REST fallback aligned with
+      # scripts/lint_pr_body_auto_close.py: no colon forms, no keyword
+      # substrings inside larger words, and support short + URL refs.
+      | ($body | test(
+          "(?i)(^|[^[:alnum:]_-])"
+          + "(close[sd]?|fix(es|ed)?|resolve[sd]?)"
+          + "[[:space:]]+"
+          + "(#"
+          + $n
+          + "|[[:alnum:]_.-]+/[[:alnum:]_.-]+#"
+          + $n
+          + "|https?://github\\.com/[[:alnum:]_.-]+/[[:alnum:]_.-]+/issues/"
+          + $n
+          + ")([^[:alnum:]_-]|$)"
+        ))
     end
   ' >/dev/null 2>&1
   _rc=$?

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -7922,12 +7922,12 @@ _fetch_standalone_marker_issues_graphql() {
 # keep working unchanged.
 #
 # `linked_pr` is derived from the most recent CrossReferencedEvent
-# whose source is a pull request (equivalent to the REST
-# `[.[] | select(.event=="cross-referenced" and .source.issue.pull_request != null)] | last`
-# walk used by the existing open-PR guard).  It is consumed by the
-# merged-PR stall-recovery guard (ENABLE_STALL_MERGED_PR_GUARD) to
-# avoid firing /reclarify (and friends) on issues whose work has
-# already been merged.
+# whose source is a pull request AND whose `willCloseTarget` flag is
+# true, so reference-only links (`Refs #N`) do not populate the
+# stall-recovery/cache state.  It is consumed by the merged-PR
+# stall-recovery guard (ENABLE_STALL_MERGED_PR_GUARD) to avoid firing
+# /reclarify (and friends) on issues whose work has already been
+# merged.
 #
 # Trade-off: we fetch `comments(last: 100)` which covers only the 100
 # newest comments rather than the full pagination walk the REST path
@@ -7978,6 +7978,7 @@ _fetch_candidate_issue_details_graphql() {
           timelineItems(last: 50, itemTypes: [CROSS_REFERENCED_EVENT]) {
             nodes {
               ... on CrossReferencedEvent {
+                willCloseTarget
                 source {
                   __typename
                   ... on PullRequest {
@@ -8030,8 +8031,9 @@ _fetch_candidate_issue_details_graphql() {
             linked_pr: (
               [
                 (.value.timelineItems.nodes // [])[]?
-                | (.source // null)
-                | select(. != null and .__typename == "PullRequest")
+                | select(.willCloseTarget == true and (.source // null) != null)
+                | .source
+                | select(.__typename == "PullRequest")
                   | {
                       number: .number,
                       state: .state,
@@ -8179,6 +8181,59 @@ _fetch_linked_pr_status_graphql() {
   done
 
   echo "${merged}"
+}
+
+# _single_issue_linked_pr_status_graphql — convenience wrapper around
+# _fetch_linked_pr_status_graphql for cache-miss paths.  Returns the
+# same per-issue JSON entry ({number,state,merged,headPushedAt} or
+# null) while keeping the common path batched.
+_single_issue_linked_pr_status_graphql() {
+  local issue_num="$1"
+  if ! [[ "${issue_num}" =~ ^[0-9]+$ ]]; then
+    echo "null"
+    return
+  fi
+
+  local _single_resp
+  _single_resp="$(_fetch_linked_pr_status_graphql "[$issue_num]")"
+  printf '%s' "${_single_resp}" | jq -c --arg n "${issue_num}" '.[$n] // null' 2>/dev/null || echo "null"
+}
+
+# _pr_json_closes_issue — conservative closing-keyword check used only
+# after the authoritative GraphQL linked-PR lookups missed.  Return
+# codes: 0=yes, 1=no, 2=unknown/error.  Unknown preserves the candidate
+# PR so guards fail closed on transient payload/parse problems.
+_pr_json_closes_issue() {
+  local issue_num="$1"
+  local pr_json="$2"
+
+  if ! [[ "${issue_num}" =~ ^[0-9]+$ ]]; then
+    return 2
+  fi
+  if [ -z "${pr_json}" ] || [ "${pr_json}" = "{}" ]; then
+    return 2
+  fi
+
+  local _rc=0
+  printf '%s' "${pr_json}" | jq -e --arg n "${issue_num}" '
+    if type != "object" then
+      false
+    else
+      (.body // "") as $body
+      | ($body | test("(?i)(close[sd]?|fix(es|ed)?|resolve[sd]?):?[[:space:]]+#" + $n + "\\b"))
+        or
+        ($body | test("(?i)(close[sd]?|fix(es|ed)?|resolve[sd]?):?[[:space:]]+https?://github\\.com/[^[:space:]]+/[^[:space:]]+/issues/" + $n + "\\b"))
+    end
+  ' >/dev/null 2>&1
+  _rc=$?
+  if [ "${_rc}" -eq 0 ]; then
+    return 0
+  fi
+
+  if [ "${_rc}" -eq 1 ]; then
+    return 1
+  fi
+  return 2
 }
 
 # _check_merged_pr_guard — Shared guard used by both the standalone and
@@ -8626,6 +8681,11 @@ PY
     # before fresh-push suppression can short-circuit this issue for the cycle.
     local _std_linked_json
     _std_linked_json="$(printf '%s' "${_candidate_details_json}" | jq -c --arg n "${issue_num}" '.[$n].linked_pr // null' 2>/dev/null || echo "null")"
+    if [ -z "${_std_linked_json}" ] || [ "${_std_linked_json}" = "null" ] || [ "${_std_linked_json}" = "{}" ]; then
+      # Cache miss — retry a narrow single-issue GraphQL lookup before
+      # falling back to the legacy timeline/body heuristics.
+      _std_linked_json="$(_single_issue_linked_pr_status_graphql "${issue_num}")"
+    fi
     if _check_merged_pr_guard "${issue_num}" "${_std_linked_json}"; then
       echo "  [standalone-stall] Issue #${issue_num} linked PR #${STALL_MERGED_PR_NUM} is MERGED — skipping '${action}' and tagging ai:merged."
       _reconcile_merged_pr_issue "${issue_num}" "${phase}" "${action}" "${STALL_MERGED_PR_NUM}"
@@ -8660,17 +8720,25 @@ PY
     # are empty — the stall action then runs as before.
     case "${action}" in
       retrigger_pipeline|auto_respond_clarify|retrigger_plan|auto_approve|retrigger_implement)
-        # Cache miss — REST fallback (timeline → PR payload → merged_at).
-        # Two extra API calls per cache-miss issue, bounded by the
-        # rarity of prefetch failures.  Gated on the guard flag so
+        # True cache miss — the batched lookup AND the single-issue
+        # GraphQL retry both missed, so fall back to the legacy
+        # timeline → PR-payload path.  Gated on the guard flag so
         # disabling it still gives full opt-out.
         if { [ -z "${_std_linked_json}" ] || [ "${_std_linked_json}" = "null" ]; } && [ "${ENABLE_STALL_MERGED_PR_GUARD}" = "true" ]; then
-          local _std_lpr_num _std_lpr_json _std_lpr_merged
+          local _std_lpr_num _std_lpr_json _std_lpr_merged _std_body_check_rc
           _std_lpr_num="$(_issue_cross_ref_pr_number_last "${issue_num}" 2>/dev/null || echo "")"
           if [[ "${_std_lpr_num}" =~ ^[0-9]+$ ]]; then
             _std_lpr_json="$(_fetch_pr_json "${_std_lpr_num}")"
+            if _pr_json_closes_issue "${issue_num}" "${_std_lpr_json}"; then
+              _std_body_check_rc=0
+            else
+              _std_body_check_rc=$?
+            fi
+            if [ "${_std_body_check_rc}" -eq 1 ]; then
+              _std_lpr_num=""
+            fi
             _std_lpr_merged="$(_jq_field "${_std_lpr_json}" '.merged_at != null' 'true|false')"
-            if [ "${_std_lpr_merged}" = "true" ]; then
+            if [ -n "${_std_lpr_num}" ] && [ "${_std_lpr_merged}" = "true" ]; then
               # Synthesise the same shape the cache would have produced
               # so _check_merged_pr_guard can consume it uniformly.
               _std_linked_json="$(jq -cn --argjson n "${_std_lpr_num}" '{number: $n, state: "MERGED", merged: true}' 2>/dev/null || echo "null")"
@@ -9525,7 +9593,18 @@ recover_stalled_issue() {
         return 1  # Signal: no action taken (caller should not increment counter)
       fi
 
-      # --- Open-PR sub-guard (uses cache first, falls back to per-issue REST) ---
+      if [ -z "${_lpr_cache_entry}" ] || [ "${_lpr_cache_entry}" = "null" ] || [ "${_lpr_cache_entry}" = "{}" ]; then
+        _lpr_cache_entry="$(_single_issue_linked_pr_status_graphql "${issue_num}")"
+        if _check_merged_pr_guard "${issue_num}" "${_lpr_cache_entry}"; then
+          echo "STALL_SKIP issue=${issue_num} reason=merged_linked_pr pr=${STALL_MERGED_PR_NUM} phase=${phase} action=${action} source=single_issue_graphql"
+          _reconcile_merged_pr_issue "${issue_num}" "${phase}" "${action}" "${STALL_MERGED_PR_NUM}"
+          STALL_HEALING_CHANGED=true
+          return 1  # Signal: no action taken (caller should not increment counter)
+        fi
+      fi
+
+      # --- Open-PR sub-guard (uses cache first, then single-issue GraphQL,
+      #     then falls back to per-issue REST) ---
       local _lpr_num=""
       local _lpr_state=""
       if [ -n "${_lpr_cache_entry}" ] && [ "${_lpr_cache_entry}" != "null" ]; then
@@ -9539,22 +9618,21 @@ recover_stalled_issue() {
         if [[ "${_lpr_num}" =~ ^[0-9]+$ ]]; then
           local _lpr_json=""
           local _lpr_merged=""
-          local _lpr_body=""
+          local _lpr_body_check_rc=""
           _lpr_json="$(_fetch_pr_json "${_lpr_num}")"
           _lpr_state="$(_jq_field "${_lpr_json}" '.state' 'open|closed')"
           _lpr_merged="$(_jq_field "${_lpr_json}" '.merged_at != null' 'true|false')"
-          # Skip reference-only PRs ("Refs #N") — only implementation PRs
-          # that will auto-close the issue must trigger the merged/open guards.
-          # A "Refs #N" cross-reference (e.g. an infrastructure-fix PR that
-          # merely mentions the issue) must not block stall recovery or
-          # cause _reconcile_merged_pr_issue to tag the issue ai:merged.
-          # The GraphQL cache already filters by willCloseTarget; this REST
-          # fallback check mirrors that for the cache-miss path.
-          _lpr_body="$(printf '%s' "${_lpr_json}" | jq -r '.body // ""' 2>/dev/null || echo "")"
-          if ! { printf '%s' "${_lpr_body}" \
-              | grep -qiE "(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]:]+#${issue_num}\b" 2>/dev/null \
-              || printf '%s' "${_lpr_body}" \
-              | grep -qiE "(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]:]+(https?://github\.com/[^[:space:]]*/issues/${issue_num}([^0-9]|\$))" 2>/dev/null; }; then
+          # Skip reference-only PRs ("Refs #N") only after the batched
+          # cache and single-issue GraphQL retry both missed.  At that
+          # point the PR body is the best available signal; when even the
+          # body parse is indeterminate, preserve the candidate PR so the
+          # guard fails closed on transient API/payload errors.
+          if _pr_json_closes_issue "${issue_num}" "${_lpr_json}"; then
+            _lpr_body_check_rc=0
+          else
+            _lpr_body_check_rc=$?
+          fi
+          if [ "${_lpr_body_check_rc}" -eq 1 ]; then
             _lpr_num=""
           else
             # REST-fallback merged-PR sub-guard: catches merged PRs that

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -1211,6 +1211,7 @@ if args[0] == 'api':
 					if pr_state == 'MERGED':
 						pr_state = 'CLOSED'
 					timeline_nodes.append({
+						'willCloseTarget': bool(pr.get('willCloseTarget', True)),
 						'source': {
 							'__typename': 'PullRequest',
 							'number': int(pr.get('number', linked_pr_num)),
@@ -3927,6 +3928,43 @@ def test_standalone_stall_recovery_honors_ai_done_phase_attempt_override():
 	assert standalone_state["stall_recovery_count"] == 1
 	assert standalone_state["phase_attempts"]["ai:done"] == 6
 	assert "ai:closed" not in result["issues"]["501"]["labels"]
+
+
+def test_standalone_merged_guard_ignores_refs_only_cross_reference():
+	state = _base_state(status="complete")
+	standalone_state_comment = (
+		"<!-- AI_STANDALONE_STALL_STATE_V1\n"
+		+ json.dumps({
+			"schema_version": 1,
+			"last_seen_phase": "ai:planning",
+			"status_since_ts": 1,
+			"stall_recovery_count": 0,
+		})
+		+ "\nAI_STANDALONE_STALL_STATE_V1 -->"
+	)
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		issue_labels={10: ["ai:merged"], 501: ["ai:planning"]},
+		issue_comments={501: [standalone_state_comment]},
+		issue_linked_prs={501: 416},
+		mock_gh_issue_list_label_filter=True,
+		prs=[
+			{
+				"number": 416,
+				"state": "closed",
+				"merged": True,
+				"merged_at": "2026-04-15T00:00:00Z",
+				"body": "Refs #501",
+				"willCloseTarget": False,
+			},
+		],
+	)
+	standalone_state = _extract_latest_standalone_state(result["issues"]["501"]["comments"])
+	assert standalone_state is not None
+	assert standalone_state["stall_recovery_count"] == 1
+	assert "ai:merged" not in result["issues"]["501"]["labels"]
 
 
 def test_standalone_retrigger_review_does_not_increment_when_empty_commit_checkout_fails():
@@ -6916,6 +6954,36 @@ def test_no_labels_with_open_linked_pr_skips_retrigger_pipeline():
 	issue_entry = result["latest_state"]["waves"][0]["issues"][0]
 	# Counter must NOT increment when the guard skips the action.
 	assert issue_entry["stall_recovery_count"] == 0
+	assert issue_entry["status"] == "in_progress"
+
+
+def test_no_labels_with_refs_only_linked_pr_still_retriggers_pipeline():
+	state = _base_state(status="in_progress")
+	state["waves"][0]["issues"][0]["status"] = "in_progress"
+	state["waves"][0]["issues"][0]["status_since_ts"] = 1
+	state["waves"][0]["issues"][0]["last_seen_phase"] = "no_labels"
+	state["waves"][0]["issues"][0]["stall_recovery_count"] = 0
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		issue_labels={10: []},
+		issue_linked_prs={10: 931},
+		prs=[{
+			"number": 931,
+			"state": "open",
+			"body": "Refs #10",
+			"willCloseTarget": False,
+			"baseRefName": "main",
+			"headRefName": "infra/fix-931",
+			"mergeable": True,
+			"mergeable_state": "clean",
+		}],
+	)
+	issue_comments = [c.get("body", "") for c in result["issues"]["10"]["comments"]]
+	assert any("/reclarify" in body for body in issue_comments)
+	issue_entry = result["latest_state"]["waves"][0]["issues"][0]
+	assert issue_entry["stall_recovery_count"] == 1
 	assert issue_entry["status"] == "in_progress"
 
 

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -6957,6 +6957,97 @@ def test_no_labels_with_open_linked_pr_skips_retrigger_pipeline():
 	assert issue_entry["status"] == "in_progress"
 
 
+def test_no_labels_with_rest_fallback_closing_linked_pr_skips_retrigger_pipeline():
+	state = _base_state(status="in_progress")
+	state["waves"][0]["issues"][0]["status"] = "in_progress"
+	state["waves"][0]["issues"][0]["status_since_ts"] = 1
+	state["waves"][0]["issues"][0]["last_seen_phase"] = "no_labels"
+	state["waves"][0]["issues"][0]["stall_recovery_count"] = 0
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		gql_mode="error",
+		issue_labels={10: []},
+		issue_linked_prs={10: 932},
+		prs=[{
+			"number": 932,
+			"state": "open",
+			"body": "Fixes #10",
+			"baseRefName": "main",
+			"headRefName": "ai/issue-10",
+			"mergeable": True,
+			"mergeable_state": "clean",
+		}],
+	)
+	issue_comments = [c.get("body", "") for c in result["issues"]["10"]["comments"]]
+	assert not any("/reclarify" in body for body in issue_comments)
+	assert not any("/answer" in body for body in issue_comments)
+	issue_entry = result["latest_state"]["waves"][0]["issues"][0]
+	assert issue_entry["stall_recovery_count"] == 0
+	assert issue_entry["status"] == "in_progress"
+
+
+def test_no_labels_with_rest_fallback_keyword_substring_still_retriggers_pipeline():
+	state = _base_state(status="in_progress")
+	state["waves"][0]["issues"][0]["status"] = "in_progress"
+	state["waves"][0]["issues"][0]["status_since_ts"] = 1
+	state["waves"][0]["issues"][0]["last_seen_phase"] = "no_labels"
+	state["waves"][0]["issues"][0]["stall_recovery_count"] = 0
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		gql_mode="error",
+		issue_labels={10: []},
+		issue_linked_prs={10: 933},
+		prs=[{
+			"number": 933,
+			"state": "open",
+			"body": "We need to prefix #10 before rollout",
+			"baseRefName": "main",
+			"headRefName": "infra/fix-933",
+			"mergeable": True,
+			"mergeable_state": "clean",
+		}],
+	)
+	issue_comments = [c.get("body", "") for c in result["issues"]["10"]["comments"]]
+	assert any("/reclarify" in body for body in issue_comments)
+	issue_entry = result["latest_state"]["waves"][0]["issues"][0]
+	assert issue_entry["stall_recovery_count"] == 1
+	assert issue_entry["status"] == "in_progress"
+
+
+def test_no_labels_with_rest_fallback_colon_form_still_retriggers_pipeline():
+	state = _base_state(status="in_progress")
+	state["waves"][0]["issues"][0]["status"] = "in_progress"
+	state["waves"][0]["issues"][0]["status_since_ts"] = 1
+	state["waves"][0]["issues"][0]["last_seen_phase"] = "no_labels"
+	state["waves"][0]["issues"][0]["stall_recovery_count"] = 0
+	result = _run_poller(
+		state=state,
+		enable_validation="false",
+		max_validate_cycles="3",
+		gql_mode="error",
+		issue_labels={10: []},
+		issue_linked_prs={10: 934},
+		prs=[{
+			"number": 934,
+			"state": "open",
+			"body": "Closes: #10",
+			"baseRefName": "main",
+			"headRefName": "infra/fix-934",
+			"mergeable": True,
+			"mergeable_state": "clean",
+		}],
+	)
+	issue_comments = [c.get("body", "") for c in result["issues"]["10"]["comments"]]
+	assert any("/reclarify" in body for body in issue_comments)
+	issue_entry = result["latest_state"]["waves"][0]["issues"][0]
+	assert issue_entry["stall_recovery_count"] == 1
+	assert issue_entry["status"] == "in_progress"
+
+
 def test_no_labels_with_refs_only_linked_pr_still_retriggers_pipeline():
 	state = _base_state(status="in_progress")
 	state["waves"][0]["issues"][0]["status"] = "in_progress"


### PR DESCRIPTION
## Summary

- `_fetch_linked_pr_status_graphql` now adds `willCloseTarget` to the `CrossReferencedEvent` GraphQL fragment and filters to only closing PRs, so `Refs #N` links no longer populate the stall-recovery guard cache
- REST fallback path now checks the PR body for closing keywords (`Closes/Fixes/Resolves #N` and the URL form) before applying either the merged-PR or open-PR guard

## Root cause

PR #2889 used `Refs #2872` to document the causal link between an infrastructure fix and the issue whose plan run it unblocked. GitHub recorded a `CrossReferencedEvent` on #2872's timeline. The stall recovery guard at `recover_stalled_issue` treated any cross-referenced PR as an implementation PR — picking the last event regardless of `willCloseTarget`. This caused:

1. **Immediate**: `auto_respond_clarify` was silently skipped for issue #2872 (phase=`ai:clarification`), leaving it permanently stuck because the planning phase could never be re-triggered.
2. **Latent**: Once PR #2889 merged, `_reconcile_merged_pr_issue` would have tagged #2872 with `ai:merged` and `close_merged_issues_sweep` would have closed it — even though #2872 was never implemented.

## Fix (two-part)

**GraphQL cache** (`_fetch_linked_pr_status_graphql`, `scripts/orchestrate_poll_process.sh:8116-8168`):
- Added `willCloseTarget` to the `CrossReferencedEvent` fragment
- jq filter now `select(.willCloseTarget == true ...)` before `last // null`
- Issues with only `Refs #N` references get a `null` cache entry → neither guard fires

**REST fallback** (`recover_stalled_issue`, `scripts/orchestrate_poll_process.sh:9539-9579`):
- After fetching PR JSON, checks body for closing keywords (`Closes/Fixes/Resolves #N` and the URL form used by the implement workflow)
- Non-closing bodies clear `_lpr_num` before the merged-PR guard runs, preventing both the open-PR skip and the spurious `ai:merged` tag

## Proactive fixes included

None — this is a targeted, in-scope fix for the stall recovery false-positive.

Refs #2872

https://claude.ai/code/session_01KQtZiVbwx3QCKFjQWYZ3N5

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQtZiVbwx3QCKFjQWYZ3N5)_