### PR TITLE
Stage lint_pr_body_auto_close.py into consumer checkout (implement.yml) — main companion

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -843,7 +843,7 @@ jobs:
 
           mkdir -p scripts
           _fetched_scripts=()
-          for f in gh_helpers.sh git_ref_health_check.sh render_prompt.sh validate_changed_files_syntax.sh tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py implement_diagnose_post_codex_failure.sh build_static_context.sh targeted_file_context.py write_codex_config.sh; do
+          for f in gh_helpers.sh git_ref_health_check.sh render_prompt.sh validate_changed_files_syntax.sh tg_helpers.sh label_helpers.sh memory_helpers.sh ai_memory.py ai_memory_lib.py openrouter_prompt_cache.py implement_diagnose_post_codex_failure.sh build_static_context.sh targeted_file_context.py write_codex_config.sh lint_pr_body_auto_close.py; do
             src=".codex-workflow-src/scripts/${f}"
             if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then
               src=".codex-workflow-src-main/scripts/${f}"


### PR DESCRIPTION
## Summary

`implement.yml`'s required pre-flight step **"Pre-flight — lint PR title/body for auto-close keywords against tracking issues"** (`implement.yml:4233`) runs `python3 scripts/lint_pr_body_auto_close.py` under `set -euo pipefail` whenever Codex commits, but the **"Stage workflow support files"** step (`implement.yml:846`) never staged that script into the consumer's `scripts/` checkout.

Consumer repos gitignore runtime-staged workflow scripts, so the file is absent there → `Errno 2: No such file or directory` / exit 2 — after a successful implementation + commit. Self-repo runs pass only because the script is git-tracked. The bug is present on `main` as well as `stable`.

## Fix

Append `lint_pr_body_auto_close.py` to the **required** (`exit 1`-on-missing) staging loop at `implement.yml:846`, so it is `install`-ed into `scripts/` and recorded in `_fetched_scripts` (→ generated `scripts/.gitignore`), exactly like every other workflow runtime script. The required loop is correct: the §19 auto-close guard is load-bearing and the lint step has no fail-open fallback.

## Scope / blast radius

- Pure addition — §6 clean (no rename/removal), §10 N/A (no DB/contract change).
- Only `implement.yml:4233` executes the script in a consumer checkout; `lint-pr-body-auto-close.yml` is a self-repo CI check (not in `workflow-templates/`). `plan.yml` / `review_autofix.yml` / conflict-resolver do not execute it — no staging entry needed there.

## Delivery

This is the **main companion** half of a two-PR delivery (the other PR targets `stable` as a hotfix). Landing the same fix on `main` keeps `stable` an ancestor of `main` so the next `promote-main-to-stable` fast-forward stays clean and the hotfix is not dropped on the next promotion.

Regression surfaced by `shubhodeep1/binance-blessings` Actions run `27053503738`. Refs binance-blessings issue 196 (no auto-close linkage — cross-repo).

https://claude.ai/code/session_01H5c7oMvqU9PzWYpk6D1qmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5c7oMvqU9PzWYpk6D1qmL)_