### PR TITLE
Fix stale retry-prelude staging assertion that false-failed v1.17.0 release

### DIFF
--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -12569,12 +12569,17 @@ def test_resolver_tooling_refresh_allowlist_includes_both_retry_preludes():
 	# shape used by every prompt-staging block in the helper.
 	wf_body = (REPO_ROOT / ".github" / "workflows" / "review_autofix.yml").read_text(encoding="utf-8")
 	stage_helper_body = (REPO_ROOT / "scripts" / "stage_workflow_support.sh").read_text(encoding="utf-8")
+	wf_lines = wf_body.splitlines()
 	timeout_prelude_install_re = re.compile(
 		r"install -m 0644 [^\n]*\$\{SUPPORT_PROMPTS_DIR\}/integration-sync-conflict-resolver-retry-timeout-prelude\.txt",
 	)
-	stage_helper_exec_re = re.compile(
-		r'^\s*helper="[^"\n]*stage_workflow_support\.sh"$\n(?:.*\n){0,10}?^\s*bash "\$\{helper\}"$',
-		re.MULTILINE,
+	helper_line_idx = next(
+		(
+			idx
+			for idx, line in enumerate(wf_lines)
+			if re.search(r'helper="[^"\n]*stage_workflow_support\.sh"', line)
+		),
+		None,
 	)
 	assert timeout_prelude_install_re.search(stage_helper_body) is not None, (
 		"scripts/stage_workflow_support.sh does not stage the timeout-prelude "
@@ -12584,9 +12589,25 @@ def test_resolver_tooling_refresh_allowlist_includes_both_retry_preludes():
 		"the new prelude file would still hit a missing-template "
 		"::warning:: at runtime."
 	)
-	assert stage_helper_exec_re.search(wf_body) is not None, (
+	assert helper_line_idx is not None, (
+		"review_autofix.yml does not define a helper pointing at "
+		"stage_workflow_support.sh; the workflow-side bootstrap that stages "
+		"the resolver retry preludes is unwired."
+	)
+	next_step_idx = next(
+		(
+			idx
+			for idx, line in enumerate(wf_lines[helper_line_idx + 1 :], start=helper_line_idx + 1)
+			if re.match(r"^\s*-\s+name:", line)
+		),
+		len(wf_lines),
+	)
+	assert any(
+		re.search(r'^\s*bash "\$\{helper\}"$', line)
+		for line in wf_lines[helper_line_idx + 1 : next_step_idx]
+	), (
 		"review_autofix.yml no longer wires scripts/stage_workflow_support.sh via "
-		"the expected helper-assignment + `bash \"${helper}\"` sequence; "
+		"the expected helper-assignment + same-step `bash \"${helper}\"` sequence; "
 		"the workflow-side bootstrap that stages the resolver retry preludes "
 		"(including the timeout prelude) is unwired, so the script_ref pin "
 		"path no longer mirrors the orchestrator refresh path."

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -12572,6 +12572,10 @@ def test_resolver_tooling_refresh_allowlist_includes_both_retry_preludes():
 	timeout_prelude_install_re = re.compile(
 		r"install -m 0644 [^\n]*\$\{SUPPORT_PROMPTS_DIR\}/integration-sync-conflict-resolver-retry-timeout-prelude\.txt",
 	)
+	stage_helper_exec_re = re.compile(
+		r'^\s*helper="[^"\n]*stage_workflow_support\.sh"$\n(?:.*\n){0,10}?^\s*bash "\$\{helper\}"$',
+		re.MULTILINE,
+	)
 	assert timeout_prelude_install_re.search(stage_helper_body) is not None, (
 		"scripts/stage_workflow_support.sh does not stage the timeout-prelude "
 		"template via the expected `install -m 0644 ... ${SUPPORT_PROMPTS_DIR}/"
@@ -12580,8 +12584,9 @@ def test_resolver_tooling_refresh_allowlist_includes_both_retry_preludes():
 		"the new prelude file would still hit a missing-template "
 		"::warning:: at runtime."
 	)
-	assert "stage_workflow_support.sh" in wf_body, (
-		"review_autofix.yml no longer invokes scripts/stage_workflow_support.sh; "
+	assert stage_helper_exec_re.search(wf_body) is not None, (
+		"review_autofix.yml no longer wires scripts/stage_workflow_support.sh via "
+		"the expected helper-assignment + `bash \"${helper}\"` sequence; "
 		"the workflow-side bootstrap that stages the resolver retry preludes "
 		"(including the timeout prelude) is unwired, so the script_ref pin "
 		"path no longer mirrors the orchestrator refresh path."

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -12552,26 +12552,39 @@ def test_resolver_tooling_refresh_allowlist_includes_both_retry_preludes():
 			"would not pick up this prelude after a release, "
 			"silently disabling the corresponding retry-reflexion path."
 		)
-	# Defence-in-depth: the matching workflow-side bootstrap in
-	# review_autofix.yml must also stage the timeout-prelude file so the
-	# script_ref pin path mirrors the orchestrator refresh path.  Anchor
-	# the assertion on the actual `install -m 0644` staging line —
-	# matching the bare filename anywhere in the YAML would false-positive
-	# if the string remained only in an `echo "::warning::..."` line while
-	# the `install` line was removed or altered.  The signature
+	# Defence-in-depth: the matching workflow-side bootstrap must also
+	# stage the timeout-prelude file so the script_ref pin path mirrors
+	# the orchestrator refresh path.  PR #3191 extracted the inline
+	# support-staging block out of review_autofix.yml into
+	# scripts/stage_workflow_support.sh (to stay under GitHub Actions'
+	# per-step expression-template limit), so the `install -m 0644` line
+	# now lives in that script — but review_autofix.yml must still invoke
+	# it.  Anchor the staging assertion on the actual `install -m 0644`
+	# line in the helper script (matching the bare filename anywhere
+	# would false-positive if the string remained only in an
+	# `echo "::warning::..."` line while the `install` line was removed
+	# or altered) AND verify the workflow wires the helper, so neither
+	# half of the mirror can be silently dropped.  The signature
 	# `install -m 0644 ... ${SUPPORT_PROMPTS_DIR}/<file>` is the exact
-	# shape used by every prompt-staging block in this workflow.
+	# shape used by every prompt-staging block in the helper.
 	wf_body = (REPO_ROOT / ".github" / "workflows" / "review_autofix.yml").read_text(encoding="utf-8")
+	stage_helper_body = (REPO_ROOT / "scripts" / "stage_workflow_support.sh").read_text(encoding="utf-8")
 	timeout_prelude_install_re = re.compile(
 		r"install -m 0644 [^\n]*\$\{SUPPORT_PROMPTS_DIR\}/integration-sync-conflict-resolver-retry-timeout-prelude\.txt",
 	)
-	assert timeout_prelude_install_re.search(wf_body) is not None, (
-		"review_autofix.yml does not stage the timeout-prelude template "
-		"via the expected `install -m 0644 ... ${SUPPORT_PROMPTS_DIR}/"
+	assert timeout_prelude_install_re.search(stage_helper_body) is not None, (
+		"scripts/stage_workflow_support.sh does not stage the timeout-prelude "
+		"template via the expected `install -m 0644 ... ${SUPPORT_PROMPTS_DIR}/"
 		"integration-sync-conflict-resolver-retry-timeout-prelude.txt` "
 		"signature; consumer-repo runs whose pinned script_ref includes "
 		"the new prelude file would still hit a missing-template "
 		"::warning:: at runtime."
+	)
+	assert "stage_workflow_support.sh" in wf_body, (
+		"review_autofix.yml no longer invokes scripts/stage_workflow_support.sh; "
+		"the workflow-side bootstrap that stages the resolver retry preludes "
+		"(including the timeout prelude) is unwired, so the script_ref pin "
+		"path no longer mirrors the orchestrator refresh path."
 	)
 
 


### PR DESCRIPTION
## Summary

The v1.17.0 release run ([27136418558](https://github.com/shubhodeep1/coding-workflows/actions/runs/27136418558)) failed two jobs. Root causes are independent:

- **`validate-scripts` ✗ — real, fixed here.** A single unit test false-failed: `test_resolver_tooling_refresh_allowlist_includes_both_retry_preludes` (284 passed, **1 failed**, 285 total).
- **`e2e-smoke-test` ✗ — environmental, not fixable in code.** See below.

## `validate-scripts` root cause

PR #3191 extracted the inline support-staging block out of `.github/workflows/review_autofix.yml` into a new helper `scripts/stage_workflow_support.sh` (865 lines added; 721 removed from the YAML) to stay under GitHub Actions' per-step expression-template limit. That move carried the prompt-staging lines with it, including:

```
install -m 0644 "${src}" "${SUPPORT_PROMPTS_DIR}/integration-sync-conflict-resolver-retry-timeout-prelude.txt"
```

The defence-in-depth half of `test_resolver_tooling_refresh_allowlist_includes_both_retry_preludes` still grepped **`review_autofix.yml`** for that `install -m 0644` line. After the extraction the line lives in `scripts/stage_workflow_support.sh:336`, so the assertion false-failed — even though the staging is intact and correctly wired (`review_autofix.yml:1260` invokes `stage_workflow_support.sh`, which stages **both** the standard prelude `:324` and the timeout prelude `:336`). The migration simply wasn't applied to this one test.

### Fix

Retarget the staging assertion to `scripts/stage_workflow_support.sh` (where the `install -m 0644` line now lives) and additionally assert that `review_autofix.yml` still invokes `stage_workflow_support.sh`, so neither half of the script-ref mirror can be silently dropped. This mirrors the migration already applied to `test_review_autofix_workflow_wires_optional_verifier_bootstrap_and_gate`. The orchestrator-side half of the test (the `refresh_files=( ... )` array check against `orchestrate_poll_process.sh`) is unchanged and was already passing.

Verified locally: the test now **PASSES** and no other test in the file regressed. (The file's one remaining local failure, `test_verify_integration_fingerprints_baseline_regressions`, is a sandbox-only `git commit` exit-128 artifact — it **PASSED** in the v1.17.0 CI run and does not read either touched file.)

## `e2e-smoke-test` — environmental, no code fix

Phase 4 stalled with *"Review phase stalled — no activity for 30 minutes."* The review_autofix run it waited on ([27137141175](https://github.com/shubhodeep1/coding-workflows/actions/runs/27137141175), head `fa6f587`) was created at 12:19:01, sat **queued with zero jobs ever scheduled** for the full 30 minutes (`step: ?, log: 0b` every poll), and was then cancelled by the e2e cleanup at 12:49:13 (`conclusion: cancelled`, `total_count: 0` jobs). It was the first review run for that PR, so no sibling run held the `pr-autofix-<PR#>` concurrency group. The run never started a job, so the `stage_workflow_support.sh` extraction cannot be implicated. This is GitHub-hosted runner starvation during a very heavy release (the same release ran `workflow-log-analysis-test` for 2h56m plus a full clarify→plan→implement→review pipeline spawned by the e2e test issue, all competing for runners). No code defect; not addressed in this PR.

Refs the v1.17.0 release failure investigation.

---
_Generated by [Claude Code](https://claude.ai/code/session_012c6MMn1xrFdRAYZvETGJF9)_