### PR TITLE
Fix release v1.17.0 validate-scripts: align implementation-failed reissue test with the #3048 U2 blocker gate

### DIFF
--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -8032,11 +8032,24 @@ def test_implementation_failed_reissue_preserves_dependency_gates_and_pending_de
 		issue_labels={10: ["ai:implementation-failed"]},
 	)
 	latest = result["latest_state"]
-	assert str(latest["issue_number_map"]["issue-1"]) == "901"
-	assert str(latest["issue_number_map"]["issue-2"]) == "900"
-	assert latest["pending_issue_defs"] == {}
+	# issue-1 was implementation-failed and is reissued as a fresh issue.
+	assert str(latest["issue_number_map"]["issue-1"]) == "900"
+	# issue-2 depends on issue-1, which is non-terminal this tick
+	# (implementation-failed, being reissued). The U2 runtime blocker gate
+	# (scripts/blocker_check.py, added in #3048) defers issue-2's deferred
+	# creation until its blocker terminalizes, so it stays pending rather than
+	# being created alongside the reissue — preserving both the dependency
+	# edges and the pending definition.
+	assert "issue-2" not in latest["issue_number_map"]
+	assert latest["pending_issue_defs"] == {
+		"issue-2": {"title": "Issue 2", "body": "Body 2", "priority": 2},
+	}
 	created = result.get("created_issues", [])
-	assert any(item.get("title") == "Issue 2" for item in created)
+	assert not any(item.get("title") == "Issue 2" for item in created)
+	assert (
+		"dispatch_deferred_blocker local_id=issue-2 wave=1 reason=blocked_by_dependency"
+		in result["stdout"]
+	)
 	assert latest["dependency_edges"] == [{"from": "issue-1", "to": "issue-2"}]
 
 


### PR DESCRIPTION
## Summary

Release **v1.17.0** ([run 27112686470](https://github.com/shubhodeep1/coding-workflows/actions/runs/27112686470)) failed with three red jobs. Of those, exactly one is a **deterministic, repo-fixable regression** — this PR fixes it. The other two are live-infrastructure/LLM-pipeline flakes (see "Other two failures" below), not code defects.

### Root cause (validate-scripts → "Unit tests")

`tests/test_orchestrate_poll_process.py::test_implementation_failed_reissue_preserves_dependency_gates_and_pending_defs` failed deterministically (`284 passed, 1 failed`).

- PR #3048 introduced the **U2 runtime blocker gate** (`scripts/blocker_check.py` + the deferred-creation gate in `scripts/orchestrate_poll_process.sh`), with `RUNTIME_BLOCKER_CHECK_ENABLED` defaulting to `true`.
- That gate defers a dependent issue's *deferred creation* until its blocker terminalizes.
- This test **pre-dates #3048** and encoded the old, un-gated behavior (create the dependent unconditionally). #3048 did not update it, so `main` has been red on this test since #3048 merged.

Verified empirically: pre-#3048 the poll script had no blocker gate and `blocker_check.py` did not exist → the dependent was created → test passed. Post-#3048 the gate defers it → test fails.

### The fix

Update the stale test to the documented U2 behavior. In the scenario, `issue-2` depends on `issue-1`, which is `implementation-failed` (non-terminal) and being reissued this tick, so the gate **correctly** defers `issue-2`:

- `issue-1` is reissued as a fresh issue (`#900`).
- `issue-2` stays in `pending_issue_defs` with its dependency edge intact, and the poller emits `dispatch_deferred_blocker`.

This is the same contract the companion tests `tests/test_blocker_check.py::test_next_wave_dispatch_defers_blocked_issue_until_future_tick` and `::test_current_wave_deferred_creation_uses_live_blocker_truth` already assert (dependent deferred while blocker non-terminal; created only once the blocker is terminal/merged). The test name — "preserves dependency gates **and pending defs**" — now matches its assertions (the pending def is preserved rather than cleared).

No production code changed; only the assertions inside this one test function.

## Other two failures (environmental — not fixed here)

- **e2e-smoke-test** — `Review phase stalled — no activity for 30 minutes` (Phase 4). The live `review_autofix` run never produced activity for the bait SHA within the 30m window — an LLM/CI timing stall, not a deterministic code defect.
- **workflow-log-analysis-test** — the dispatched `workflow-log-analysis` run ([27112704280](https://github.com/shubhodeep1/coding-workflows/actions/runs/27112704280)) failed because its `deep-audit` job was externally **canceled** ~30s into the Codex pass (`The operation was canceled.`). Not a job timeout (cap 75m), not concurrency (`cancel-in-progress: false`, no sibling run) — an infra-level cancellation.

Both should clear on a release re-run; this PR removes the only deterministic blocker.

## Verification

- `test_implementation_failed_reissue_preserves_dependency_gates_and_pending_defs` now passes.
- Full `tests/test_orchestrate_poll_process.py` and `tests/test_blocker_check.py` suites run clean locally.

Refs #3048

https://claude.ai/code/session_01EnNLD923e95Eqmuicaunum

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnNLD923e95Eqmuicaunum)_