### PR TITLE
Add /deploy-activate slash command for completed projects

### DIFF
--- a/.claude/commands/deploy-activate.md
+++ b/.claude/commands/deploy-activate.md
@@ -1,0 +1,94 @@
+Given a reference to a **completed** project in `$ARGUMENTS` — a GitHub issue (number / URL), a PR, a plan doc, or a clearly-named feature — walk me through **deploying it and making it active** in this repo (`shubhodeep1/coding-workflows`), **one step at a time**, starting from a **fresh MacBook with no GitHub repos synced**. This is the action companion to `/verify-activation`: that command only diagnoses (LIVE / DORMANT / INCOMPLETE); this one drives a DORMANT-but-complete project all the way to LIVE. Interactive by contract: emit **exactly one step**, then **stop and wait** for me to paste the command output (or say `done` / `next`) before emitting the next step. The deploy commands run on **my** machine — you guide, I execute and paste back; never run the mutating deploy steps yourself. `$ARGUMENTS` should contain at least one concrete reference (`#1234`, an issue/PR URL, a plan path, or a clearly-named feature).
+
+$ARGUMENTS
+
+## Procedure
+
+1. **Parse `$ARGUMENTS`.** Extract the issue number / URL, PR refs, plan-doc path, or feature name. If there is no concrete reference — just vague prose — stop and ask for one. Restate the parsed reference in the opening summary.
+
+2. **Build the full deploy plan internally, before emitting Step 1.** Do all the read-only analysis up front so the runbook is stable; only the *delivery* is one-at-a-time.
+
+   a. **Understand the project.** Fetch the issue and everything linked to it — linked PRs, tracking comments, sub-issues, the orchestrator state comment if present — via `mcp__github__issue_read` / `pull_request_read` (or `gh`, see [Tool Access](#tool-access)). Pin down what it builds, its acceptance criteria, and **how it is meant to run**: a cron schedule, a `pull_request` / `push` trigger, `repository_dispatch`, `workflow_dispatch` (manual), a long-running supervisor (§18.C), or on-demand. Read `README.md` / `agents.md` for the env-var / repo-var / secret contract.
+
+   b. **Completeness gate — STOP if not complete.** This command is scoped to *completed* projects. Verify on the implicated branch (and on `main` where relevant) that the code / config / workflows / contracts actually exist and that the project's PR(s) are **merged or genuinely merge-ready**. Cheap checks: `Grep` / `Read` the files the project names; confirm linked-PR merge state. If it is clearly **INCOMPLETE** (code missing, PR neither merged nor open, scaffold-only), **do not emit a deploy runbook** — report exactly what is missing, point me to `/implement-plan-claude` (in-session) or `/implement-plan-ai` (AI orchestrator), and stop.
+
+   c. **Enumerate the activation gates** that stand between "code merged" and "runs automatically," using the `/verify-activation` lens — for *this* repo specifically:
+      - **Default-branch reachability** — a **cron** schedule only fires from the **default branch**. If the project lives on a branch / unmerged PR, merging to `main` is an activation step.
+      - **Repo-vars / feature flags that default OFF** — e.g. `*_ENABLED=0`, an empty roster var. Name each variable, its **read-site (`file:line`)**, and its default.
+      - **Required secrets** — does the run need `GH_PAT`, `TG_BOT_SECRET`, `TG_ADMIN_CHAT_ID`, a model API key, etc.? An unset required secret means dormant.
+      - **Consumer propagation (§14)** — if it is a `workflow-templates/**` or `.claude/**` change consumers must pick up, activation includes **tagging a new `@stable` release** and confirming the `repository_dispatch` to every repo in `.github/ai/consumer_repos.json` (the `GH_PAT` needs `repo` scope on each). Read the actual release / dispatch workflow under `.github/workflows/` to get the **exact** tag/dispatch mechanism — do not hardcode it.
+      - **Supervisor / long-running (§18.C)** — does it need a supervisor that must be started and wired into startup automation?
+      - **DB gates (§18.D)** — does a backfill / migration run from code behind a gate, or is it (wrongly) waiting on a manual step?
+
+   d. **Compose the ordered runbook** and keep it as a stable numbered list you track across turns:
+      - **Prerequisite bootstrap (fresh Mac, nothing synced):** install Homebrew → `brew install git gh` (plus any tool the deploy needs) → `gh auth login` (or export `GH_TOKEN`) with the scopes the deploy needs (`repo`; for §14 dispatch, a PAT with `repo` scope on the consumer repos) → clone `shubhodeep1/coding-workflows` and check out the branch / PR that holds the project.
+      - **Activation steps:** one gate per step — `gh variable set NAME --body 1 -R shubhodeep1/coding-workflows` for a repo-var flip; `gh secret set NAME -R shubhodeep1/coding-workflows` for a secret; merge the PR to `main`; tag / move `@stable` per the release workflow; verify the consumer dispatch fired.
+      - **Verification:** confirm the trigger will actually fire (a scheduled run appears, the dispatch was delivered, the flag now reads ON).
+
+3. **Deliver the runbook one step at a time.** Follow the [Interaction Protocol](#interaction-protocol) exactly. The opening message previews the plan (summary + gate list + total step count) and then gives **Step 1 only**.
+
+4. **Finish on a verified LIVE state.** The final step verifies the project now runs automatically; close with the `✅ LIVE` line from the [Output Format](#output-format).
+
+## Interaction Protocol
+
+This is the load-bearing behavior — honor it strictly:
+
+- **One step per turn.** Emit a single step, then **end the turn**. Never include Step k+1 in the same message as Step k. Each step states: a short title; the **exact** command(s) to paste into a Mac terminal; what **success** looks like; and the literal ask — *"paste the output (or say `done`) and I'll give you the next step."*
+- **Wait, then react to the pasted output.** On my reply, read what I pasted. If it shows success → advance to the next step. If it shows an **error or unexpected state** → do **not** advance; diagnose and emit a **corrective step** (still one at a time). If I say `done` with no output, trust me, but where a cheap read-only check settles it, verify before moving on.
+- **Track progress visibly.** Each turn, show a compact checklist of the runbook (done ✓ / current ▶ / remaining) so I always see where we are, e.g. `Step 4 of ~9`. The count may grow if a step fails and needs a fix-up — say so.
+- **Adapt to reality.** If pasted output proves a gate is already satisfied (var already `1`, PR already merged, secret already present), **skip** that step and say why.
+- **Never bundle, never auto-execute.** Do not merge steps to "save time," and do not run the mutating deploy commands yourself — they run on my machine. Read-only verification commands against your own checkout (or `mcp__github__*` / `gh ... --json` reads) are fine.
+- **Stop conditions.** STOP and ask in Q/A format if a step needs a decision with material tradeoffs, would rename/remove a §6 identifier, or is otherwise ambiguous. STOP and report if the project turns out to be incomplete mid-run.
+
+## Output Format
+
+**Opening message (plan preview, then Step 1):**
+
+```
+Summary: <parsed reference; project in one phrase; deploy target: shubhodeep1/coding-workflows>
+How it runs: <cron «expr» from default branch | push | pull_request | repository_dispatch | supervisor>
+Completeness: COMPLETE — <evidence: file:line, merged/merge-ready PR#>   (if INCOMPLETE: stop per Procedure 2b)
+
+Activation gates (~N steps total):
+- [ ] Prereqs: Homebrew, git, gh, auth, clone + checkout
+- [ ] <merge PR #… to main>            (cron needs default branch)
+- [ ] <set repo-var X=1 — read at file:line, default 0>
+- [ ] <add secret Y>
+- [ ] <tag @stable / confirm consumer dispatch §14>     (only if a template/.claude change)
+- [ ] <verify LIVE>
+
+—— Step 1 of ~N: <title> ——
+Run:
+  <exact command(s)>
+Success looks like: <what to expect>
+Paste the output (or say `done`) and I'll give you Step 2.
+```
+
+**Each subsequent turn:** the updated checklist, then exactly one `—— Step k of ~N ——` block in the same shape.
+
+**Final message:**
+
+```
+✅ LIVE — <project> now runs automatically.
+Trigger: <cron «expr» from default branch | push | pull_request | repository_dispatch>
+Verified by: <the scheduled run / delivered dispatch / flag-now-ON evidence>
+```
+
+## Tool Access
+
+The deploy is executed by **me** on my Mac; your tools are for building and adapting the runbook and for read-only verification:
+
+- **`mcp__github__*` MCP tools** — `issue_read`, `pull_request_read`, `list_commits`, `get_file_contents`, `list_tags`, `get_tag`, `search_issues`, `search_pull_requests` for the project, its merge state, and release/tag state. Read at `main` (or the project's branch).
+- **`gh` CLI (read-only)** — when `GH_TOKEN` / `GITHUB_TOKEN` is set (verify nounset-safe: `{ [ -n "${GH_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ]; } && gh auth status`). **Pass `-R shubhodeep1/coding-workflows` on every call** — Claude Code Web's remote is a local proxy and bare `gh` calls fail with `failed to determine base repo`; the SessionStart hook prints the resolved slug. Use `gh` here only to *inspect* state (`gh run list`, `gh variable list`, `gh pr view --json`), never to mutate.
+- **`Read` / `Grep` / `Glob`** — verify completeness, workflow triggers, flag defaults, and the release/dispatch mechanism on the local checkout. **`Bash`** for read-only inspection only.
+
+## Rules
+
+- **One step, then wait — always.** The whole value of this command is the paced, paste-driven loop. Emitting multiple steps at once, or racing ahead before I confirm, breaks it.
+- **You guide; I execute.** Never run the mutating deploy commands (`gh variable set`, `gh secret set`, merge, tag, dispatch) yourself — they run on my machine and I paste the result. Read-only inspection on your side is encouraged to keep the next step accurate.
+- **Completed projects only.** If the project is not fully implemented / merge-ready, stop and route me to `/implement-plan-claude` or `/implement-plan-ai` (Procedure 2b) — do not improvise a deploy for incomplete code.
+- **Assume a clean machine.** Start from prerequisites (Homebrew, git, gh, auth, clone) because nothing is synced. Do not assume any tool, repo, or credential is already present until a pasted output proves it.
+- **"Activated" ≠ "implemented."** A merged feature behind `FOO_ENABLED=0`, an unset required secret, or a scheduled workflow not yet on the default branch is dormant. Name the exact gate and the exact flip.
+- **Distinguish trigger types precisely.** `workflow_dispatch` is manual, never "automatic." `cron` requires the workflow on the **default branch**. `repository_dispatch` requires a dispatcher and a token with scope (§14). Name which one applies and what "LIVE" means for it.
+- **Honor §14 for template / `.claude` changes.** Activation for consumers means tagging a new `@stable` release and confirming the `repository_dispatch` to every repo in `.github/ai/consumer_repos.json`; read the real release workflow for the exact commands.
+- **Honor §6 / §10.** Never instruct a rename/removal of an existing identifier without the Q/A ask flow first; DB activation runs from code behind a gate (§18.D), never an ad-hoc mongo shell step.

--- a/workflow-templates/.claude/commands/deploy-activate.md
+++ b/workflow-templates/.claude/commands/deploy-activate.md
@@ -1,0 +1,103 @@
+Given a reference to a **completed** project in `$ARGUMENTS` — a GitHub issue (number / URL), a PR, a plan doc, or a clearly-named feature — walk me through **deploying it and making it active** in this repo, **one step at a time**, starting from a **fresh MacBook with no GitHub repos synced**. A project here can live on one of two sides — **this consumer repo's own code/config**, or the **upstream workflow library** (`shubhodeep1/coding-workflows`) that this repo's wrappers call — and you decide which from the evidence. This is the action companion to `/verify-activation`: that command only diagnoses (LIVE / DORMANT / INCOMPLETE); this one drives a DORMANT-but-complete project all the way to LIVE. Interactive by contract: emit **exactly one step**, then **stop and wait** for me to paste the command output (or say `done` / `next`) before emitting the next step. The deploy commands run on **my** machine — you guide, I execute and paste back; never run the mutating deploy steps yourself. `$ARGUMENTS` should contain at least one concrete reference.
+
+$ARGUMENTS
+
+## Procedure
+
+1. **Parse `$ARGUMENTS`.** Extract the issue number / URL, PR refs, plan-doc path, or feature name. If there is no concrete reference, stop and ask for one. Restate the parsed reference in the opening summary.
+
+2. **Build the full deploy plan internally, before emitting Step 1.** Do all the read-only analysis up front so the runbook is stable; only the *delivery* is one-at-a-time.
+
+   a. **Understand the project and resolve `THIS_REPO`.** Fetch the issue and everything linked — linked PRs, tracking comments, sub-issues — via `mcp__github__issue_read` / `pull_request_read` (or `gh`). Pin down what it builds, its acceptance criteria, and **how it is meant to run** (cron, `pull_request` / `push`, `repository_dispatch`, `workflow_dispatch` manual, a supervisor, or on-demand). Determine **`THIS_REPO`** — the `owner/repo` the command runs in (the SessionStart hook prints the resolved slug; otherwise derive it from the git remote).
+
+   b. **Classify the side that owns activation.**
+      - **`[CONSUMER]`** — this repo's own workflows / config / code (a wrapper workflow, a repo-var this repo sets). Read at `THIS_REPO@main`.
+      - **`[UPSTREAM]`** — behavior that lives in the upstream library and only runs through this repo's wrapper at the **ref this repo is pinned to**. Read upstream pinned to `UPSTREAM_SHA` (see below).
+      - **`[BOTH]`** — a wrapper here plus the upstream reusable workflow it calls.
+
+      **Resolving the upstream pin (for the `[UPSTREAM]` / `[BOTH]` side):** find every `uses:` / `repository:` / `ref:` in this repo's `.github/workflows/*.yml` that references `shubhodeep1/coding-workflows`. The exact `ref` is the pin: tag `@vX.Y.Z` → resolve `UPSTREAM_SHA` via `mcp__github__get_tag` / `list_tags`; direct SHA → use it; moving `@stable` → resolve via `list_tags`; branch `@main` → resolve to that branch's tip. Record `UPSTREAM_TAG` + `UPSTREAM_SHA`; pass `ref=<UPSTREAM_SHA>` on **every** upstream read.
+
+   c. **Completeness gate — STOP if not complete.** This command is scoped to *completed* projects. Verify the code / config / workflows / contracts exist and the project's PR(s) are **merged or genuinely merge-ready**, **at the ref for its side** (`THIS_REPO@main` for `[CONSUMER]`; `shubhodeep1/coding-workflows@UPSTREAM_SHA` for `[UPSTREAM]`). If clearly **INCOMPLETE** (code missing, PR neither merged nor open, scaffold-only), **do not emit a deploy runbook** — report what is missing, point me to `/implement-plan-claude` or `/implement-plan-ai`, and stop.
+
+   d. **Enumerate the activation gates** between "code present" and "runs automatically here," using the `/verify-activation` lens:
+      - **Wrapper wiring (consumer side)** — does this repo have the `.github/workflows/*.yml` wrapper with the right trigger, calling the upstream reusable workflow at the expected ref? A feature that exists upstream but is **not wired into a consumer wrapper** will never run here — adding/adjusting the wrapper is an activation step.
+      - **Default-branch reachability** — a **cron** schedule only fires from the **default branch**; a wrapper change must be merged to the default branch to take effect.
+      - **Repo-vars / feature flags that default OFF** — `*_ENABLED=0`, an empty roster var. Consumers commonly must **opt in** by setting a repo-var. Name each variable, its read-site, and its default.
+      - **Required secrets** — does the run need a model API key, `GH_PAT`, a Telegram token, etc. that I must add in this repo's settings? Unset → dormant.
+      - **Upstream version gap** — is this repo pinned to an `UPSTREAM_TAG` that **predates** the feature? If so the feature is not available here until the pin is bumped — **bumping the pin** is the activation step.
+      - **Supervisor / DB gates** — does it need a started supervisor or a code-gated migration rather than a manual step?
+
+   e. **Compose the ordered runbook** and keep it as a stable numbered list you track across turns:
+      - **Prerequisite bootstrap (fresh Mac, nothing synced):** install Homebrew → `brew install git gh` (plus any tool the deploy needs) → `gh auth login` (or export `GH_TOKEN`) with the scopes the deploy needs → clone `THIS_REPO` and check out the branch / PR that holds the project.
+      - **Activation steps:** one gate per step — `gh variable set NAME --body 1 -R <THIS_REPO>` for a repo-var; `gh secret set NAME -R <THIS_REPO>` for a secret; edit the wrapper `.github/workflows/*.yml` (add it, fix the trigger, or bump the `ref:` pin) then commit / push / open a PR / merge to the default branch.
+      - **Verification:** confirm the trigger will actually fire (a scheduled run appears, the workflow is enabled, the flag now reads ON).
+
+3. **Deliver the runbook one step at a time.** Follow the [Interaction Protocol](#interaction-protocol) exactly. The opening message previews the plan (summary + side + gate list + total step count) and then gives **Step 1 only**.
+
+4. **Finish on a verified LIVE state.** The final step verifies the project now runs automatically here; close with the `✅ LIVE` line from the [Output Format](#output-format).
+
+## Interaction Protocol
+
+This is the load-bearing behavior — honor it strictly:
+
+- **One step per turn.** Emit a single step, then **end the turn**. Never include Step k+1 in the same message as Step k. Each step states: a short title; the **exact** command(s) to paste into a Mac terminal (or the precise YAML edit to make); what **success** looks like; and the literal ask — *"paste the output (or say `done`) and I'll give you the next step."*
+- **Wait, then react to the pasted output.** On my reply, read what I pasted. If it shows success → advance. If it shows an **error or unexpected state** → do **not** advance; diagnose and emit a **corrective step** (still one at a time). If I say `done` with no output, trust me, but where a cheap read-only check settles it, verify before moving on.
+- **Track progress visibly.** Each turn, show a compact checklist (done ✓ / current ▶ / remaining), e.g. `Step 4 of ~9`. The count may grow if a step fails and needs a fix-up — say so.
+- **Adapt to reality.** If pasted output proves a gate is already satisfied (var already set, wrapper already present, pin already current), **skip** that step and say why.
+- **Never bundle, never auto-execute.** Do not merge steps, and do not run the mutating deploy commands or git pushes yourself — they run on my machine. Read-only verification (`mcp__github__*` / `gh ... --json` reads, `Read`/`Grep` on your checkout) is fine.
+- **Stop conditions.** STOP and ask in Q/A format if a step needs a decision with material tradeoffs, would rename/remove a §6 identifier, or is ambiguous. STOP and report if the project turns out to be incomplete mid-run.
+
+## Output Format
+
+**Opening message (plan preview, then Step 1):**
+
+```
+Summary: <parsed reference; project in one phrase; side [CONSUMER]/[UPSTREAM]/[BOTH]; deploy target: THIS_REPO>
+Side: [CONSUMER] THIS_REPO@main  |  [UPSTREAM] shubhodeep1/coding-workflows@<UPSTREAM_TAG> (<short-sha>)  |  [BOTH]
+How it runs: <cron «expr» from default branch | push | pull_request | repository_dispatch | supervisor>
+Completeness: COMPLETE — <evidence: file:line, merged/merge-ready PR#>   (if INCOMPLETE: stop per Procedure 2c)
+
+Activation gates (~N steps total):
+- [ ] Prereqs: Homebrew, git, gh, auth, clone THIS_REPO + checkout
+- [ ] <add/adjust wrapper .github/workflows/Z.yml — trigger / upstream ref>
+- [ ] <bump upstream pin @vA.B.C → @vA.B.D>     (only if the pin predates the feature)
+- [ ] <set repo-var X=1 — read at file:line, default 0>
+- [ ] <add secret Y>
+- [ ] <merge wrapper change to the default branch>     (cron needs default branch)
+- [ ] <verify LIVE>
+
+—— Step 1 of ~N: <title> ——
+Run:
+  <exact command(s)>
+Success looks like: <what to expect>
+Paste the output (or say `done`) and I'll give you Step 2.
+```
+
+**Each subsequent turn:** the updated checklist, then exactly one `—— Step k of ~N ——` block in the same shape.
+
+**Final message:**
+
+```
+✅ LIVE — <project> now runs automatically in <THIS_REPO>.
+Trigger: <cron «expr» from default branch | push | pull_request | repository_dispatch>
+Verified by: <the scheduled run / enabled workflow / flag-now-ON evidence>
+```
+
+## Tool Access
+
+The deploy is executed by **me** on my Mac; your tools are for building and adapting the runbook and for read-only verification:
+
+- **`mcp__github__*` MCP tools** — `issue_read`, `pull_request_read`, `list_commits`, `list_tags`, `get_tag`, `get_file_contents`, `search_issues`, `search_pull_requests`. For the upstream side, pass `ref=<UPSTREAM_SHA>` on every read; for the consumer side, read `THIS_REPO@main`.
+- **`gh` CLI (read-only)** — when `gh` is installed and `GH_TOKEN` / `GITHUB_TOKEN` is set (verify nounset-safe: `{ [ -n "${GH_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ]; } && gh auth status`). **Pass `-R <owner>/<repo>`** on every call — Claude Code Web's remote is a local proxy; bare `gh` fails with `failed to determine base repo`. Use `gh` here only to *inspect* state (`gh run list`, `gh variable list`, `gh pr view --json`), never to mutate.
+- **`Read` / `Grep` / `Glob`** — verify completeness, the consumer wrapper, triggers, flag defaults, and the upstream pin on the local checkout. **`Bash`** for read-only inspection only.
+
+## Rules
+
+- **One step, then wait — always.** The whole value of this command is the paced, paste-driven loop. Emitting multiple steps at once, or racing ahead before I confirm, breaks it.
+- **You guide; I execute.** Never run the mutating deploy commands (`gh variable set`, `gh secret set`, the wrapper edit's commit/push, merge) yourself — they run on my machine and I paste the result. Read-only inspection on your side keeps the next step accurate.
+- **Pick the side from evidence, pin upstream reads to the consumer's ref.** A feature implemented upstream but not wired into a consumer wrapper, or gated behind a repo-var this repo never set, is **DORMANT for this repo** even though the upstream code is perfect. Analyzing upstream activation at `main` when this repo is pinned to a release is wrong — read at `UPSTREAM_SHA`.
+- **Completed projects only.** If the project is not fully implemented / merge-ready on its side, stop and route me to `/implement-plan-claude` or `/implement-plan-ai` (Procedure 2c) — do not improvise a deploy for incomplete code.
+- **Assume a clean machine.** Start from prerequisites (Homebrew, git, gh, auth, clone) because nothing is synced. Do not assume any tool, repo, or credential is present until a pasted output proves it.
+- **"Activated" ≠ "implemented."** Name the exact gate: wrapper wiring, a `*_ENABLED` default, an unset secret, or an upstream pin that predates the feature — and the exact flip.
+- **Distinguish trigger types precisely.** `workflow_dispatch` is manual, never automatic. `cron` requires the workflow on the **default branch**. `repository_dispatch` needs a dispatcher + token scope. Name which applies and what "LIVE" means for it.
+- **Honor §6.** Never instruct a rename/removal of an existing identifier without the Q/A ask flow first.


### PR DESCRIPTION
## What

Adds a new interactive slash command, **`/deploy-activate`**, that walks the user through **deploying a completed project and making it active**, **one step at a time** — emit a single step, wait for the user to paste the command output (or say `done`), then emit the next — starting from a **fresh MacBook with no GitHub repos synced** (so it begins at prerequisites: Homebrew, git, `gh`, auth, clone).

It is the **action companion** to the existing read-only `/verify-activation`, which explicitly stops at diagnosis (*"this command only diagnoses … activation is a follow-up task"*). `/deploy-activate` drives a DORMANT-but-complete project all the way to LIVE.

## Files

- `.claude/commands/deploy-activate.md` — tailored to deploying **this** repo (the workflow library): merge to `main`, set repo-vars/secrets, tag a new `@stable` release and confirm the consumer `repository_dispatch` (§14).
- `workflow-templates/.claude/commands/deploy-activate.md` — **consumer-repo** perspective: resolves `THIS_REPO` and the `[CONSUMER]`/`[UPSTREAM]`/`[BOTH]` side, wrapper wiring, repo-vars/secrets, and upstream pin bumps. Mirrors the consumer/upstream split already used by `/verify-activation` so consumer repos get a correctly-tailored copy when they pull the templates.

## Behavior

- **Completed projects only** — both versions cheaply verify completeness first and, if the project is not merge-ready, report what's missing and stop (routing to `/implement-plan-claude` / `/implement-plan-ai`) instead of improvising a deploy.
- **One step, then wait** — a strict paced, paste-driven loop with a visible progress checklist; reacts to pasted output (advance on success, emit a corrective step on error, skip gates already satisfied).
- **Read-only / advisory** — Claude builds and adapts the runbook and does read-only verification; the **user** executes the mutating deploy commands on their machine. Honors §6 (no renames without the ask flow), §14 (consumer dispatch), and §18.D (DB activation runs from code, not a manual shell step).

## Design choices (confirmed with the requester)

- Name: `/deploy-activate`.
- Placement: both locations, tailored per side (like `/verify-activation`).
- Incomplete projects: verify first, stop and route to the implement commands.

https://claude.ai/code/session_01GXP9duQigxyzKw3JdJdgjT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXP9duQigxyzKw3JdJdgjT)_