### PR TITLE
Fix memory origin resolution when repo_root is a work-tree-only checkout

### DIFF
--- a/scripts/ai_memory_lib.py
+++ b/scripts/ai_memory_lib.py
@@ -2304,14 +2304,27 @@ def _git_subprocess_env() -> dict[str, str]:
     return env
 
 
-def _run_git(cwd: Path, args: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+def _run_git(
+    cwd: Path,
+    args: list[str],
+    check: bool = True,
+    *,
+    inherit_location_env: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    # Mutating memory git subprocesses (clone/fetch/checkout/commit/push) MUST
+    # run with the repo-pinning git vars stripped so they resolve their
+    # throwaway /tmp repo from ``cwd`` (see ``_git_subprocess_env``). A read
+    # that legitimately needs to discover the *host* repository — e.g.
+    # ``git remote get-url origin`` when ``cwd`` is a bare work tree whose
+    # ``.git`` lives elsewhere via GIT_DIR — sets ``inherit_location_env`` so
+    # the inherited GIT_DIR/GIT_WORK_TREE locate the host repo instead.
     process = subprocess.run(
         ["git", *args],
         cwd=str(cwd),
         check=False,
         text=True,
         capture_output=True,
-        env=_git_subprocess_env(),
+        env=dict(os.environ) if inherit_location_env else _git_subprocess_env(),
     )
     if check and process.returncode != 0:
         message = (
@@ -2354,7 +2367,23 @@ def _inject_token_into_url(url: str, token: str) -> str:
 
 
 def _resolve_origin_url(repo_root: Path) -> str:
-    process = _run_git(repo_root, ["remote", "get-url", "origin"], check=False)
+    # ``git remote get-url origin`` is a read against the *host* repository so
+    # the memory branch can be cloned from /tmp. Under the implement /
+    # review_autofix / validate workflows ``repo_root`` is the per-issue work
+    # tree (the exported GIT_WORK_TREE), which is frequently not itself a
+    # discoverable git directory — the host repo is reachable only via the
+    # exported GIT_DIR. Stripping the location env here (as every mutating
+    # memory git subprocess does) makes this read fail and fall back to the
+    # bare work-tree path, which is not a clonable repository, so the
+    # subsequent clone aborts with exit 128. Preserve the inherited location
+    # env for this read only so origin resolves correctly; the clone/fetch/
+    # checkout that follow still run with the env stripped.
+    process = _run_git(
+        repo_root,
+        ["remote", "get-url", "origin"],
+        check=False,
+        inherit_location_env=True,
+    )
     if process.returncode == 0:
         url = process.stdout.strip()
     else:

--- a/tests/test_ai_memory_git_env_isolation.py
+++ b/tests/test_ai_memory_git_env_isolation.py
@@ -189,6 +189,63 @@ def test_clone_for_memory_branch_ignores_leaked_git_dir_and_work_tree() -> None:
 			shutil.rmtree(clone_dir, ignore_errors=True)
 
 
+def test_resolve_origin_url_uses_host_repo_via_leaked_git_dir() -> None:
+	# Repro of the implement-workflow "Claim /approved command" failure
+	# (issues #3186 / #3188): repo_root is the per-issue work tree exported as
+	# GIT_WORK_TREE, which is *not* itself a git directory; the host repo is
+	# reachable only via the exported GIT_DIR. _resolve_origin_url must return
+	# the host repo's configured origin, not the bare work-tree path (which is
+	# not a clonable repository and makes the subsequent clone abort exit 128).
+	with tempfile.TemporaryDirectory(prefix="memory-git-env-") as td:
+		root = Path(td)
+		source = _init_source_repo(root)
+		upstream = root / "upstream.git"
+		_git(root, "clone", "--bare", "--quiet", str(source), str(upstream))
+		_git(source, "remote", "add", "origin", str(upstream))
+
+		leaked_work_tree = root / "issue-work-tree"
+		leaked_work_tree.mkdir()  # pure work tree — no .git inside
+
+		with _leaked_git_env(source / ".git", leaked_work_tree):
+			origin = ai_memory_lib._resolve_origin_url(leaked_work_tree)
+
+		assert origin == str(upstream), (
+			f"expected host origin {upstream}, got {origin!r}"
+		)
+
+
+def test_clone_for_memory_branch_resolves_origin_from_leaked_git_dir() -> None:
+	# End-to-end: cloning the memory branch must succeed even when repo_root is
+	# a work tree whose .git lives elsewhere (host repo via GIT_DIR). Before the
+	# fix the origin fell back to the bare work-tree path and the clone failed.
+	with tempfile.TemporaryDirectory(prefix="memory-git-env-") as td:
+		root = Path(td)
+		source = _init_source_repo(root)
+		upstream = root / "upstream.git"
+		_git(root, "clone", "--bare", "--quiet", str(source), str(upstream))
+		_git(source, "remote", "add", "origin", str(upstream))
+
+		leaked_work_tree = root / "issue-work-tree"
+		leaked_work_tree.mkdir()
+
+		with _leaked_git_env(source / ".git", leaked_work_tree):
+			clone_dir = ai_memory_lib._clone_for_memory_branch(leaked_work_tree, "ai-memory")
+
+		try:
+			assert (Path(clone_dir) / "marker.txt").read_text(encoding="utf-8") == "hello\n"
+			head_branch = subprocess.run(
+				["git", "rev-parse", "--abbrev-ref", "HEAD"],
+				cwd=clone_dir,
+				check=True,
+				capture_output=True,
+				text=True,
+				env=_git_process_env(),
+			).stdout.strip()
+			assert head_branch == "ai-memory"
+		finally:
+			shutil.rmtree(clone_dir, ignore_errors=True)
+
+
 def main() -> int:
 	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
 	passed = 0

--- a/tests/test_ai_memory_push_retry_backoff.py
+++ b/tests/test_ai_memory_push_retry_backoff.py
@@ -124,8 +124,15 @@ def _scripted_run_git(
 	rebase_results = iter(rebase_codes or [])
 	rebase_abort_results = iter(rebase_abort_codes or [])
 
-	def fake_run_git(cwd, args, check: bool = True):  # noqa: ANN001 - test stub
+	def fake_run_git(  # noqa: ANN001 - test stub
+		cwd,
+		args,
+		check: bool = True,
+		*,
+		inherit_location_env: bool = False,
+	):
 		op = args[0] if args else ""
+		_ = inherit_location_env
 		if call_log is not None:
 			call_log.append((op, tuple(args)))
 		if op == "ls-remote":


### PR DESCRIPTION
## Summary

The AI implement workflow's **"Claim /approved command"** step was exiting with code 2, aborting AI implementation runs for orchestrator-managed issues (Refs #3186, Refs #3188; runs [27086947361](https://github.com/shubhodeep1/coding-workflows/actions/runs/27086947361), [27086948345](https://github.com/shubhodeep1/coding-workflows/actions/runs/27086948345)).

## Root cause

Commit #3190 (`335e5fc`) added `_git_subprocess_env()` so every memory git subprocess strips `GIT_DIR`/`GIT_WORK_TREE` and resolves its throwaway `/tmp` repo from `cwd`. That isolation is correct for the mutating ops (clone/fetch/checkout/commit/push), but it also stripped the env for the `git remote get-url origin` read inside `_resolve_origin_url`.

Under `implement` / `review_autofix` / `validate`, `repo_root` is the **per-issue work tree** (the exported `GIT_WORK_TREE`, e.g. `/home/runner/work/_temp/workspaces/3188-...-1`), which is **not itself a git directory** — the host repo is reachable only via the exported `GIT_DIR`. With `GIT_DIR` stripped, the origin read failed and `_resolve_origin_url` fell back to the bare work-tree path. The subsequent `git clone <work-tree>` then aborted:

```
fatal: repository '/home/runner/work/_temp/workspaces/3188-27086948345-1' does not exist
git clone ... failed with exit 128
```

`processed-command-check` is fail-open and absorbed it, but `processed-command-claim` is **not** fail-open, so the step failed under `set -e` → `Process completed with exit code 2`.

## Fix

`scripts/ai_memory_lib.py`
- `_run_git`: add an opt-in `inherit_location_env` flag. When set, the subprocess inherits the full env (so `GIT_DIR`/`GIT_WORK_TREE` locate the host repo); otherwise it keeps stripping them as before.
- `_resolve_origin_url`: pass `inherit_location_env=True` for the `git remote get-url origin` read only, so origin resolves against the host repo while the clone/fetch/checkout that follow still run with the env stripped.

This mirrors the shell `memory_ensure_branch` path, which already reads origin with `GIT_DIR` intact.

## Tests

`tests/test_ai_memory_git_env_isolation.py`
- `test_resolve_origin_url_uses_host_repo_via_leaked_git_dir` — origin resolves to the host repo's remote (not the bare work-tree path) when `repo_root` is a work-tree-only dir behind `GIT_DIR`.
- `test_clone_for_memory_branch_resolves_origin_from_leaked_git_dir` — end-to-end clone of the memory branch succeeds in the same scenario.

Both reproduce the exact `exit 128 / does not exist` failure on the pre-fix code and pass with the fix; the full suite (7 tests) is green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eg5oowjFQZbBU5rVXfPFxa)_