### PR TITLE
fix(ci): exempt optional render_prompt.py backend from script cross-reference gate

### DIFF
--- a/.github/workflows/mark-stable.yml
+++ b/.github/workflows/mark-stable.yml
@@ -300,11 +300,11 @@ jobs:
           # (render_prompt.sh), so their absence here is expected and must not
           # fail the cross-reference gate. Keep this list in sync with the
           # optional-bootstrap handling in the consumer-facing workflows.
-          OPTIONAL_SCRIPTS="scripts/render_prompt.py"
+          OPTIONAL_SCRIPTS=("scripts/render_prompt.py")
           MISSING=0
           for ref in $(grep -rhoE 'scripts/[a-zA-Z0-9_.-]+\.(sh|py|json)' .github/workflows/ | sort -u); do
             if [ ! -f "$ref" ]; then
-              if printf '%s\n' $OPTIONAL_SCRIPTS | grep -qxF "$ref"; then
+              if printf '%s\n' "${OPTIONAL_SCRIPTS[@]}" | grep -qxF "$ref"; then
                 echo "OPTIONAL (absent on main, staged by shim branches): $ref"
                 continue
               fi

--- a/.github/workflows/mark-stable.yml
+++ b/.github/workflows/mark-stable.yml
@@ -292,9 +292,22 @@ jobs:
         run: |
           set -euo pipefail
           echo "Verifying all scripts referenced by workflows exist..."
+          # Scripts intentionally absent on main: optional backends that shim
+          # branches stage at runtime (see #3057). They appear as literal
+          # scripts/<name> tokens in workflow YAML (e.g. validate.yml stages
+          # render_prompt.py conditionally; review_autofix.yml's leaked-path
+          # guard lists it), but main ships a self-contained alternative
+          # (render_prompt.sh), so their absence here is expected and must not
+          # fail the cross-reference gate. Keep this list in sync with the
+          # optional-bootstrap handling in the consumer-facing workflows.
+          OPTIONAL_SCRIPTS="scripts/render_prompt.py"
           MISSING=0
           for ref in $(grep -rhoE 'scripts/[a-zA-Z0-9_.-]+\.(sh|py|json)' .github/workflows/ | sort -u); do
             if [ ! -f "$ref" ]; then
+              if printf '%s\n' $OPTIONAL_SCRIPTS | grep -qxF "$ref"; then
+                echo "OPTIONAL (absent on main, staged by shim branches): $ref"
+                continue
+              fi
               echo "FAIL: $ref referenced in workflows but does not exist"
               MISSING=$((MISSING + 1))
             else

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3360,11 +3360,11 @@ jobs:
           # (render_prompt.sh), so their absence here is expected and must not
           # fail the cross-reference gate. Keep this list in sync with the
           # optional-bootstrap handling in the consumer-facing workflows.
-          OPTIONAL_SCRIPTS="scripts/render_prompt.py"
+          OPTIONAL_SCRIPTS=("scripts/render_prompt.py")
           MISSING=0
           for ref in $(grep -rhoE 'scripts/[a-zA-Z0-9_.-]+\.(sh|py|json)' .github/workflows/ | sort -u); do
             if [ ! -f "$ref" ]; then
-              if printf '%s\n' $OPTIONAL_SCRIPTS | grep -qxF "$ref"; then
+              if printf '%s\n' "${OPTIONAL_SCRIPTS[@]}" | grep -qxF "$ref"; then
                 echo "OPTIONAL (absent on main, staged by shim branches): $ref"
                 continue
               fi

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3352,9 +3352,22 @@ jobs:
         run: |
           set -euo pipefail
           echo "Verifying all scripts referenced by workflows exist..."
+          # Scripts intentionally absent on main: optional backends that shim
+          # branches stage at runtime (see #3057). They appear as literal
+          # scripts/<name> tokens in workflow YAML (e.g. validate.yml stages
+          # render_prompt.py conditionally; review_autofix.yml's leaked-path
+          # guard lists it), but main ships a self-contained alternative
+          # (render_prompt.sh), so their absence here is expected and must not
+          # fail the cross-reference gate. Keep this list in sync with the
+          # optional-bootstrap handling in the consumer-facing workflows.
+          OPTIONAL_SCRIPTS="scripts/render_prompt.py"
           MISSING=0
           for ref in $(grep -rhoE 'scripts/[a-zA-Z0-9_.-]+\.(sh|py|json)' .github/workflows/ | sort -u); do
             if [ ! -f "$ref" ]; then
+              if printf '%s\n' $OPTIONAL_SCRIPTS | grep -qxF "$ref"; then
+                echo "OPTIONAL (absent on main, staged by shim branches): $ref"
+                continue
+              fi
               echo "FAIL: $ref referenced in workflows but does not exist"
               MISSING=$((MISSING + 1))
             else


### PR DESCRIPTION
## Summary

The `validate-scripts` job failed in run [26942520644](https://github.com/shubhodeep1/coding-workflows/actions/runs/26942520644) at the **Script-workflow cross-reference** step with `1 script(s) referenced by workflows are missing` → `FAIL: scripts/render_prompt.py referenced in workflows but does not exist`.

### Root cause

The cross-reference step greps every `scripts/<name>.{sh,py,json}` token out of `.github/workflows/` and asserts each file exists on disk:

```bash
for ref in $(grep -rhoE 'scripts/[a-zA-Z0-9_.-]+\.(sh|py|json)' .github/workflows/ | sort -u); do
  if [ ! -f "$ref" ]; then echo "FAIL: ..."; fi
done
```

PR #3057 (`a904c88`) added literal `scripts/render_prompt.py` strings to:
- `validate.yml:323-333` — conditional staging of the optional backend
- `review_autofix.yml:2883` — leaked-path detection guard

`render_prompt.py` is the **optional** Python backend for the `render_prompt.sh` shim adopted by `#3043`-refactor branches. `main` ships a self-contained bash `render_prompt.sh` that needs no backend, so the file is intentionally absent on `main` (documented in clarify/implement/orchestrate/review_autofix workflows: *"render_prompt.py does not exist on main and MUST stay optional"*). The naive gate didn't know that and flagged the intentional absence as a missing required script.

### Fix

Add an `OPTIONAL_SCRIPTS` allowlist (currently `scripts/render_prompt.py`) to the cross-reference step in both `test-and-mark-stable.yml` and `mark-stable.yml`. Referenced scripts on that list are reported as `OPTIONAL` instead of `FAIL` when absent, restoring the gate's true intent — catch references to scripts that *should* exist but don't — without masking real misses.

### Verification

- Pre-fix repro of the exact check logic: `FAIL: scripts/render_prompt.py` / `MISSING=1` (matches the run).
- Post-fix: `OPTIONAL (absent on main, staged by shim branches): scripts/render_prompt.py` / `All referenced scripts exist.`
- YAML parses clean for both edited workflows.

Refs #3057

https://claude.ai/code/session_017dmpy7TV8LfCXaTpJBkBUH

---
_Generated by [Claude Code](https://claude.ai/code/session_017dmpy7TV8LfCXaTpJBkBUH)_