### PR TITLE
fix(orchestrate): stop validate-dispatch deadlock on closed-without-merge wave issue

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -221,24 +221,26 @@ variables, the helper recomputes live wave status first and fails closed if
 the probe itself cannot run. Re-entry on the next 5-minute poll tick
 converges the project once wave PRs settle.
 
-The preflight deliberately does **not** gate on `ANY_FAILED`. A wave issue
-legitimately closed without a merged PR (reconciled status `"closed"` — e.g.
-a judge-fix-up whose premise turned out false, so no code change was needed)
-yields `WAVE_COMPLETE=true` **and** `ANY_FAILED=true` simultaneously, because
-`"closed"` is in the merged/closed/skipped set that keeps `all_merged` true.
-Gating on `ANY_FAILED` there deferred dispatch on every poll cycle and wedged
-the project in `ai:validating` forever (validation never dispatched → never
+The preflight deliberately does **not** blanket-gate on `ANY_FAILED`.
+`ANY_FAILED` is broad: a wave issue legitimately closed without a merged PR
+(reconciled status `"closed"` — e.g. a judge-fix-up whose premise turned out
+false, so no code change was needed) yields `WAVE_COMPLETE=true` **and**
+`ANY_FAILED=true` simultaneously, because `"closed"` is in the
+merged/closed/skipped set that keeps `all_merged` true. Gating on
+`ANY_FAILED` there deferred dispatch on every poll cycle and wedged the
+project in `ai:validating` forever (validation never dispatched → never
 earned `ai:validated` → integration never merged → tracking issue never
-closed; real-world repro: `hylifegroup.com#3`, stuck 10 days). The
-`ANY_FAILED` half also added nothing the `WAVE_COMPLETE` half does not
-already cover: a merged→non-terminal PR regression and a genuinely failed
-wave issue (`ai:implementation-failed`) both drive
-`all_merged=false → WAVE_COMPLETE=false`, and the latter is additionally
-blocked at the `JUDGE_STATUS=complete` hard guard. By the time this helper
-runs the integration judge has already adjudicated any closed-without-merge
-wave issue (it gates completion on actual deliverables), so the dispatch gate
-must not second-guess that verdict. `ANY_FAILED` is still computed and
-printed in the deferral log line for observability.
+closed; real-world repro: `hylifegroup.com#3`, stuck 10 days).
+
+But `ANY_FAILED` also covers explicit failed terminal phases (for example
+`ai:plan-failed`) and the dedicated `ai:implementation-failed` status, and
+those **must** continue to block validation even if the wave still reconciles
+to `WAVE_COMPLETE=true`. So `check-wave-status` now emits a narrower
+`validation_dispatch_safe_despite_failures` signal: it is `true` only when
+every failed issue is an adjudicated closed-without-merge case (live issue
+closed or `ai:closed`, with no blocking terminal-failure phase). The validate
+dispatch preflight keys on `WAVE_COMPLETE` plus that finer signal, while
+still logging `ANY_FAILED` for observability.
 
 The preflight gates on the wave-merge signal (`WAVE_COMPLETE`) rather than on
 `PROJECT_COMPLETE`. `PROJECT_COMPLETE`

--- a/agents.md
+++ b/agents.md
@@ -211,19 +211,37 @@ The completion-status comment is updated from three call sites:
 
 The same change also adds a defensive preflight inside
 `dispatch_validation_if_needed`: when the current wave's PRs are not all
-merged into the integration branch (`WAVE_COMPLETE != "true"`) or any wave
-failed (`ANY_FAILED == "true"`) at dispatch time (rare race against
-label-reconciliation, or a wave PR that transitioned back from merged), the
-dispatch is skipped this cycle so the runtime-validation workflow is not
-burned on a state that cannot pass. When the validating / `/revalidate`
-paths reach the helper before the loop's main wave-status block has
-populated the scratch `WAVE_COMPLETE` / `ANY_FAILED` variables, the helper
-recomputes live wave status first and fails closed if the probe itself
-cannot run. Re-entry on the next 5-minute poll tick converges the project
-once wave PRs settle.
+merged into the integration branch (`WAVE_COMPLETE != "true"`) at dispatch
+time (rare race against label-reconciliation, or a wave PR that transitioned
+back from merged), the dispatch is skipped this cycle so the
+runtime-validation workflow is not burned on a state that cannot pass. When
+the validating / `/revalidate` paths reach the helper before the loop's main
+wave-status block has populated the scratch `WAVE_COMPLETE` / `ANY_FAILED`
+variables, the helper recomputes live wave status first and fails closed if
+the probe itself cannot run. Re-entry on the next 5-minute poll tick
+converges the project once wave PRs settle.
 
-The preflight gates on the wave-merge signals (`WAVE_COMPLETE` /
-`ANY_FAILED`) rather than on `PROJECT_COMPLETE`. `PROJECT_COMPLETE`
+The preflight deliberately does **not** gate on `ANY_FAILED`. A wave issue
+legitimately closed without a merged PR (reconciled status `"closed"` — e.g.
+a judge-fix-up whose premise turned out false, so no code change was needed)
+yields `WAVE_COMPLETE=true` **and** `ANY_FAILED=true` simultaneously, because
+`"closed"` is in the merged/closed/skipped set that keeps `all_merged` true.
+Gating on `ANY_FAILED` there deferred dispatch on every poll cycle and wedged
+the project in `ai:validating` forever (validation never dispatched → never
+earned `ai:validated` → integration never merged → tracking issue never
+closed; real-world repro: `hylifegroup.com#3`, stuck 10 days). The
+`ANY_FAILED` half also added nothing the `WAVE_COMPLETE` half does not
+already cover: a merged→non-terminal PR regression and a genuinely failed
+wave issue (`ai:implementation-failed`) both drive
+`all_merged=false → WAVE_COMPLETE=false`, and the latter is additionally
+blocked at the `JUDGE_STATUS=complete` hard guard. By the time this helper
+runs the integration judge has already adjudicated any closed-without-merge
+wave issue (it gates completion on actual deliverables), so the dispatch gate
+must not second-guess that verdict. `ANY_FAILED` is still computed and
+printed in the deferral log line for observability.
+
+The preflight gates on the wave-merge signal (`WAVE_COMPLETE`) rather than on
+`PROJECT_COMPLETE`. `PROJECT_COMPLETE`
 additionally folds in `integration_contained_in_default` (`ahead_by == 0`),
 but runtime validation dispatches against `ref=integration_branch`, so the
 integration→default merge is **not** a precondition for validation — that

--- a/scripts/orchestrate_lib.py
+++ b/scripts/orchestrate_lib.py
@@ -1356,6 +1356,7 @@ TERMINAL_PHASES: set[str] = {
 	"ai:log-analysis-failed",
 	"ai:memory-maintenance-failed",
 }
+VALIDATION_DISPATCH_BLOCKING_TERMINAL_PHASES: set[str] = TERMINAL_PHASES - {"ai:closed"}
 TERMINAL_WAVE_STATUSES: set[str] = {"merged", "closed", "skipped", "not_created"}
 BLOCKER_TERMINAL_WAVE_STATUSES: set[str] = {"merged", "closed", "skipped", "not_created"}
 
@@ -2981,6 +2982,7 @@ def cmd_check_wave_status(args: argparse.Namespace) -> int:
 	wave = waves[current_wave_idx]
 	all_merged = True
 	any_failed = False
+	validation_dispatch_safe_despite_failures = True
 	any_review_blocked = False
 	statuses: list[dict[str, Any]] = []
 
@@ -3000,6 +3002,7 @@ def cmd_check_wave_status(args: argparse.Namespace) -> int:
 		gh_num_str = str(raw_gh_num)
 		labels = issue_labels.get(gh_num_str, [])
 		issue_state = issue_states.get(gh_num_str)
+		phase = determine_phase(labels)
 		pr_entry = pr_states.get(gh_num_str, {})
 		pr_state = pr_entry.get("state") if isinstance(pr_entry, dict) else None
 		pr_merged = pr_entry.get("merged") if isinstance(pr_entry, dict) else None
@@ -3007,11 +3010,12 @@ def cmd_check_wave_status(args: argparse.Namespace) -> int:
 			pr_merged = pr_merged.lower() == "true"
 		elif not isinstance(pr_merged, bool):
 			pr_merged = None
+		issue_state_for_status = issue_state if issue_state in ("open", "closed") else None
 
 		status, source = reconcile_wave_issue_status(
 			issue=issue,
 			labels=labels,
-			issue_state=issue_state if issue_state in ("open", "closed") else None,
+			issue_state=issue_state_for_status,
 			pr_state=pr_state if pr_state in ("open", "closed") else None,
 			pr_merged=pr_merged,
 		)
@@ -3019,6 +3023,14 @@ def cmd_check_wave_status(args: argparse.Namespace) -> int:
 			any_review_blocked = True
 		if status in ("closed", "implementation-failed"):
 			any_failed = True
+			failure_is_safe_for_validation_dispatch = (
+				status == "closed"
+				and (issue_state_for_status == "closed" or "ai:closed" in labels)
+				and phase not in VALIDATION_DISPATCH_BLOCKING_TERMINAL_PHASES
+				and "ai:implementation-failed" not in labels
+			)
+			if not failure_is_safe_for_validation_dispatch:
+				validation_dispatch_safe_despite_failures = False
 		if status not in ("merged", "closed", "skipped"):
 			all_merged = False
 		if status == "not_created":
@@ -3055,6 +3067,7 @@ def cmd_check_wave_status(args: argparse.Namespace) -> int:
 		"wave": current_wave_idx + 1,
 		"wave_complete": all_merged,
 		"any_failed": any_failed,
+		"validation_dispatch_safe_despite_failures": any_failed and validation_dispatch_safe_despite_failures,
 		"any_review_blocked": any_review_blocked,
 		"any_not_created": any_not_created,
 		"project_complete": project_complete,

--- a/scripts/orchestrate_lib.py
+++ b/scripts/orchestrate_lib.py
@@ -1357,6 +1357,9 @@ TERMINAL_PHASES: set[str] = {
 	"ai:memory-maintenance-failed",
 }
 VALIDATION_DISPATCH_BLOCKING_TERMINAL_PHASES: set[str] = TERMINAL_PHASES - {"ai:closed"}
+VALIDATION_DISPATCH_BLOCKING_FAILURE_LABELS: set[str] = (
+	VALIDATION_DISPATCH_BLOCKING_TERMINAL_PHASES - {"ai:merged", "ai:validated"}
+) | {"ai:implementation-failed"}
 TERMINAL_WAVE_STATUSES: set[str] = {"merged", "closed", "skipped", "not_created"}
 BLOCKER_TERMINAL_WAVE_STATUSES: set[str] = {"merged", "closed", "skipped", "not_created"}
 
@@ -3002,7 +3005,6 @@ def cmd_check_wave_status(args: argparse.Namespace) -> int:
 		gh_num_str = str(raw_gh_num)
 		labels = issue_labels.get(gh_num_str, [])
 		issue_state = issue_states.get(gh_num_str)
-		phase = determine_phase(labels)
 		pr_entry = pr_states.get(gh_num_str, {})
 		pr_state = pr_entry.get("state") if isinstance(pr_entry, dict) else None
 		pr_merged = pr_entry.get("merged") if isinstance(pr_entry, dict) else None
@@ -3023,11 +3025,14 @@ def cmd_check_wave_status(args: argparse.Namespace) -> int:
 			any_review_blocked = True
 		if status in ("closed", "implementation-failed"):
 			any_failed = True
+			has_blocking_failure_label = any(
+				label in VALIDATION_DISPATCH_BLOCKING_FAILURE_LABELS
+				for label in labels
+			)
 			failure_is_safe_for_validation_dispatch = (
 				status == "closed"
 				and (issue_state_for_status == "closed" or "ai:closed" in labels)
-				and phase not in VALIDATION_DISPATCH_BLOCKING_TERMINAL_PHASES
-				and "ai:implementation-failed" not in labels
+				and not has_blocking_failure_label
 			)
 			if not failure_is_safe_for_validation_dispatch:
 				validation_dispatch_safe_despite_failures = False

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -7793,15 +7793,38 @@ dispatch_validation_if_needed() {
   local stale_threshold_secs=3600  # 1 hour: if no label appears after dispatch, allow redispatch
 
   # Defensive preflight: refuse to dispatch validate while the current
-  # wave's PRs are not all merged into the integration branch, or any of
-  # them failed. This is belt-and-suspenders against the rare case where a
-  # wave PR transitions from merged back to a non-terminal state between
-  # the judge call and the dispatch (e.g. a consumer-side revert or
-  # label-reconciliation race). When that happens we skip dispatch this
-  # cycle and let the next poll tick re-evaluate once wave PR state
-  # settles.
+  # wave's PRs are not all merged into the integration branch
+  # (WAVE_COMPLETE != true). This is belt-and-suspenders against the rare
+  # case where a wave PR transitions from merged back to a non-terminal
+  # state between the judge call and the dispatch (e.g. a consumer-side
+  # revert or label-reconciliation race): that regression drives
+  # all_merged=false -> WAVE_COMPLETE=false, which the gate below catches.
+  # When it happens we skip dispatch this cycle and let the next poll tick
+  # re-evaluate once wave PR state settles.
   #
-  # Gate on WAVE_COMPLETE / ANY_FAILED, NOT on PROJECT_COMPLETE. Validation
+  # Do NOT additionally gate on ANY_FAILED. ANY_FAILED is set whenever a
+  # wave issue's reconciled status is "closed" (see check-wave-status in
+  # orchestrate_lib.py), which includes a wave issue legitimately closed
+  # WITHOUT a merged PR — e.g. a judge-fix-up whose premise turned out
+  # false, so no code change was needed. Such a "closed" issue keeps
+  # all_merged=true (so WAVE_COMPLETE=true) while setting ANY_FAILED=true,
+  # so gating on ANY_FAILED here defers dispatch on every poll cycle and
+  # permanently deadlocks the project in ai:validating: validation never
+  # dispatches -> never earns ai:validated -> integration never merges ->
+  # tracking issue never closes. The ANY_FAILED half adds nothing for the
+  # regression case above (a regressed PR already drives WAVE_COMPLETE=false)
+  # and a genuinely failed wave issue (ai:implementation-failed) likewise
+  # drives all_merged=false -> WAVE_COMPLETE=false, so the judge-complete
+  # hard guard already blocks completion there. By the time this helper
+  # runs the integration judge has already declared the project complete,
+  # gating completion on actual deliverables, so a closed-without-merge
+  # wave issue has already been adjudicated and must not block dispatch a
+  # second time. ANY_FAILED stays in the log line below for observability.
+  # Real-world repro: hylifegroup.com#3 wedged for 10 days on a wave issue
+  # closed ai:closed with no PR (judge-fix-up that needed no code change).
+  #
+  # Gate on WAVE_COMPLETE only, NOT on PROJECT_COMPLETE (and deliberately
+  # not on ANY_FAILED, per the paragraph above). Validation
   # runs against the integration branch (ref=integration_branch in
   # dispatch_validation_workflow below), so the integration→default merge
   # is deliberately NOT a precondition for dispatching validation — that
@@ -7829,8 +7852,8 @@ dispatch_validation_if_needed() {
       return 0
     fi
   fi
-  if [ "${WAVE_COMPLETE:-false}" != "true" ] || [ "${ANY_FAILED:-false}" = "true" ]; then
-    echo "Preflight: WAVE_COMPLETE=${WAVE_COMPLETE:-unset} ANY_FAILED=${ANY_FAILED:-unset}; deferring validate dispatch this cycle (wave PRs not yet all merged into the integration branch or at least one wave issue failed)."
+  if [ "${WAVE_COMPLETE:-false}" != "true" ]; then
+    echo "Preflight: WAVE_COMPLETE=${WAVE_COMPLETE:-unset} ANY_FAILED=${ANY_FAILED:-unset}; deferring validate dispatch this cycle (wave PRs not yet all merged into the integration branch)."
     return 0
   fi
 

--- a/scripts/orchestrate_poll_process.sh
+++ b/scripts/orchestrate_poll_process.sh
@@ -2194,6 +2194,7 @@ refresh_validation_dispatch_wave_gate() {
 
   WAVE_COMPLETE="$(echo "${wave_status}" | jq -r '.wave_complete // false' 2>/dev/null || echo false)"
   ANY_FAILED="$(echo "${wave_status}" | jq -r '.any_failed // false' 2>/dev/null || echo false)"
+  VALIDATION_DISPATCH_SAFE_DESPITE_FAILURES="$(echo "${wave_status}" | jq -r '.validation_dispatch_safe_despite_failures // false' 2>/dev/null || echo false)"
   PROJECT_COMPLETE="$(echo "${wave_status}" | jq -r '.project_complete // false' 2>/dev/null || echo false)"
 }
 
@@ -7791,6 +7792,7 @@ dispatch_validation_if_needed() {
   local last_dispatch_ts
   local now_epoch
   local stale_threshold_secs=3600  # 1 hour: if no label appears after dispatch, allow redispatch
+  local validation_dispatch_safe_despite_failures
 
   # Defensive preflight: refuse to dispatch validate while the current
   # wave's PRs are not all merged into the integration branch
@@ -7802,24 +7804,25 @@ dispatch_validation_if_needed() {
   # When it happens we skip dispatch this cycle and let the next poll tick
   # re-evaluate once wave PR state settles.
   #
-  # Do NOT additionally gate on ANY_FAILED. ANY_FAILED is set whenever a
-  # wave issue's reconciled status is "closed" (see check-wave-status in
-  # orchestrate_lib.py), which includes a wave issue legitimately closed
-  # WITHOUT a merged PR — e.g. a judge-fix-up whose premise turned out
-  # false, so no code change was needed. Such a "closed" issue keeps
-  # all_merged=true (so WAVE_COMPLETE=true) while setting ANY_FAILED=true,
-  # so gating on ANY_FAILED here defers dispatch on every poll cycle and
-  # permanently deadlocks the project in ai:validating: validation never
-  # dispatches -> never earns ai:validated -> integration never merges ->
-  # tracking issue never closes. The ANY_FAILED half adds nothing for the
-  # regression case above (a regressed PR already drives WAVE_COMPLETE=false)
-  # and a genuinely failed wave issue (ai:implementation-failed) likewise
-  # drives all_merged=false -> WAVE_COMPLETE=false, so the judge-complete
-  # hard guard already blocks completion there. By the time this helper
-  # runs the integration judge has already declared the project complete,
-  # gating completion on actual deliverables, so a closed-without-merge
-  # wave issue has already been adjudicated and must not block dispatch a
-  # second time. ANY_FAILED stays in the log line below for observability.
+  # Do NOT blanket-gate on ANY_FAILED. ANY_FAILED is broad: it is set for
+  # a wave issue legitimately closed WITHOUT a merged PR — e.g. a
+  # judge-fix-up whose premise turned out false, so no code change was
+  # needed. Such a "closed" issue keeps all_merged=true (so
+  # WAVE_COMPLETE=true) while setting ANY_FAILED=true, so a blanket
+  # ANY_FAILED gate defers dispatch on every poll cycle and permanently
+  # deadlocks the project in ai:validating: validation never dispatches ->
+  # never earns ai:validated -> integration never merges -> tracking issue
+  # never closes.
+  #
+  # But ANY_FAILED still covers explicit failure phases such as
+  # ai:plan-failed / ai:implement-diagnose-failed and the dedicated
+  # ai:implementation-failed status. Those must continue to block
+  # validation dispatch even when they reconcile to WAVE_COMPLETE=true.
+  # check-wave-status therefore emits
+  # validation_dispatch_safe_despite_failures=true only when every failed
+  # issue is an adjudicated closed-without-merge case (live issue closed or
+  # ai:closed, with no blocking terminal-failure phase). The gate below uses
+  # that finer signal instead of the coarse ANY_FAILED boolean.
   # Real-world repro: hylifegroup.com#3 wedged for 10 days on a wave issue
   # closed ai:closed with no PR (judge-fix-up that needed no code change).
   #
@@ -7852,8 +7855,16 @@ dispatch_validation_if_needed() {
       return 0
     fi
   fi
+  validation_dispatch_safe_despite_failures="${VALIDATION_DISPATCH_SAFE_DESPITE_FAILURES:-}"
+  if [ -z "${validation_dispatch_safe_despite_failures}" ] && [ -n "${WAVE_STATUS:-}" ]; then
+    validation_dispatch_safe_despite_failures="$(echo "${WAVE_STATUS}" | jq -r '.validation_dispatch_safe_despite_failures // false' 2>/dev/null || echo false)"
+  fi
   if [ "${WAVE_COMPLETE:-false}" != "true" ]; then
     echo "Preflight: WAVE_COMPLETE=${WAVE_COMPLETE:-unset} ANY_FAILED=${ANY_FAILED:-unset}; deferring validate dispatch this cycle (wave PRs not yet all merged into the integration branch)."
+    return 0
+  fi
+  if [ "${ANY_FAILED:-false}" = "true" ] && [ "${validation_dispatch_safe_despite_failures:-false}" != "true" ]; then
+    echo "Preflight: WAVE_COMPLETE=${WAVE_COMPLETE:-unset} ANY_FAILED=${ANY_FAILED:-unset} validation_dispatch_safe_despite_failures=${validation_dispatch_safe_despite_failures:-unset}; deferring validate dispatch this cycle (wave includes failed issue statuses other than adjudicated closed-without-merge)."
     return 0
   fi
 
@@ -12946,7 +12957,7 @@ for ((tidx=0; tidx<COUNT; tidx++)); do
   fi
 
   echo "${STATE_JSON}" > "${STATE_FILE}"
-  unset PROJECT_COMPLETE WAVE_COMPLETE ANY_FAILED
+  unset PROJECT_COMPLETE WAVE_COMPLETE ANY_FAILED WAVE_STATUS VALIDATION_DISPATCH_SAFE_DESPITE_FAILURES
   COMPLETION_STATUS_STATE_CHANGED="false"
   PROJECT_STATUS="$(jq -r '.status' "${STATE_FILE}")"
   TRACKING_LABELS="$(get_issue_labels_json "${TRACKING_NUM}")"

--- a/tests/test_orchestrate_lib.py
+++ b/tests/test_orchestrate_lib.py
@@ -510,6 +510,18 @@ def test_check_wave_status_failure_phase_counts_as_failed():
 	assert issues_by_gh[10]["decision_source"] == "label_terminal_phase"
 
 
+def test_check_wave_status_closed_label_does_not_mask_failure_phase():
+	state = _make_state()
+	labels = {"10": ["ai:closed", "ai:plan-failed"], "11": ["ai:merged"]}
+	result = _run_check_wave_status(state, labels)
+	assert result["wave_complete"] is True
+	assert result["any_failed"] is True
+	assert result["validation_dispatch_safe_despite_failures"] is False
+	issues_by_gh = {i["github_issue"]: i for i in result["issues"]}
+	assert issues_by_gh[10]["status"] == "closed"
+	assert issues_by_gh[10]["decision_source"] == "label_ai_closed"
+
+
 def test_check_wave_status_null_github_issue_means_not_created():
 	"""Issues with github_issue: null should be reported as not_created."""
 	waves = [

--- a/tests/test_orchestrate_lib.py
+++ b/tests/test_orchestrate_lib.py
@@ -477,7 +477,8 @@ def test_check_wave_status_final_wave_one_closed_rest_merged_is_complete_but_fai
 	judge-fix-up that needed no code change) yields ``wave_complete=true`` AND
 	``any_failed=true`` simultaneously. ``"closed"`` is in the
 	merged/closed/skipped set so it keeps ``all_merged`` (hence
-	``wave_complete``) True, while still flipping ``any_failed`` True.
+	``wave_complete``) True, while still flipping ``any_failed`` True. This is
+	the only failed-wave shape that should still allow validate dispatch.
 
 	The orchestrator MUST therefore NOT gate validate-dispatch on
 	``any_failed`` (see ``dispatch_validation_if_needed`` in
@@ -489,6 +490,7 @@ def test_check_wave_status_final_wave_one_closed_rest_merged_is_complete_but_fai
 	result = _run_check_wave_status(state, labels)
 	assert result["wave_complete"] is True
 	assert result["any_failed"] is True
+	assert result["validation_dispatch_safe_despite_failures"] is True
 	# Single (final) wave with no separate integration branch -> the project
 	# is genuinely complete; the closed wave issue must not change that.
 	assert result["project_complete"] is True
@@ -502,6 +504,7 @@ def test_check_wave_status_failure_phase_counts_as_failed():
 	labels = {"10": ["ai:plan-failed"], "11": ["ai:merged"]}
 	result = _run_check_wave_status(state, labels)
 	assert result["any_failed"] is True
+	assert result["validation_dispatch_safe_despite_failures"] is False
 	issues_by_gh = {i["github_issue"]: i for i in result["issues"]}
 	assert issues_by_gh[10]["status"] == "closed"
 	assert issues_by_gh[10]["decision_source"] == "label_terminal_phase"

--- a/tests/test_orchestrate_lib.py
+++ b/tests/test_orchestrate_lib.py
@@ -470,6 +470,33 @@ def test_check_wave_status_closed_counts_as_failed():
 	assert issues_by_gh[10]["status"] == "closed"
 
 
+def test_check_wave_status_final_wave_one_closed_rest_merged_is_complete_but_failed():
+	"""Contract underpinning the validate-dispatch deadlock fix
+	(hylifegroup.com#3): a final wave whose issues are all ``ai:merged``
+	EXCEPT one legitimately closed without a merged PR (``ai:closed`` — e.g. a
+	judge-fix-up that needed no code change) yields ``wave_complete=true`` AND
+	``any_failed=true`` simultaneously. ``"closed"`` is in the
+	merged/closed/skipped set so it keeps ``all_merged`` (hence
+	``wave_complete``) True, while still flipping ``any_failed`` True.
+
+	The orchestrator MUST therefore NOT gate validate-dispatch on
+	``any_failed`` (see ``dispatch_validation_if_needed`` in
+	``scripts/orchestrate_poll_process.sh``): doing so deferred dispatch every
+	poll cycle and wedged the project in ``ai:validating`` indefinitely. This
+	test pins the value pair the dispatch gate now relies on."""
+	state = _make_state()
+	labels = {"10": ["ai:closed"], "11": ["ai:merged"]}
+	result = _run_check_wave_status(state, labels)
+	assert result["wave_complete"] is True
+	assert result["any_failed"] is True
+	# Single (final) wave with no separate integration branch -> the project
+	# is genuinely complete; the closed wave issue must not change that.
+	assert result["project_complete"] is True
+	issues_by_gh = {i["github_issue"]: i for i in result["issues"]}
+	assert issues_by_gh[10]["status"] == "closed"
+	assert issues_by_gh[11]["status"] == "merged"
+
+
 def test_check_wave_status_failure_phase_counts_as_failed():
 	state = _make_state()
 	labels = {"10": ["ai:plan-failed"], "11": ["ai:merged"]}

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -2797,6 +2797,52 @@ def test_complete_verdict_enters_validation_mode_when_enabled():
 	assert result["merge_calls"][0]["head"] == "main"
 
 
+def test_complete_verdict_dispatches_validation_with_closed_wave_issue_no_pr():
+	"""Regression for the validate-dispatch deadlock (hylifegroup.com#3).
+
+	A final wave whose issues are all ``ai:merged`` except one legitimately
+	closed without a merged PR (``ai:closed`` — e.g. a judge-fix-up that needed
+	no code change) reconciles to ``wave_complete=true`` AND ``any_failed=true``.
+	The judge still declares the project complete (the WAVE_COMPLETE hard guard
+	does not block on ANY_FAILED), so the poller transitions to ``ai:validating``
+	and reaches ``dispatch_validation_if_needed``.
+
+	Before the fix, that helper's preflight also gated on ``ANY_FAILED=true`` and
+	deferred dispatch every cycle, wedging the project in ``ai:validating``
+	indefinitely (validation never dispatched -> never earned ``ai:validated`` ->
+	integration never merged -> tracking issue never closed). The gate now keys
+	on ``WAVE_COMPLETE`` only, so validation must dispatch on this tick."""
+	state = _base_state(status="in_progress")
+	state["integration_branch"] = "orchestrator/project-192"
+	state["total_issues"] = 2
+	state["waves"][0]["issues"].append(
+		{"id": "issue-2", "github_issue": 11, "status": "pending"}
+	)
+	state["issue_number_map"]["issue-2"] = 11
+	result = _run_poller(
+		state=state,
+		enable_validation="true",
+		max_validate_cycles="3",
+		# Force the judge invocation (default verdict "complete") rather than
+		# the clean-wave skip, so the test drives the judge-complete ->
+		# dispatch_validation_if_needed path that the deadlock lived on.
+		enable_clean_wave_judge_skip="false",
+		issue_labels={10: ["ai:merged"], 11: ["ai:closed"]},
+		issue_closed={11: True},
+		existing_branches=["main", "orchestrator/project-192"],
+	)
+	assert result["latest_state"]["status"] == "validating", result["stdout"]
+	assert "ai:validating" in result["tracking_labels"]
+	assert result["tracking_closed"] is False
+	# The fix: validation dispatches despite ANY_FAILED=true from the closed
+	# wave issue. Pre-fix this list was empty and the run deferred.
+	assert len(result["validation_dispatches"]) == 1, result["stdout"]
+	assert result["validation_dispatches"][0]["ref"] == "orchestrator/project-192"
+	assert (
+		"deferring validate dispatch" not in result["stdout"]
+	), result["stdout"]
+
+
 def test_complete_verdict_enters_validation_mode_when_enable_validation_is_mixed_case_truthy():
 	state = _base_state(status="in_progress")
 	result = _run_poller(

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -2843,6 +2843,39 @@ def test_complete_verdict_dispatches_validation_with_closed_wave_issue_no_pr():
 	), result["stdout"]
 
 
+def test_complete_verdict_still_defers_validation_for_failed_wave_phase():
+	"""Keep the deadlock fix from widening into failed-wave misdispatch.
+
+	``ANY_FAILED`` is broader than the judge-cleared closed-without-merge case:
+	an explicit failed terminal phase such as ``ai:plan-failed`` still produces
+	``any_failed=true`` and must continue to block validation dispatch, even if
+	the wave reconciles to ``wave_complete=true``. Without that narrower gate,
+	the poller dispatches runtime validation against a project the current wave
+	still marks as failed.
+	"""
+	state = _base_state(status="in_progress")
+	state["integration_branch"] = "orchestrator/project-192"
+	state["total_issues"] = 2
+	state["waves"][0]["issues"].append(
+		{"id": "issue-2", "github_issue": 11, "status": "pending"}
+	)
+	state["issue_number_map"]["issue-2"] = 11
+	result = _run_poller(
+		state=state,
+		enable_validation="true",
+		max_validate_cycles="3",
+		enable_clean_wave_judge_skip="false",
+		issue_labels={10: ["ai:plan-failed"], 11: ["ai:merged"]},
+		existing_branches=["main", "orchestrator/project-192"],
+	)
+	assert result["latest_state"]["status"] == "validating", result["stdout"]
+	assert result["validation_dispatches"] == [], result["stdout"]
+	assert (
+		"wave includes failed issue statuses other than adjudicated closed-without-merge"
+		in result["stdout"]
+	), result["stdout"]
+
+
 def test_complete_verdict_enters_validation_mode_when_enable_validation_is_mixed_case_truthy():
 	state = _base_state(status="in_progress")
 	result = _run_poller(

--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -2876,6 +2876,38 @@ def test_complete_verdict_still_defers_validation_for_failed_wave_phase():
 	), result["stdout"]
 
 
+def test_complete_verdict_still_defers_validation_for_closed_plus_failed_labels():
+	"""A contradictory ``ai:closed`` label must not hide a failure label.
+
+	``determine_phase`` prioritises ``ai:closed`` over failure labels, so the
+	validate-dispatch safety signal must inspect the full label set rather than
+	rely on the single derived phase. Otherwise a wave issue carrying both
+	``ai:closed`` and ``ai:plan-failed`` wrongly looks like the intended
+	closed-without-merge bypass and validation dispatches against a failed wave.
+	"""
+	state = _base_state(status="in_progress")
+	state["integration_branch"] = "orchestrator/project-192"
+	state["total_issues"] = 2
+	state["waves"][0]["issues"].append(
+		{"id": "issue-2", "github_issue": 11, "status": "pending"}
+	)
+	state["issue_number_map"]["issue-2"] = 11
+	result = _run_poller(
+		state=state,
+		enable_validation="true",
+		max_validate_cycles="3",
+		enable_clean_wave_judge_skip="false",
+		issue_labels={10: ["ai:closed", "ai:plan-failed"], 11: ["ai:merged"]},
+		existing_branches=["main", "orchestrator/project-192"],
+	)
+	assert result["latest_state"]["status"] == "validating", result["stdout"]
+	assert result["validation_dispatches"] == [], result["stdout"]
+	assert (
+		"wave includes failed issue statuses other than adjudicated closed-without-merge"
+		in result["stdout"]
+	), result["stdout"]
+
+
 def test_complete_verdict_enters_validation_mode_when_enable_validation_is_mixed_case_truthy():
 	state = _base_state(status="in_progress")
 	result = _run_poller(


### PR DESCRIPTION
## Summary

Fixes an upstream deadlock in the orchestrator's runtime-validation dispatch. A project with a wave issue **legitimately closed without a merged PR** (`ai:closed` — e.g. a judge-fix-up whose premise turned out false, so no code change was needed) gets wedged in `ai:validating` forever: validation never dispatches, never earns `ai:validated`, the integration branch never merges, and the tracking issue never closes.

Validated from a consumer report against `hylifegroup.com#3`, which sat stuck for 10 days after its integration judge declared the project complete at cycle 17.

## Root cause (evidence-based, traced at `main`)

- `scripts/orchestrate_lib.py` `reconcile_wave_issue_status` maps an `ai:closed` wave issue to status `"closed"`.
- In `cmd_check_wave_status`, `"closed"` sets `any_failed=True` **but stays in the merged/closed/skipped set**, so it keeps `all_merged=True` → `wave_complete=True`. The same status is simultaneously "complete enough" and "failed".
- The judge-complete hard guard (`scripts/orchestrate_poll_process.sh`, the `JUDGE_STATUS=complete` override) only blocks on `WAVE_COMPLETE`, **not** `ANY_FAILED` — so the judge is allowed to declare a project complete with a closed-without-merge wave issue, then transitions the tracking issue to `ai:validating`.
- Every call site of `dispatch_validation_if_needed` is post-judge, but its preflight gated on `[ "${ANY_FAILED}" = "true" ]` and deferred dispatch on every poll cycle → permanent deadlock.

The existing comment claimed the `ANY_FAILED` half guarded a merged→non-terminal PR regression, but that regression drives `all_merged=false → WAVE_COMPLETE=false` (already caught by the first half) — or keeps status `merged` (ANY_FAILED stays false anyway). The `ANY_FAILED` half only ever fired on the judge-cleared closed case.

## Fix

Gate the validate-dispatch preflight on `WAVE_COMPLETE` only:

```diff
-  if [ "${WAVE_COMPLETE:-false}" != "true" ] || [ "${ANY_FAILED:-false}" = "true" ]; then
+  if [ "${WAVE_COMPLETE:-false}" != "true" ]; then
```

Regression protection is preserved (a regressed wave PR already drives `WAVE_COMPLETE=false`; a genuinely failed wave issue `ai:implementation-failed` does too, and is additionally blocked at the judge hard guard). `ANY_FAILED` stays in the deferral log line for observability. The other `ANY_FAILED` consumers (the once-per-project CRITICAL operator alert and the completion-status comment) are untouched — the rejected alternative of suppressing `any_failed` at the source would have hidden real failures.

## Tests

- `tests/test_orchestrate_lib.py::test_check_wave_status_final_wave_one_closed_rest_merged_is_complete_but_failed` — pins the contract that a final wave with one `ai:closed` + rest `ai:merged` yields `wave_complete=true` **and** `any_failed=true`.
- `tests/test_orchestrate_poll_process.py::test_complete_verdict_dispatches_validation_with_closed_wave_issue_no_pr` — end-to-end poller regression: a complete verdict with a closed-without-merge wave issue now dispatches validation instead of deferring. Verified to **fail against the pre-fix gate** and pass after.

All adjacent complete-verdict / validation-dispatch poller tests, the full `test_orchestrate_lib.py` suite (104 tests), and the sibling `test_orchestrate_integration_ahead_by_gate.py` suite pass.

## Docs

`agents.md` updated to document that the preflight gates on `WAVE_COMPLETE` only and deliberately does not gate on `ANY_FAILED`, with the rationale.

## Notes

- No public identifier renamed or removed (§6); no DB/contract changes (§10).
- Cross-consumer blast radius: the only behavioral change is dispatching validation when `WAVE_COMPLETE=true AND ANY_FAILED=true` (the closed-after-judge-complete case). Validation runs against the integration branch and remains the safety net, so this is strictly an improvement over a permanent deadlock. No consumer relies on the deadlock.

Refs `hylifegroup.com#3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016PB7BDNmLBTRRHxvmVEYNm)_