### PR TITLE
fix(workflows): stage render_prompt.py optionally on main so shim branches resolve their backend

### DIFF
--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -231,6 +231,27 @@ jobs:
             _fetched_scripts+=("${f}")
           done
 
+          # render_prompt.py is the optional Python backend for the
+          # render_prompt.sh shim adopted by branches that took the issue
+          # #3043 refactor.  main ships a self-contained bash render_prompt.sh
+          # that needs no backend, so the file is absent on main and must be
+          # staged only when the branch under processing actually carries it.
+          # Absence is expected (non-shim branches, incl. main) and must not
+          # fail the bootstrap; presence stages it beside the shim so the
+          # shim resolves ${SCRIPT_DIR}/render_prompt.py.
+          for f in render_prompt.py; do
+            src=".codex-workflow-src/scripts/${f}"
+            if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then
+              src=".codex-workflow-src-main/scripts/${f}"
+            fi
+            if [ ! -f "${src}" ]; then
+              echo "::notice::Optional render_prompt.py backend unavailable on ${SCRIPT_REF}; render_prompt.sh shim (if present) resolves it elsewhere or the bundled bash renderer is used."
+              continue
+            fi
+            install -m 0755 "${src}" "scripts/${f}"
+            _fetched_scripts+=("${f}")
+          done
+
           # Stage codex_model_catalog.json so scripts/write_codex_config.sh
           # can wire `model_catalog_json` and codex registers
           # `apply_patch_tool_type = "freeform"` for our `openai/gpt-5.*`

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -838,6 +838,27 @@ jobs:
             # see the persistence note above the loop.
           done
 
+          # render_prompt.py is the optional Python backend for the
+          # render_prompt.sh shim adopted by branches that took the issue
+          # #3043 refactor.  main ships a self-contained bash render_prompt.sh
+          # that needs no backend, so the file is absent on main and must be
+          # staged only when the branch under processing actually carries it.
+          # Absence is expected (non-shim branches, incl. main) and must not
+          # fail the bootstrap; presence stages it beside the shim so the
+          # shim resolves ${SCRIPT_DIR}/render_prompt.py.
+          for f in render_prompt.py; do
+            src=".codex-workflow-src/scripts/${f}"
+            if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then
+              src=".codex-workflow-src-main/scripts/${f}"
+            fi
+            if [ ! -f "${src}" ]; then
+              echo "::notice::Optional render_prompt.py backend unavailable on ${SCRIPT_REF}; render_prompt.sh shim (if present) resolves it elsewhere or the bundled bash renderer is used."
+              continue
+            fi
+            install -m 0755 "${src}" "scripts/${f}"
+            _fetched_scripts+=("${f}")
+          done
+
           for f in setup_serena.sh serena_stats_emit.py mcp_handshake_probe.py; do
             src=".codex-workflow-src/scripts/${f}"
             if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then

--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -355,6 +355,27 @@ jobs:
             _fetched_scripts+=("${f}")
           done
 
+          # render_prompt.py is the optional Python backend for the
+          # render_prompt.sh shim adopted by branches that took the issue
+          # #3043 refactor.  main ships a self-contained bash render_prompt.sh
+          # that needs no backend, so the file is absent on main and must be
+          # staged only when the branch under processing actually carries it.
+          # Absence is expected (non-shim branches, incl. main) and must not
+          # fail the bootstrap; presence stages it beside the shim so the
+          # shim resolves ${SCRIPT_DIR}/render_prompt.py.
+          for f in render_prompt.py; do
+            src=".codex-workflow-src/scripts/${f}"
+            if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then
+              src=".codex-workflow-src-main/scripts/${f}"
+            fi
+            if [ ! -f "${src}" ]; then
+              echo "::notice::Optional render_prompt.py backend unavailable on ${SCRIPT_REF}; render_prompt.sh shim (if present) resolves it elsewhere or the bundled bash renderer is used."
+              continue
+            fi
+            install -m 0755 "${src}" "scripts/${f}"
+            _fetched_scripts+=("${f}")
+          done
+
           mkdir -p ai-memory/schemas
           for sf in memory_record.v1.json processed_command_entry.v1.json run_ledger_entry.v1.json task_lineage.v1.json actions_runs_cache.v1.json workflow_log_analysis_cache.v1.json validation_history.v1.json operator_bypass_audit.v1.json revalidate_events.v1.json validation_discovery.v1.json; do
             src=".codex-workflow-src/ai-memory/schemas/${sf}"

--- a/.github/workflows/orchestrate_clarify_respond.yml
+++ b/.github/workflows/orchestrate_clarify_respond.yml
@@ -275,6 +275,27 @@ jobs:
             _fetched_scripts+=("${f}")
           done
 
+          # render_prompt.py is the optional Python backend for the
+          # render_prompt.sh shim adopted by branches that took the issue
+          # #3043 refactor.  main ships a self-contained bash render_prompt.sh
+          # that needs no backend, so the file is absent on main and must be
+          # staged only when the branch under processing actually carries it.
+          # Absence is expected (non-shim branches, incl. main) and must not
+          # fail the bootstrap; presence stages it beside the shim so the
+          # shim resolves ${SCRIPT_DIR}/render_prompt.py.
+          for f in render_prompt.py; do
+            src=".codex-workflow-src/scripts/${f}"
+            if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then
+              src=".codex-workflow-src-main/scripts/${f}"
+            fi
+            if [ ! -f "${src}" ]; then
+              echo "::notice::Optional render_prompt.py backend unavailable on ${SCRIPT_REF}; render_prompt.sh shim (if present) resolves it elsewhere or the bundled bash renderer is used."
+              continue
+            fi
+            install -m 0755 "${src}" "scripts/${f}"
+            _fetched_scripts+=("${f}")
+          done
+
           # Fetch AI memory schema files so consumer repos that lack
           # schemas on their default branch can bootstrap the ai-memory
           # branch (schemas are validated during memory operations).

--- a/.github/workflows/orchestrate_poll.yml
+++ b/.github/workflows/orchestrate_poll.yml
@@ -305,6 +305,27 @@ jobs:
             _fetched_scripts+=("${f}")
           done
 
+          # render_prompt.py is the optional Python backend for the
+          # render_prompt.sh shim adopted by branches that took the issue
+          # #3043 refactor.  main ships a self-contained bash render_prompt.sh
+          # that needs no backend, so the file is absent on main and must be
+          # staged only when the branch under processing actually carries it.
+          # Absence is expected (non-shim branches, incl. main) and must not
+          # fail the bootstrap; presence stages it beside the shim so the
+          # shim resolves ${SCRIPT_DIR}/render_prompt.py.
+          for f in render_prompt.py; do
+            src=".codex-workflow-src/scripts/${f}"
+            if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then
+              src=".codex-workflow-src-main/scripts/${f}"
+            fi
+            if [ ! -f "${src}" ]; then
+              echo "::notice::Optional render_prompt.py backend unavailable on ${SCRIPT_REF}; render_prompt.sh shim (if present) resolves it elsewhere or the bundled bash renderer is used."
+              continue
+            fi
+            install -m 0755 "${src}" "scripts/${f}"
+            _fetched_scripts+=("${f}")
+          done
+
           for f in install_semble.sh build_semble_wrapper.sh semble_helpers.sh; do
             src=".codex-workflow-src/scripts/${f}"
             if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -281,6 +281,27 @@ jobs:
             _fetched_scripts+=("${f}")
           done
 
+          # render_prompt.py is the optional Python backend for the
+          # render_prompt.sh shim adopted by branches that took the issue
+          # #3043 refactor.  main ships a self-contained bash render_prompt.sh
+          # that needs no backend, so the file is absent on main and must be
+          # staged only when the branch under processing actually carries it.
+          # Absence is expected (non-shim branches, incl. main) and must not
+          # fail the bootstrap; presence stages it beside the shim so the
+          # shim resolves ${SCRIPT_DIR}/render_prompt.py.
+          for f in render_prompt.py; do
+            src=".codex-workflow-src/scripts/${f}"
+            if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then
+              src=".codex-workflow-src-main/scripts/${f}"
+            fi
+            if [ ! -f "${src}" ]; then
+              echo "::notice::Optional render_prompt.py backend unavailable on ${SCRIPT_REF}; render_prompt.sh shim (if present) resolves it elsewhere or the bundled bash renderer is used."
+              continue
+            fi
+            install -m 0755 "${src}" "scripts/${f}"
+            _fetched_scripts+=("${f}")
+          done
+
           # Stage codex_model_catalog.json so scripts/write_codex_config.sh
           # can wire `model_catalog_json` and codex registers
           # `apply_patch_tool_type = "freeform"` for our `openai/gpt-5.*`

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1263,7 +1263,20 @@ jobs:
           # that depend on these must themselves tolerate absence.  Keep
           # this list empty unless a genuinely optional helper is added;
           # the default should always be "required".
-          OPTIONAL_BOOTSTRAP_SCRIPTS="install_semble.sh build_semble_wrapper.sh semble_helpers.sh"
+          #
+          # render_prompt.py is the Python backend for the render_prompt.sh
+          # shim adopted by branches that took the issue #3043 refactor.  main
+          # ships a self-contained bash render_prompt.sh that needs no backend,
+          # so render_prompt.py does not exist on main and MUST stay optional
+          # here: this workflow runs pinned @main (internal-review.yml), so it
+          # is main's bootstrap list — not the branch's — that decides what
+          # gets staged from the branch checkout.  Staging it required would
+          # break every normal main-based PR (where the file is absent from
+          # both refs); staging it optionally lets shim-adopting branches
+          # resolve their backend (the shim looks for render_prompt.py beside
+          # itself in SUPPORT_SCRIPTS_DIR) while non-shim branches bootstrap
+          # cleanly.
+          OPTIONAL_BOOTSTRAP_SCRIPTS="install_semble.sh build_semble_wrapper.sh semble_helpers.sh render_prompt.py"
           for f in ${REQUIRED_BOOTSTRAP_SCRIPTS}; do
             src=".codex-workflow-src/scripts/${f}"
             if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then
@@ -2867,7 +2880,7 @@ jobs:
 
           leaked_paths="$(git ls-files -- \
             'scripts/gh_helpers.sh' 'scripts/git_ref_health_check.sh' \
-            'scripts/render_prompt.sh' 'scripts/validate_changed_files_syntax.sh' \
+            'scripts/render_prompt.sh' 'scripts/render_prompt.py' 'scripts/validate_changed_files_syntax.sh' \
             'scripts/tg_helpers.sh' 'scripts/label_helpers.sh' 'scripts/memory_helpers.sh' \
             'scripts/ai_memory.py' 'scripts/ai_memory_lib.py' 'scripts/openrouter_prompt_cache.py' \
             'scripts/codex_model_catalog.json' \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -312,6 +312,28 @@ jobs:
             _fetched_scripts+=("${f}")
           done
 
+          # render_prompt.py is the optional Python backend for the
+          # render_prompt.sh shim adopted by branches that took the issue
+          # #3043 refactor.  main ships a self-contained bash render_prompt.sh
+          # that needs no backend, so the file is absent on main and is staged
+          # only when the branch under processing actually carries it.  Absence
+          # is expected (non-shim branches, incl. main) and must not fail the
+          # bootstrap; presence stages it beside the shim so the shim resolves
+          # ${SCRIPT_DIR}/render_prompt.py.
+          if [ ! -f "scripts/render_prompt.py" ]; then
+            if copy_from_ref_or_local "scripts/render_prompt.py" "scripts/render_prompt.py.tmp" "false" "true"; then
+              mv "scripts/render_prompt.py.tmp" "scripts/render_prompt.py"
+              chmod +x "scripts/render_prompt.py"
+              _fetched_scripts+=(render_prompt.py)
+            else
+              rm -f "scripts/render_prompt.py.tmp"
+              echo "render_prompt.py backend not on ${script_ref} yet; render_prompt.sh shim (if present) resolves it elsewhere or the bundled bash renderer is used."
+            fi
+          else
+            chmod +x "scripts/render_prompt.py"
+            _fetched_scripts+=(render_prompt.py)
+          fi
+
           if [ ! -f "scripts/render_validation_templates.py" ]; then
             if copy_from_ref_or_local "scripts/render_validation_templates.py" "scripts/render_validation_templates.py.tmp" "false" "true"; then
               mv "scripts/render_validation_templates.py.tmp" "scripts/render_validation_templates.py"

--- a/scripts/check_workflow_script_refs.py
+++ b/scripts/check_workflow_script_refs.py
@@ -27,6 +27,18 @@ import re
 import sys
 from typing import Iterable
 
+# Scripts that workflows reference but which are intentionally NOT present in
+# this repo's scripts/ on main.  These are staged optionally (fail-open) from
+# the branch under processing when that branch carries them, so a missing file
+# on main is expected and must not be reported as a hallucinated reference.
+#
+#   render_prompt.py — Python backend for the render_prompt.sh shim adopted by
+#     branches that took the issue #3043 refactor.  main ships a self-contained
+#     bash render_prompt.sh that needs no backend, so render_prompt.py does not
+#     exist on main; the staging steps reference it only to copy it when a
+#     shim-adopting branch actually provides it.
+OPTIONAL_REFS = frozenset({"render_prompt.py"})
+
 EXPLICIT_REF = re.compile(r"scripts/([a-zA-Z0-9_.\-]+\.(?:sh|py|json|txt|md))")
 SCRIPTS_VAR_REF = re.compile(
 	r"\$\{SUPPORT_SCRIPTS_DIR\}/([a-zA-Z0-9_.\-]+\.(?:sh|py|json|txt|md))"
@@ -77,6 +89,8 @@ def check_workflows(repo_root: pathlib.Path) -> list[str]:
 			continue
 		refs = extract_refs(text)
 		for ref in sorted(refs):
+			if ref in OPTIONAL_REFS:
+				continue
 			target = scripts_dir / ref
 			if not target.is_file():
 				errors.append(
@@ -99,6 +113,8 @@ def check_paths(paths: Iterable[pathlib.Path], scripts_dir: pathlib.Path) -> lis
 			errors.append(f"{p}: cannot read ({exc})")
 			continue
 		for ref in sorted(extract_refs(text)):
+			if ref in OPTIONAL_REFS:
+				continue
 			target = scripts_dir / ref
 			if not target.is_file():
 				errors.append(


### PR DESCRIPTION
## Summary

Fixes the "PR autofix failed" notifications for runs
[26817501460](https://github.com/shubhodeep1/coding-workflows/actions/runs/26817501460)
(claude-branch-review of PR #3047's branch) and
[26826820499](https://github.com/shubhodeep1/coding-workflows/actions/runs/26826820499)
(PR #3054). Both failed at the **Run reviewer models** step with:

```
render_prompt.py not found for /tmp/.../reviewer_prompt_body.txt
##[error]Process completed with exit code 1.
```

## Root cause

The issue #3043 refactor converts `scripts/render_prompt.sh` from a
self-contained bash renderer into a **shim that execs
`scripts/render_prompt.py`**. That refactor lives on the
`orchestrator/project-3042` line, **not main**.

`internal-review.yml` invokes the reusable `review_autofix.yml` pinned
**`@main`** (and the other AI workflows likewise execute from main for
in-flight branches). So it is **main's** "Stage workflow support files" step —
not the branch's — that decides which support scripts get copied out of the
branch checkout (`.codex-workflow-src`) into `SUPPORT_SCRIPTS_DIR`.

main's staging lists only know `render_prompt.sh`. For a shim-adopting branch
the shim gets staged **without** its `render_prompt.py` backend. The shim's
resolver (`${SCRIPT_DIR}/render_prompt.py` + the `.codex-workflow-src` copies)
then finds nothing — `review_run_reviewers.sh` runs `cd "${SUPPORT_ROOT_DIR}"`
first, so the relative `.codex-workflow-src` candidates don't exist there —
and aborts before any reviewer runs.

The branch-side commit `8d937ac` ("stage render_prompt.py alongside
render_prompt.sh in bootstrap lists") added `render_prompt.py` to the
**branch's** bootstrap lists, but that has zero effect because review_autofix
executes from main.

## Evidence

- Both runs' executed `REQUIRED_BOOTSTRAP_SCRIPTS` contained `render_prompt.sh`
  only (no `render_prompt.py`) — matching **main's** `review_autofix.yml`,
  even though each run's `SCRIPT_REF` (`8d937ac`, `c0882bf`) *does* list
  `render_prompt.py`. Proves the executing workflow is main's.
- `internal-review.yml` `review` and `review-claude-branch-push` jobs both:
  `uses: shubhodeep1/coding-workflows/.github/workflows/review_autofix.yml@main`.
- `scripts/render_prompt.sh@c0882bf` is the Python shim; emits
  `render_prompt.py not found for ${PROMPT_FILE}` — the exact log line.

## Fix (on main, where it actually governs staging)

- **Stage `render_prompt.py` optionally** (absent-tolerant) alongside
  `render_prompt.sh` in every workflow that stages the shim: `review_autofix`
  (added to `OPTIONAL_BOOTSTRAP_SCRIPTS`), `implement`, `plan`, `clarify`,
  `orchestrate`, `orchestrate_clarify_respond`, `orchestrate_poll`, `validate`.
  **Optional, not required**, because `render_prompt.py` does not exist on main
  — making it required would break every normal main-based PR's bootstrap
  (file absent from both refs → `exit 1`). When a shim-adopting branch provides
  it, it is staged beside the shim so the shim resolves
  `${SCRIPT_DIR}/render_prompt.py`; non-shim branches (incl. main) bootstrap
  cleanly.
- **Allowlist `render_prompt.py`** in `scripts/check_workflow_script_refs.py`
  (new `OPTIONAL_REFS`) so the CI gate and inline merge-resolver guard don't
  flag the new references as hallucinated while the file is legitimately absent
  on main.
- Mirror `scripts/render_prompt.py` into review_autofix's consumer-repo
  leaked-paths guard for symmetry with `render_prompt.sh`.

## Validation

- `scripts/check_workflow_script_refs.py` → passes; `py_compile` + `ruff` clean.
- `yamllint -s` and `actionlint -shellcheck=` clean on all 8 edited workflows.
- `tests/test_validate_workflow_validate_bootstrap.py`,
  `tests/test_judge_semble_prefetch_contract.py` (render_prompt.sh contract),
  and the passing review_autofix contract tests are green; my changes add no
  new failures (3 unrelated `test_review_autofix_*` failures pre-exist on clean
  main, verified by stashing this diff).

## Notes

- This is the sequencing fix the orchestrator project #3042 needs: every
  project branch's autofix fails until main learns to stage `render_prompt.py`.
- Once the #3043 refactor merges to main (bringing `render_prompt.py` + the
  shim), the optional staging can be promoted to required and the
  `OPTIONAL_REFS` allowlist entry dropped.

Refs #3043, #3047, #3054.

https://claude.ai/code/session_01U8PKBfR3kSKsKFT8wmVvAw

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8PKBfR3kSKsKFT8wmVvAw)_