### PR TITLE
test: make editor cache-busting-nonce guard refactor-tolerant (unblocks project #3042 / PR #3048)

### DIFF
--- a/tests/test_review_autofix_editor_noop_cascade_contract.py
+++ b/tests/test_review_autofix_editor_noop_cascade_contract.py
@@ -296,10 +296,11 @@ def test_review_apply_fixes_has_per_attempt_cache_busting_nonce() -> None:
 	# still does.
 	assert 'codex --ask-for-approval never' in text
 	codex_stdin_vars = re.findall(
-		r'codex --ask-for-approval never[^\n]*< "\$\{(\w+)\}"', text
+		r'codex --ask-for-approval never[^\n]*<\s*"?\$\{?(\w+)\}?"?', text
 	)
 	assert codex_stdin_vars, (
-		"No `codex --ask-for-approval never … < \"${<file>}\"` stdin redirect "
+		"No `codex --ask-for-approval never … < \"$file\"`-style stdin "
+		"redirect "
 		"found; the editor must feed codex a prompt file on stdin."
 	)
 	assert "EDITOR_PROMPT_FILE" not in codex_stdin_vars, (
@@ -313,8 +314,17 @@ def test_review_apply_fixes_has_per_attempt_cache_busting_nonce() -> None:
 		# parameter, and a call site forwards the per-attempt file in as
 		# that first argument.
 		fed_via_helper = (
-			re.search(rf'local {re.escape(_stdin_var)}="\$1"', text) is not None
-			and re.search(r'\b\w+ "\$\{attempt_prompt_file\}"', text) is not None
+			re.search(
+				rf'(?<!\w)(?:local(?:\s+-[A-Za-z]+)*\s+)?{re.escape(_stdin_var)}='
+				r'"?\$\{?1\}?"?',
+				text,
+			)
+			is not None
+			and re.search(
+				r'\b\w+\s+"?\$\{?attempt_prompt_file\}?"?(?:\s|$)',
+				text,
+			)
+			is not None
 		)
 		assert fed_directly or fed_via_helper, (
 			f"codex stdin `${{{_stdin_var}}}` is neither the per-attempt prompt "

--- a/tests/test_review_autofix_editor_noop_cascade_contract.py
+++ b/tests/test_review_autofix_editor_noop_cascade_contract.py
@@ -295,43 +295,132 @@ def test_review_apply_fixes_has_per_attempt_cache_busting_nonce() -> None:
 	# refactor does not trip this guard while a regression to the base prompt
 	# still does.
 	assert 'codex --ask-for-approval never' in text
-	codex_stdin_vars = re.findall(
-		r'codex --ask-for-approval never[^\n]*<\s*"?\$\{?(\w+)\}?"?', text
-	)
-	assert codex_stdin_vars, (
+
+	def _shell_function_blocks(script_text: str) -> dict[str, str]:
+		function_blocks: dict[str, str] = {}
+		current_function: str | None = None
+		current_lines: list[str] = []
+		brace_depth = 0
+		for line in script_text.splitlines():
+			if current_function is None:
+				function_start = re.match(r'^\s*(?!#)(\w+)\s*\(\)\s*\{\s*$', line)
+				if function_start is None:
+					continue
+				current_function = function_start.group(1)
+				current_lines = [line]
+				brace_depth = 1
+				continue
+			current_lines.append(line)
+			stripped = line.strip()
+			if re.match(r'^\{\s*(?:#.*)?$', stripped):
+				brace_depth += 1
+				continue
+			if stripped.startswith("}"):
+				brace_depth -= 1
+				if brace_depth == 0:
+					function_blocks[current_function] = "\n".join(current_lines)
+					current_function = None
+					current_lines = []
+		return function_blocks
+
+	def _codex_stdin_targets(script_text: str) -> list[tuple[str, str | None]]:
+		targets: list[tuple[str, str | None]] = []
+		current_function: str | None = None
+		brace_depth = 0
+		for line in script_text.splitlines():
+			function_start = None
+			if current_function is None:
+				function_start = re.match(r'^\s*(?!#)(\w+)\s*\(\)\s*\{\s*$', line)
+				if function_start is not None:
+					current_function = function_start.group(1)
+					brace_depth = 1
+			if not re.match(r'^\s*#', line):
+				for operand in re.findall(
+					r'codex --ask-for-approval never[^\n]*<\s*"?([$](?:\{?\w+\}?))"?',
+					line,
+				):
+					targets.append((
+						operand.strip('"').lstrip("$").strip("{}"),
+						current_function,
+					))
+			if current_function is None or function_start is not None:
+				continue
+			stripped = line.strip()
+			if re.match(r'^\{\s*(?:#.*)?$', stripped):
+				brace_depth += 1
+			elif stripped.startswith("}"):
+				brace_depth -= 1
+				if brace_depth == 0:
+					current_function = None
+		return targets
+
+	function_blocks = _shell_function_blocks(text)
+	codex_stdin_targets = _codex_stdin_targets(text)
+	assert codex_stdin_targets, (
 		"No `codex --ask-for-approval never … < \"$file\"`-style stdin "
 		"redirect "
 		"found; the editor must feed codex a prompt file on stdin."
 	)
-	assert "EDITOR_PROMPT_FILE" not in codex_stdin_vars, (
+	assert all(
+		stdin_var != "EDITOR_PROMPT_FILE"
+		for stdin_var, _helper_name in codex_stdin_targets
+	), (
 		"codex stdin is the unchanging `${EDITOR_PROMPT_FILE}` — every retry "
 		"sends identical bytes and a cached refusal is served instantly "
 		"(PR #3053 / run 26081926521). Feed `${attempt_prompt_file}` instead."
 	)
-	for _stdin_var in codex_stdin_vars:
-		fed_directly = _stdin_var == "attempt_prompt_file"
-		# Helper indirection: codex reads a function's first positional
-		# parameter, and a call site forwards the per-attempt file in as
-		# that first argument.
-		fed_via_helper = (
+	unsafe_targets = []
+	for _stdin_var, _helper_name in codex_stdin_targets:
+		if _helper_name is None:
+			if _stdin_var == "attempt_prompt_file":
+				continue
+			unsafe_targets.append(f"script:${{{_stdin_var}}}")
+			continue
+		helper_body = function_blocks.get(_helper_name, "")
+		first_arg_reaches_stdin = (
+			_stdin_var == "1"
+			or re.search(
+				rf'(?m)^(?!\s*#)\s*(?:local(?:\s+-[A-Za-z]+)*\s+)?{re.escape(_stdin_var)}='
+				r'"?[$]\{?1\}?"?',
+				helper_body,
+			)
+			is not None
+		)
+		call_forwards_attempt_prompt = (
 			re.search(
-				rf'(?<!\w)(?:local(?:\s+-[A-Za-z]+)*\s+)?{re.escape(_stdin_var)}='
-				r'"?\$\{?1\}?"?',
-				text,
-			)
-			is not None
-			and re.search(
-				r'\b\w+\s+"?\$\{?attempt_prompt_file\}?"?(?:\s|$)',
+				rf'(?m)^(?!\s*#)\s*{re.escape(_helper_name)}\s+"?[$]'
+				r'\{?attempt_prompt_file\}?"?(?:\s|$)',
 				text,
 			)
 			is not None
 		)
-		assert fed_directly or fed_via_helper, (
-			f"codex stdin `${{{_stdin_var}}}` is neither the per-attempt prompt "
-			f"file nor a helper parameter fed `${{attempt_prompt_file}}`; the "
-			f"per-attempt nonce cannot reach codex, re-opening the cached-"
-			f"refusal cascade (PR #3053)."
+		call_forwards_base_prompt = (
+			re.search(
+				rf'(?m)^(?!\s*#)\s*{re.escape(_helper_name)}\s+"?[$]'
+				r'\{?EDITOR_PROMPT_FILE\}?"?(?:\s|$)',
+				text,
+			)
+			is not None
 		)
+		if first_arg_reaches_stdin and call_forwards_attempt_prompt and not call_forwards_base_prompt:
+			continue
+		unsafe_reasons = []
+		if not first_arg_reaches_stdin:
+			unsafe_reasons.append("stdin is not helper arg1")
+		if not call_forwards_attempt_prompt:
+			unsafe_reasons.append("no helper call forwards attempt_prompt_file")
+		if call_forwards_base_prompt:
+			unsafe_reasons.append("helper is called with EDITOR_PROMPT_FILE")
+		unsafe_targets.append(
+			f"{_helper_name}:${{{_stdin_var}}} ({'; '.join(unsafe_reasons)})"
+		)
+	assert not unsafe_targets, (
+		"Each codex stdin redirect must either read `${attempt_prompt_file}` "
+		"directly from the script body or live in a helper whose first "
+		"argument reaches codex and whose call site forwards "
+		"`${attempt_prompt_file}` — never `${EDITOR_PROMPT_FILE}`. "
+		f"Unsafe targets: {', '.join(unsafe_targets)}"
+	)
 
 
 def test_review_apply_fixes_cleans_attempt_prompt_file_on_success() -> None:

--- a/tests/test_review_autofix_editor_noop_cascade_contract.py
+++ b/tests/test_review_autofix_editor_noop_cascade_contract.py
@@ -286,12 +286,42 @@ def test_review_apply_fixes_has_per_attempt_cache_busting_nonce() -> None:
 		"actual cache-buster; without it the per-attempt copy is byte-"
 		"identical and the cache still hits."
 	)
-	# codex must read the attempt-specific file, not the base prompt.
+	# codex must read the per-attempt file (which carries the nonce trailer),
+	# never the unchanging base prompt. The stdin redirect may be inline
+	# (`< "${attempt_prompt_file}"`) or inside a one-arg helper that the call
+	# site feeds `${attempt_prompt_file}` into — the S4 continuation-thread-
+	# reuse change extracted `run_editor_codex_attempt` for exactly this.
+	# Assert the behaviour, not one code shape, so a cache-buster-preserving
+	# refactor does not trip this guard while a regression to the base prompt
+	# still does.
 	assert 'codex --ask-for-approval never' in text
-	assert '< "${attempt_prompt_file}"' in text, (
-		"codex stdin must be fed from the per-attempt prompt file, not "
-		"from the unchanging `${EDITOR_PROMPT_FILE}`."
+	codex_stdin_vars = re.findall(
+		r'codex --ask-for-approval never[^\n]*< "\$\{(\w+)\}"', text
 	)
+	assert codex_stdin_vars, (
+		"No `codex --ask-for-approval never … < \"${<file>}\"` stdin redirect "
+		"found; the editor must feed codex a prompt file on stdin."
+	)
+	assert "EDITOR_PROMPT_FILE" not in codex_stdin_vars, (
+		"codex stdin is the unchanging `${EDITOR_PROMPT_FILE}` — every retry "
+		"sends identical bytes and a cached refusal is served instantly "
+		"(PR #3053 / run 26081926521). Feed `${attempt_prompt_file}` instead."
+	)
+	for _stdin_var in codex_stdin_vars:
+		fed_directly = _stdin_var == "attempt_prompt_file"
+		# Helper indirection: codex reads a function's first positional
+		# parameter, and a call site forwards the per-attempt file in as
+		# that first argument.
+		fed_via_helper = (
+			re.search(rf'local {re.escape(_stdin_var)}="\$1"', text) is not None
+			and re.search(r'\b\w+ "\$\{attempt_prompt_file\}"', text) is not None
+		)
+		assert fed_directly or fed_via_helper, (
+			f"codex stdin `${{{_stdin_var}}}` is neither the per-attempt prompt "
+			f"file nor a helper parameter fed `${{attempt_prompt_file}}`; the "
+			f"per-attempt nonce cannot reach codex, re-opening the cached-"
+			f"refusal cascade (PR #3053)."
+		)
 
 
 def test_review_apply_fixes_cleans_attempt_prompt_file_on_success() -> None:

--- a/tests/test_review_autofix_editor_noop_cascade_contract.py
+++ b/tests/test_review_autofix_editor_noop_cascade_contract.py
@@ -299,16 +299,33 @@ def test_review_apply_fixes_has_per_attempt_cache_busting_nonce() -> None:
 	def _shell_function_blocks(script_text: str) -> dict[str, str]:
 		function_blocks: dict[str, str] = {}
 		current_function: str | None = None
+		pending_function: str | None = None
+		pending_lines: list[str] = []
 		current_lines: list[str] = []
 		brace_depth = 0
 		for line in script_text.splitlines():
 			if current_function is None:
-				function_start = re.match(r'^\s*(?!#)(\w+)\s*\(\)\s*\{\s*$', line)
-				if function_start is None:
+				stripped = line.strip()
+				if pending_function is not None:
+					if re.match(r'^\{\s*(?:#.*)?$', stripped):
+						current_function = pending_function
+						current_lines = pending_lines + [line]
+						brace_depth = 1
+						pending_function = None
+						pending_lines = []
+						continue
+					pending_function = None
+					pending_lines = []
+				function_start = re.match(r'^\s*(?!#)(\w+)\s*\(\)\s*\{\s*(?:#.*)?$', line)
+				if function_start is not None:
+					current_function = function_start.group(1)
+					current_lines = [line]
+					brace_depth = 1
 					continue
-				current_function = function_start.group(1)
-				current_lines = [line]
-				brace_depth = 1
+				function_declaration = re.match(r'^\s*(?!#)(\w+)\s*\(\)\s*(?:#.*)?$', line)
+				if function_declaration is not None:
+					pending_function = function_declaration.group(1)
+					pending_lines = [line]
 				continue
 			current_lines.append(line)
 			stripped = line.strip()
@@ -326,14 +343,28 @@ def test_review_apply_fixes_has_per_attempt_cache_busting_nonce() -> None:
 	def _codex_stdin_targets(script_text: str) -> list[tuple[str, str | None]]:
 		targets: list[tuple[str, str | None]] = []
 		current_function: str | None = None
+		pending_function: str | None = None
 		brace_depth = 0
 		for line in script_text.splitlines():
-			function_start = None
+			started_function = False
 			if current_function is None:
-				function_start = re.match(r'^\s*(?!#)(\w+)\s*\(\)\s*\{\s*$', line)
-				if function_start is not None:
-					current_function = function_start.group(1)
-					brace_depth = 1
+				stripped = line.strip()
+				if pending_function is not None:
+					if re.match(r'^\{\s*(?:#.*)?$', stripped):
+						current_function = pending_function
+						brace_depth = 1
+						started_function = True
+					pending_function = None
+				if not started_function:
+					function_start = re.match(r'^\s*(?!#)(\w+)\s*\(\)\s*\{\s*(?:#.*)?$', line)
+					if function_start is not None:
+						current_function = function_start.group(1)
+						brace_depth = 1
+						started_function = True
+					else:
+						function_declaration = re.match(r'^\s*(?!#)(\w+)\s*\(\)\s*(?:#.*)?$', line)
+						if function_declaration is not None:
+							pending_function = function_declaration.group(1)
 			if not re.match(r'^\s*#', line):
 				for operand in re.findall(
 					r'codex --ask-for-approval never[^\n]*<\s*"?([$](?:\{?\w+\}?))"?',
@@ -343,7 +374,7 @@ def test_review_apply_fixes_has_per_attempt_cache_busting_nonce() -> None:
 						operand.strip('"').lstrip("$").strip("{}"),
 						current_function,
 					))
-			if current_function is None or function_start is not None:
+			if current_function is None or started_function:
 				continue
 			stripped = line.strip()
 			if re.match(r'^\{\s*(?:#.*)?$', stripped):

--- a/tests/test_review_autofix_editor_noop_cascade_contract.py
+++ b/tests/test_review_autofix_editor_noop_cascade_contract.py
@@ -315,7 +315,7 @@ def test_review_apply_fixes_has_per_attempt_cache_busting_nonce() -> None:
 			if re.match(r'^\{\s*(?:#.*)?$', stripped):
 				brace_depth += 1
 				continue
-			if stripped.startswith("}"):
+			if re.match(r'^\}(?=\s*(?:$|#|[;|&<>]|\d))', stripped):
 				brace_depth -= 1
 				if brace_depth == 0:
 					function_blocks[current_function] = "\n".join(current_lines)
@@ -348,7 +348,7 @@ def test_review_apply_fixes_has_per_attempt_cache_busting_nonce() -> None:
 			stripped = line.strip()
 			if re.match(r'^\{\s*(?:#.*)?$', stripped):
 				brace_depth += 1
-			elif stripped.startswith("}"):
+			elif re.match(r'^\}(?=\s*(?:$|#|[;|&<>]|\d))', stripped):
 				brace_depth -= 1
 				if brace_depth == 0:
 					current_function = None


### PR DESCRIPTION
## Why

Orchestrator project #3042 (integration PR #3048, the "Symphony-inspired improvements") has been stuck in a non-converging review→autofix→validate loop for ~4 days. Root-cause investigation found a **single real, gating blocker**: the `CI / lint` job fails on every commit at

```
tests/test_review_autofix_editor_noop_cascade_contract.py
test_review_apply_fixes_has_per_attempt_cache_busting_nonce
AssertionError: codex stdin must be fed from the per-attempt prompt file…
```

That test is a postmortem-derived guard (PR #3053 / run 26081926521 burned 4 retry attempts on a provider-cached refusal; a per-attempt cache-busting **nonce** closed that loop). It asserted a **single code literal** — `< "${attempt_prompt_file}"` — for how codex stdin is fed.

The project's **S4** change (continuation-thread reuse) legitimately refactored the codex invocation in `scripts/review_apply_fixes.sh` into a `run_editor_codex_attempt` helper, passing the per-attempt file as the helper's first argument. The cache-buster is **preserved behaviourally** (the attempt file, with its `retry_attempt=… epoch=… nonce=…` trailer, is still what reaches codex), but the literal the test greps for moved into the helper as `< "${prompt_file}"`. So the guard became a **false positive** that the autofix loop structurally cannot resolve — you can't satisfy a literal-grep test without either un-refactoring the script or editing a postmortem guard, and the editor agent does neither. CI stays red, finalize is blocked, the orchestrator throttles (`ai:integration-backpressure`) and keeps spawning fix-issues, ballooning the PR.

This is the systemic shape worth fixing once: **a brittle literal-string contract test deadlocks any project that refactors the code it guards.**

## What

Rewrite the assertion to check the **behaviour**, not one code shape:

- codex stdin must be fed a prompt file, **never** the unchanging `${EDITOR_PROMPT_FILE}` base prompt;
- that file must be the per-attempt copy directly (main's inline form) **or** a one-arg helper that the call site forwards `${attempt_prompt_file}` into (the branch's helper form).

The two existing asserts (per-attempt file is built; nonce trailer is appended) are unchanged. Net effect: the guard is now **refactor-tolerant and strictly stronger** — it additionally fails fast if codex is ever fed the base prompt directly.

This lands on `main`; the orchestrator's periodic `chore: sync main into orchestrator/project-3042` carries it into the integration branch, where the branch's CI clears the nonce wall it's been stuck on.

## Verification

- ✅ Full `tests/test_review_autofix_editor_noop_cascade_contract.py` passes against **main**'s `review_apply_fixes.sh` (no regression).
- ✅ Target test passes against the **branch**'s S4-refactored `review_apply_fixes.sh`.
- ✅ All 6 `review_apply_fixes.sh`-dependent tests in the file pass against the branch script (no masked second blocker in this file).
- ✅ Negative cases still **fail** the guard: feeding codex `${EDITOR_PROMPT_FILE}`, and dropping the nonce trailer.
- ✅ `py_compile` clean; tab-indented per repo style.

## Note on the "AI Validate" red runs (chased, not a blocker)

While diagnosing, the `AI Validate (Reusable)` runs looked red too — but those are **phantom GitHub `startup_failure` artifacts** (all 59 are `event:push`, 0 jobs, 0 successes, every one on a Symphony branch, none on `main`), generated because the branch modified a `workflow_call`-only reusable workflow. They are **not** the real validation — which runs via `internal-validate.yml` pinned `@main` (workflow_dispatch) and is **green** (matches PR #3048's "Last outcome: success") — and they **don't gate** anything (23 child PRs merged straight through them; they aren't in PR #3048's check set). No code fix is included for those; they're non-gating noise, called out here so reviewers don't mistake them for a second blocker.

Refs #3048, #3042

---
_Generated by [Claude Code](https://claude.ai/code/session_012jjdAcwS1j8jikcyWACf4Z)_