### PR TITLE
fix(e2e): stop release smoke-test review poller hanging on a concurrency-cancelled sibling run

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1347,29 +1347,15 @@ jobs:
             # workflow_dispatch run at that SHA was filtered out and the
             # poll timed out 30m later.
             if [ -n "${PIN_SHA:-}" ]; then
-              # Among name-matching runs at PIN_SHA, prefer the latest
-              # NON-cancelled run; fall back to the latest cancelled run
-              # only when every run at PIN_SHA is cancelled. Without the
-              # non-cancelled preference a `cancelled` sibling masks a
-              # `success` run on the same head SHA: on run-26989483268 the
-              # bait/fix-triggered internal-review.yml run #26990664122
-              # (conclusion=success — it ran the reviewer, applied the
-              # editor fix, committed, and enabled auto-merge) was created
-              # 15s before a redundant review_autofix.yml workflow_dispatch
-              # run #26990671639 that GitHub immediately cancelled via the
-              # `pr-autofix-<pr>` concurrency group ("a higher priority
-              # waiting request … exists"). The plain
-              # `sort_by(.created_at) | last` latched onto the newer
-              # cancelled run; because the cancellation was a concurrency
-              # preemption (not an editor-pushed commit) the PR head never
-              # advanced past the pin, so the pin-advance guard below never
-              # fired and the loop polled the dead run until the 30-minute
-              # REVIEW_TIMEOUT — blocking the release even though
-              # review+autofix had already succeeded. The `//` fallback
-              # keeps a genuine all-cancelled stall reaching the timeout as
-              # before. The head_sha==PIN_SHA filter still scopes selection
-              # to the pinned commit, so preferring non-cancelled cannot
-              # latch onto a stale success on a prior head.
+              # Among matching runs at PIN_SHA, prefer the newest
+              # non-cancelled run and fall back to the newest cancelled
+              # run only when every matching run is cancelled. This fixes
+              # run-26989483268, where a newer concurrency-cancelled
+              # sibling masked an older successful review run on the same
+              # head SHA; because the PR head did not move, the pin-
+              # advance guard never fired and the loop waited until
+              # REVIEW_TIMEOUT. The PIN_SHA filter still prevents latching
+              # onto a stale success from an earlier commit.
               REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&per_page=100" \
                 --jq "[.workflow_runs[] | select(.name | test(\"Review|review|autofix|self-healing\"; \"i\")) | select(.head_sha == \"${PIN_SHA}\")] as \$m | (\$m | map(select(.conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | sort_by(.created_at) | last)" || echo "")
             else

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1348,16 +1348,14 @@ jobs:
             # poll timed out 30m later.
             if [ -n "${PIN_SHA:-}" ]; then
               # Among matching runs at PIN_SHA, prefer the newest
-              # non-cancelled run and fall back to the newest cancelled
-              # run only when every matching run is cancelled. This fixes
-              # run-26989483268, where a newer concurrency-cancelled
-              # sibling masked an older successful review run on the same
-              # head SHA; because the PR head did not move, the pin-
-              # advance guard never fired and the loop waited until
-              # REVIEW_TIMEOUT. The PIN_SHA filter still prevents latching
-              # onto a stale success from an earlier commit.
+              # completed non-cancelled run. If none has completed yet,
+              # watch the newest non-cancelled live run, and fall back to
+              # the newest cancelled run only when every matching run is
+              # cancelled. This fixes run-26989483268 and avoids picking a
+              # newer queued/in-progress sibling over an already-completed
+              # success on the same head SHA.
               REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&per_page=100" \
-                --jq "[.workflow_runs[] | select(.name | test(\"Review|review|autofix|self-healing\"; \"i\")) | select(.head_sha == \"${PIN_SHA}\")] as \$m | (\$m | map(select(.conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | sort_by(.created_at) | last)" || echo "")
+                --jq "[.workflow_runs[] | select(.name | test(\"Review|review|autofix|self-healing\"; \"i\")) | select(.head_sha == \"${PIN_SHA}\")] as \$m | (\$m | map(select(.status == \"completed\" and .conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | map(select(.conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | sort_by(.created_at) | last)" || echo "")
             else
               REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&event=pull_request&per_page=5" \
                 --jq '[.workflow_runs[] | select(.name | test("Review|review|autofix|self-healing"; "i"))] | sort_by(.created_at) | last' || echo "")

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1347,8 +1347,31 @@ jobs:
             # workflow_dispatch run at that SHA was filtered out and the
             # poll timed out 30m later.
             if [ -n "${PIN_SHA:-}" ]; then
+              # Among name-matching runs at PIN_SHA, prefer the latest
+              # NON-cancelled run; fall back to the latest cancelled run
+              # only when every run at PIN_SHA is cancelled. Without the
+              # non-cancelled preference a `cancelled` sibling masks a
+              # `success` run on the same head SHA: on run-26989483268 the
+              # bait/fix-triggered internal-review.yml run #26990664122
+              # (conclusion=success — it ran the reviewer, applied the
+              # editor fix, committed, and enabled auto-merge) was created
+              # 15s before a redundant review_autofix.yml workflow_dispatch
+              # run #26990671639 that GitHub immediately cancelled via the
+              # `pr-autofix-<pr>` concurrency group ("a higher priority
+              # waiting request … exists"). The plain
+              # `sort_by(.created_at) | last` latched onto the newer
+              # cancelled run; because the cancellation was a concurrency
+              # preemption (not an editor-pushed commit) the PR head never
+              # advanced past the pin, so the pin-advance guard below never
+              # fired and the loop polled the dead run until the 30-minute
+              # REVIEW_TIMEOUT — blocking the release even though
+              # review+autofix had already succeeded. The `//` fallback
+              # keeps a genuine all-cancelled stall reaching the timeout as
+              # before. The head_sha==PIN_SHA filter still scopes selection
+              # to the pinned commit, so preferring non-cancelled cannot
+              # latch onto a stale success on a prior head.
               REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&per_page=100" \
-                --jq "[.workflow_runs[] | select(.name | test(\"Review|review|autofix|self-healing\"; \"i\")) | select(.head_sha == \"${PIN_SHA}\")] | sort_by(.created_at) | last" || echo "")
+                --jq "[.workflow_runs[] | select(.name | test(\"Review|review|autofix|self-healing\"; \"i\")) | select(.head_sha == \"${PIN_SHA}\")] as \$m | (\$m | map(select(.conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | sort_by(.created_at) | last)" || echo "")
             else
               REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&event=pull_request&per_page=5" \
                 --jq '[.workflow_runs[] | select(.name | test("Review|review|autofix|self-healing"; "i"))] | sort_by(.created_at) | last' || echo "")


### PR DESCRIPTION
## Summary

Release **v1.14.0** (run [26989483268](https://github.com/shubhodeep1/coding-workflows/actions/runs/26989483268)) failed because the **`e2e-smoke-test`** job hung in **Phase 4 (Wait for review & autofix)** and aged out at `Review FAILED (timeout)`, which skipped `validate` → `release`. `e2e-smoke-test` was the **sole hard blocker** — every other test job (incl. `workflow-log-analysis-test`) concluded `success`; the notification's `workflow-log-analysis-test: ✗` reflected a *non-blocking* dispatched audit run, and all soft-error-consolidation items were `=ok`.

## Root cause

The Phase 4 poller selects the review run to watch with `sort_by(.created_at) | last` over all name-matching runs at the pinned head SHA (`PIN_SHA`). At the final pin `98c459c`, **two** review-type runs shared that SHA:

| Run | Workflow | Created | Conclusion |
|---|---|---|---|
| `#26990664122` | `internal-review.yml` (ran reviewer, applied editor fix, committed, enabled auto-merge) | 01:55:43 | **success** |
| `#26990671639` | `review_autofix.yml` (redundant `workflow_dispatch`) | 01:55:58 | **cancelled** |

`#26990671639` was cancelled by GitHub Actions concurrency (`"Canceling since a higher priority waiting request for pr-autofix-3102 exists"`). Being 15 s newer, it won `sort_by(.created_at) | last`, so the poller latched onto the **dead cancelled run** and ignored the **successful** sibling.

The existing `cancelled` handler only advances the pin when the PR head moves past it (an editor-pushed fix). Here the cancellation was a **concurrency preemption** — the PR head stayed at `98c459c` — so the pin-advance guard never fired and the loop printed `Review run was cancelled — checking for newer run...` for the full **30-minute `REVIEW_TIMEOUT`** before failing, even though review + autofix had already **succeeded**.

## Fix

`.github/workflows/test-and-mark-stable.yml` (Phase 4 run-selection, `PIN_SHA` path): prefer the **latest non-cancelled** run at `PIN_SHA`, falling back to the latest cancelled run only when **every** run at `PIN_SHA` is cancelled (so a genuine all-cancelled stall still reaches the timeout):

```diff
- ...select(.head_sha == "${PIN_SHA}")] | sort_by(.created_at) | last
+ ...select(.head_sha == "${PIN_SHA}")] as $m
+   | ($m | map(select(.conclusion != "cancelled")) | sort_by(.created_at) | last)
+   // ($m | sort_by(.created_at) | last)
```

The legacy (no-bait) path is intentionally left unchanged: it has no `head_sha` pin and relies on recency, so a non-cancelled preference there could latch onto a stale success on a prior head.

## Verification

- jq semantics validated against the real run shapes: new filter → `#26990664122` (success); old filter → `#26990671639` (cancelled, reproduces the bug); all-cancelled → latest cancelled (timeout preserved); no-match → `null`.
- Replayed against the live timeline: once `#26990671639` flips to `cancelled`, the new filter excludes it and re-selects `#26990664122`, which the poller then exits on as `success`.
- `test-and-mark-stable.yml` re-parses as YAML; the extracted Phase 4 `run:` body passes `bash -n`; no `${{ }}` expressions added (the 21k single-expression limit does not apply).

This corrects a **detection** bug — the review genuinely succeeded — and is not a retry masking a deterministic failure.

https://claude.ai/code/session_01BuC1T9ic6J5ZoPgEm3K48E

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuC1T9ic6J5ZoPgEm3K48E)_