### PR TITLE
Fix render_prompt reference resolver crashing on inline embedded {{REFERENCE_*}} tokens

### DIFF
--- a/scripts/render_prompt.py
+++ b/scripts/render_prompt.py
@@ -227,7 +227,7 @@ def _reference_file_names_for_placeholder(mode_name: str, placeholder_name: str)
 
 
 def collect_reference_values(prompt_text: str, *, prompt_path: Path, mode_name: str) -> dict[str, str]:
-	reference_placeholders = sorted(
+	reference_placeholders = tuple(
 		name for name in collect_standalone_placeholders(prompt_text) if name.startswith("REFERENCE_")
 	)
 	values: dict[str, str] = {}

--- a/scripts/render_prompt.py
+++ b/scripts/render_prompt.py
@@ -511,13 +511,12 @@ def collect_placeholders(prompt_text: str) -> tuple[str, ...]:
 
 
 def collect_standalone_placeholders(prompt_text: str) -> tuple[str, ...]:
-	# Only placeholders that occupy a whole line are block-substituted by
-	# render_prompt_text (via STANDALONE_PLACEHOLDER_PATTERN); inline
-	# occurrences are left literal unless the name is a known scalar value.
-	# Reference resolution must mirror that contract so a {{REFERENCE_*}}
-	# token that appears *inline* inside untrusted embedded content (e.g. a
-	# reviewer-consensus example quoted in the editor prompt body) is never
-	# treated as a real placeholder.
+	# Only placeholders that occupy a whole line participate in the
+	# standalone-line branch of render_prompt_text
+	# (STANDALONE_PLACEHOLDER_PATTERN.fullmatch(line)). Reference
+	# resolution must mirror that contract so inline {{REFERENCE_*}} tokens
+	# inside embedded untrusted content are never treated as real
+	# placeholders.
 	names: set[str] = set()
 	for line in prompt_text.splitlines():
 		match = STANDALONE_PLACEHOLDER_PATTERN.fullmatch(line)

--- a/scripts/render_prompt.py
+++ b/scripts/render_prompt.py
@@ -228,7 +228,7 @@ def _reference_file_names_for_placeholder(mode_name: str, placeholder_name: str)
 
 def collect_reference_values(prompt_text: str, *, prompt_path: Path, mode_name: str) -> dict[str, str]:
 	reference_placeholders = sorted(
-		name for name in collect_placeholders(prompt_text) if name.startswith("REFERENCE_")
+		name for name in collect_standalone_placeholders(prompt_text) if name.startswith("REFERENCE_")
 	)
 	values: dict[str, str] = {}
 	for placeholder_name in reference_placeholders:
@@ -508,6 +508,22 @@ def load_contract(contract_path: Path, mode_name: str) -> PromptContract:
 
 def collect_placeholders(prompt_text: str) -> tuple[str, ...]:
 	return tuple(sorted(set(PLACEHOLDER_PATTERN.findall(prompt_text))))
+
+
+def collect_standalone_placeholders(prompt_text: str) -> tuple[str, ...]:
+	# Only placeholders that occupy a whole line are block-substituted by
+	# render_prompt_text (via STANDALONE_PLACEHOLDER_PATTERN); inline
+	# occurrences are left literal unless the name is a known scalar value.
+	# Reference resolution must mirror that contract so a {{REFERENCE_*}}
+	# token that appears *inline* inside untrusted embedded content (e.g. a
+	# reviewer-consensus example quoted in the editor prompt body) is never
+	# treated as a real placeholder.
+	names: set[str] = set()
+	for line in prompt_text.splitlines():
+		match = STANDALONE_PLACEHOLDER_PATTERN.fullmatch(line)
+		if match is not None:
+			names.add(match.group(1))
+	return tuple(sorted(names))
 
 
 def validate_contract(contract: PromptContract, prompt_text: str, values: dict[str, str]) -> None:

--- a/tests/test_render_prompt_foundation.py
+++ b/tests/test_render_prompt_foundation.py
@@ -215,6 +215,58 @@ def test_render_prompt_py_reports_missing_reference_file() -> None:
 	assert "prompts/references/output-contract.txt" in proc.stderr
 
 
+def test_render_prompt_py_ignores_inline_unknown_reference_placeholder() -> None:
+	# Runtime-assembled prompt bodies inline untrusted artifacts (reviewer
+	# consensus, PR diffs, comments). A {{REFERENCE_*}}-shaped token that
+	# appears *inline* inside such content — e.g. a reviewer quoting the typo
+	# `{{REFERENCE_OUTPUT_CONTRAC}}` as an example — must be left literal, not
+	# treated as a real placeholder. Regression for the autofix editor step
+	# aborting with "Unknown reference placeholder 'REFERENCE_OUTPUT_CONTRAC'".
+	with tempfile.TemporaryDirectory(prefix="render_prompt_foundation_inline_ref_") as td:
+		prompt_file = Path(td) / "editor_prompt_body.txt"
+		prompt_file.write_text(
+			"Header\n"
+			"Reviewer said: a typo such as `{{REFERENCE_OUTPUT_CONTRAC}}` (missing T) is bad.\n"
+			"Footer\n",
+			encoding="utf-8",
+		)
+
+		proc = subprocess.run(
+			[sys.executable, str(RENDER_PROMPT_PY), str(prompt_file)],
+			cwd=str(REPO_ROOT),
+			env=_base_env(),
+			text=True,
+			capture_output=True,
+			timeout=60,
+		)
+
+	assert proc.returncode == 0, proc.stderr
+	assert proc.stderr == ""
+	assert "{{REFERENCE_OUTPUT_CONTRAC}}" in proc.stdout
+
+
+def test_render_prompt_py_fails_on_standalone_unknown_reference_placeholder() -> None:
+	# A genuine reference-placeholder typo authored as its own line in a
+	# template must still hard-fail: the strict unresolved-placeholder
+	# guarantee is preserved for the case it was designed to catch.
+	with tempfile.TemporaryDirectory(prefix="render_prompt_foundation_standalone_ref_") as td:
+		prompt_file = Path(td) / "editor_prompt_body.txt"
+		prompt_file.write_text("Header\n{{REFERENCE_OUTPUT_CONTRAC}}\nFooter\n", encoding="utf-8")
+
+		proc = subprocess.run(
+			[sys.executable, str(RENDER_PROMPT_PY), str(prompt_file)],
+			cwd=str(REPO_ROOT),
+			env=_base_env(),
+			text=True,
+			capture_output=True,
+			timeout=60,
+		)
+
+	assert proc.returncode == 1
+	assert proc.stdout == ""
+	assert "Unknown reference placeholder 'REFERENCE_OUTPUT_CONTRAC'" in proc.stderr
+
+
 def test_render_prompt_py_reports_unknown_placeholder_contract_violation() -> None:
 	with tempfile.TemporaryDirectory(prefix="render_prompt_foundation_py_") as td:
 		prompt_file = Path(td) / "prompt.txt"
@@ -247,6 +299,8 @@ def main() -> int:
 	test_render_prompt_sh_uses_trusted_backend_locations_only()
 	test_render_prompt_py_renders_reference_placeholders_and_mode_specific_append()
 	test_render_prompt_py_reports_missing_reference_file()
+	test_render_prompt_py_ignores_inline_unknown_reference_placeholder()
+	test_render_prompt_py_fails_on_standalone_unknown_reference_placeholder()
 	test_render_prompt_py_reports_unknown_placeholder_contract_violation()
 	print("OK: render prompt foundation assertions hold")
 	return 0


### PR DESCRIPTION
## Why

The autofix run for PR #3305 failed (run 27452733541, job `review / codex-agent`). Root cause: the **editor step** of `review_apply_fixes.sh` aborted with exit 1 when `render_prompt.py` raised:

```
ERROR: Unknown reference placeholder 'REFERENCE_OUTPUT_CONTRAC'
##[error]Process completed with exit code 1.
```

PR #3305 introduced `collect_reference_values()` in `scripts/render_prompt.py`. It scanned the **entire** rendered text for any `{{REFERENCE_*}}` token (via the inline `collect_placeholders`) and hard-failed on unrecognized names. But that renderer is also run over the runtime-assembled **editor prompt body** (`review_apply_fixes.sh` → `render_prompt.sh "${EDITOR_PROMPT_BODY_FILE}"`), which inlines untrusted/model-authored artifacts including `${REVIEWER_CONSENSUS_FILE}`.

The reviewer consensus for PR #3305 literally **quoted the typo as an example** — "a typo such as `{{REFERENCE_OUTPUT_CONTRAC}}` (missing T)". Once that quoted token was inlined into the editor body, the renderer treated it as a real placeholder and crashed, failing the whole autofix.

## Fix

Scope reference resolution to **standalone-line** placeholders only (`collect_standalone_placeholders`), mirroring `render_prompt_text`, which block-substitutes standalone placeholders and leaves inline ones literal.

- Genuine template typos (authored on their own line) **still raise** — the strict unresolved-placeholder guarantee the plan required is preserved.
- Inline `{{REFERENCE_*}}`-shaped tokens from embedded untrusted content are left literal instead of crashing the render.

## Verification

- Reproduced all three behaviors: inline embedded typo → render succeeds, token kept literal; standalone typo → still exits 1 with `Unknown reference placeholder`; standalone correct reference → resolves.
- Added regression tests `test_render_prompt_py_ignores_inline_unknown_reference_placeholder` and `test_render_prompt_py_fails_on_standalone_unknown_reference_placeholder`.
- All four `test_render_prompt_*` suites pass; every real `prompts/mode-*.txt` / `review-*.txt` template still renders and resolves its references (0 leftover tokens).

## Files changed

- `scripts/render_prompt.py` — add `collect_standalone_placeholders`; `collect_reference_values` now collects only standalone `REFERENCE_*` placeholders.
- `tests/test_render_prompt_foundation.py` — two regression tests.

Note: this targets `ai/issue-3304` (PR #3305's head). The fixed mechanism does not exist on `main`. The session's direct push to `ai/issue-3304` was blocked by the environment (read-only API token + git proxy scoped to this branch), so the fix is delivered via this PR. Refs #3303.

---
_Generated by [Claude Code](https://claude.ai/code/session_0113hF7ujfPxHrsfbEF7UFL5)_