### PR TITLE
fix(noop-recovery): skip auto/forward-merge-stable-* PRs in sweep

### DIFF
--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -16596,6 +16596,34 @@ for (( nidx=0; nidx<STANDALONE_COUNT; nidx++ )); do
 	if [[ "${N_BASE}" == orchestrator/project-* ]] || [[ "${N_HEAD}" == orchestrator/project-* ]]; then
 		continue
 	fi
+	# Skip forward-merge fallback PRs opened by
+	# `.github/workflows/forward-merge-stable-to-main.yml` when the
+	# automated `stable`→`main` merge hits conflict or branch
+	# protection. Head ref is hard-coded as
+	# `auto/forward-merge-stable-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}`
+	# at forward-merge-stable-to-main.yml:255. These PRs MUST be
+	# merged via GitHub's "Create a merge commit" button — NOT
+	# squash/rebase — so the 2-parent merge keeps `stable`'s tip
+	# reachable from `main`. The retry path here would burn API
+	# budget invoking review_autofix repeatedly (the workflow's own
+	# "Enable auto-merge on PR" step suppresses auto-merge for this
+	# head-ref prefix, so the noop-suspicious flag never clears via
+	# a productive [ai-autofix] commit); worse, the force-merge
+	# fallback below executes `gh pr merge --squash --auto`, which
+	# silently strips that ancestry. promote-main-to-stable.yml's
+	# pre-flight `git merge-base --is-ancestor HEAD origin/main`
+	# check then refuses the next promote run (see
+	# `.github/workflows/promote-main-to-stable.yml:115-126` and the
+	# CAUTION banner injected into every fallback PR body at
+	# `.github/workflows/forward-merge-stable-to-main.yml:265-270`).
+	# Mirrors the existing suppressors in `review_autofix.yml`'s
+	# codex-agent "Enable auto-merge on PR" step (line ~5127) and
+	# the `deterministic-skip-merge` sibling job (line ~697). The
+	# pattern is hard-coded — the branch prefix is owned by the
+	# forward-merge workflow and never varies per repo.
+	if [[ "${N_HEAD}" == auto/forward-merge-stable-* ]]; then
+		continue
+	fi
 
 	# ── Step 1: pre-filter via comments scan ──
 	# Fetch up to 100 most-recent comments. Noop-suspicious warnings

--- a/tests/test_orchestrate_poll_noop_suspicious_recovery.py
+++ b/tests/test_orchestrate_poll_noop_suspicious_recovery.py
@@ -291,6 +291,56 @@ def test_sweep_skips_orchestrator_project_branches():
 	)
 
 
+def test_sweep_skips_forward_merge_fallback_prs():
+	"""Forward-merge fallback PRs (head ref `auto/forward-merge-stable-*`,
+	opened by `.github/workflows/forward-merge-stable-to-main.yml`) MUST
+	be merged via GitHub's "Create a merge commit" button so the
+	2-parent merge keeps `stable`'s tip reachable from `main`. The
+	sweep's force-merge path executes `gh pr merge --squash --auto`,
+	which silently strips that ancestry and trips
+	`promote-main-to-stable.yml`'s pre-flight
+	`git merge-base --is-ancestor` check on the next promote run.
+
+	`review_autofix.yml`'s codex-agent "Enable auto-merge on PR" step
+	and the `deterministic-skip-merge` sibling job both already
+	suppress auto-merge for this head-ref prefix, so the noop counter
+	never clears via a productive [ai-autofix] commit on this PR
+	class — the sweep would otherwise loop forever then force-merge
+	the very thing the workflow chain is designed to protect.
+	"""
+	sweep = _sweep_block()
+	assert '[[ "${N_HEAD}" == auto/forward-merge-stable-* ]]' in sweep, (
+		"Sweep must explicitly skip PRs whose head ref matches "
+		"`auto/forward-merge-stable-*` so the force-merge `--squash --auto` "
+		"path cannot strip the 2-parent ancestry that "
+		"`promote-main-to-stable.yml` relies on. Mirrors the existing "
+		"suppressors in `.github/workflows/review_autofix.yml`."
+	)
+
+
+def test_sweep_forward_merge_skip_precedes_api_calls():
+	"""The forward-merge skip MUST sit alongside the
+	`orchestrator/project-*` skip, before the per-PR comments fetch.
+	Otherwise every forward-merge fallback PR burns a paginated
+	`issues/<n>/comments` GraphQL/REST round-trip every poll cycle
+	(§15), and a transient API failure on that call could allow the
+	force-merge path to fire on the very PR class it's supposed to
+	skip."""
+	sweep = _sweep_block()
+	forward_skip_idx = sweep.find('[[ "${N_HEAD}" == auto/forward-merge-stable-* ]]')
+	comments_fetch_idx = sweep.find('issues/${N_PR}/comments')
+	assert forward_skip_idx != -1, "Forward-merge skip must exist (covered by sibling test)."
+	assert comments_fetch_idx != -1, (
+		"Sweep must still fetch issue comments — the pre-filter is "
+		"the whole point of the cheap-path check."
+	)
+	assert forward_skip_idx < comments_fetch_idx, (
+		"Forward-merge skip must precede the per-PR comments fetch so "
+		"this PR class costs zero extra API calls and cannot fail open "
+		"on a transient comments-fetch error."
+	)
+
+
 def test_sweep_counts_only_post_productive_warnings():
 	"""The retry counter is "noop warnings newer than latest
 	[ai-autofix] / [judge-fix] commit". This is the implicit reset on


### PR DESCRIPTION
## Summary

The noop-suspicious recovery sweep in `scripts/orchestrate_poll_process.sh` already skips `orchestrator/project-*` branches but did **not** exclude the forward-merge fallback PRs (head ref `auto/forward-merge-stable-*`) opened by `.github/workflows/forward-merge-stable-to-main.yml`.

`review_autofix.yml`'s "Enable auto-merge on PR" step suppresses auto-merge for this head-ref prefix (line ~5127), and the `deterministic-skip-merge` sibling job mirrors that (line ~697), because forward-merge fallback PRs **MUST** be merged via GitHub's "Create a merge commit" button so the 2-parent merge keeps `stable`'s tip reachable from `main`. Without this skip in the sweep:

1. The editor's "no changes needed" disposition never produces a productive `[ai-autofix]` commit on the PR, so the noop counter never resets — every poll cycle burns a `workflow_dispatch` + new review_autofix run.
2. After `NOOP_MAX_RETRIES=3` warnings, the force-merge fallback would execute `gh pr merge --squash --auto`, silently stripping the ancestry that `promote-main-to-stable.yml`'s pre-flight `git merge-base --is-ancestor HEAD origin/main` check relies on — exactly the failure mode the forward-merge workflow chain is designed to prevent.

### Triggering incident

PR #2954 (head ref `auto/forward-merge-stable-26355097687-1`):

- **1 `Editor no-op suspicious` warning** at `2026-05-24T22:34:32Z` (count=1).
- The most recent `[ai-autofix]` commit on the branch was `f99e0741` at `2026-05-24T18:27:20Z` — **before** the warning.
- The editor at `2026-05-25T05:39:14Z` (run `26384879054`) produced a clean `Changes made: - none` summary with balanced audit (so `EDITOR_NOOP_SUSPICIOUS=false`), and the workflow's own auto-merge step correctly logged: `PR #2954 head ref 'auto/forward-merge-stable-26355097687-1' matches forward-merge fallback pattern '^auto/forward-merge-stable-' — auto-merge suppressed.`
- The recovery sweep nonetheless re-dispatched retry `2/3` because `N_NOOP_COUNT=1` (only counts the warning literal, not the healthy disposition that followed).

### Fix

Mirror the existing `orchestrator/project-*` skip — `scripts/orchestrate_poll_process.sh` adds:

```bash
if [[ "${N_HEAD}" == auto/forward-merge-stable-* ]]; then
    continue
fi
```

placed alongside the orchestrator skip, **before** the per-PR `issues/<n>/comments` fetch, so this PR class costs zero extra API calls (§15) and cannot fail open on a transient comments-fetch error.

### Tests

Added two contract tests in `tests/test_orchestrate_poll_noop_suspicious_recovery.py`:

- `test_sweep_skips_forward_merge_fallback_prs` — pins the literal skip predicate.
- `test_sweep_forward_merge_skip_precedes_api_calls` — guards the ordering invariant so a later refactor cannot accidentally move the skip below the comments fetch.

All 21 contract tests pass; `bash -n scripts/orchestrate_poll_process.sh` is clean.

## Test plan

- [x] `PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_poll_noop_suspicious_recovery.py` — 21/21 pass locally
- [x] `bash -n scripts/orchestrate_poll_process.sh` — syntax clean
- [ ] CI green on this PR (covers the noop-recovery contract tests via `ci.yml`, `mark-stable.yml`, and `test-and-mark-stable.yml`)
- [ ] Next poll cycle: confirm no further `Noop-suspicious recovery: re-dispatched review_autofix for PR #2954` Telegram WARNINGs once this merges

Refs #2954

https://claude.ai/code/session_017r5ZFZ8dhDYBhg41Qyvma1

---
_Generated by [Claude Code](https://claude.ai/code/session_017r5ZFZ8dhDYBhg41Qyvma1)_