### PR TITLE
Fix memory-helper git env leak and E2E alt-model cleanup force-closing unrelated PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,6 +404,11 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_test_and_mark_stable_plan_polling_guard.py
 
+      - name: Alt-model cleanup PR-selector contract test
+        run: |
+          set -euo pipefail
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_test_and_mark_stable_alt_model_cleanup_pr_selector.py
+
       - name: Mark-stable release-tag refspec contract test
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,7 @@ jobs:
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_orchestrate_clarify_loop_guard.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_ai_memory_processed_command_entry.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_ai_memory_push_retry_backoff.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_ai_memory_git_env_isolation.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_plan_clarify_blocked_output.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_plan_auto_answer_recommended_parser.py
 

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -4726,9 +4726,15 @@ jobs:
           }
 
           close_with_retry "issues" "${ISSUE_NUMBER}"
-          # Best-effort PR + branch cleanup
-          PR_NUMBER=$(gh api "repos/${TEST_REPO}/issues/${ISSUE_NUMBER}/timeline?per_page=20" \
-            --jq '[.[] | select(.event == "cross-referenced") | .source.issue.number] | first // empty' 2>/dev/null || echo "")
+          # Best-effort PR + branch cleanup. Target ONLY the implement PR whose
+          # head branch is ai/issue-<N> (the same selector Phase 3a's
+          # wait-implement uses). The previous `first cross-referenced` timeline
+          # heuristic closed whatever PR first referenced the canary issue — so
+          # an unrelated fix PR that merely says "Refs #<N>" in its body would be
+          # force-closed as collateral damage when the implement run failed and
+          # no real ai/issue-<N> PR existed to match.
+          PR_NUMBER=$(gh api "repos/${TEST_REPO}/pulls?state=open&head=${TEST_REPO%%/*}:ai/issue-${ISSUE_NUMBER}&per_page=1" \
+            --jq '.[0].number // empty' 2>/dev/null || echo "")
           if [ -n "${PR_NUMBER}" ]; then
             close_with_retry "pulls" "${PR_NUMBER}"
           fi

--- a/scripts/ai_memory_lib.py
+++ b/scripts/ai_memory_lib.py
@@ -2239,6 +2239,37 @@ def compact_memory(
     return summary
 
 
+# Repository-location git environment variables.  The workspace shell context
+# (the "Activate workspace shell context" step in implement.yml / validate.yml /
+# review_autofix.yml) exports GIT_DIR and GIT_WORK_TREE into $GITHUB_ENV so that
+# later steps' git commands operate on the reusable workspace work tree.  Every
+# memory-helper git command instead operates on a dedicated /tmp clone selected
+# via `cwd`, so an inherited GIT_DIR/GIT_WORK_TREE would (a) make `git clone`
+# abort with `fatal: working tree '<path>' already exists` and (b) silently
+# retarget add/commit/push at the host repo rather than the clone.  Strip these
+# so git resolves the repository from `cwd`.  GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY,
+# GIT_ALTERNATE_OBJECT_DIRECTORIES, GIT_COMMON_DIR, and GIT_NAMESPACE are stripped
+# defensively for the same reason — they would re-bind the subprocess to a
+# different repository, index, or object store.
+_GIT_LOCATION_ENV_VARS = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_NAMESPACE",
+)
+
+
+def _git_env() -> dict[str, str]:
+    """Return a copy of the environment with repo-location git vars removed."""
+    env = os.environ.copy()
+    for var in _GIT_LOCATION_ENV_VARS:
+        env.pop(var, None)
+    return env
+
+
 def _run_git(cwd: Path, args: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
     process = subprocess.run(
         ["git", *args],
@@ -2246,6 +2277,7 @@ def _run_git(cwd: Path, args: list[str], check: bool = True) -> subprocess.Compl
         check=False,
         text=True,
         capture_output=True,
+        env=_git_env(),
     )
     if check and process.returncode != 0:
         message = (

--- a/scripts/memory_helpers.sh
+++ b/scripts/memory_helpers.sh
@@ -75,6 +75,14 @@ memory_ensure_branch()
 	temp_dir="$(mktemp -d)"
 
 	(
+		# The workspace shell context exports GIT_DIR/GIT_WORK_TREE pointing at
+		# the host repo (see the "Activate workspace shell context" step in the
+		# implement/validate/review_autofix workflows).  Leaving them set would
+		# make `git init` and the orphan-branch commit below operate on the host
+		# repo instead of this throwaway temp dir.  Unset them so git resolves
+		# the repository from the temp working directory.
+		unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+			GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_NAMESPACE
 		cd "${temp_dir}"
 		git init --quiet
 		git config user.name "codex-bot"

--- a/tests/test_ai_memory_git_env_isolation.py
+++ b/tests/test_ai_memory_git_env_isolation.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Regression tests for memory-helper git environment isolation.
+
+The workspace shell context (the "Activate workspace shell context" step in the
+implement / validate / review_autofix workflows) exports ``GIT_DIR`` and
+``GIT_WORK_TREE`` into ``$GITHUB_ENV`` so subsequent steps' git commands operate
+on the reusable workspace work tree.  The memory helper instead operates on a
+dedicated ``/tmp`` clone selected via ``cwd``.  When ``GIT_WORK_TREE`` was
+inherited, ``git clone`` aborted with ``fatal: working tree '<path>' already
+exists`` (exit 128), failing the "Claim /approved command" step for runs
+27057616161 / 27057622152.  ``_run_git`` must strip the repo-location git vars
+so git resolves the repository from ``cwd``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MODULE_PATH = REPO_ROOT / "scripts" / "ai_memory_lib.py"
+
+if str(REPO_ROOT) not in sys.path:
+	sys.path.insert(0, str(REPO_ROOT))
+
+spec = importlib.util.spec_from_file_location("ai_memory_lib", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+ai_memory_lib = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = ai_memory_lib
+spec.loader.exec_module(ai_memory_lib)
+
+
+def test_git_env_strips_repo_location_vars(monkeypatch) -> None:
+	# Every repo-location variable must be removed so an inherited workspace
+	# GIT_DIR/GIT_WORK_TREE cannot re-bind the subprocess to the host repo.
+	for var in ai_memory_lib._GIT_LOCATION_ENV_VARS:
+		monkeypatch.setenv(var, f"/host/{var.lower()}")
+	monkeypatch.setenv("PATH", os.environ.get("PATH", "/usr/bin"))
+	monkeypatch.setenv("GH_TOKEN", "sentinel-token")
+
+	env = ai_memory_lib._git_env()
+
+	for var in ai_memory_lib._GIT_LOCATION_ENV_VARS:
+		assert var not in env, f"{var} leaked into git env"
+	# Unrelated environment (credentials, PATH) must be preserved.
+	assert env.get("GH_TOKEN") == "sentinel-token"
+	assert "PATH" in env
+
+
+def test_git_env_includes_dir_and_work_tree() -> None:
+	# The two vars the workspace step actually exports must be covered.
+	assert "GIT_DIR" in ai_memory_lib._GIT_LOCATION_ENV_VARS
+	assert "GIT_WORK_TREE" in ai_memory_lib._GIT_LOCATION_ENV_VARS
+
+
+def _git(cwd: Path, *args: str) -> None:
+	subprocess.run(
+		["git", "-c", "commit.gpgsign=false", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+		cwd=str(cwd),
+		check=True,
+		capture_output=True,
+		text=True,
+	)
+
+
+def test_run_git_clone_survives_polluted_workspace_env(monkeypatch) -> None:
+	# End-to-end repro of the failing run: with GIT_DIR/GIT_WORK_TREE pointing at
+	# an existing work tree, an un-sanitized `git clone` aborts with exit 128.
+	# _run_git must succeed because it strips those vars.
+	with tempfile.TemporaryDirectory() as tmp:
+		root = Path(tmp)
+		src = root / "src"
+		src.mkdir()
+		_git(src, "init", "-q")
+		(src / "a.txt").write_text("hi\n")
+		_git(src, "add", "a.txt")
+		_git(src, "commit", "-qm", "init")
+
+		work_tree = root / "wt"
+		work_tree.mkdir()  # existing dir is what triggers the "already exists" abort
+
+		monkeypatch.setenv("GIT_DIR", str(src / ".git"))
+		monkeypatch.setenv("GIT_WORK_TREE", str(work_tree))
+
+		dst = root / "clone"
+		proc = ai_memory_lib._run_git(
+			root, ["clone", "--no-tags", "--quiet", str(src), str(dst)], check=False
+		)
+		assert proc.returncode == 0, (
+			f"clone failed under polluted env: rc={proc.returncode} stderr={proc.stderr!r}"
+		)
+		assert (dst / "a.txt").exists()
+
+
+if __name__ == "__main__":
+	import pytest
+
+	raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_ai_memory_git_env_isolation.py
+++ b/tests/test_ai_memory_git_env_isolation.py
@@ -145,9 +145,9 @@ def test_run_git_check_true_preserves_real_clone_error_under_polluted_env() -> N
 			else:
 				raise AssertionError("expected MemoryGitError from non-empty destination clone")
 
-		assert "destination path" in message
-		assert "already exists and is not an empty directory" in message
-		assert "working tree" not in message
+		stderr = message.partition("stderr:\n")[2]
+		assert str(dst) in stderr
+		assert str(work_tree) not in stderr
 
 
 def main() -> int:

--- a/tests/test_ai_memory_git_env_isolation.py
+++ b/tests/test_ai_memory_git_env_isolation.py
@@ -51,10 +51,7 @@ def _patched_env(updates: dict[str, str]):
 
 
 def _git_process_env() -> dict[str, str]:
-	env = os.environ.copy()
-	for var in ai_memory_lib._GIT_LOCATION_ENV_VARS:
-		env.pop(var, None)
-	return env
+	return ai_memory_lib._git_env()
 
 
 def test_git_env_strips_repo_location_vars() -> None:

--- a/tests/test_ai_memory_git_env_isolation.py
+++ b/tests/test_ai_memory_git_env_isolation.py
@@ -14,6 +14,7 @@ so git resolves the repository from ``cwd``.
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
 import os
 import subprocess
@@ -35,15 +36,36 @@ sys.modules[spec.name] = ai_memory_lib
 spec.loader.exec_module(ai_memory_lib)
 
 
-def test_git_env_strips_repo_location_vars(monkeypatch) -> None:
+@contextlib.contextmanager
+def _patched_env(updates: dict[str, str]):
+	original = {key: os.environ.get(key) for key in updates}
+	try:
+		os.environ.update(updates)
+		yield
+	finally:
+		for key, value in original.items():
+			if value is None:
+				os.environ.pop(key, None)
+			else:
+				os.environ[key] = value
+
+
+def _git_process_env() -> dict[str, str]:
+	env = os.environ.copy()
+	for var in ai_memory_lib._GIT_LOCATION_ENV_VARS:
+		env.pop(var, None)
+	return env
+
+
+def test_git_env_strips_repo_location_vars() -> None:
 	# Every repo-location variable must be removed so an inherited workspace
 	# GIT_DIR/GIT_WORK_TREE cannot re-bind the subprocess to the host repo.
-	for var in ai_memory_lib._GIT_LOCATION_ENV_VARS:
-		monkeypatch.setenv(var, f"/host/{var.lower()}")
-	monkeypatch.setenv("PATH", os.environ.get("PATH", "/usr/bin"))
-	monkeypatch.setenv("GH_TOKEN", "sentinel-token")
+	updates = {var: f"/host/{var.lower()}" for var in ai_memory_lib._GIT_LOCATION_ENV_VARS}
+	updates["PATH"] = os.environ.get("PATH", "/usr/bin")
+	updates["GH_TOKEN"] = "sentinel-token"
 
-	env = ai_memory_lib._git_env()
+	with _patched_env(updates):
+		env = ai_memory_lib._git_env()
 
 	for var in ai_memory_lib._GIT_LOCATION_ENV_VARS:
 		assert var not in env, f"{var} leaked into git env"
@@ -64,11 +86,12 @@ def _git(cwd: Path, *args: str) -> None:
 		cwd=str(cwd),
 		check=True,
 		capture_output=True,
+		env=_git_process_env(),
 		text=True,
 	)
 
 
-def test_run_git_clone_survives_polluted_workspace_env(monkeypatch) -> None:
+def test_run_git_clone_survives_polluted_workspace_env() -> None:
 	# End-to-end repro of the failing run: with GIT_DIR/GIT_WORK_TREE pointing at
 	# an existing work tree, an un-sanitized `git clone` aborts with exit 128.
 	# _run_git must succeed because it strips those vars.
@@ -84,20 +107,66 @@ def test_run_git_clone_survives_polluted_workspace_env(monkeypatch) -> None:
 		work_tree = root / "wt"
 		work_tree.mkdir()  # existing dir is what triggers the "already exists" abort
 
-		monkeypatch.setenv("GIT_DIR", str(src / ".git"))
-		monkeypatch.setenv("GIT_WORK_TREE", str(work_tree))
-
-		dst = root / "clone"
-		proc = ai_memory_lib._run_git(
-			root, ["clone", "--no-tags", "--quiet", str(src), str(dst)], check=False
-		)
+		with _patched_env({"GIT_DIR": str(src / ".git"), "GIT_WORK_TREE": str(work_tree)}):
+			dst = root / "clone"
+			proc = ai_memory_lib._run_git(
+				root, ["clone", "--no-tags", "--quiet", str(src), str(dst)], check=False
+			)
 		assert proc.returncode == 0, (
 			f"clone failed under polluted env: rc={proc.returncode} stderr={proc.stderr!r}"
 		)
 		assert (dst / "a.txt").exists()
 
 
-if __name__ == "__main__":
-	import pytest
+def test_run_git_check_true_preserves_real_clone_error_under_polluted_env() -> None:
+	# The production callers use check=True.  Even with polluted workspace
+	# GIT_DIR/GIT_WORK_TREE, the sanitized subprocess must surface the clone's
+	# real failure instead of the inherited "working tree already exists" error.
+	with tempfile.TemporaryDirectory() as tmp:
+		root = Path(tmp)
+		src = root / "src"
+		src.mkdir()
+		_git(src, "init", "-q")
+		(src / "a.txt").write_text("hi\n")
+		_git(src, "add", "a.txt")
+		_git(src, "commit", "-qm", "init")
 
-	raise SystemExit(pytest.main([__file__, "-v"]))
+		work_tree = root / "wt"
+		work_tree.mkdir()
+		dst = root / "clone"
+		dst.mkdir()
+		(dst / "junk.txt").write_text("junk\n")
+
+		with _patched_env({"GIT_DIR": str(src / ".git"), "GIT_WORK_TREE": str(work_tree)}):
+			try:
+				ai_memory_lib._run_git(root, ["clone", "--no-tags", "--quiet", str(src), str(dst)])
+			except ai_memory_lib.MemoryGitError as exc:
+				message = str(exc)
+			else:
+				raise AssertionError("expected MemoryGitError from non-empty destination clone")
+
+		assert "destination path" in message
+		assert "already exists and is not an empty directory" in message
+		assert "working tree" not in message
+
+
+def main() -> int:
+	passed = 0
+	failed = 0
+	for name, func in sorted(globals().items()):
+		if not name.startswith("test_") or not callable(func):
+			continue
+		try:
+			func()
+			print(f"  PASS  {name}", flush=True)
+			passed += 1
+		except Exception as exc:
+			print(f"  FAIL  {name}: {exc}", flush=True)
+			failed += 1
+
+	print(f"\n{passed} passed, {failed} failed, {passed + failed} total", flush=True)
+	return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_test_and_mark_stable_alt_model_cleanup_pr_selector.py
+++ b/tests/test_test_and_mark_stable_alt_model_cleanup_pr_selector.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Regression check for the alt-model E2E cleanup PR selector.
+
+The "Cleanup alt-model artifacts" step in test-and-mark-stable.yml closes the
+throwaway implement PR for the alt-model canary issue.  It used to discover that
+PR via the *first* `cross-referenced` event on the canary issue's timeline.
+When the alt-model implement run failed, no `ai/issue-<N>` PR ever existed, so
+the first cross-reference was whatever unrelated PR merely mentioned the canary
+issue (e.g. a fix PR whose body said `Refs #<N>`).  That PR was then force-closed
+as collateral damage (this is exactly what closed PR #3179).  The selector must
+instead target only the implement PR whose head branch is `ai/issue-<N>` — the
+same selector Phase 3a's wait-implement uses.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "test-and-mark-stable.yml"
+
+
+def _read_workflow() -> str:
+	return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _cleanup_alt_model_step(wf: str) -> str:
+	marker = "- name: Cleanup alt-model artifacts"
+	start = wf.index(marker)
+	# The step body runs until the next step (`- name:`) or job boundary.
+	next_step = wf.find("\n      - name:", start + len(marker))
+	end = next_step if next_step != -1 else len(wf)
+	return wf[start:end]
+
+
+def test_cross_referenced_timeline_heuristic_is_gone() -> None:
+	wf = _read_workflow()
+	# The brittle "first cross-referenced issue number" PR-discovery heuristic
+	# must not exist anywhere in the workflow.
+	assert 'select(.event == "cross-referenced") | .source.issue.number] | first' not in wf
+
+
+def test_alt_model_cleanup_targets_ai_issue_head_branch_pr() -> None:
+	wf = _read_workflow()
+	step = _cleanup_alt_model_step(wf)
+	# PR discovery for cleanup must use the ai/issue-<N> head-branch selector.
+	assert "pulls?state=open&head=${TEST_REPO%%/*}:ai/issue-${ISSUE_NUMBER}&per_page=1" in step
+	# And it must not fall back to the canary issue's cross-reference timeline.
+	assert "issues/${ISSUE_NUMBER}/timeline" not in step
+	# The discovered PR is still closed via the shared retry helper.
+	assert 'close_with_retry "pulls" "${PR_NUMBER}"' in step
+
+
+def main() -> int:
+	tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+	for test in tests:
+		test()
+	print(f"{len(tests)} passed")
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two related fixes surfaced while investigating why the AI implement workflow failed for the E2E smoke-test canary issues #3174 / #3175 — and why this very PR was force-closed once before being reopened.

---

## Fix 1 — Isolate memory-helper git from workspace `GIT_DIR`/`GIT_WORK_TREE`

**Root cause.** The "Activate workspace shell context" step (in `implement.yml` / `validate.yml` / `review_autofix.yml`) writes `GIT_DIR` and `GIT_WORK_TREE` to `$GITHUB_ENV`, making them **process-wide** for every later step. The AI-memory helper (`scripts/ai_memory_lib.py` → `_run_git`) clones the repo into `/tmp` and selects the repo via `cwd`, but passed no `env=`, so it inherited those vars. With `GIT_WORK_TREE` pointing at the existing workspace dir, `git clone` aborts:

```
git clone --no-tags --quiet *** /tmp/ai-memory-branch-XXXX failed with exit 128
fatal: working tree '/home/runner/work/_temp/workspaces/3174-27057616161-1' already exists.
##[error]Process completed with exit code 2.
```

This aborted the `memory_processed_command_claim` call in the "Claim /approved command" step, failing the whole implement workflow (runs 27057616161 / 27057622152). An inherited absolute `GIT_DIR` would also silently retarget later `add`/`commit`/`push` at the host repo, so the fix lives at the git chokepoint.

**Change.**
- `scripts/ai_memory_lib.py` `_run_git` — run git with a sanitized env (`_git_env()`) dropping `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`, `GIT_COMMON_DIR`, `GIT_NAMESPACE`. Credentials/PATH preserved.
- `scripts/memory_helpers.sh` `memory_ensure_branch` — `unset` the same vars inside the orphan-branch subshell (latent bug on the same flow).
- `tests/test_ai_memory_git_env_isolation.py` — `_git_env` stripping + end-to-end clone repro under polluted env.

## Fix 2 — E2E alt-model cleanup force-closing unrelated PRs

**Root cause.** The "Cleanup alt-model artifacts" step in `test-and-mark-stable.yml` closed the alt-model canary issue, then discovered the "smoke PR to clean up" by taking the **first `cross-referenced` event** on the canary issue's timeline and closing that number as a PR:

```yaml
PR_NUMBER=$(gh api ".../issues/${ISSUE_NUMBER}/timeline?per_page=20" \
  --jq '[.[] | select(.event == "cross-referenced") | .source.issue.number] | first // empty')
close_with_retry "pulls" "${PR_NUMBER}"
```

Because the alt-model implement run failed (Fix 1's bug), no `ai/issue-3175` PR was ever created, so the only cross-reference on #3175 was **this PR** (whose body said `Refs #3175`). The cleanup misidentified it and force-closed it at 09:47:30 — one second after closing issue #3175 — even though §19 keyword discipline (`Refs` not `Fixes`) was followed, because a `cross-referenced` event is created by *any* mention.

**Change.**
- `test-and-mark-stable.yml` — discover the PR the same way Phase 3a's `wait-implement` does: open PRs whose head branch is `ai/issue-<N>`. A PR that merely references the canary issue is never matched.
- `tests/test_test_and_mark_stable_alt_model_cleanup_pr_selector.py` — asserts the head-branch selector is used and the timeline cross-reference heuristic is gone.
- `ci.yml` — wire the new test into the Python test allowlist.

## Verification

- All new tests pass (`test_ai_memory_git_env_isolation.py` 4/4; `test_test_and_mark_stable_alt_model_cleanup_pr_selector.py` 2/2).
- Local repro confirms the clone failure (exit 128 → 0 after sanitizing env).
- YAML validates for both touched workflows.

Refs #3174, #3175, #3179