### PR TITLE
ci: raise prompt-length cap for mode-judge-review-blocked.txt (unblock #2974 finalize)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,6 +445,10 @@ jobs:
           # exception — its 700+ lines of conditional procedure are slated
           # for sidecar extraction in a separate smoke-gated PR. Same for
           # the validate-fix-harness / validate-diagnose phase prompts.
+          # mode-judge-review-blocked.txt is capped at 230 (not 200) to fit
+          # the deliberate prompt-injection guard + approval-rubric / break-
+          # glass hardening added by the review-learnings project; the extra
+          # lines are security-relevant invariants, not process bloat.
           declare -A CAPS=(
             [prompts/mode-implement.txt]=200
             [prompts/mode-implement-repair.txt]=200
@@ -456,7 +460,7 @@ jobs:
             [prompts/mode-orchestrate.txt]=200
             [prompts/mode-judge.txt]=150
             [prompts/mode-orchestrate-poll-judge.txt]=150
-            [prompts/mode-judge-review-blocked.txt]=200
+            [prompts/mode-judge-review-blocked.txt]=230
             [prompts/mode-judge-stall-recovery.txt]=150
             [prompts/conflict-resolver.txt]=150
             [prompts/integration-sync-conflict-resolver.txt]=200

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -2598,7 +2598,13 @@ jobs:
       # this cache pair. Missing cache is fail-open: iteration-scoping and
       # reviewer failback health both treat absence as first-run state.
       - name: Restore review-issue ledger
-        if: steps.retrigger_guard.outputs.max_iterations_reached != 'true' && env.PR_CLOSED != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true'
+        # NOTE: this step runs BEFORE the `retrigger_guard` step (id below),
+        # so `steps.retrigger_guard.outputs.*` is not yet populated here — the
+        # former `max_iterations_reached != 'true'` guard was a no-op at this
+        # point (always an empty string) and actionlint correctly rejected the
+        # forward step reference. Gate only on the env signals that are already
+        # set this early in the job.
+        if: env.PR_CLOSED != 'true' && env.CLAUDE_BRANCH_REVIEW_MODE != 'true'
         continue-on-error: true
         uses: actions/cache/restore@v4
         with:


### PR DESCRIPTION
## What

Raise the `Prompt-length budget` cap for `prompts/mode-judge-review-blocked.txt` from 200 → 230 in `ci.yml`.

## Why

This project (#2974) deliberately hardened the review-blocked judge prompt — #2976 added the prompt-injection guard / UNTRUSTED-fence rules, #2997 added the approval rubric + break-glass handling — growing the file past the 200-line cap that predates the hardening. The `lint` job's `Prompt-length budget` gate therefore failed on every integration-branch commit:

```
##[error]Prompt length budget exceeded: prompts/mode-judge-review-blocked.txt = 215 lines (cap 200).
```

(now 222 lines and still under active fix-up churn). With `CI` in the orchestrator's default `ORCH_FINAL_MERGE_REQUIRED_CHECKS` set, this red check was blocking the integration→default squash merge of the eager final PR #2981 — stranding the project even though all sub-issues are merged.

The added lines are security-relevant invariants (injection guard, approval rubric), not process bloat, so the right fix is to raise this one file's cap rather than slim the hardening away. 230 leaves headroom over the current 222 lines for in-flight fix-up edits.

This is the second of two lint blockers on the integration branch; the first (an actionlint forward-reference) landed via #3013.

Refs #2974

---
_Generated by [Claude Code](https://claude.ai/code/session_019TsUbj34GZiiVKAtAc8qXL)_