### PR TITLE
Suppress 'PR merged' Telegram alert across all consumer repos

### DIFF
--- a/.github/workflows/issue_pr_status.yml
+++ b/.github/workflows/issue_pr_status.yml
@@ -466,7 +466,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
           TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID || '' }}
-          ALERT_MSG_LEVEL: ${{ vars.ALERT_MSG_LEVEL || 'DEBUG' }}
+          ALERT_MSG_LEVEL: SILENT
           REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
## Summary

- Hardcode `ALERT_MSG_LEVEL: SILENT` on the `Send PR merged Telegram alert` step in `.github/workflows/issue_pr_status.yml` so the existing `tg_send_msg "${MSG}" "DEBUG"` call is filtered out by `_tg_should_send` in `scripts/tg_helpers.sh` (`0 >= 99` is false).
- Stops the recurring `🔍 DEBUG: PR #N merged: <title>` chat messages observed on consumer repos (e.g. `tele-funtoken-msg-scoring`) and on `coding-workflows` itself.
- One-line change; no other alert site is affected because `vars.ALERT_MSG_LEVEL` is unused elsewhere in this workflow file. Repo-level `vars.ALERT_MSG_LEVEL` overrides are intentionally ignored for this specific step — the suppression is global by design (matches the "all consumer repos" scope decision).

## Why this approach

Two alternatives were considered:
1. Set the *message* level to `SILENT`. Doesn't work — `_tg_should_send` treats `SILENT` (99) as the highest possible level, so `msg_num >= threshold_num` becomes `99 >= 0 = true` and the alert would still send. `SILENT` is a threshold semantic, not a sender semantic (see comment at `scripts/tg_helpers.sh:46-50`).
2. Delete the entire step. Larger diff and loses the orchestrator-suppression branch wiring. Hardcoding the threshold instead keeps the step intact and reversible.

## Rollout

- `coding-workflows` picks the change up immediately because the reusable workflow at `.github/workflows/issue_pr_status.yml` is sourced via `${{ github.sha }}` when `github.repository == "shubhodeep1/coding-workflows"` (line 484).
- Consumer repos pick it up on the next `@stable` tag, since their wrappers in `workflow-templates/ai-issue-pr-status.yml` pin to `shubhodeep1/coding-workflows/.github/workflows/issue_pr_status.yml@stable`.

## Test plan

- [ ] Merge a PR in `coding-workflows` and confirm no `🔍 DEBUG: PR #N merged: …` message appears in the admin Telegram chat.
- [ ] After the next `@stable` cut, merge a PR in a consumer repo (e.g. `tele-funtoken-msg-scoring`) and confirm the same.
- [ ] Confirm other Telegram alerts (orchestrator notifications, clarify/plan/implement/review messages) are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_015L3fAbpukitLo8vZbZB4yj)_