### PR TITLE
fix: auto-resolve merge conflicts in forward-merge PRs

### DIFF
--- a/.github/workflows/forward-merge-stable-to-main.yml
+++ b/.github/workflows/forward-merge-stable-to-main.yml
@@ -24,11 +24,13 @@ name: Forward-merge stable to main
 permissions:
   contents: write
   pull-requests: write
-  # actions: read is required by the hard-failure TG alert step so
-  # the failing-step lookup against the Actions Jobs API works when
-  # GH_PAT is unset and we fall back to github.token. Without this,
-  # `failing_step` would always be empty on github.token-only runs.
-  actions: read
+  # actions: write lets the "Dispatch AI review for the fallback PR" step
+  # below start internal-review.yml via `gh workflow run` (workflow_dispatch
+  # is exempt from the GITHUB_TOKEN no-trigger rule). It is a superset of
+  # actions: read, so the hard-failure TG alert step's failing-step lookup
+  # against the Actions Jobs API still works when GH_PAT is unset and we
+  # fall back to github.token.
+  actions: write
 
 concurrency:
   group: forward-merge-stable-to-main
@@ -312,6 +314,13 @@ jobs:
             PR_URL=$(printf '%s' "${PR_OUTPUT}" | grep -oE 'https://github\.com/[^[:space:]]+' | head -n1 || true)
             echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
             echo "reason=${MERGE_STATUS}" >> "$GITHUB_OUTPUT"
+            # Trailing path segment of the PR URL is its number — consumed by
+            # the "Dispatch AI review for the fallback PR" step below. A PR
+            # opened with GITHUB_TOKEN does not emit the pull_request event
+            # that would otherwise auto-start internal-review.yml's reviewer
+            # and conflict-resolver, so it must be dispatched explicitly.
+            PR_NUMBER=$(printf '%s' "${PR_URL}" | grep -oE '[0-9]+$' || true)
+            echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
           elif printf '%s' "${PR_OUTPUT}" | grep -qiE 'pull request for branch .* already exists'; then
             # Anchored to gh CLI's canonical phrasing: "a pull request
             # for branch <name> into branch <base> already exists". The
@@ -363,6 +372,28 @@ jobs:
           msg+=$'\n'"Bug fixes on stable will not reach main until this PR is merged."
 
           tg_send_msg "${msg}" "ERROR" >/dev/null || true
+
+      - name: Dispatch AI review for the fallback PR
+        # A fallback PR opened with GITHUB_TOKEN does not emit the
+        # pull_request event, so internal-review.yml's reviewer and
+        # conflict-resolver never auto-start. Dispatch it explicitly
+        # (workflow_dispatch is exempt from the GITHUB_TOKEN no-trigger
+        # rule) so the conflict resolver runs promptly instead of
+        # waiting for the orchestrator poller to discover the PR.
+        # Non-fatal: the PR is the durable safety net, and the poller
+        # remains the fallback if this dispatch fails.
+        if: steps.fallback.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          PR_NUMBER: ${{ steps.fallback.outputs.pr_number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh workflow run internal-review.yml -f "pr_number=${PR_NUMBER}"; then
+            echo "Dispatched internal-review.yml for PR #${PR_NUMBER}"
+          else
+            echo "::warning::Failed to dispatch internal-review.yml for PR #${PR_NUMBER}; the orchestrator poller will pick the PR up on its next cycle."
+          fi
 
       - name: Summary
         if: always()

--- a/.github/workflows/forward-merge-stable-to-main.yml
+++ b/.github/workflows/forward-merge-stable-to-main.yml
@@ -244,6 +244,14 @@ jobs:
           # branch name — without it, the second `git push origin
           # <branch>` would fail (non-fast-forward or already-exists)
           # and abort before the PR is opened.
+          resolve_existing_pr_number() {
+            # `gh pr create` only returns a machine-readable URL on the success
+            # path. The benign "already exists" branch still needs the open PR
+            # number for the follow-up review dispatch, so look it up by head/base.
+            gh pr list --head "${BRANCH}" --base main --state open \
+              --json number --jq '.[0].number // empty' 2>/dev/null || true
+          }
+
           BRANCH="auto/forward-merge-stable-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
           # The merge-strategy warning is identical on both paths and
@@ -330,6 +338,12 @@ jobs:
             # already alerted, and a re-run shouldn't spam TG.
             echo "::warning::PR already exists for ${BRANCH} — treating as benign"
             echo "${PR_OUTPUT}"
+            PR_NUMBER="$(resolve_existing_pr_number)"
+            if [ -n "${PR_NUMBER}" ]; then
+              echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+            else
+              echo "::warning::Could not resolve the existing fallback PR number for ${BRANCH}; skipping immediate review dispatch."
+            fi
           else
             echo "::error::Failed to create fallback PR for ${BRANCH} (rc=${PR_RC})"
             echo "${PR_OUTPUT}" >&2
@@ -386,10 +400,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
           PR_NUMBER: ${{ steps.fallback.outputs.pr_number }}
+          ALLOW_WORKFLOW_EDITS: ${{ contains(' 1 true yes on ', format(' {0} ', vars.ALLOW_WORKFLOW_EDITS || 'true')) && 'true' || 'false' }}
         shell: bash
         run: |
           set -euo pipefail
-          if gh workflow run internal-review.yml -f "pr_number=${PR_NUMBER}"; then
+          if gh workflow run internal-review.yml \
+            -f "pr_number=${PR_NUMBER}" \
+            -f "allow_workflow_edits=${ALLOW_WORKFLOW_EDITS}"; then
             echo "Dispatched internal-review.yml for PR #${PR_NUMBER}"
           else
             echo "::warning::Failed to dispatch internal-review.yml for PR #${PR_NUMBER}; the orchestrator poller will pick the PR up on its next cycle."

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3140,6 +3140,32 @@ jobs:
             sed 's/^/git merge stderr: /' "${MERGE_STDERR_FILE}"
           fi
 
+          # Blobless partial clone recovery (the codex-agent checkout uses
+          # `filter: blob:none`): the 3-way merge lazy-fetches blob content
+          # from the promisor remote, and that batched on-demand fetch fails
+          # hard (exit 128) when any single OID in the batch is unreachable
+          # server-side ("not our ref" / "could not fetch ... from promisor
+          # remote") — even though the merge itself is well-formed. On that
+          # signature, drop the partial filter, refetch the merge inputs so
+          # every blob is materialised locally, and retry the merge once.
+          # Without this the gate misreads a transient/infra fetch failure as
+          # a deterministic stale base and skips the conflict resolver.
+          if [ "${merge_exit}" -ne 0 ] && [ ! -f "$(git rev-parse --git-dir)/MERGE_HEAD" ] \
+             && grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${MERGE_STDERR_FILE}" 2>/dev/null; then
+            echo "::warning::Pre-review merge probe hit a partial-clone promisor fetch failure; backfilling blobs and retrying the merge once."
+            git reset --hard HEAD >/dev/null 2>&1 || true
+            git config --unset-all remote.origin.partialclonefilter 2>/dev/null || true
+            if ! git fetch --no-tags --prune --refetch origin "${_merge_refspecs[@]}" 2>/dev/null; then
+              echo "::warning::blob-backfill refetch failed during pre-review merge gate; retrying the merge anyway."
+            fi
+            merge_exit=0
+            : > "${MERGE_STDERR_FILE}"
+            git merge --no-commit --no-ff "origin/${BASE_BRANCH}" 2> "${MERGE_STDERR_FILE}" || merge_exit=$?
+            if [ -s "${MERGE_STDERR_FILE}" ]; then
+              sed 's/^/git merge stderr (after blob backfill): /' "${MERGE_STDERR_FILE}"
+            fi
+          fi
+
           if [ -z "$(git ls-files --unmerged)" ]; then
             if [ "${merge_exit}" -ne 0 ] && [ ! -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
               _merge_stderr_oneline="$(tr '\n' ' ' < "${MERGE_STDERR_FILE}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
@@ -3158,10 +3184,20 @@ jobs:
                   exit 0
                 fi
               elif [ "${merge_exit}" -eq 128 ]; then
-                echo "::error::Pre-review merge topology gate failed (exit 128): git merge aborted before entering merge state. Skipping reviewer/editor spend. See pre-review diagnostics above. git stderr: ${_merge_stderr_oneline}"
-                echo "AUTOFIX_PRE_REVIEW_MERGE_TOPOLOGY pr=${PR_NUMBER} base_branch=${BASE_BRANCH} local_sha=${LOCAL_HEAD_SHA} result=merge_precheck_failed_exit_128 action=soft_exit"
-                echo "AUTOFIX_STALE_BASE_SKIP=true" >> "$GITHUB_ENV"
-                exit 0
+                if grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${MERGE_STDERR_FILE}" 2>/dev/null; then
+                  # A partial-clone promisor fetch failure that survived the
+                  # blob-backfill retry above is an infrastructure error, not
+                  # a deterministic stale base. Fail OPEN so the reviewer +
+                  # conflict-resolver path still runs (the resolver runs its
+                  # own merge with its own backfill) rather than skipping it.
+                  echo "::warning::Pre-review merge topology gate: exit 128 from a partial-clone promisor fetch failure that survived the blob-backfill retry. Failing open to the reviewer/resolver path. git stderr: ${_merge_stderr_oneline}"
+                  echo "AUTOFIX_PRE_REVIEW_MERGE_TOPOLOGY pr=${PR_NUMBER} base_branch=${BASE_BRANCH} local_sha=${LOCAL_HEAD_SHA} result=merge_precheck_promisor_fetch_failed action=fail_open"
+                else
+                  echo "::error::Pre-review merge topology gate failed (exit 128): git merge aborted before entering merge state. Skipping reviewer/editor spend. See pre-review diagnostics above. git stderr: ${_merge_stderr_oneline}"
+                  echo "AUTOFIX_PRE_REVIEW_MERGE_TOPOLOGY pr=${PR_NUMBER} base_branch=${BASE_BRANCH} local_sha=${LOCAL_HEAD_SHA} result=merge_precheck_failed_exit_128 action=soft_exit"
+                  echo "AUTOFIX_STALE_BASE_SKIP=true" >> "$GITHUB_ENV"
+                  exit 0
+                fi
               else
                 echo "::warning::Pre-review merge topology gate hit an inconclusive merge failure (exit ${merge_exit}); continuing to reviewers. git stderr: ${_merge_stderr_oneline}"
                 echo "AUTOFIX_PRE_REVIEW_MERGE_TOPOLOGY pr=${PR_NUMBER} base_branch=${BASE_BRANCH} local_sha=${LOCAL_HEAD_SHA} result=merge_failure_inconclusive_exit_${merge_exit} action=fail_open"

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3135,9 +3135,16 @@ jobs:
           echo "========================================"
 
           merge_exit=0
+          merge_promisor_fetch_failure_seen=false
+          merge_promisor_initial_stderr=""
           git merge --no-commit --no-ff "origin/${BASE_BRANCH}" 2> "${MERGE_STDERR_FILE}" || merge_exit=$?
           if [ -s "${MERGE_STDERR_FILE}" ]; then
             sed 's/^/git merge stderr: /' "${MERGE_STDERR_FILE}"
+          fi
+          if grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${MERGE_STDERR_FILE}" 2>/dev/null; then
+            merge_promisor_fetch_failure_seen=true
+            merge_promisor_initial_stderr="$(tr '\n' ' ' < "${MERGE_STDERR_FILE}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
+            merge_promisor_initial_stderr="${merge_promisor_initial_stderr:-<git merge produced no stderr>}"
           fi
 
           # Blobless partial clone recovery (the codex-agent checkout uses
@@ -3151,12 +3158,16 @@ jobs:
           # Without this the gate misreads a transient/infra fetch failure as
           # a deterministic stale base and skips the conflict resolver.
           if [ "${merge_exit}" -ne 0 ] && [ ! -f "$(git rev-parse --git-dir)/MERGE_HEAD" ] \
-             && grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${MERGE_STDERR_FILE}" 2>/dev/null; then
+             && [ "${merge_promisor_fetch_failure_seen}" = "true" ]; then
             echo "::warning::Pre-review merge probe hit a partial-clone promisor fetch failure; backfilling blobs and retrying the merge once."
             git reset --hard HEAD >/dev/null 2>&1 || true
             git config --unset-all remote.origin.partialclonefilter 2>/dev/null || true
-            if ! git fetch --no-tags --prune --refetch origin "${_merge_refspecs[@]}" 2>/dev/null; then
-              echo "::warning::blob-backfill refetch failed during pre-review merge gate; retrying the merge anyway."
+            _refetch_rc=0
+            _refetch_stderr="$(git fetch --no-tags --prune --refetch origin "${_merge_refspecs[@]}" 2>&1 >/dev/null)" || _refetch_rc=$?
+            if [ "${_refetch_rc}" -ne 0 ]; then
+              _refetch_stderr="$(printf '%s' "${_refetch_stderr}" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
+              _refetch_stderr="${_refetch_stderr:-<git fetch produced no stderr>}"
+              echo "::warning::blob-backfill refetch failed during pre-review merge gate; retrying the merge anyway. git fetch stderr: ${_refetch_stderr}"
             fi
             merge_exit=0
             : > "${MERGE_STDERR_FILE}"
@@ -3170,6 +3181,10 @@ jobs:
             if [ "${merge_exit}" -ne 0 ] && [ ! -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
               _merge_stderr_oneline="$(tr '\n' ' ' < "${MERGE_STDERR_FILE}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
               _merge_stderr_oneline="${_merge_stderr_oneline:-<git merge produced no stderr>}"
+              if [ "${merge_promisor_fetch_failure_seen}" = "true" ] && [ -n "${merge_promisor_initial_stderr}" ] \
+                 && [ "${merge_promisor_initial_stderr}" != "${_merge_stderr_oneline}" ]; then
+                _merge_stderr_oneline="${_merge_stderr_oneline} | initial promisor stderr: ${merge_promisor_initial_stderr}"
+              fi
               _merge_stderr_oneline="$(printf '%s' "${_merge_stderr_oneline}" | sed 's/%/%25/g; s/\r/%0D/g')"
               if grep -qi 'refusing to merge unrelated histories' "${MERGE_STDERR_FILE}" 2>/dev/null; then
                 if [ "${merge_probe_ambiguous}" = "true" ]; then
@@ -3184,7 +3199,8 @@ jobs:
                   exit 0
                 fi
               elif [ "${merge_exit}" -eq 128 ]; then
-                if grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${MERGE_STDERR_FILE}" 2>/dev/null; then
+                if [ "${merge_promisor_fetch_failure_seen}" = "true" ] \
+                   || grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${MERGE_STDERR_FILE}" 2>/dev/null; then
                   # A partial-clone promisor fetch failure that survived the
                   # blob-backfill retry above is an infrastructure error, not
                   # a deterministic stale base. Fail OPEN so the reviewer +

--- a/scripts/review_conflict_prepare.sh
+++ b/scripts/review_conflict_prepare.sh
@@ -118,6 +118,8 @@ git clean -ffdx -e .codex-workflow-src -e .codex-workflow-src-main 2>/dev/null |
 #              happens we must surface it instead of silently
 #              running Codex against an empty conflict set.
 _merge_exit=0
+_merge_promisor_fetch_failure_seen=false
+_merge_promisor_initial_stderr=""
 # Capture stderr so the hard-fail annotation below can surface git's
 # real complaint (e.g. "refusing to merge unrelated histories") instead
 # of a generic "investigate" message.
@@ -126,6 +128,11 @@ trap 'rm -f "${_merge_stderr_file}"' EXIT INT TERM
 git merge --no-commit --no-ff "origin/${BASE_BRANCH}" 2> "${_merge_stderr_file}" || _merge_exit=$?
 if [ -s "${_merge_stderr_file}" ]; then
   sed 's/^/git merge stderr: /' "${_merge_stderr_file}"
+fi
+if grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${_merge_stderr_file}" 2>/dev/null; then
+  _merge_promisor_fetch_failure_seen=true
+  _merge_promisor_initial_stderr="$(tr '\n' ' ' < "${_merge_stderr_file}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
+  _merge_promisor_initial_stderr="${_merge_promisor_initial_stderr:-<git merge produced no stderr>}"
 fi
 
 # Blobless partial clone recovery (review_autofix.yml's checkout uses
@@ -139,7 +146,7 @@ fi
 # "nothing to resolve" / a hard merge-replay failure, leaving the PR's
 # real conflicts unresolved.
 if [ "${_merge_exit}" -ne 0 ] && [ ! -f "$(git rev-parse --git-dir)/MERGE_HEAD" ] \
-  && grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${_merge_stderr_file}" 2>/dev/null; then
+  && [ "${_merge_promisor_fetch_failure_seen}" = "true" ]; then
   echo "::warning::Merge replay hit a partial-clone promisor fetch failure; backfilling blobs and retrying the merge once."
   git reset --hard HEAD >/dev/null 2>&1 || true
   git config --unset-all remote.origin.partialclonefilter 2>/dev/null || true
@@ -147,8 +154,12 @@ if [ "${_merge_exit}" -ne 0 ] && [ ! -f "$(git rev-parse --git-dir)/MERGE_HEAD" 
   if [ -n "${TARGET_BRANCH:-}" ]; then
     _backfill_refspecs+=("refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}")
   fi
-  if ! git fetch --no-tags --prune --refetch origin "${_backfill_refspecs[@]}" 2>/dev/null; then
-    echo "::warning::blob-backfill refetch failed during merge replay; retrying the merge anyway."
+  _refetch_rc=0
+  _refetch_stderr="$(git fetch --no-tags --prune --refetch origin "${_backfill_refspecs[@]}" 2>&1 >/dev/null)" || _refetch_rc=$?
+  if [ "${_refetch_rc}" -ne 0 ]; then
+    _refetch_stderr="$(printf '%s' "${_refetch_stderr}" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
+    _refetch_stderr="${_refetch_stderr:-<git fetch produced no stderr>}"
+    echo "::warning::blob-backfill refetch failed during merge replay; retrying the merge anyway. git fetch stderr: ${_refetch_stderr}"
   fi
   _merge_exit=0
   : > "${_merge_stderr_file}"
@@ -224,6 +235,10 @@ if [ "${_resolver_allowlist_count}" -eq 0 ]; then
   # without re-reading the raw log.
   _merge_stderr_oneline="$(tr '\n' ' ' < "${_merge_stderr_file}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
   _merge_stderr_oneline="${_merge_stderr_oneline:-<git merge produced no stderr>}"
+  if [ "${_merge_promisor_fetch_failure_seen}" = "true" ] && [ -n "${_merge_promisor_initial_stderr}" ] \
+    && [ "${_merge_promisor_initial_stderr}" != "${_merge_stderr_oneline}" ]; then
+    _merge_stderr_oneline="${_merge_stderr_oneline} | initial promisor stderr: ${_merge_promisor_initial_stderr}"
+  fi
   _merge_stderr_oneline="$(printf '%s' "${_merge_stderr_oneline}" | sed 's/%/%25/g; s/\r/%0D/g')"
   if grep -qi 'refusing to merge unrelated histories' "${_merge_stderr_file}" 2>/dev/null; then
     _head_sha="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"

--- a/scripts/review_conflict_prepare.sh
+++ b/scripts/review_conflict_prepare.sh
@@ -128,6 +128,36 @@ if [ -s "${_merge_stderr_file}" ]; then
   sed 's/^/git merge stderr: /' "${_merge_stderr_file}"
 fi
 
+# Blobless partial clone recovery (review_autofix.yml's checkout uses
+# `filter: blob:none`): the 3-way merge lazy-fetches blob content from the
+# promisor remote, and that batched on-demand fetch fails hard (exit 128)
+# when any single OID in the batch is unreachable server-side ("not our
+# ref" / "could not fetch ... from promisor remote"). On that signature,
+# drop the partial filter, refetch the merge inputs so every blob is
+# materialised locally, and retry the merge once — otherwise the merge
+# replay produces an empty conflict set and this step aborts with
+# "nothing to resolve" / a hard merge-replay failure, leaving the PR's
+# real conflicts unresolved.
+if [ "${_merge_exit}" -ne 0 ] && [ ! -f "$(git rev-parse --git-dir)/MERGE_HEAD" ] \
+  && grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${_merge_stderr_file}" 2>/dev/null; then
+  echo "::warning::Merge replay hit a partial-clone promisor fetch failure; backfilling blobs and retrying the merge once."
+  git reset --hard HEAD >/dev/null 2>&1 || true
+  git config --unset-all remote.origin.partialclonefilter 2>/dev/null || true
+  _backfill_refspecs=("refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}")
+  if [ -n "${TARGET_BRANCH:-}" ]; then
+    _backfill_refspecs+=("refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}")
+  fi
+  if ! git fetch --no-tags --prune --refetch origin "${_backfill_refspecs[@]}" 2>/dev/null; then
+    echo "::warning::blob-backfill refetch failed during merge replay; retrying the merge anyway."
+  fi
+  _merge_exit=0
+  : > "${_merge_stderr_file}"
+  git merge --no-commit --no-ff "origin/${BASE_BRANCH}" 2> "${_merge_stderr_file}" || _merge_exit=$?
+  if [ -s "${_merge_stderr_file}" ]; then
+    sed 's/^/git merge stderr (after blob backfill): /' "${_merge_stderr_file}"
+  fi
+fi
+
 # Capture the set of actually-unmerged paths produced by this
 # merge replay.  This is the authoritative allowlist the Codex
 # resolver is permitted to modify: the resolver prompt


### PR DESCRIPTION
## Summary

Investigated why the conflict resolver never ran on forward-merge PR #2895 (`stable` → `main`, 17 conflicting files) and shipped a fix.

**Root cause** — the conflict resolver lives inside `review_autofix.yml`. PR #2895's review run hit the *pre-review deterministic merge-topology gate*, whose `git merge --no-commit origin/main` exited 128 with a partial-clone promisor fetch failure:

```
fatal: remote error: upload-pack: not our ref 71ad430d...
fatal: could not fetch 242c09d9... from promisor remote
```

The codex-agent checkout uses `filter: blob:none`, so the 3-way merge lazy-fetches blob content from the promisor remote, and that batched on-demand fetch fails hard (exit 128) when any single OID in the batch is unreachable server-side. The gate's exit-128 branch assumed exit 128 == deterministic stale base, set `AUTOFIX_STALE_BASE_SKIP=true`, and soft-exited — skipping reviewers, the editor, **and the conflict resolver** while the job still reported `success`.

**Secondary** — the forward-merge fallback PR is created with `GITHUB_TOKEN`, which never emits `pull_request` events, so `internal-review.yml` never auto-started for it (the review only ran ~57 min later when the orchestrator poller dispatched it).

## Changes

- **`.github/workflows/review_autofix.yml`** — the pre-review merge gate now detects a promisor fetch failure in the merge stderr, drops the partial-clone filter, refetches the merge inputs (a reachability-based `--refetch` cannot hit the unreachable-OID failure that the on-demand lazy fetch does), and retries the merge once. Its exit-128 branch now **fails open** on a promisor fetch failure — the reviewer + conflict-resolver path still runs — instead of soft-exiting, consistent with the gate's documented "fail open on ambiguous git errors" design.
- **`scripts/review_conflict_prepare.sh`** — the same blob-backfill + retry around the resolver's own `git merge` replay, so the resolver doesn't see an empty conflict set and abort with "nothing to resolve".
- **`.github/workflows/forward-merge-stable-to-main.yml`** — explicitly dispatches `internal-review.yml` via `gh workflow run` after a fallback PR is opened (`workflow_dispatch` is exempt from the `GITHUB_TOKEN` no-trigger rule). Bumps the workflow's `actions:` permission `read` → `write` (a superset of `read`, so the existing Telegram failing-step lookup still works). Non-fatal: the PR is the durable safety net and the poller remains the fallback.

## Test plan

- [x] `yamllint`, `actionlint`, `shellcheck --severity=error`, `bash -n` all pass on the three modified files
- [x] `test_review_autofix_merge_precheck.py` (14), `test_review_autofix_smoke_conflict_resolver_override.py` (4), `test_review_semble_contract.py`, and the conflict-resolve + review-pipeline contract suites pass
- [ ] Runtime verification requires the fix on `main` — `internal-review.yml` pins `review_autofix.yml@main`; re-dispatching a review for PR #2895 after this merges should let the conflict resolver run and resolve its conflicts

> Note: one unrelated test (`test_verify_integration_fingerprints_baseline_capture_honours_ref_and_records_matching_head_sha`) fails in the build container due to a git commit-signing server error (`environment-runner code-sign ... status 400`) — environmental, not caused by these changes.

https://claude.ai/code/session_01ATThNX5KtMSRSmqGg9ACuw

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATThNX5KtMSRSmqGg9ACuw)_