### PR TITLE
Raise ai-memory push retry budget 5→8 so branch contention can't kill the plan phase

### DIFF
--- a/ai-memory/README.md
+++ b/ai-memory/README.md
@@ -82,7 +82,7 @@ Processed command CLI:
 - `AI_MEMORY_BRANCH` (default `ai-memory`)
 - `AI_MEMORY_ROOT` (default `ai-memory`)
 - `AI_MEMORY_RETRIEVAL_PROFILES` (default `ai-memory/config/retrieval_profiles.v1.json`)
-- `AI_MEMORY_PUSH_RETRIES` (default `5`)
+- `AI_MEMORY_PUSH_RETRIES` (default `8`)
 - `AI_MEMORY_KEYWORD_MODEL` (default `openai/gpt-5.4-nano`) — model for semantic keyword extraction
 - `AI_MEMORY_KEYWORD_BASE_URL` (default `https://openrouter.ai/api/v1`) — API base URL for keyword model
 - `AI_MEMORY_TOKEN_BUDGET_<ROLE>` — per-role token budget override (e.g. `AI_MEMORY_TOKEN_BUDGET_IMPLEMENTATION=3200`)

--- a/scripts/ai_memory.py
+++ b/scripts/ai_memory.py
@@ -106,10 +106,14 @@ def _read_env_defaults(args: argparse.Namespace) -> argparse.Namespace:
         # loop fetches+rebases+re-pushes — but 5 attempts only sleeps for the
         # first 4 (backoff ceilings 0.5/1/2/4s, never reaching the 8s cap the
         # jitter was designed around), so heavy bursts exhaust the budget and the
-        # fail-closed claim aborts the whole phase before it can post (issue
-        # #3244). 8 attempts activates the 8s-cap sleeps and widens the
-        # decorrelation window to ~30s without weakening the mutex semantics.
-        args.push_retries = int(os.getenv("AI_MEMORY_PUSH_RETRIES", "8"))
+        # fail-closed claim aborts the whole phase before it can post. 8
+        # attempts activates the 8s-cap sleeps and widens the decorrelation
+        # window to ~30s without weakening the mutex semantics.
+        push_retries_env = os.getenv("AI_MEMORY_PUSH_RETRIES")
+        args.push_retries = _require_positive_int(
+            "8" if push_retries_env is None else push_retries_env,
+            "AI_MEMORY_PUSH_RETRIES",
+        )
     if not getattr(args, "enabled", None):
         args.enabled = parse_bool(os.getenv("AI_MEMORY_ENABLED", "true"), default=True)
     if not getattr(args, "retrieval_profiles", None):

--- a/scripts/ai_memory.py
+++ b/scripts/ai_memory.py
@@ -100,7 +100,16 @@ def _read_env_defaults(args: argparse.Namespace) -> argparse.Namespace:
     if not getattr(args, "memory_root", None):
         args.memory_root = os.getenv("AI_MEMORY_ROOT", "ai-memory")
     if getattr(args, "push_retries", None) is None:
-        args.push_retries = int(os.getenv("AI_MEMORY_PUSH_RETRIES", "5"))
+        # The single shared `ai-memory` branch is a hot contention point under
+        # orchestrator bursts: every concurrent clarify/plan/implement/review run
+        # pushes to it. A non-fast-forward rejection is transient — the retry
+        # loop fetches+rebases+re-pushes — but 5 attempts only sleeps for the
+        # first 4 (backoff ceilings 0.5/1/2/4s, never reaching the 8s cap the
+        # jitter was designed around), so heavy bursts exhaust the budget and the
+        # fail-closed claim aborts the whole phase before it can post (issue
+        # #3244). 8 attempts activates the 8s-cap sleeps and widens the
+        # decorrelation window to ~30s without weakening the mutex semantics.
+        args.push_retries = int(os.getenv("AI_MEMORY_PUSH_RETRIES", "8"))
     if not getattr(args, "enabled", None):
         args.enabled = parse_bool(os.getenv("AI_MEMORY_ENABLED", "true"), default=True)
     if not getattr(args, "retrieval_profiles", None):

--- a/scripts/collect_workflow_logs.py
+++ b/scripts/collect_workflow_logs.py
@@ -1305,7 +1305,7 @@ def main(argv: list[str] | None = None) -> int:
     memory_branch = str(os.getenv("AI_MEMORY_BRANCH", "ai-memory")).strip() or "ai-memory"
     memory_root_relative = str(os.getenv("AI_MEMORY_ROOT", "ai-memory")).strip() or "ai-memory"
     # Keep the AI_MEMORY_PUSH_RETRIES default in sync with scripts/ai_memory.py
-    # (raised 5 -> 8 to survive shared ai-memory branch contention; see #3244).
+    # (raised 5 -> 8 to survive shared ai-memory branch contention).
     push_retries = _to_int(os.getenv("AI_MEMORY_PUSH_RETRIES", "8"), 8)
 
     cache_payload, _cache_load_error, cache_branch_dir = _cache_read_context(

--- a/scripts/collect_workflow_logs.py
+++ b/scripts/collect_workflow_logs.py
@@ -1304,7 +1304,9 @@ def main(argv: list[str] | None = None) -> int:
     repo_root = REPO_ROOT
     memory_branch = str(os.getenv("AI_MEMORY_BRANCH", "ai-memory")).strip() or "ai-memory"
     memory_root_relative = str(os.getenv("AI_MEMORY_ROOT", "ai-memory")).strip() or "ai-memory"
-    push_retries = _to_int(os.getenv("AI_MEMORY_PUSH_RETRIES", "5"), 5)
+    # Keep the AI_MEMORY_PUSH_RETRIES default in sync with scripts/ai_memory.py
+    # (raised 5 -> 8 to survive shared ai-memory branch contention; see #3244).
+    push_retries = _to_int(os.getenv("AI_MEMORY_PUSH_RETRIES", "8"), 8)
 
     cache_payload, _cache_load_error, cache_branch_dir = _cache_read_context(
         repo_root=repo_root,

--- a/tests/test_ai_memory_processed_command_entry.py
+++ b/tests/test_ai_memory_processed_command_entry.py
@@ -1256,6 +1256,28 @@ def test_tracking_issue_cli_validation_happens_before_memory_io() -> None:
 			assert "tracking_issue must be a positive integer" in stderr
 
 
+def test_push_retries_env_default_survives_shared_branch_contention() -> None:
+	# Regression for #3244: the /answer claim aborted the whole plan phase when
+	# 5 push attempts were exhausted by ai-memory branch contention. The default
+	# budget must stay >= 8 so the jittered backoff has enough attempts (and
+	# reaches the 8s cap) to win the ref-lock race under orchestrator bursts.
+	import argparse as _argparse
+
+	original = os.environ.pop("AI_MEMORY_PUSH_RETRIES", None)
+	try:
+		args = ai_memory._read_env_defaults(_argparse.Namespace())
+		assert args.push_retries >= 8, args.push_retries
+		# An explicit override is still honoured.
+		os.environ["AI_MEMORY_PUSH_RETRIES"] = "3"
+		overridden = ai_memory._read_env_defaults(_argparse.Namespace())
+		assert overridden.push_retries == 3, overridden.push_retries
+	finally:
+		if original is None:
+			os.environ.pop("AI_MEMORY_PUSH_RETRIES", None)
+		else:
+			os.environ["AI_MEMORY_PUSH_RETRIES"] = original
+
+
 def main() -> int:
 	test_cleanup_paths = globals().setdefault("_TEST_CLEANUP_PATHS", [])
 	test_funcs = [v for k, v in sorted(globals().items()) if k.startswith("test_")]

--- a/tests/test_ai_memory_processed_command_entry.py
+++ b/tests/test_ai_memory_processed_command_entry.py
@@ -1256,11 +1256,9 @@ def test_tracking_issue_cli_validation_happens_before_memory_io() -> None:
 			assert "tracking_issue must be a positive integer" in stderr
 
 
-def test_push_retries_env_default_survives_shared_branch_contention() -> None:
-	# Regression for #3244: the /answer claim aborted the whole plan phase when
-	# 5 push attempts were exhausted by ai-memory branch contention. The default
-	# budget must stay >= 8 so the jittered backoff has enough attempts (and
-	# reaches the 8s cap) to win the ref-lock race under orchestrator bursts.
+def test_push_retries_env_default_override_and_validation() -> None:
+	# Lock in the raised default budget, explicit override handling, and
+	# malformed-env validation for the shared ai-memory branch retry knob.
 	import argparse as _argparse
 
 	original = os.environ.pop("AI_MEMORY_PUSH_RETRIES", None)
@@ -1271,6 +1269,13 @@ def test_push_retries_env_default_survives_shared_branch_contention() -> None:
 		os.environ["AI_MEMORY_PUSH_RETRIES"] = "3"
 		overridden = ai_memory._read_env_defaults(_argparse.Namespace())
 		assert overridden.push_retries == 3, overridden.push_retries
+		os.environ["AI_MEMORY_PUSH_RETRIES"] = "abc"
+		try:
+			ai_memory._read_env_defaults(_argparse.Namespace())
+		except ai_memory.MemoryValidationError as exc:
+			assert "AI_MEMORY_PUSH_RETRIES must be a positive integer" in str(exc)
+		else:
+			raise AssertionError("expected MemoryValidationError for malformed AI_MEMORY_PUSH_RETRIES")
 	finally:
 		if original is None:
 			os.environ.pop("AI_MEMORY_PUSH_RETRIES", None)

--- a/tests/test_ai_memory_push_retry_backoff.py
+++ b/tests/test_ai_memory_push_retry_backoff.py
@@ -260,6 +260,22 @@ def test_persist_memory_operation_backs_off_every_attempt_before_raising() -> No
 	assert backoff_attempts == [1, 2, 3], backoff_attempts
 
 
+def test_persist_memory_operation_survives_seven_rejections_with_default_budget() -> None:
+	# Regression for #3244: under the raised default budget (8) a burst of 7
+	# consecutive non-fast-forward rejections (shared ai-memory branch
+	# contention) must still land on the 8th attempt instead of aborting the
+	# fail-closed claim — which previously killed the plan phase at 5 attempts.
+	result, backoff_attempts, _call_log, exc = _run_persist(
+		[1, 1, 1, 1, 1, 1, 1, 0], push_retries=8
+	)
+	assert exc is None, exc
+	assert result is not None
+	assert result["did_push"] is True, result
+	assert result["push_attempts"] == 8, result
+	# Backoff fires after each of the 7 failed attempts, not after the success.
+	assert backoff_attempts == [1, 2, 3, 4, 5, 6, 7], backoff_attempts
+
+
 def test_persist_memory_operation_raises_on_fetch_failure_before_rebase() -> None:
 	result, backoff_attempts, call_log, exc = _run_persist([1], push_retries=2, fetch_codes=[1])
 	assert result is None

--- a/tests/test_ai_memory_push_retry_backoff.py
+++ b/tests/test_ai_memory_push_retry_backoff.py
@@ -260,11 +260,11 @@ def test_persist_memory_operation_backs_off_every_attempt_before_raising() -> No
 	assert backoff_attempts == [1, 2, 3], backoff_attempts
 
 
-def test_persist_memory_operation_survives_seven_rejections_with_default_budget() -> None:
-	# Regression for #3244: under the raised default budget (8) a burst of 7
-	# consecutive non-fast-forward rejections (shared ai-memory branch
-	# contention) must still land on the 8th attempt instead of aborting the
-	# fail-closed claim — which previously killed the plan phase at 5 attempts.
+def test_persist_memory_operation_survives_seven_rejections_with_eight_retry_budget() -> None:
+	# Regression coverage for shared ai-memory branch contention: under the
+	# raised retry budget (8), a burst of 7 consecutive non-fast-forward
+	# rejections must still land on the 8th attempt instead of aborting the
+	# fail-closed claim.
 	result, backoff_attempts, _call_log, exc = _run_persist(
 		[1, 1, 1, 1, 1, 1, 1, 0], push_retries=8
 	)


### PR DESCRIPTION
## Summary

The AI Plan phase for issue #3244 failed at the **`Check and claim /answer command`** step, before posting the implementation plan ([run 27233531187](https://github.com/shubhodeep1/coding-workflows/actions/runs/27233531187)).

**Root cause:** the `/answer` command claim persists to the single shared `ai-memory` git branch, which every concurrent clarify/plan/implement/review run also pushes to. Under an orchestrator burst the push hit a non-fast-forward rejection (`! [rejected] HEAD -> ai-memory (fetch first)`) on all 5 retry attempts and raised `MemoryGitError`. Unlike every other memory wrapper (which fail open), `memory_processed_command_claim` is a deliberately **fail-closed mutex** — so the exhausted retry budget aborted the entire planning phase before it could post.

The retry loop already fetches + rebases + re-pushes with jittered exponential backoff that was built specifically for this contention (see `tests/test_ai_memory_push_retry_backoff.py`). But at **5** attempts it only sleeps for attempts 1–4 (backoff ceilings 0.5 / 1 / 2 / 4 s) and **never reaches the 8 s cap** the jitter was designed around. Raising the default budget to **8** activates the 8 s-cap sleeps and widens the decorrelation window from ~7.5 s to ~30 s, giving the push enough attempts to win the ref-lock race — **without weakening the fail-closed mutex semantics** (the test asserting `claiming is mutual exclusion and is not fail-open` is unchanged and still passes).

## Evidence

- `Failed to push memory branch after 5 attempts … ! [rejected] HEAD -> ai-memory (fetch first)` → `##[error]Process completed with exit code 2` in the `Check and claim /answer command` step (run 27233531187, job 80419555378).
- `memory_processed_command_claim` is the only memory wrapper without a fail-open `||` guard — `scripts/memory_helpers.sh:420-429` vs. the fail-open `complete`/`check`/etc. wrappers.
- The exhausted-budget raise: `scripts/ai_memory_lib.py:2504-2507`; the recovery path only swallows the error when a *duplicate* claim already exists (`scripts/ai_memory.py:1816-1855`), so pure contention re-raises.
- Backoff was added for this exact `Failed to push memory branch after N attempts` failure and its tests already iterate attempts 1..8 — `tests/test_ai_memory_push_retry_backoff.py`.

## Changes

- `scripts/ai_memory.py` — `AI_MEMORY_PUSH_RETRIES` default `5` → `8` (env override still honoured).
- `scripts/collect_workflow_logs.py` — keep the same env-var default in sync.
- `tests/test_ai_memory_processed_command_entry.py` — lock in the `>= 8` default and that an explicit override is still honoured.
- `tests/test_ai_memory_push_retry_backoff.py` — assert a 7-rejection burst lands on the 8th attempt under the default budget.

Refs #3244

https://claude.ai/code/session_01FcgeQJF3vopkGHSKB371Wx

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcgeQJF3vopkGHSKB371Wx)_