### PR TITLE
fix(release): bump promote-main-to-stable review_timeout default 30→40

### DIFF
--- a/.github/workflows/promote-main-to-stable.yml
+++ b/.github/workflows/promote-main-to-stable.yml
@@ -62,10 +62,17 @@ name: Promote main to stable
         type: number
         default: 30
       review_timeout:
-        description: Forwarded to test-and-mark-stable.yml.
+        description: >
+          Forwarded to test-and-mark-stable.yml. Default mirrors that
+          workflow's own `review_timeout` default (40), which was raised
+          30→40 in #3290 to absorb slow multi-pass reviewer LLM steps.
+          Because this dispatcher forwards the value explicitly
+          (`-f review_timeout=...`), a 30 here would override the
+          downstream 40 default and re-introduce the v1.17.0 wait-review
+          false-timeout (run 27456112610), so it must track 40.
         required: false
         type: number
-        default: 30
+        default: 40
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Release **v1.17.0** ([run 27456112610](https://github.com/shubhodeep1/coding-workflows/actions/runs/27456112610)) failed: `e2e-smoke-test` **Phase 4 (wait-review)** aged out with `Review phase stalled — no activity for 30 minutes`.

The internal-review run it was waiting on ([27456337761](https://github.com/shubhodeep1/coding-workflows/actions/runs/27456337761)) actually **succeeded** — but took **42m36s**, longer than the 30-minute inactivity window the e2e poller was given.

## Root cause

The e2e wait-review loop is an *inactivity* timer (`REVIEW_TIMEOUT` minutes) that resets whenever it detects progress. In this run it was set to **30**, and a legitimately slow review tripped it:

- The review job's single `Run reviewer models` GA step ran ~30 min straight — two ~9 min `codex` passes on `minimax/minimax-m2.5` with `ENABLE_REVIEWER_TWO_PASS=true`.
- During that step **none of the poller's activity signals advanced**: step name constant, head SHA constant, review-comment count `0`, and the job-log byte size frozen at `52267b` for all 153 polls (GitHub's in-progress job-logs API does not stream growing bytes, so the "log output growth" heuristic is dead for live runs).
- With only a 30-minute window, the healthy-but-slow run was falsely declared stalled.

This is the **same failure mode** that [#3290](https://github.com/shubhodeep1/coding-workflows/pull/3290) (commit `c977066`) fixed by raising `test-and-mark-stable.yml`'s `review_timeout` default **30→40**. But #3290 missed this dispatcher: `promote-main-to-stable.yml` — the only workflow that dispatches `test-and-mark-stable.yml` — owns its **own** `review_timeout` input (default `30`) and forwards it **explicitly** via `-f review_timeout=...`. On the release path that stale `30` overrode the downstream `40`, re-introducing the timeout.

## Fix

`.github/workflows/promote-main-to-stable.yml` — raise the forwarded `review_timeout` default **30 → 40** so it tracks the downstream default and completes #3290. (`phase_timeout` default of 30 is unchanged — it governs the clarify/implement phases, not review, and was not implicated.)

## Verification

- `promote-main-to-stable.yml` is the only dispatcher of `test-and-mark-stable.yml` (grep confirmed), so this single change closes the leak on every release path.
- YAML validated with `yaml.safe_load`.
- The `40` value was already validated by #3290 against this exact failure mode; the longest no-activity window observed here was ~30 min within one reviewer step, which a 40-min inactivity allowance absorbs (the step transitions and resets the timer before 40 min).

Refs #3290

https://claude.ai/code/session_01Xc12eTtrswsqH8TRo9yFqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xc12eTtrswsqH8TRo9yFqw)_