### PR TITLE
test(orchestrate-poll): sync OPTIONAL_BOOTSTRAP_SCRIPTS assertion with render_prompt.py

### DIFF
--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -12550,7 +12550,9 @@ def test_review_autofix_workflow_wires_optional_verifier_bootstrap_and_gate():
 	assert 'SUPPORT_ROOT_DIR="${RUNNER_TEMP}/coding-workflows-runtime-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"' in wf_body
 	assert 'SUPPORT_SCRIPTS_DIR="${SUPPORT_ROOT_DIR}/scripts"' in wf_body
 	assert 'SUPPORT_SCRIPTS_DIR="scripts"' not in wf_body
-	assert 'OPTIONAL_BOOTSTRAP_SCRIPTS="install_semble.sh build_semble_wrapper.sh semble_helpers.sh"' in wf_body
+	# render_prompt.py is staged optionally on main so shim branches resolve
+	# their backend (PR #3057); keep this list in sync with review_autofix.yml.
+	assert 'OPTIONAL_BOOTSTRAP_SCRIPTS="install_semble.sh build_semble_wrapper.sh semble_helpers.sh render_prompt.py"' in wf_body
 	assert "for f in ${MAIN_PRIMARY_BOOTSTRAP_SCRIPTS}; do" in wf_body
 	assert "Bootstrapped ${f} from main snapshot (branch copy ignored)." in wf_body
 	# The bootstrap still enumerates the script name in review_autofix.yml


### PR DESCRIPTION
## Summary

`main` is currently red on `test_orchestrate_poll_process.py::test_review_autofix_workflow_wires_optional_verifier_bootstrap_and_gate`, which gates PR CI (`ci.yml:544`).

PR #3057 ("stage render_prompt.py optionally on main so shim branches resolve their backend") appended `render_prompt.py` to `OPTIONAL_BOOTSTRAP_SCRIPTS` in `.github/workflows/review_autofix.yml`:

```
OPTIONAL_BOOTSTRAP_SCRIPTS="install_semble.sh build_semble_wrapper.sh semble_helpers.sh render_prompt.py"
```

…but the matching assertion in the test (line 12553) still expected the list **without** `render_prompt.py`, so the test has been failing since #3057 merged.

## Change

One-line fix: update the expected string to include `render_prompt.py` so the assertion matches the shipped workflow, plus a short comment noting the source (#3057) and the sync requirement.

## Verification

- `test_review_autofix_workflow_wires_optional_verifier_bootstrap_and_gate` now passes.
- `python3 -m py_compile tests/test_orchestrate_poll_process.py` clean.
- Diff is 1 assertion line changed + 2 comment lines; no behavior change.

## Note

This was surfaced while validating an unrelated stall-recovery fix (#3072) — it is split out here per the single-responsibility request and is independent of that work. A second failure observed locally (`test_verify_integration_fingerprints_baseline_regressions`, `git commit` exit 128) is a **sandbox commit-signing-server artifact**, not a real test failure, and is not addressed here.

https://claude.ai/code/session_01YbKThUNMm3NXBi3YATFZFd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbKThUNMm3NXBi3YATFZFd)_