### PR TITLE
fix(validation-refresh): wire OpenRouter auth + codex config for discovery

### DIFF
--- a/.github/workflows/validation-refresh.yml
+++ b/.github/workflows/validation-refresh.yml
@@ -90,6 +90,12 @@ jobs:
         id: refresh
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
+          # Codex discovery (`codex exec`) authenticates to the model provider
+          # (OpenRouter) defined in ~/.codex/config.toml via this key. Without
+          # it every discovery attempt exits non-zero (codex_rc_nonzero) and the
+          # daily refresh silently degrades to drift-monitoring only. Same secret
+          # the rest of the codex pipeline (plan/implement/validate/...) uses.
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           VALIDATION_DISCOVERY_ENABLED: ${{ github.event.inputs.discovery_enabled || vars.VALIDATION_DISCOVERY_ENABLED || 'true' }}
           VALIDATION_DISCOVERY_DRY_RUN: ${{ github.event.inputs.discovery_dry_run || vars.VALIDATION_DISCOVERY_DRY_RUN || 'false' }}
           VALIDATION_DISCOVERY_DEDUP_DAYS: ${{ vars.VALIDATION_DISCOVERY_DEDUP_DAYS || '7' }}
@@ -108,6 +114,25 @@ jobs:
           # Wire git to use the gh credential helper so raw `git fetch`/`ls-remote`
           # calls inside cloned consumer repos authenticate with GH_TOKEN.
           gh auth setup-git
+
+          # Codex discovery routes `openai/gpt-5.*` slugs through OpenRouter, which
+          # is defined in ~/.codex/config.toml (model_provider="openrouter",
+          # env_key="OPENROUTER_API_KEY"). Mirror the central "Create Codex config"
+          # step that plan/implement/validate/etc. run; without it `codex exec` has
+          # no provider routing or credentials and exits non-zero. Keep this
+          # best-effort: discovery must never block drift monitoring (runner Q4:A),
+          # so a config or key problem downgrades to a warning, not a job failure.
+          export CODEX_HOME="${HOME}/.codex"
+          if ! bash scripts/write_codex_config.sh \
+              --model "${VALIDATION_DISCOVERY_MODEL}" \
+              --reasoning "${VALIDATION_DISCOVERY_REASONING_EFFORT}"; then
+            echo "::warning::write_codex_config.sh failed; codex discovery will be skipped/failed but drift monitoring continues."
+          fi
+          if [ "${VALIDATION_DISCOVERY_ENABLED}" = "true" ] \
+              && [ "${VALIDATION_DISCOVERY_DRY_RUN}" != "true" ] \
+              && [ -z "${OPENROUTER_API_KEY:-}" ]; then
+            echo "::warning::VALIDATION_DISCOVERY_ENABLED=true but OPENROUTER_API_KEY is empty; codex discovery will fail with codex_rc_nonzero. Set the OPENROUTER_API_KEY repository secret to enable discovery."
+          fi
 
           RUNTIME_DIR="${RUNNER_TEMP}/validation-refresh-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           mkdir -p "${RUNTIME_DIR}"

--- a/README.md
+++ b/README.md
@@ -1665,6 +1665,7 @@ self-heal patches cannot be merged without explicit human action.
 
 - Authentication:
   - Uses `GH_PAT` (exported as `GH_TOKEN`) for all cross-repository clone/branch/PR operations.
+  - Uses `OPENROUTER_API_KEY` for the codex-driven discovery dispatch below. The workflow writes `~/.codex/config.toml` via `scripts/write_codex_config.sh` (provider `openrouter`, `env_key=OPENROUTER_API_KEY`); without this secret `codex exec` exits non-zero and discovery degrades to drift-monitoring only. `GH_PAT` alone is not sufficient — it authenticates GitHub git/PR operations, not the model provider.
 - Workflow: [`.github/workflows/validation-refresh.yml`](.github/workflows/validation-refresh.yml)
 - Triggers:
   - Daily cron (`17 2 * * *`)

--- a/tests/test_validation_refresh_workflow_contract.py
+++ b/tests/test_validation_refresh_workflow_contract.py
@@ -35,6 +35,21 @@ def test_validation_refresh_workflow_invokes_runner_with_auth() -> None:
 	assert "--summary-json" in content
 
 
+def test_validation_refresh_workflow_wires_codex_provider_auth() -> None:
+	# Discovery dispatch invokes `codex exec` (via the refresh runner), which
+	# can only authenticate to the model provider when (a) ~/.codex/config.toml
+	# defines model_provider=openrouter + env_key=OPENROUTER_API_KEY (written by
+	# scripts/write_codex_config.sh) and (b) the OPENROUTER_API_KEY secret is
+	# present in the step env. PR #2959 shipped discovery without either, so
+	# every `codex exec` exited codex_rc_nonzero(rc=1) and the daily refresh
+	# silently degraded to drift-monitoring only. Lock both halves in so the
+	# provider wiring can't regress again.
+	content = WORKFLOW_PATH.read_text(encoding="utf-8")
+	assert "OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}" in content
+	assert "scripts/write_codex_config.sh" in content
+	assert "CODEX_HOME" in content
+
+
 def test_validation_refresh_workflow_summarizes_and_notifies_on_failure() -> None:
 	content = WORKFLOW_PATH.read_text(encoding="utf-8")
 	assert "GITHUB_STEP_SUMMARY" in content


### PR DESCRIPTION
## Summary

Investigated run [26702179432](https://github.com/shubhodeep1/coding-workflows/actions/runs/26702179432) — "why did all discoveries fail when we already use a PAT with full access to all consumer repos?"

**Root cause: not the PAT.** The codex-driven `.ai/validate.yml` discovery dispatch (added whole in #2959) runs `codex exec --model openai/gpt-5.4` via `scripts/validation_refresh_runner.py`, but the workflow never wired the **model-provider** credentials. The refresh step passed only `GH_PAT` (for GitHub git/PR operations) and never:

1. wrote `~/.codex/config.toml` (which defines `model_provider = "openrouter"` + `env_key = "OPENROUTER_API_KEY"`), nor
2. exported `OPENROUTER_API_KEY`.

Codex resolves `openai/gpt-5.*` slugs through OpenRouter via that config — the exact setup every other codex workflow (`plan` / `implement` / `validate` / …) performs through `scripts/write_codex_config.sh`. With neither present, every `codex exec` exited `codex_rc_nonzero(rc=1)`. The run shows **all 11 consumers** failing discovery (`attempts=3` each) while drift monitoring stayed green — the PAT is used *after* the codex call, for the consumer-repo push/PR, so it was never reached.

### Evidence
- Job log: `VALIDATION_DISCOVERY_FAILED repository=… attempts=3 reason=codex_rc_nonzero(rc=1)` for every repo; 17-min silent gap (codex startup + auth-fail + backoff × 11 repos × 3 attempts).
- `validation-refresh.yml` refresh step env had only `GH_PAT` — no `OPENROUTER_API_KEY`, no "Create Codex config" step (`grep` found neither).
- `scripts/write_codex_config.sh` emits `model_provider = "openrouter"` / `env_key = "OPENROUTER_API_KEY"`; working workflows pair it with `OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}`.

## Fix
- Pass `OPENROUTER_API_KEY` (existing repo secret, already used by 10 other workflows) into the refresh step env.
- Write `~/.codex/config.toml` via `scripts/write_codex_config.sh` + export `CODEX_HOME` before invoking the runner. **Best-effort:** a config/key problem downgrades to a `::warning::` rather than failing the job, preserving the "discovery never blocks drift monitoring" invariant (runner Q4:A). Adds an explicit warning when discovery is enabled but the key is empty, so the next opaque `rc=1` is self-diagnosing.
- Lock both halves with a new contract-test assertion (`test_validation_refresh_workflow_wires_codex_provider_auth`); document the `OPENROUTER_API_KEY` requirement in README.

The read-only `permissions:` contract is untouched — `OPENROUTER_API_KEY` is a secret like `GH_PAT`, it does not change `GITHUB_TOKEN` scope.

## Verification
- `tests/test_validation_refresh_workflow_contract.py` — **4/4 pass** (incl. new assertion).
- YAML parses; no tab-indented lines (§9).
- `write_codex_config.sh` sanity run emits the OpenRouter provider block for `openai/gpt-5.4`.
- `test_write_codex_config.py` — 10/10 pass.

### Out of scope (pre-existing, NOT touched)
`test_validation_refresh_runner.py` (3) and `test_validation_discovery_bootstrap.py` (3) fail identically at `HEAD` with this PR's changes stashed — canned-executor command-prefix fixture drift in `discover_manifest_via_codex` / `_run_discovery_dispatch`. Unrelated to this auth fix; left untouched to avoid a silent test edit.

> Note: operators must ensure the `OPENROUTER_API_KEY` secret is configured on the repo (it already is for the other codex workflows). The added warning annotation makes a missing key obvious in the run log.

_Refs run 26702179432._


---
_Generated by [Claude Code](https://claude.ai/code/session_01NHPbDskRVKz6PknP15Vmp3)_