### PR TITLE
fix(workflows): stage render_prompt.py so PR #3045 review autofix can run

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -218,7 +218,7 @@ jobs:
           mkdir -p scripts
 
           _fetched_scripts=()
-          for f in gh_helpers.sh git_ref_health_check.sh render_prompt.sh tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py semantic_cache.py build_static_context.sh install_semble.sh build_semble_wrapper.sh write_codex_config.sh; do
+          for f in gh_helpers.sh git_ref_health_check.sh render_prompt.sh render_prompt.py tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py semantic_cache.py build_static_context.sh install_semble.sh build_semble_wrapper.sh write_codex_config.sh; do
             src=".codex-workflow-src/scripts/${f}"
             if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then
               src=".codex-workflow-src-main/scripts/${f}"

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -823,7 +823,7 @@ jobs:
 
           mkdir -p scripts
           _fetched_scripts=()
-          for f in gh_helpers.sh git_ref_health_check.sh render_prompt.sh validate_changed_files_syntax.sh tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py implement_diagnose_post_codex_failure.sh build_static_context.sh targeted_file_context.py write_codex_config.sh; do
+          for f in gh_helpers.sh git_ref_health_check.sh render_prompt.sh render_prompt.py validate_changed_files_syntax.sh tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py implement_diagnose_post_codex_failure.sh build_static_context.sh targeted_file_context.py write_codex_config.sh; do
             src=".codex-workflow-src/scripts/${f}"
             if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then
               src=".codex-workflow-src-main/scripts/${f}"

--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -342,7 +342,7 @@ jobs:
           wf_source="shubhodeep1/coding-workflows"
           mkdir -p scripts
           _fetched_scripts=()
-          for f in gh_helpers.sh label_helpers.sh git_ref_health_check.sh orchestrate_lib.py render_prompt.sh tg_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py install_semble.sh build_semble_wrapper.sh write_codex_config.sh; do
+          for f in gh_helpers.sh label_helpers.sh git_ref_health_check.sh orchestrate_lib.py render_prompt.sh render_prompt.py tg_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py install_semble.sh build_semble_wrapper.sh write_codex_config.sh; do
             src=".codex-workflow-src/scripts/${f}"
             if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then
               src=".codex-workflow-src-main/scripts/${f}"

--- a/.github/workflows/orchestrate_clarify_respond.yml
+++ b/.github/workflows/orchestrate_clarify_respond.yml
@@ -262,7 +262,7 @@ jobs:
           mkdir -p scripts
 
           _fetched_scripts=()
-          for f in gh_helpers.sh render_prompt.sh tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py semantic_cache.py install_semble.sh build_semble_wrapper.sh write_codex_config.sh; do
+          for f in gh_helpers.sh render_prompt.sh render_prompt.py tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py semantic_cache.py install_semble.sh build_semble_wrapper.sh write_codex_config.sh; do
             src=".codex-workflow-src/scripts/${f}"
             if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then
               src=".codex-workflow-src-main/scripts/${f}"

--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -292,7 +292,7 @@ jobs:
           mkdir -p scripts prompts .github/ai
 
           _fetched_scripts=()
-          for f in gh_helpers.sh git_ref_health_check.sh ai_labels.py orchestrate_lib.py orchestrate_poll_process.sh orchestrate_state_v2.py render_prompt.sh tg_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py targeted_file_context.py write_codex_config.sh; do
+          for f in gh_helpers.sh git_ref_health_check.sh ai_labels.py orchestrate_lib.py orchestrate_poll_process.sh orchestrate_state_v2.py render_prompt.sh render_prompt.py tg_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py targeted_file_context.py write_codex_config.sh; do
             src=".codex-workflow-src/scripts/${f}"
             if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then
               src=".codex-workflow-src-main/scripts/${f}"

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -268,7 +268,7 @@ jobs:
           wf_source="shubhodeep1/coding-workflows"
           mkdir -p scripts
           _fetched_scripts=()
-          for f in gh_helpers.sh render_prompt.sh tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py build_static_context.sh install_semble.sh build_semble_wrapper.sh write_codex_config.sh; do
+          for f in gh_helpers.sh render_prompt.sh render_prompt.py tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py build_static_context.sh install_semble.sh build_semble_wrapper.sh write_codex_config.sh; do
             src=".codex-workflow-src/scripts/${f}"
             if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then
               src=".codex-workflow-src-main/scripts/${f}"

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1252,7 +1252,7 @@ jobs:
             echo "SUPPORT_AGENTS_FILE=${SUPPORT_ROOT_DIR}/agents.md"
           } >> "$GITHUB_ENV"
 
-          REQUIRED_BOOTSTRAP_SCRIPTS="gh_helpers.sh git_ref_health_check.sh generate_symbol_diff_summary.py render_prompt.sh tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py cost_audit.py codex_heartbeat.sh review_run_reviewers.sh review_apply_fixes.sh review_reject_verify.sh review_rb_judge.sh review_run_judge_interim.sh review_synthesise_smoke.sh review_commit_changes.sh review_conflict_prepare.sh review_conflict_resolve.sh check_workflow_script_refs.py check_resolver_diff.sh summarize_reviewer_consensus.sh check_external_branch_advance.sh post_review_comment.sh targeted_file_context.py write_codex_config.sh detect_editor_changes_lost.sh validate_editor_audit.sh"
+          REQUIRED_BOOTSTRAP_SCRIPTS="gh_helpers.sh git_ref_health_check.sh generate_symbol_diff_summary.py render_prompt.sh render_prompt.py tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py cost_audit.py codex_heartbeat.sh review_run_reviewers.sh review_apply_fixes.sh review_reject_verify.sh review_rb_judge.sh review_run_judge_interim.sh review_synthesise_smoke.sh review_commit_changes.sh review_conflict_prepare.sh review_conflict_resolve.sh check_workflow_script_refs.py check_resolver_diff.sh summarize_reviewer_consensus.sh check_external_branch_advance.sh post_review_comment.sh targeted_file_context.py write_codex_config.sh detect_editor_changes_lost.sh validate_editor_audit.sh"
           # Main-primary bootstrap scripts: prefer the fresh main snapshot so
           # wedged integration branches still pick up resolver safety fixes
           # shipped on main. Missing from both refs remains fail-open so older
@@ -2867,7 +2867,7 @@ jobs:
 
           leaked_paths="$(git ls-files -- \
             'scripts/gh_helpers.sh' 'scripts/git_ref_health_check.sh' \
-            'scripts/render_prompt.sh' 'scripts/validate_changed_files_syntax.sh' \
+            'scripts/render_prompt.sh' 'scripts/render_prompt.py' 'scripts/validate_changed_files_syntax.sh' \
             'scripts/tg_helpers.sh' 'scripts/label_helpers.sh' 'scripts/memory_helpers.sh' \
             'scripts/ai_memory.py' 'scripts/ai_memory_lib.py' 'scripts/openrouter_prompt_cache.py' \
             'scripts/codex_model_catalog.json' \
@@ -3368,6 +3368,7 @@ jobs:
 
           check_required_file "${SUPPORT_SCRIPTS_DIR}/review_run_reviewers.sh"
           check_required_file "${SUPPORT_SCRIPTS_DIR}/render_prompt.sh"
+          check_required_file "${SUPPORT_SCRIPTS_DIR}/render_prompt.py"
           check_required_nonempty_file "${SUPPORT_INSTRUCTIONS_FILE}"
           check_required_file "./pre_assembled_static.txt"
           check_required_file "${PR_DIFF_FILE}"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -306,7 +306,7 @@ jobs:
           }
 
           _fetched_scripts=()
-          for f in gh_helpers.sh ai_labels.py render_prompt.sh tg_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py write_codex_config.sh; do
+          for f in gh_helpers.sh ai_labels.py render_prompt.sh render_prompt.py tg_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py write_codex_config.sh; do
             copy_from_ref_or_local "scripts/${f}" "scripts/${f}"
             chmod +x "scripts/${f}"
             _fetched_scripts+=("${f}")


### PR DESCRIPTION
## Why

PR #3045 (`ai/issue-3043`) converted `scripts/render_prompt.sh` into a shim that `exec`s the new `scripts/render_prompt.py`, but never added `render_prompt.py` to any workflow's bootstrap staging list. The "Stage workflow support files" step copies support scripts **explicitly by name**, so the staged shim could not locate its Python backend and aborted with `render_prompt.py not found for ...` in the `review / codex-agent` → "Run reviewer models" step ([run 26813459080](https://github.com/shubhodeep1/coding-workflows/actions/runs/26813459080)) — before any reviewer model ran. That is the "PR autofix failed" error reported on #3045.

This PR targets `ai/issue-3043`; merging it lands the fix on #3045's branch so its review/autofix can run.

## Fix

Add `render_prompt.py` next to `render_prompt.sh` in `review_autofix.yml`'s `REQUIRED_BOOTSTRAP_SCRIPTS`. The shim's hardened resolver only trusts `${SCRIPT_DIR}/render_prompt.py` (beside the shim) and the `.codex-workflow-src` copies, so staging the backend into the same directory as the shim resolves it for the out-of-tree (`SUPPORT_SCRIPTS_DIR`) path used by the reviewer / judge / synthesise scripts.

## Proactive fixes included

The same missing-backend gap exists in every other workflow that stages the shim; left unfixed they break the moment they invoke the staged shim. Added `render_prompt.py` beside `render_prompt.sh` in: `clarify.yml`, `plan.yml`, `implement.yml`, `orchestrate.yml`, `orchestrate_poll.yml`, `orchestrate_clarify_respond.yml`, `validate.yml`.

Also hardened `review_autofix.yml`:
- Added `render_prompt.py` to the pre-reviewer `check_required_file` preflight so this class of missing-backend failure fails fast with a clear message instead of mid-reviewer.
- Added `scripts/render_prompt.py` to the consumer-repo leaked-paths guard, keeping it symmetric with `render_prompt.sh`.

## Verification

- **Reproduced**: staging `render_prompt.sh` without `render_prompt.py` and invoking it the way `review_run_reviewers.sh` does → `render_prompt.py not found ... rc=1` (matches CI); staging both → `rc=0`, renders correctly.
- `scripts/check_workflow_script_refs.py` → "All workflow script references resolve to existing files."
- `tests/test_render_prompt_foundation.py` passes; judge/review semble contract tests pass. The 2 unrelated pre-existing failures (an `AGENTS_MD_MATERIALITY_ENABLED` env-wiring assertion and `git commit ... 128` sandbox errors) reproduce identically without this change.
- All 8 edited workflow files parse as YAML.

## Note on branch routing

The session credential is read-only for this repo and the git proxy only permits the session's designated branch, so a direct push to `ai/issue-3043` was not possible. This PR delivers the same single fix commit into `ai/issue-3043` via review instead.

Refs #3045

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2yfZmmkRa84KwAbCMENZs)_