### PR TITLE
Stage lint_pr_body_auto_close.py into consumer checkout (implement.yml) — stable hotfix

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -843,7 +843,7 @@ jobs:
 
           mkdir -p scripts
           _fetched_scripts=()
-          for f in gh_helpers.sh git_ref_health_check.sh render_prompt.sh validate_changed_files_syntax.sh tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py implement_diagnose_post_codex_failure.sh build_static_context.sh targeted_file_context.py write_codex_config.sh; do
+          for f in gh_helpers.sh git_ref_health_check.sh render_prompt.sh validate_changed_files_syntax.sh tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py implement_diagnose_post_codex_failure.sh build_static_context.sh targeted_file_context.py write_codex_config.sh lint_pr_body_auto_close.py; do
             src=".codex-workflow-src/scripts/${f}"
             if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then
               src=".codex-workflow-src-main/scripts/${f}"


### PR DESCRIPTION
## Summary

`implement.yml`'s required pre-flight step **"Pre-flight — lint PR title/body for auto-close keywords against tracking issues"** (`implement.yml:4233`) runs `python3 scripts/lint_pr_body_auto_close.py` under `set -euo pipefail` whenever Codex commits (`if: ... did_commit == 'true'`). But the **"Stage workflow support files"** step (`implement.yml:846`) never staged that script into the consumer's `scripts/` checkout.

Consumer repos gitignore runtime-staged workflow scripts (the staging step generates `scripts/.gitignore` from `_fetched_scripts` for non-self repos), so the file is simply **absent** there → `python3` exits with `Errno 2: No such file or directory` / exit 2 — **after a successful implementation + commit**. Self-repo (`coding-workflows`) runs pass only because the script is git-tracked there.

This is a latent regression: the lint step and the script were added together, but the script was never added to the staging list — so it works in self-repo and fails in **every** consumer repo.

## Fix

Append `lint_pr_body_auto_close.py` to the **required** (`exit 1`-on-missing) staging loop at `implement.yml:846`. The loop sources from `.codex-workflow-src` (`SCRIPT_REF`, with a `.codex-workflow-src-main` fallback), both of which carry the script, so it is `install`-ed into `scripts/` and recorded in `_fetched_scripts` — which feeds the generated `scripts/.gitignore`, keeping it out of consumer commits exactly like every other workflow runtime script.

The **required** loop (not the optional `continue`-on-missing loop used for `files_touched_scope_guard.py`) is correct here: the §19 auto-close guard is a load-bearing invariant and the lint step has **no** fail-open fallback, so the script's presence must be guaranteed.

## Scope / blast radius

- Pure addition — no rename/removal (§6 clean), no DB/contract change (§10 N/A).
- Helps **all** consumers pinned to `@stable`; breaks none. No version skew: any `implement.yml` carrying the lint step came from a ref that also carries the script.
- Audited the sibling PR-body paths: the only workflows that **execute** the script are `implement.yml:4233` (consumer-run — this bug) and `lint-pr-body-auto-close.yml:74` (self-repo CI check, **not** shipped in `workflow-templates/`, unaffected). `plan.yml` / `review_autofix.yml` / conflict-resolver do **not** execute it, so no staging entry is needed there.

## Delivery

This is the **stable hotfix** half of a two-PR delivery. A companion PR targets `main` so `stable` does not diverge ahead of `main` and the next `promote-main-to-stable` fast-forward stays clean. After merge, dispatch `test-and-mark-stable.yml` from `stable` to move the `@stable` tag consumers resolve.

Regression surfaced by `shubhodeep1/binance-blessings` Actions run `27053503738`. Refs binance-blessings issue 196 (no auto-close linkage — cross-repo).

https://claude.ai/code/session_01H5c7oMvqU9PzWYpk6D1qmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5c7oMvqU9PzWYpk6D1qmL)_