### PR TITLE
fix(review_autofix): drop forward step reference breaking actionlint on the integration branch

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2598,7 +2598,13 @@ jobs:
       # this cache pair. Missing cache is fail-open: iteration-scoping and
       # reviewer failback health both treat absence as first-run state.
       - name: Restore review-issue ledger
-        if: steps.retrigger_guard.outputs.max_iterations_reached != 'true' && env.PR_CLOSED != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true'
+        # NOTE: this step runs BEFORE the `retrigger_guard` step (id below),
+        # so `steps.retrigger_guard.outputs.*` is not yet populated here — the
+        # former `max_iterations_reached != 'true'` guard was a no-op at this
+        # point (always an empty string) and actionlint correctly rejected the
+        # forward step reference. Gate only on the env signals that are already
+        # set this early in the job.
+        if: env.PR_CLOSED != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true'
         continue-on-error: true
         uses: actions/cache/restore@v4
         with:


### PR DESCRIPTION
## What

One-line fix to `.github/workflows/review_autofix.yml` on the `orchestrator/project-2974` integration branch.

The **"Restore review-issue ledger"** step (added by the wave-5 `ledger-rereview-and-approval-rubric` work, issue #2997) runs *before* the `retrigger_guard` step, but its `if:` referenced `steps.retrigger_guard.outputs.max_iterations_reached`. That output is empty at this point in the job (the step hasn't run yet), so the guard was a runtime no-op — but actionlint rejects the forward step reference:

```
.github/workflows/review_autofix.yml:2601:13: property "retrigger_guard" is not defined in object type {...} [expression]
```

## Why this matters

This failed the `lint` CI job on **every commit of the integration branch** since the step landed (~17:43Z 2026-05-29), leaving the integration→default PR #2981 `UNSTABLE`. `CI` is in the orchestrator's default `ORCH_FINAL_MERGE_REQUIRED_CHECKS` blocking set, so `finalize_integration_merge_if_needed` keeps deferring the final merge — stranding orchestrator project #2974 even though all sub-issues are merged into the integration branch.

## Fix

Gate the step only on the env signals already set this early in the job (`PR_CLOSED` / `CLAUDE_BRANCH_REVIEW_MODE`), dropping the invalid forward reference. Runtime behavior is unchanged (the dropped clause was always empty here).

Verified locally with `actionlint -shellcheck=` across all 52 workflow/template files — all clean.

Refs #2974

---
_Generated by [Claude Code](https://claude.ai/code/session_019TsUbj34GZiiVKAtAc8qXL)_