### PR TITLE
fix(smoke): accept in-flight PR-open review as the bait review in wait-review

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1203,6 +1203,9 @@ jobs:
           # falls back to the strict head_sha pin instead of broadening
           # leg (b) with a non-timestamp placeholder.
           BAIT_CREATED_AT=$(jq -r '.commit.committer.date // .commit.author.date // empty | select(type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))' /tmp/bait_resp.json 2>/dev/null || echo "")
+          if [ -z "${BAIT_CREATED_AT}" ]; then
+            echo "::warning::bait_created_at is empty despite bait injection; wait-review leg (b) will be inert (strict head_sha pin only)"
+          fi
           echo "bait_created_at=${BAIT_CREATED_AT}" >> "$GITHUB_OUTPUT"
 
           # Defense-in-depth for "Bug B" (PR #1811): the Contents-API PUT

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1199,7 +1199,10 @@ jobs:
           # bait landed and is an acceptable bait review; a run that
           # finished before the bait is not. committer.date is the
           # GitHub-assigned push time for the Contents-API commit.
-          BAIT_CREATED_AT=$(jq -r '.commit.committer.date // .commit.author.date // empty' /tmp/bait_resp.json 2>/dev/null || echo "")
+          # Invalid/malformed values are cleared to empty so wait-review
+          # falls back to the strict head_sha pin instead of broadening
+          # leg (b) with a non-timestamp placeholder.
+          BAIT_CREATED_AT=$(jq -r '.commit.committer.date // .commit.author.date // empty | select(type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))' /tmp/bait_resp.json 2>/dev/null || echo "")
           echo "bait_created_at=${BAIT_CREATED_AT}" >> "$GITHUB_OUTPUT"
 
           # Defense-in-depth for "Bug B" (PR #1811): the Contents-API PUT
@@ -1406,16 +1409,18 @@ jobs:
               #
               # Preference order over $m:
               #   1. newest completed non-cancelled run (terminal accept);
-              #   2. newest in_progress run — an actively-running review,
-              #      preferred over a queued/pending sibling so the loop
-              #      watches real progress (the v1.17.0 fix);
-              #   3. newest non-cancelled run (queued/pending fallback);
-              #   4. newest run overall (all cancelled).
+              #   2. oldest in_progress run that already spanned the bait
+              #      timestamp — this is the original long-running PR-open
+              #      review, and it must win over a newer caller workflow
+              #      run that is merely blocked behind it;
+              #   3. newest in_progress run (generic active-run fallback);
+              #   4. newest non-cancelled run (queued/pending fallback);
+              #   5. newest run overall (all cancelled).
               # Tier 1 still precedes 2 so an already-completed success
-              # wins over a newer in-progress sibling (preserves the
-              # run-26989483268 fix).
+              # wins over an active sibling (preserves the run-26989483268
+              # fix).
               REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&per_page=100" \
-                --jq "[.workflow_runs[] | select(.name | test(\"Review|review|autofix|self-healing\"; \"i\")) | select(.head_sha == \"${PIN_SHA}\" or (\"${BAIT_CREATED_AT:-}\" != \"\" and .created_at <= \"${BAIT_CREATED_AT:-}\" and .updated_at >= \"${BAIT_CREATED_AT:-}\"))] as \$m | (\$m | map(select(.status == \"completed\" and .conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | map(select(.status == \"in_progress\")) | sort_by(.created_at) | last) // (\$m | map(select(.conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | sort_by(.created_at) | last)" || echo "")
+                --jq "[.workflow_runs[] | select(.name | test(\"Review|review|autofix|self-healing\"; \"i\")) | select(.head_sha == \"${PIN_SHA}\" or (\"${BAIT_CREATED_AT:-}\" != \"\" and .created_at <= \"${BAIT_CREATED_AT:-}\" and .updated_at >= \"${BAIT_CREATED_AT:-}\"))] as \$m | (\$m | map(select(.status == \"completed\" and .conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | map(select(.status == \"in_progress\" and \"${BAIT_CREATED_AT:-}\" != \"\" and .created_at <= \"${BAIT_CREATED_AT:-}\" and .updated_at >= \"${BAIT_CREATED_AT:-}\")) | sort_by(.created_at) | first) // (\$m | map(select(.status == \"in_progress\")) | sort_by(.created_at) | last) // (\$m | map(select(.conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | sort_by(.created_at) | last)" || echo "")
             else
               REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&event=pull_request&per_page=5" \
                 --jq '[.workflow_runs[] | select(.name | test("Review|review|autofix|self-healing"; "i"))] | sort_by(.created_at) | last' || echo "")

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1181,6 +1181,27 @@ jobs:
           echo "status=injected" >> "$GITHUB_OUTPUT"
           echo "bait_sha=${BAIT_SHA}" >> "$GITHUB_OUTPUT"
 
+          # Emit the bait commit's timestamp (ISO-8601 UTC, e.g.
+          # 2026-06-10T00:11:43Z) so wait-review (Phase 4) can recognise
+          # the in-flight PR-open review run as a valid bait review.
+          # That run is TRIGGERED on the pre-bait head SHA, so its
+          # run-level head_sha never equals BAIT_SHA and the strict
+          # head_sha pin excludes it — yet because review_autofix.yml
+          # checks out the live branch tip at runtime, a review still
+          # running when the bait lands actually reviews+edits the bait
+          # tree (confirmed by INITIAL_HEAD_SHA=<bait> in its log). The
+          # only thing distinguishing it from the historical
+          # stale-implement-review false match (run 25147636528, which
+          # COMPLETED before the bait) is whether it was still in flight
+          # at bait-injection time. wait-review uses this timestamp as
+          # the lower bound: a run with created_at <= bait_created_at
+          # and updated_at >= bait_created_at was in flight when the
+          # bait landed and is an acceptable bait review; a run that
+          # finished before the bait is not. committer.date is the
+          # GitHub-assigned push time for the Contents-API commit.
+          BAIT_CREATED_AT=$(jq -r '.commit.committer.date // .commit.author.date // empty' /tmp/bait_resp.json 2>/dev/null || echo "")
+          echo "bait_created_at=${BAIT_CREATED_AT}" >> "$GITHUB_OUTPUT"
+
           # Defense-in-depth for "Bug B" (PR #1811): the Contents-API PUT
           # above sometimes succeeds (commit + PR head pointer updated)
           # without GitHub fanning out a `pull_request: synchronize`
@@ -1243,6 +1264,15 @@ jobs:
           # filter so non-bait runs (no bait was injected this run) are
           # unaffected.
           BAIT_SHA: ${{ steps.inject-bait.outputs.bait_sha }}
+          # ISO-8601 UTC timestamp of the bait commit (see inject-bait).
+          # Lower bound for recognising the in-flight PR-open review run
+          # as a valid bait review even though its run-level head_sha is
+          # the pre-bait SHA: a review still running when the bait landed
+          # checked out the live (post-bait) tip and reviewed+edited it.
+          # Empty when no bait was injected (status != injected); the jq
+          # below then leaves the strict head_sha pin untouched because
+          # the date comparison short-circuits to false on an empty bound.
+          BAIT_CREATED_AT: ${{ steps.inject-bait.outputs.bait_created_at }}
           # Promoted to env so the run: script body contains no ${{ }}
           # interpolations. With even one inline expression, GitHub Actions
           # treats the entire script as a single expression and enforces a
@@ -1347,15 +1377,45 @@ jobs:
             # workflow_dispatch run at that SHA was filtered out and the
             # poll timed out 30m later.
             if [ -n "${PIN_SHA:-}" ]; then
-              # Among matching runs at PIN_SHA, prefer the newest
-              # completed non-cancelled run. If none has completed yet,
-              # watch the newest non-cancelled live run, and fall back to
-              # the newest cancelled run only when every matching run is
-              # cancelled. This fixes run-26989483268 and avoids picking a
-              # newer queued/in-progress sibling over an already-completed
-              # success on the same head SHA.
+              # Candidate set ($m): name-matched review runs that EITHER
+              #   (a) carry head_sha == PIN_SHA — the Phase 3c
+              #       workflow_dispatch fallback and the bait
+              #       pull_request:synchronize run; OR
+              #   (b) were in flight when the bait commit landed
+              #       (created_at <= BAIT_CREATED_AT <= updated_at).
+              # Leg (b) recovers the original PR-open review run: it is
+              # triggered on the pre-bait head SHA (so its run-level
+              # head_sha never equals BAIT_SHA and leg (a) misses it),
+              # but because review_autofix.yml checks out the live branch
+              # tip at runtime, a review still running when the bait
+              # landed actually reviews+edits the bait tree. Crucially,
+              # the bait-SHA runs in leg (a) all serialise behind that
+              # original run in review_autofix.yml's `pr-autofix-${PR}`
+              # concurrency group (cancel-in-progress: false), so when
+              # the original review runs long they stay queued/pending
+              # past REVIEW_TIMEOUT and the loop, pinned to a 0-activity
+              # pending sibling, ages out — the failure on runs
+              # 27137020958 / 27244093614 (v1.17.0). Leg (b) lets the
+              # loop watch the actually-running review instead; its
+              # growing job log registers as activity each poll and
+              # resets the inactivity timer until it completes.
+              # The BAIT_CREATED_AT guard (!= "") keeps leg (b) inert
+              # when no bait was injected, and the updated_at >= bound
+              # excludes the historical stale-implement-review false
+              # match (run 25147636528) which COMPLETED before the bait.
+              #
+              # Preference order over $m:
+              #   1. newest completed non-cancelled run (terminal accept);
+              #   2. newest in_progress run — an actively-running review,
+              #      preferred over a queued/pending sibling so the loop
+              #      watches real progress (the v1.17.0 fix);
+              #   3. newest non-cancelled run (queued/pending fallback);
+              #   4. newest run overall (all cancelled).
+              # Tier 1 still precedes 2 so an already-completed success
+              # wins over a newer in-progress sibling (preserves the
+              # run-26989483268 fix).
               REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&per_page=100" \
-                --jq "[.workflow_runs[] | select(.name | test(\"Review|review|autofix|self-healing\"; \"i\")) | select(.head_sha == \"${PIN_SHA}\")] as \$m | (\$m | map(select(.status == \"completed\" and .conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | map(select(.conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | sort_by(.created_at) | last)" || echo "")
+                --jq "[.workflow_runs[] | select(.name | test(\"Review|review|autofix|self-healing\"; \"i\")) | select(.head_sha == \"${PIN_SHA}\" or (\"${BAIT_CREATED_AT:-}\" != \"\" and .created_at <= \"${BAIT_CREATED_AT:-}\" and .updated_at >= \"${BAIT_CREATED_AT:-}\"))] as \$m | (\$m | map(select(.status == \"completed\" and .conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | map(select(.status == \"in_progress\")) | sort_by(.created_at) | last) // (\$m | map(select(.conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | sort_by(.created_at) | last)" || echo "")
             else
               REVIEW_RUN=$(gh_api_safe "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&event=pull_request&per_page=5" \
                 --jq '[.workflow_runs[] | select(.name | test("Review|review|autofix|self-healing"; "i"))] | sort_by(.created_at) | last' || echo "")


### PR DESCRIPTION
## Summary

The `e2e-smoke-test` release gate failed at **"Phase 4: Wait for review & autofix to complete"** on the v1.17.0 release ([run 27243679027](https://github.com/shubhodeep1/coding-workflows/actions/runs/27243679027)) — and on the two prior releases (06-08 ×2). All three failed at the same step, so this is a reproducible structural failure, not a flake.

## Root cause

The `review_autofix` `codex-agent` runtime regressed from **~15 min** (last passing run, 06-06: job `27055123443`, 06:34:23→06:48:59) to **~37–41 min** (failing runs: `27244093614` ran 00:09:38→00:47:05; `27137020958` ran 41 min). Combined with two pre-existing harness assumptions, that slowdown became fatal:

1. Every `review_autofix` run for a PR serialises in `review_autofix.yml`'s `pr-autofix-${PR}` concurrency group with `cancel-in-progress: false` (`review_autofix.yml:1059-1060`).
2. The smoke test injects the bait commit while the original PR-open review is still running. The bait's `pull_request:synchronize` run (`27244183219`) and the Phase 3c `workflow_dispatch` fallback (`27244180619`) — the only runs carrying `head_sha == BAIT_SHA` — therefore sit **queued/pending** behind the long original review and cannot start within the 30-min `REVIEW_TIMEOUT`.

`wait-review` pinned strictly to `head_sha == BAIT_SHA`, so it latched onto the **0-activity `pending`** synchronize run and aged out on the inactivity timer (`log_sz` stuck at `0b` for the full 30 min). Meanwhile the **original PR-open review run** — triggered on the pre-bait SHA but checking out the live, post-bait tip at runtime (`INITIAL_HEAD_SHA=35369ba…` in its log) — actually reviewed+edited the bait tree and **succeeded at 00:47**, but was excluded by the strict pin (its run-level `head_sha` is the pre-bait SHA).

Because the 30-min budget is an **inactivity** timer (it resets on activity), watching the actively-running original review would have kept it alive to completion. The loop was simply watching the wrong (blocked) run.

## Fix (harness only — `test-and-mark-stable.yml`)

- **inject-bait** now emits `bait_created_at` (the bait commit's ISO-8601 push time) as a step output.
- **wait-review** broadens its candidate set to also include a review run that was *in flight when the bait landed* (`created_at <= bait_created_at <= updated_at`). The `updated_at` lower bound preserves the stale-implement-review guard (run 25147636528, which **completed before** the bait); the `bait_created_at != ""` guard keeps the broadening inert when no bait was injected.
- The selection gains an **`in_progress` preference tier** so the loop watches an actively-running review (whose growing log keeps the inactivity timer alive) instead of a blocked `pending` sibling. Tier 1 (completed non-cancelled) still precedes it, preserving the run-26989483268 fix.

Phase 4b independently re-verifies (pytest) that the editor restored the canary, so a broadened accept here is still backstopped.

## Verification

Tested the jq selection against the v1.17.0 inventory:
- original `in_progress` while bait-SHA runs queued/pending → picks the **in_progress original** (not the pending sibling);
- original completed success → accepts it;
- stale review that completed **before** the bait → returns `null` (guard preserved);
- empty `bait_created_at` → no behavior change (legacy head_sha pin only);
- completed bait-SHA success vs in-progress sibling → success still wins.

The `wait-review` `run:` body remains free of `${{ }}` expressions (the 21k-char guard). YAML validated.

## Note on the underlying slowdown

This PR makes the gate robust to a slow-but-successful predecessor review; it does **not** address *why* `codex-agent` regressed ~2.5×. That window is one long codex-exec block plus a fixed 300s check-run wait, and the soft-error analysis flags misclassified retries / "editor produced no summary — retrying" — largely LLM-latency/behavioral and not pinned to a specific commit. Worth a separate investigation if review runtimes stay elevated.

Refs run 27243679027.

https://claude.ai/code/session_01XDf39TNf8kMbQ2UBwEHvSv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDf39TNf8kMbQ2UBwEHvSv)_