### PR TITLE
fix(implement): pass --skip-git-repo-check to in-workspace codex exec calls + enforce it repo-wide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,7 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_validate_workflow_validate_bootstrap.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_codex_thread_reuse_core.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_codex_skip_git_repo_check_contract.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_codex_stall_guard_scripts.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_workspace_init.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_workspace_safety_check.py

--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -861,7 +861,7 @@ jobs:
           max_attempts=3
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "Codex clarify attempt ${attempt}/${max_attempts}..."
-            if cat "${CODEX_PROMPT_FILE}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
+            if cat "${CODEX_PROMPT_FILE}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --skip-git-repo-check --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
               if grep -q '[^[:space:]]' "${CODEX_OUTPUT_FILE}"; then
                 echo "Codex clarify succeeded on attempt ${attempt}."
                 break

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -2178,6 +2178,7 @@ jobs:
               CODEX_THREAD_REUSE_OUTPUT_FILE="${CODEX_OUTPUT_FILE}" \
               CODEX_THREAD_REUSE_PHASE="implement" \
               CODEX_THREAD_REUSE_MODEL="${MODEL_EDITOR}" \
+              CODEX_THREAD_REUSE_SKIP_GIT_REPO_CHECK="true" \
               CODEX_THREAD_REUSE_LOG_FILE="${attempt_log_file}" \
               CODEX_THREAD_REUSE_CUMULATIVE_LOG_FILE="${RUNTIME_DIR}/codex_log.txt" \
               CODEX_THREAD_REUSE_STATUS_FILE="${attempt_stall_status_file}" \
@@ -3282,6 +3283,7 @@ jobs:
               CODEX_THREAD_REUSE_OUTPUT_FILE="${REPAIR_OUTPUT_FILE}" \
               CODEX_THREAD_REUSE_PHASE="implement_repair" \
               CODEX_THREAD_REUSE_MODEL="${MODEL_EDITOR}" \
+              CODEX_THREAD_REUSE_SKIP_GIT_REPO_CHECK="true" \
               CODEX_THREAD_REUSE_LOG_FILE="${REPAIR_LOG_FILE}" \
               CODEX_THREAD_REUSE_CONTINUATION_FILE="${repair_thread_reuse_continuation_file}" \
               CODEX_THREAD_REUSE_TRANSFORM_MODE="replace-prefix" \
@@ -4908,7 +4910,7 @@ jobs:
               sanitize_codex_prompt_file "${_summary_combined_prompt}"
             fi
             bash scripts/workspace_safety_check.sh
-            codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${_summary_combined_prompt}" > "${ISSUE_SUMMARY_FILE}" || true
+            codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --skip-git-repo-check --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${_summary_combined_prompt}" > "${ISSUE_SUMMARY_FILE}" || true
             if [ -s "${ISSUE_SUMMARY_FILE}" ] && grep -q '^### AI Issue Summary' "${ISSUE_SUMMARY_FILE}"; then
               echo "Summary generated on attempt ${_summary_attempt}."
               break

--- a/.github/workflows/mark-stable.yml
+++ b/.github/workflows/mark-stable.yml
@@ -276,6 +276,7 @@ jobs:
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_validation_discovery_bootstrap.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_validate_workflow_validate_bootstrap.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_codex_thread_reuse_core.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_codex_skip_git_repo_check_contract.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_workspace_init.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_workspace_hooks.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_workspace_cache_maintenance.py

--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -704,7 +704,7 @@ jobs:
             # `timeout` wrapper governs codex directly — wrapping a
             # pipeline would only time out `cat`, not the model call.
             if timeout --signal=TERM --kill-after=30s -- "${ORCHESTRATE_DECOMPOSER_PER_ATTEMPT_TIMEOUT_SECS}" \
-                 codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
+                 codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --skip-git-repo-check --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
               if ! grep -q '[^[:space:]]' "${CODEX_OUTPUT_FILE}"; then
                 echo "::warning::Codex returned empty output on attempt ${attempt}."
                 last_status="empty output"

--- a/.github/workflows/orchestrate_clarify_respond.yml
+++ b/.github/workflows/orchestrate_clarify_respond.yml
@@ -780,7 +780,7 @@ jobs:
               sanitize_codex_prompt_file "${RUNTIME_DIR}/critic_prompt.txt"
             fi
             if cat "${RUNTIME_DIR}/critic_prompt.txt" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec \
-              --model "${CRITIC_MODEL}" --sandbox danger-full-access > "${RUNTIME_DIR}/critic_output.txt" 2>/dev/null; then
+              --skip-git-repo-check --model "${CRITIC_MODEL}" --sandbox danger-full-access > "${RUNTIME_DIR}/critic_output.txt" 2>/dev/null; then
               if grep -q 'VERDICT: REJECT' "${RUNTIME_DIR}/critic_output.txt"; then
                 echo "::warning::Self-critique rejected the decision. Appending critique and re-running."
                 CRITIC_REASON="$(grep -A5 'REASON:' "${RUNTIME_DIR}/critic_output.txt" || echo "No reason provided")"
@@ -796,7 +796,7 @@ jobs:
                   sanitize_codex_prompt_file "${CODEX_PROMPT_FILE}.v2"
                 fi
                 if cat "${CODEX_PROMPT_FILE}.v2" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec \
-                  --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2>/dev/null; then
+                  --skip-git-repo-check --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2>/dev/null; then
                   echo "Revised decision produced after self-critique."
                 else
                   echo "::warning::Revised Codex call failed; using original output."

--- a/.github/workflows/orchestrate_clarify_respond.yml
+++ b/.github/workflows/orchestrate_clarify_respond.yml
@@ -711,7 +711,7 @@ jobs:
             if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
               sanitize_codex_prompt_file "${CODEX_PROMPT_FILE}"
             fi
-            if cat "${CODEX_PROMPT_FILE}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
+            if cat "${CODEX_PROMPT_FILE}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --skip-git-repo-check --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
               if grep -q '[^[:space:]]' "${CODEX_OUTPUT_FILE}"; then
                 echo "Codex clarify-respond succeeded on attempt ${attempt}."
                 break

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -1053,7 +1053,7 @@ jobs:
           max_attempts=3
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "Codex planning attempt ${attempt}/${max_attempts}..."
-            if cat "${CODEX_PROMPT_FILE}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
+            if cat "${CODEX_PROMPT_FILE}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --skip-git-repo-check --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${CODEX_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/codex_log.txt" >&2); then
               if grep -q '[^[:space:]]' "${CODEX_OUTPUT_FILE}"; then
                 PLAN_LINES="$(wc -l < "${CODEX_OUTPUT_FILE}")"
                 echo "Codex planning succeeded on attempt ${attempt} (${PLAN_LINES} lines of output)."

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -3343,6 +3343,7 @@ jobs:
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_validation_discovery_bootstrap.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_validate_workflow_validate_bootstrap.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_codex_thread_reuse_core.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_codex_skip_git_repo_check_contract.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_workspace_init.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_workspace_safety_check.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_workspace_hooks.py

--- a/.github/workflows/workflow-log-analysis.yml
+++ b/.github/workflows/workflow-log-analysis.yml
@@ -596,7 +596,7 @@ jobs:
             bash scripts/codex_heartbeat.sh \
               --phase workflow_log_analysis \
               --stdout-file "${REPORT_FILE}" \
-              -- codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${WORKFLOW_EDITOR_MODEL}" --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" 2> >(tee -a /tmp/workflow-analysis-codex.log >&2)
+              -- codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --skip-git-repo-check --model "${WORKFLOW_EDITOR_MODEL}" --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" 2> >(tee -a /tmp/workflow-analysis-codex.log >&2)
             ANALYZE_EXIT=$?
             set -e
             if [ "${ANALYZE_EXIT}" -eq 0 ] && grep -q '[^[:space:]]' "${REPORT_FILE}"; then
@@ -1124,7 +1124,7 @@ jobs:
             bash scripts/codex_heartbeat.sh \
               --phase workflow_deep_audit \
               --stdout-file "${SECTION_FILE}" \
-              -- codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${WORKFLOW_EDITOR_MODEL}" --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" 2> >(tee -a /tmp/workflow-audit-codex.log >&2)
+              -- codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --skip-git-repo-check --model "${WORKFLOW_EDITOR_MODEL}" --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" 2> >(tee -a /tmp/workflow-audit-codex.log >&2)
             AUDIT_EXIT=$?
             set -e
             if [ "${AUDIT_EXIT}" -eq 0 ] && grep -q '[^[:space:]]' "${SECTION_FILE}"; then
@@ -1592,7 +1592,7 @@ jobs:
             bash scripts/codex_heartbeat.sh \
               --phase workflow_api_redundancy \
               --stdout-file "${SECTION_FILE}" \
-              -- codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${WORKFLOW_EDITOR_MODEL}" --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" 2> >(tee -a /tmp/workflow-api-redundancy-codex.log >&2)
+              -- codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --skip-git-repo-check --model "${WORKFLOW_EDITOR_MODEL}" --sandbox danger-full-access < "${CODEX_PROMPT_FILE}" 2> >(tee -a /tmp/workflow-api-redundancy-codex.log >&2)
             API_EXIT=$?
             set -e
             if [ "${API_EXIT}" -eq 0 ] && grep -q '[^[:space:]]' "${SECTION_FILE}"; then

--- a/scripts/codex_thread_reuse.sh
+++ b/scripts/codex_thread_reuse.sh
@@ -473,8 +473,8 @@ codex_thread_reuse_run_once()
 	# workspace (GIT_DIR/GIT_WORK_TREE split, no .git in cwd), where codex
 	# aborts with "Not inside a trusted directory and --skip-git-repo-check
 	# was not specified". Omitting the flag is a deterministic failure (see
-	# #3077, #3194/#3195), so the safe default is to skip the check; a caller
-	# may still pass "false" to opt back in.
+	# #3077, #3194/#3195), so automation callers should leave the check
+	# skipped.
 	local skip_git_repo_check="${9:-true}"
 	local log_file="${10:-}"
 	local cumulative_log_file="${11:-}"
@@ -582,9 +582,8 @@ codex_thread_reuse_direct_run()
 	local status_file="${CODEX_THREAD_REUSE_STATUS_FILE:-}"
 	local stall_guard="${CODEX_THREAD_REUSE_STALL_GUARD_HELPER:-}"
 	local heartbeat_helper="${CODEX_THREAD_REUSE_HEARTBEAT_HELPER:-}"
-	# Default ON — see the rationale in codex_thread_reuse_run_once. Callers
-	# may set CODEX_THREAD_REUSE_SKIP_GIT_REPO_CHECK=false to re-enable codex's
-	# git-repo/trust check when running in a real checkout.
+	# Default ON — see the rationale in codex_thread_reuse_run_once.
+	# Automation callers should leave codex's git-repo/trust check skipped.
 	local skip_git_repo_check="${CODEX_THREAD_REUSE_SKIP_GIT_REPO_CHECK:-true}"
 	local timeout_secs="${CODEX_THREAD_REUSE_TIMEOUT_SECS:-}"
 	local continuation_file="${CODEX_THREAD_REUSE_CONTINUATION_FILE:-}"

--- a/scripts/codex_thread_reuse.sh
+++ b/scripts/codex_thread_reuse.sh
@@ -469,7 +469,13 @@ codex_thread_reuse_run_once()
 	local phase="${6:?phase required}"
 	local model="${7:?model required}"
 	local sandbox="${8:-danger-full-access}"
-	local skip_git_repo_check="${9:-false}"
+	# Default ON: every workflow runs codex inside the worktree-only
+	# workspace (GIT_DIR/GIT_WORK_TREE split, no .git in cwd), where codex
+	# aborts with "Not inside a trusted directory and --skip-git-repo-check
+	# was not specified". Omitting the flag is a deterministic failure (see
+	# #3077, #3194/#3195), so the safe default is to skip the check; a caller
+	# may still pass "false" to opt back in.
+	local skip_git_repo_check="${9:-true}"
 	local log_file="${10:-}"
 	local cumulative_log_file="${11:-}"
 	local status_file="${12:-}"
@@ -576,7 +582,10 @@ codex_thread_reuse_direct_run()
 	local status_file="${CODEX_THREAD_REUSE_STATUS_FILE:-}"
 	local stall_guard="${CODEX_THREAD_REUSE_STALL_GUARD_HELPER:-}"
 	local heartbeat_helper="${CODEX_THREAD_REUSE_HEARTBEAT_HELPER:-}"
-	local skip_git_repo_check="${CODEX_THREAD_REUSE_SKIP_GIT_REPO_CHECK:-false}"
+	# Default ON — see the rationale in codex_thread_reuse_run_once. Callers
+	# may set CODEX_THREAD_REUSE_SKIP_GIT_REPO_CHECK=false to re-enable codex's
+	# git-repo/trust check when running in a real checkout.
+	local skip_git_repo_check="${CODEX_THREAD_REUSE_SKIP_GIT_REPO_CHECK:-true}"
 	local timeout_secs="${CODEX_THREAD_REUSE_TIMEOUT_SECS:-}"
 	local continuation_file="${CODEX_THREAD_REUSE_CONTINUATION_FILE:-}"
 	local transform_mode="${CODEX_THREAD_REUSE_TRANSFORM_MODE:-none}"

--- a/scripts/implement_diagnose_post_codex_failure.sh
+++ b/scripts/implement_diagnose_post_codex_failure.sh
@@ -607,7 +607,7 @@ DIAGNOSE_SUCCESS=false
 if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
   sanitize_codex_prompt_file "${IMPLEMENT_DIAGNOSE_PROMPT_FILE}"
 fi
-if timeout "${IMPLEMENT_DIAGNOSE_TIMEOUT_SEC}"s codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${DIAGNOSE_MODEL}" --sandbox danger-full-access \
+if timeout "${IMPLEMENT_DIAGNOSE_TIMEOUT_SEC}"s codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --skip-git-repo-check --model "${DIAGNOSE_MODEL}" --sandbox danger-full-access \
   < "${IMPLEMENT_DIAGNOSE_PROMPT_FILE}" > "${IMPLEMENT_DIAGNOSE_OUTPUT_FILE}" \
   2> >(tee -a "${IMPLEMENT_DIAGNOSE_LOG_FILE}" >&2); then
   if extract_last_json_with_key "${IMPLEMENT_DIAGNOSE_OUTPUT_FILE}" "status" "${IMPLEMENT_DIAGNOSE_RESULT_FILE}"; then

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -5344,7 +5344,7 @@ invoke_judge_for_integration_conflict() {
   } > "${prompt_file}"
 
   sanitize_codex_prompt_file "${prompt_file}"
-  if cat "${prompt_file}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR:-openai/gpt-5.4}" --sandbox danger-full-access > "${output_file}" 2>> "${RUNTIME_DIR}/integration_judge.log"; then
+  if cat "${prompt_file}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --skip-git-repo-check --model "${MODEL_EDITOR:-openai/gpt-5.4}" --sandbox danger-full-access > "${output_file}" 2>> "${RUNTIME_DIR}/integration_judge.log"; then
     echo "  [integration-heal] Judge exec completed for PR #${final_pr}."
     rm -f "${prompt_file}" "${output_file}" "${judge_static_file}" "${judge_semble_query_file}"
     return 0
@@ -10380,7 +10380,7 @@ invoke_stall_judge() {
         printf '%s\n' "${MOCK_STALL_JUDGE_JSON}" > "${stall_judge_output_file}"
       else
         sanitize_codex_prompt_file "${stall_judge_prompt_file}"
-        codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${stall_judge_prompt_file}" > "${stall_judge_output_file}" 2>> "${RUNTIME_DIR}/stall_judge.log" || true
+        codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --skip-git-repo-check --model "${MODEL_EDITOR}" --sandbox danger-full-access < "${stall_judge_prompt_file}" > "${stall_judge_output_file}" 2>> "${RUNTIME_DIR}/stall_judge.log" || true
       fi
       if grep -q '[^[:space:]]' "${stall_judge_output_file}"; then
         judge_success="true"
@@ -15109,7 +15109,7 @@ ${FOLLOWUP_BLOCK_REASON}"
       for attempt in 1 2; do
         echo "  Review-blocked judge attempt ${attempt}/2..."
         sanitize_codex_prompt_file "${RB_JUDGE_PROMPT_FILE}"
-        cat "${RB_JUDGE_PROMPT_FILE}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${RB_JUDGE_OUTPUT_FILE}" 2>/dev/null || true
+        cat "${RB_JUDGE_PROMPT_FILE}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --skip-git-repo-check --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${RB_JUDGE_OUTPUT_FILE}" 2>/dev/null || true
         if grep -q '[^[:space:]]' "${RB_JUDGE_OUTPUT_FILE}"; then
           RB_JUDGE_SUCCESS=true
           break
@@ -16862,7 +16862,7 @@ ${PR_DIFF}
     # The pipeline may return 141 (SIGPIPE) when the prompt is larger
     # than the OS pipe buffer and codex closes stdin before cat finishes.
     # This is harmless — check the output file regardless of exit code.
-    cat "${JUDGE_PROMPT_FILE}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${JUDGE_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/judge_log.txt" >&2) || true
+    cat "${JUDGE_PROMPT_FILE}" | codex --ask-for-approval never -c model_verbosity=low -c include_apply_patch_tool=true exec --skip-git-repo-check --model "${MODEL_EDITOR}" --sandbox danger-full-access > "${JUDGE_OUTPUT_FILE}" 2> >(tee -a "${RUNTIME_DIR}/judge_log.txt" >&2) || true
     if grep -q '[^[:space:]]' "${JUDGE_OUTPUT_FILE}"; then
       JUDGE_SUCCESS=true
       break

--- a/scripts/validation_discovery_bootstrap.py
+++ b/scripts/validation_discovery_bootstrap.py
@@ -310,6 +310,7 @@ def discover_manifest_via_codex(
 			"-c",
 			"include_apply_patch_tool=true",
 			"exec",
+			"--skip-git-repo-check",
 			"--model",
 			model,
 			"--sandbox",

--- a/tests/test_codex_skip_git_repo_check_contract.py
+++ b/tests/test_codex_skip_git_repo_check_contract.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Repo-wide contract: every codex `exec` invocation must skip the git-repo check.
+
+Background — the recurring "Not inside a trusted directory" regression
+=====================================================================
+
+Every AI workflow runs ``codex exec`` inside a worktree-only workspace: a
+materialized copy of the tree whose git linkage is supplied purely via the
+``GIT_DIR`` / ``GIT_WORK_TREE`` environment variables, with no ``.git`` entry
+in the working directory. Codex's git-repo / trust discovery ignores those env
+vars, so when the flag is missing codex aborts every attempt with::
+
+    Not inside a trusted directory and --skip-git-repo-check was not specified.
+
+returning empty output. This is deterministic, not flaky.
+
+This exact failure has now bitten the repo repeatedly, each time in a workflow
+that was migrated into the workspace model without carrying the guard over:
+
+* #3076/#3077 — review + validate codex calls.
+* #3194/#3195 — implement codex calls (regressed by the Symphony change #3048,
+  which moved implement into the worktree workspace but never added the flag).
+
+Both rounds were point-fixes to individual call sites. Nothing prevented the
+next omission, so the same deterministic failure kept resurfacing. This test
+makes the invariant enforceable at PR time instead of in production:
+
+1. ``scripts/codex_thread_reuse.sh`` (the shared thread-reuse runner that every
+   ``direct-run`` caller funnels through) must default ``skip_git_repo_check``
+   to ``true`` — so a caller that forgets the env var is still safe.
+
+2. Every standalone single-line ``codex ... exec ... --model ... --sandbox``
+   invocation in ``scripts/*.sh`` and ``.github/workflows/*.yml`` must carry
+   ``--skip-git-repo-check``.
+
+``--skip-git-repo-check`` is a no-op inside a real git checkout, so it is always
+safe to require it — there is no codex call in this automation that wants the
+trust check on.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HELPER = REPO_ROOT / "scripts" / "codex_thread_reuse.sh"
+
+# A single-line, fully-specified codex invocation: the `codex` binary, the
+# `exec` subcommand, and both `--model` and `--sandbox` on one physical line.
+# Real invocations always carry all four on the same line; this deliberately
+# does NOT try to reassemble multi-line array constructions (those keep the
+# flag on its own continuation line and are covered by manual review + the
+# helper default). Requiring --model and --sandbox keeps comments and prose
+# that merely mention "codex exec" from matching.
+_INVOCATION = re.compile(r"\bcodex\b.*\bexec\b.*--model\b.*--sandbox\b")
+
+# The shared runner builds its codex command line conditionally across several
+# array-append lines, so it is validated by the default-value assertion below
+# rather than the line scanner.
+_SCANNER_EXCLUDE = {"codex_thread_reuse.sh"}
+
+
+def _scanned_files() -> list[Path]:
+	files = sorted((REPO_ROOT / "scripts").glob("*.sh"))
+	files += sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
+	return files
+
+
+def test_helper_defaults_skip_git_repo_check_on() -> None:
+	"""The shared runner must be safe-by-default for every direct-run caller."""
+	text = HELPER.read_text(encoding="utf-8")
+	# Positional default in codex_thread_reuse_run_once (arg 9).
+	assert 'local skip_git_repo_check="${9:-true}"' in text, (
+		"codex_thread_reuse_run_once must default skip_git_repo_check to true "
+		"so workspace runs skip codex's git-repo/trust check"
+	)
+	# Env-var default in codex_thread_reuse_direct_run.
+	assert (
+		'local skip_git_repo_check="${CODEX_THREAD_REUSE_SKIP_GIT_REPO_CHECK:-true}"'
+		in text
+	), (
+		"codex_thread_reuse_direct_run must default "
+		"CODEX_THREAD_REUSE_SKIP_GIT_REPO_CHECK to true"
+	)
+	# And it must still be the flag actually appended to the command line.
+	assert "cmd+=(--skip-git-repo-check)" in text
+
+
+def test_all_codex_exec_invocations_skip_git_repo_check() -> None:
+	"""No standalone codex exec call may omit --skip-git-repo-check.
+
+	If this fails, a new (or migrated) codex invocation was added without the
+	guard and will deterministically abort with "Not inside a trusted
+	directory" the moment that workflow runs in the worktree workspace. Add
+	``--skip-git-repo-check`` immediately after ``exec``.
+	"""
+	violations: list[str] = []
+	for path in _scanned_files():
+		if path.name in _SCANNER_EXCLUDE:
+			continue
+		for lineno, line in enumerate(
+			path.read_text(encoding="utf-8").splitlines(), start=1
+		):
+			if line.lstrip().startswith("#"):
+				continue
+			if _INVOCATION.search(line) and "--skip-git-repo-check" not in line:
+				rel = path.relative_to(REPO_ROOT)
+				violations.append(f"{rel}:{lineno}: {line.strip()}")
+
+	assert not violations, (
+		"codex exec invocation(s) missing --skip-git-repo-check (will abort with "
+		"'Not inside a trusted directory' in the worktree workspace):\n"
+		+ "\n".join(violations)
+	)
+
+
+def test_scanner_actually_matches_known_invocations() -> None:
+	"""Guard against the scanner silently matching nothing (e.g. a regex typo).
+
+	A contract test that matches zero lines would pass vacuously and stop
+	protecting anything, so assert it still sees the real fleet of calls.
+	"""
+	matched = 0
+	for path in _scanned_files():
+		if path.name in _SCANNER_EXCLUDE:
+			continue
+		for line in path.read_text(encoding="utf-8").splitlines():
+			if line.lstrip().startswith("#"):
+				continue
+			if _INVOCATION.search(line):
+				matched += 1
+	assert matched >= 10, (
+		f"scanner matched only {matched} codex exec invocations; the detection "
+		"regex is probably broken"
+	)

--- a/tests/test_codex_skip_git_repo_check_contract.py
+++ b/tests/test_codex_skip_git_repo_check_contract.py
@@ -29,9 +29,10 @@ makes the invariant enforceable at PR time instead of in production:
    ``direct-run`` caller funnels through) must default ``skip_git_repo_check``
    to ``true`` — so a caller that forgets the env var is still safe.
 
-2. Every standalone single-line ``codex ... exec ... --model ... --sandbox``
-   invocation in ``scripts/*.sh`` and ``.github/workflows/*.yml`` must carry
-   ``--skip-git-repo-check``.
+2. Every standalone ``codex ... exec ... --model ... --sandbox`` invocation
+   in ``scripts/*.sh`` and ``.github/workflows/*.yml`` must carry
+   ``--skip-git-repo-check``. The scanner reassembles backslash-continued
+   shell / YAML commands into one logical line before checking.
 
 ``--skip-git-repo-check`` is a no-op inside a real git checkout, so it is always
 safe to require it — there is no codex call in this automation that wants the
@@ -46,12 +47,10 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 HELPER = REPO_ROOT / "scripts" / "codex_thread_reuse.sh"
 
-# A single-line, fully-specified codex invocation: the `codex` binary, the
-# `exec` subcommand, and both `--model` and `--sandbox` on one physical line.
-# Real invocations always carry all four on the same line; this deliberately
-# does NOT try to reassemble multi-line array constructions (those keep the
-# flag on its own continuation line and are covered by manual review + the
-# helper default). Requiring --model and --sandbox keeps comments and prose
+# A fully-specified codex invocation on one logical shell / YAML command line:
+# after reassembling backslash-continued physical lines, the command must
+# mention the `codex` binary, the `exec` subcommand, and both `--model` and
+# `--sandbox`. Requiring `--model` and `--sandbox` keeps comments and prose
 # that merely mention "codex exec" from matching.
 _INVOCATION = re.compile(r"\bcodex\b.*\bexec\b.*--model\b.*--sandbox\b")
 
@@ -65,6 +64,55 @@ def _scanned_files() -> list[Path]:
 	files = sorted((REPO_ROOT / "scripts").glob("*.sh"))
 	files += sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
 	return files
+
+
+def _iter_logical_lines(path: Path) -> list[tuple[int, str]]:
+	logical_lines: list[tuple[int, str]] = []
+	pending: list[str] = []
+	start_lineno = 0
+
+	for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+		if not pending:
+			if not line.strip() or line.lstrip().startswith("#"):
+				continue
+			start_lineno = lineno
+		pending.append(line)
+
+		if line.rstrip().endswith("\\"):
+			continue
+
+		parts: list[str] = []
+		for part in pending:
+			trimmed = part.rstrip()
+			if trimmed.endswith("\\"):
+				trimmed = trimmed[:-1].rstrip()
+			if trimmed.strip():
+				parts.append(trimmed.strip())
+		logical_lines.append((start_lineno, " ".join(parts)))
+		pending = []
+
+	if pending:
+		parts = []
+		for part in pending:
+			trimmed = part.rstrip()
+			if trimmed.endswith("\\"):
+				trimmed = trimmed[:-1].rstrip()
+			if trimmed.strip():
+				parts.append(trimmed.strip())
+		logical_lines.append((start_lineno, " ".join(parts)))
+
+	return logical_lines
+
+
+def _iter_codex_exec_invocations() -> list[tuple[Path, int, str]]:
+	matches: list[tuple[Path, int, str]] = []
+	for path in _scanned_files():
+		if path.name in _SCANNER_EXCLUDE:
+			continue
+		for lineno, logical_line in _iter_logical_lines(path):
+			if _INVOCATION.search(logical_line):
+				matches.append((path.relative_to(REPO_ROOT), lineno, logical_line))
+	return matches
 
 
 def test_helper_defaults_skip_git_repo_check_on() -> None:
@@ -96,22 +144,32 @@ def test_all_codex_exec_invocations_skip_git_repo_check() -> None:
 	``--skip-git-repo-check`` immediately after ``exec``.
 	"""
 	violations: list[str] = []
-	for path in _scanned_files():
-		if path.name in _SCANNER_EXCLUDE:
-			continue
-		for lineno, line in enumerate(
-			path.read_text(encoding="utf-8").splitlines(), start=1
-		):
-			if line.lstrip().startswith("#"):
-				continue
-			if _INVOCATION.search(line) and "--skip-git-repo-check" not in line:
-				rel = path.relative_to(REPO_ROOT)
-				violations.append(f"{rel}:{lineno}: {line.strip()}")
+	for rel, lineno, logical_line in _iter_codex_exec_invocations():
+		if "--skip-git-repo-check" not in logical_line:
+			violations.append(f"{rel}:{lineno}: {logical_line}")
 
 	assert not violations, (
 		"codex exec invocation(s) missing --skip-git-repo-check (will abort with "
 		"'Not inside a trusted directory' in the worktree workspace):\n"
 		+ "\n".join(violations)
+	)
+
+
+
+def test_scanner_matches_backslash_continued_invocations() -> None:
+	"""Backslash-continued codex commands must be part of the contract scan."""
+	matches = [
+		logical_line
+		for path, _, logical_line in _iter_codex_exec_invocations()
+		if path == Path(".github/workflows/orchestrate_clarify_respond.yml")
+	]
+	assert any("critic_prompt.txt" in logical_line for logical_line in matches), (
+		"scanner must detect the self-critique critic codex invocation in "
+		"orchestrate_clarify_respond.yml"
+	)
+	assert any('${CODEX_PROMPT_FILE}.v2' in logical_line for logical_line in matches), (
+		"scanner must detect the self-critique re-run codex invocation in "
+		"orchestrate_clarify_respond.yml"
 	)
 
 
@@ -121,15 +179,7 @@ def test_scanner_actually_matches_known_invocations() -> None:
 	A contract test that matches zero lines would pass vacuously and stop
 	protecting anything, so assert it still sees the real fleet of calls.
 	"""
-	matched = 0
-	for path in _scanned_files():
-		if path.name in _SCANNER_EXCLUDE:
-			continue
-		for line in path.read_text(encoding="utf-8").splitlines():
-			if line.lstrip().startswith("#"):
-				continue
-			if _INVOCATION.search(line):
-				matched += 1
+	matched = len(_iter_codex_exec_invocations())
 	assert matched >= 10, (
 		f"scanner matched only {matched} codex exec invocations; the detection "
 		"regex is probably broken"

--- a/tests/test_codex_skip_git_repo_check_contract.py
+++ b/tests/test_codex_skip_git_repo_check_contract.py
@@ -184,3 +184,24 @@ def test_scanner_actually_matches_known_invocations() -> None:
 		f"scanner matched only {matched} codex exec invocations; the detection "
 		"regex is probably broken"
 	)
+
+
+def main() -> int:
+	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+	passed = 0
+	failed = 0
+	for func in test_funcs:
+		name = func.__name__
+		try:
+			func()
+			print(f"  PASS  {name}")
+			passed += 1
+		except Exception as e:
+			print(f"  FAIL  {name}: {e}")
+			failed += 1
+	print(f"\n{passed} passed, {failed} failed, {passed + failed} total")
+	return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_codex_skip_git_repo_check_contract.py
+++ b/tests/test_codex_skip_git_repo_check_contract.py
@@ -46,6 +46,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 HELPER = REPO_ROOT / "scripts" / "codex_thread_reuse.sh"
+DISCOVERY_BOOTSTRAP = REPO_ROOT / "scripts" / "validation_discovery_bootstrap.py"
 
 # A fully-specified codex invocation on one logical shell / YAML command line:
 # after reassembling backslash-continued physical lines, the command must
@@ -133,6 +134,19 @@ def test_helper_defaults_skip_git_repo_check_on() -> None:
 	)
 	# And it must still be the flag actually appended to the command line.
 	assert "cmd+=(--skip-git-repo-check)" in text
+
+
+def test_python_discovery_helper_skips_git_repo_check() -> None:
+	"""The production Python discovery helper must carry the same flag."""
+	text = DISCOVERY_BOOTSTRAP.read_text(encoding="utf-8")
+	assert re.search(
+		r'command = \[\s*"codex",.*?"exec",\s*"--skip-git-repo-check",\s*"--model",.*?"--sandbox",',
+		text,
+		re.S,
+	), (
+		"validation_discovery_bootstrap.py must pass --skip-git-repo-check "
+		"in its codex command list"
+	)
 
 
 def test_all_codex_exec_invocations_skip_git_repo_check() -> None:


### PR DESCRIPTION
## Summary

The AI implementation workflow failed for issues #3194 and #3195 ([run 27089938485](https://github.com/shubhodeep1/coding-workflows/actions/runs/27089938485), [run 27089942607](https://github.com/shubhodeep1/coding-workflows/actions/runs/27089942607)). Both failed identically at the **Run Codex implementation** step:

```
Codex implement attempt 1/5...
Not inside a trusted directory and --skip-git-repo-check was not specified.
##[warning]Codex exited with code 1 and returned empty output on attempt 1.
...
##[error]Codex produced no actionable output 2 attempts in a row ... Aborting retry loop.
```

## Root cause

The Symphony workspace change (#3048, commit `7af02b5`, 2026-06-06) moved implement's codex runs into a **worktree-only workspace**. The *Activate workspace shell context* step sets `BASH_ENV` to `cd "${WORKSPACE_PATH}"` and exports `GIT_DIR=${GITHUB_WORKSPACE}/.git` + `GIT_WORK_TREE=${WORKSPACE_PATH}`. So codex now runs with `cwd = ${WORKSPACE_PATH}` — a directory whose git linkage exists only via env vars and which contains **no `.git` entry**. Codex's git-repo/trust check aborts immediately, emits no output, and the implement attempt loop counts two empty attempts as a stuck agent and bails. Issues #3194/#3195 (created the day after #3048) are the first to hit it.

## Why this keeps recurring

This is the **third** time this exact deterministic failure has appeared, and the prior fixes were point-fixes that didn't prevent the next one:

- **#3076/#3077** fixed the review + validate codex calls — and the commit body explicitly *predicted* this: *"guards against the deterministic failure that breaks every reviewer once the workspace-reuse feature lands on main."*
- **#3048** then landed that workspace model and extended it to `implement.yml` (668 lines changed there) **without carrying the guard over**.

There was no shared default and no test enforcing the invariant, so each newly-migrated workflow silently regressed. This PR fixes that structurally.

## Fix

**1 — the immediate failure (4 implement call sites):**
- `.github/workflows/implement.yml` — *Run Codex implementation* and *implement_repair* thread-reuse env blocks (`CODEX_THREAD_REUSE_SKIP_GIT_REPO_CHECK="true"`); issue-summary direct `codex exec` (`--skip-git-repo-check`)
- `scripts/implement_diagnose_post_codex_failure.sh` — post-failure diagnose `codex exec`

**2 — make it safe-by-default:** flip `scripts/codex_thread_reuse.sh`'s `skip_git_repo_check` default from `false` → `true` (both `codex_thread_reuse_run_once` and `codex_thread_reuse_direct_run`). Every `direct-run` caller funnels through this helper, so forgetting the env var is now harmless. The flag is a no-op in a real checkout, so this is strictly safer.

**3 — enforce it at PR time:** new `tests/test_codex_skip_git_repo_check_contract.py` scans every `scripts/*.sh` and `.github/workflows/*.yml` for single-line `codex … exec … --model … --sandbox` invocations and fails if any omits `--skip-git-repo-check`, and asserts the helper default is `true`. The next omission fails CI instead of production.

## Proactive fixes included

Bringing the tree green for the new contract surfaced the **same latent omission in six more workflows/scripts** that were never migrated-with-the-guard — each would fail identically the moment it runs in the worktree workspace. All fixed (purely additive flag, `bash -n` / YAML clean):

- `scripts/orchestrate_poll_process.sh` (integration-judge, stall-judge, rb-judge, judge codex calls — 4 sites)
- `.github/workflows/clarify.yml`, `plan.yml`, `orchestrate.yml`, `orchestrate_clarify_respond.yml`, `workflow-log-analysis.yml`

## Verification

- New contract test passes (3/3); existing `tests/test_codex_thread_reuse_core.py` passes (19/19).
- `bash -n` clean on all touched scripts; all touched workflow YAML parses.
- The 26 failures in `tests/test_implement_post_codex_recovery.py` are pre-existing/environmental (the sandbox's `git commit` signing server returns HTTP 400 in `_bootstrap_git_repo`) — identical on the unmodified baseline; none assert the codex command line. yaml-importing suites can't run under the local `pytest` interpreter (no `pyyaml`); CI installs it.

Refs #3194, #3195