### PR TITLE
Add pinned-toolchain authority guard to live judge + plan prompts

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -992,6 +992,19 @@ jobs:
             endpoint/method/parameter details in the plan so the implementation editor
             has the contract inlined. If the docs are genuinely unavailable after web
             search, ask for clarification instead of inventing details.
+          - Pinned-toolchain authority: a repo validator (`npm run typecheck`/`tsc`,
+            `eslint`, `vitest`/`jest`, `npm run build`, or any language equivalent) is
+            authoritative only on the repo's pinned toolchain — i.e. after the repo's
+            own dependencies are installed (`npm ci`, `pnpm i --frozen-lockfile`,
+            `uv sync --frozen`, `cargo build --locked`). Do NOT run such a command
+            against a globally-installed or newer tool (e.g. a system `tsc`) and treat
+            its failure as ground truth: a newer compiler/linter can flag options the
+            pinned version accepts (e.g. TS5101 on `baseUrl`, which the pinned compiler
+            does not raise). If the pinned deps are not installed, mark any local
+            validator result UNVERIFIED and defer to the branch's CI check results;
+            never plan a fix for a validator failure you cannot reproduce on the
+            pinned toolchain, and never recommend a config value without confirming
+            the pinned tool accepts it.
           - Do NOT write code.
           - Do NOT modify repository files.
           - Only generate the implementation plan when answers are interpretable and sufficient.

--- a/prompts/mode-judge.txt
+++ b/prompts/mode-judge.txt
@@ -22,8 +22,10 @@ Rules:
   harness/infrastructure failure by default, not as evidence of an application regression
   in merged code, unless the repository evidence clearly shows the product code caused
   the failure.
-- Pinned-toolchain authority: treat the provided "=== CI STATUS ON <branch> ==="
-  check-runs block as the authoritative source for `ci_status`. A repo validator
+- Pinned-toolchain authority: treat the provided CI check-runs block (headed
+  `=== CI STATUS ON ... ===` with the actual default-branch name, e.g.
+  `=== CI STATUS ON main ===`) as the authoritative source for `ci_status`. A
+  repo validator
   (`npm run typecheck`/`tsc`, `eslint`, `vitest`/`jest`, `npm run build`, or any
   language equivalent) is authoritative ONLY when run on the repo's pinned
   toolchain — i.e. after the repo's own dependencies are installed (`npm ci`,
@@ -36,7 +38,9 @@ Rules:
   config value without confirming the pinned tool accepts it. If the pinned deps
   are not installed and cannot be installed, derive `ci_status` and any
   validator-based finding from the provided check-runs block, NOT from a local
-  re-run.
+  re-run. If that check-runs block is missing, empty, or otherwise unusable,
+  set `ci_status` to `unknown` instead of inferring it from an off-toolchain
+  local validator run.
 - Fallback on empty lookups: if the primary lookup returns empty, partial,
   or suspiciously narrow results, try at least one fallback (sibling-PR
   diff, parent-PR comments, prior wave logs, file-history grep) before

--- a/prompts/mode-judge.txt
+++ b/prompts/mode-judge.txt
@@ -22,6 +22,21 @@ Rules:
   harness/infrastructure failure by default, not as evidence of an application regression
   in merged code, unless the repository evidence clearly shows the product code caused
   the failure.
+- Pinned-toolchain authority: treat the provided "=== CI STATUS ON <branch> ==="
+  check-runs block as the authoritative source for `ci_status`. A repo validator
+  (`npm run typecheck`/`tsc`, `eslint`, `vitest`/`jest`, `npm run build`, or any
+  language equivalent) is authoritative ONLY when run on the repo's pinned
+  toolchain — i.e. after the repo's own dependencies are installed (`npm ci`,
+  `pnpm i --frozen-lockfile`, `uv sync --frozen`, `cargo build --locked`). Do NOT
+  run such a command against a globally-installed or newer tool (e.g. a system
+  `tsc`) and report its failure as a defect: a newer compiler/linter can flag
+  options the pinned version accepts (e.g. TS5101 on `baseUrl`, which the pinned
+  compiler does not raise). Never add a `new_issues[]` entry for a validator
+  failure you cannot reproduce on the pinned toolchain, and never recommend a
+  config value without confirming the pinned tool accepts it. If the pinned deps
+  are not installed and cannot be installed, derive `ci_status` and any
+  validator-based finding from the provided check-runs block, NOT from a local
+  re-run.
 - Fallback on empty lookups: if the primary lookup returns empty, partial,
   or suspiciously narrow results, try at least one fallback (sibling-PR
   diff, parent-PR comments, prior wave logs, file-history grep) before


### PR DESCRIPTION
## Summary

Adds a "pinned-toolchain authority" rule to the two **live** prompts that the orchestrate-poll judge and the planner actually run, so neither files (or plans a fix for) a false validator failure observed off the repo's pinned toolchain.

This originates from a consumer-reported incident: the orchestrate-poll judge ran a consumer's `npm run typecheck` **without the consumer's pinned dependencies installed**, so `tsc` resolved to a global/newer TypeScript that flagged an option the pinned compiler accepts (e.g. `TS5101` on `baseUrl`). It filed a false fix-up issue recommending `ignoreDeprecations: "6.0"` — a value the pinned TS 5.9 rejects (`TS5103`) — even though the branch's pinned-toolchain CI was green the whole time. The planner then re-ran the same off-toolchain command and reinforced the false finding.

## Why these targets (and not the ones in the original report)

The consumer's proposed diff targeted `prompts/mode-orchestrate-poll-judge.txt` and `prompts/mode-plan.txt`. Both are **non-live on `main`** — editing them would have had zero runtime effect:

- The live orchestrate-poll judge renders `prompts/mode-judge.txt` (`scripts/orchestrate_poll_process.sh:16202`). `prompts/mode-orchestrate-poll-judge.txt` is an intentionally **unwired** reference file — asserted by `tests/test_judge_semble_prefetch_contract.py::test_unwired_orchestrate_poll_judge_prompt_remains_unconsumed`.
- The live planner renders an **inline heredoc** written into `.github/workflows/plan.yml` (lines ~875–1000); `prompts/mode-plan.txt` is referenced only as a pointer to the "Mandatory Question Format" section.

So this PR applies the guard to the corrected **live** targets.

## Changes

- **`prompts/mode-judge.txt`** — new rule after the existing `raw_status=harness_error` rule. It directs the judge to treat the harness-provided `=== CI STATUS ON <branch> ===` check-runs block (built at `scripts/orchestrate_poll_process.sh:16155-16240`) as the authoritative `ci_status` source, declares repo validators authoritative only on the pinned toolchain (`npm ci` / `pnpm i --frozen-lockfile` / `uv sync --frozen` / `cargo build --locked`), and forbids adding a `new_issues[]` entry for a validator failure not reproducible on the pinned toolchain.
- **`.github/workflows/plan.yml`** (inline planner heredoc) — same guard, framed for the planner: mark off-toolchain validator results UNVERIFIED and defer to CI rather than planning a fix for them.

## Notes

- Mirrors the harness/application carve-out intent already present in `prompts/mode-validate-diagnose.txt`.
- The unwired reference copies `prompts/mode-orchestrate-poll-judge.txt` and `prompts/mode-plan.txt` are intentionally left untouched. They can be mirrored separately for documentation consistency if desired — purely cosmetic, no runtime effect.
- Low cross-consumer blast radius: the guard points the judge at the already-supplied authoritative CI block and only suppresses off-toolchain false positives — genuine CI failures still surface via the check-runs block. Language-agnostic (no per-cycle `npm ci` forced on non-Node repos).
- No identifiers renamed (§6); no DB/contract changes (§10). `mode-judge.txt` is 90 lines, under the 150-line CI cap.

## Verification

- `plan.yml` parses as valid YAML.
- Passing contract tests: `test_judge_semble_prefetch_contract`, `test_phase_prompt_untrusted_context_contract`, `test_plan_clarify_blocked_output`, `test_targeted_file_context`, `test_plan_auto_answer_recommended_parser`, `test_validate_process_cross_cycle_escalation`.

https://claude.ai/code/session_01XFDv3TagUhBmvWeGoupLja

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFDv3TagUhBmvWeGoupLja)_