### PR TITLE
Add strict new-identifier-uniqueness rule to AI coding system instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,25 @@ All renames are **breaking changes**. If a new name is needed:
 - Add alongside the old one, accept both inputs, preserve old outputs,
   document aliases.
 
+### New Identifier Uniqueness (STRICT)
+
+When creating **new** variables — or any new identifier you introduce for a
+task (functions, classes, constants, parameters, env vars, JSON/DB fields,
+log/metric keys) — you MUST ensure the chosen name is unique and does not
+clash with any existing identifier reachable in that scope. This is a
+**strict, non-negotiable condition**.
+
+- Before introducing a new name, check the surrounding function, file,
+  module, and any imported / shared / global scope for an existing
+  identifier of the same name. Never shadow or collide with existing
+  variables, parameters, imports, globals, inherited members, or any other
+  in-scope identifier.
+- If the intended name is already taken, choose a distinct, descriptive
+  alternative — do not reuse, shadow, or overload the existing one.
+- This is the complement of the immutability rule above: §6 forbids renaming
+  existing identifiers; this rule forbids new identifiers from colliding with
+  them.
+
 Section numbers in this file are also covered by §6 — they are referenced from
 `.github/workflows/`, `scripts/`, and `prompts/` and must not be renumbered.
 

--- a/codex.md
+++ b/codex.md
@@ -132,6 +132,25 @@ All renames are **breaking changes**. If a new name is needed:
 - Add alongside the old one, accept both inputs, preserve old outputs,
   document aliases.
 
+### New Identifier Uniqueness (STRICT)
+
+When creating **new** variables — or any new identifier you introduce for a
+task (functions, classes, constants, parameters, env vars, JSON/DB fields,
+log/metric keys) — you MUST ensure the chosen name is unique and does not
+clash with any existing identifier reachable in that scope. This is a
+**strict, non-negotiable condition**.
+
+- Before introducing a new name, check the surrounding function, file,
+  module, and any imported / shared / global scope for an existing
+  identifier of the same name. Never shadow or collide with existing
+  variables, parameters, imports, globals, inherited members, or any other
+  in-scope identifier.
+- If the intended name is already taken, choose a distinct, descriptive
+  alternative — do not reuse, shadow, or overload the existing one.
+- This is the complement of the immutability rule above: §6 forbids renaming
+  existing identifiers; this rule forbids new identifiers from colliding with
+  them.
+
 Section numbers in this file are also covered by §6 — they are referenced from
 `.github/workflows/`, `scripts/`, and `prompts/` and must not be renumbered.
 

--- a/unattended_system_instructions.md
+++ b/unattended_system_instructions.md
@@ -227,6 +227,18 @@ index/event/metric names, log keys) without an explicit instruction.
 All renames are breaking changes. If a new name is needed: add alongside
 the old one, accept both inputs, preserve old outputs, document aliases.
 
+**New identifier uniqueness (strict).** When creating new variables — or any
+new identifier you introduce for a task (functions, classes, constants,
+parameters, env vars, JSON/DB fields, log/metric keys) — you MUST ensure the
+chosen name is unique and does not clash with any existing identifier
+reachable in that scope. Before introducing a new name, check the surrounding
+function, file, module, and any imported / shared / global scope; never shadow
+or collide with an existing variable, parameter, import, global, or inherited
+member. If the intended name is already taken, choose a distinct, descriptive
+alternative rather than shadowing or overloading it. This is the complement of
+the immutability rule above: that rule forbids renaming existing identifiers;
+this one forbids new identifiers from colliding with them.
+
 ---
 
 ## §11. Code Style


### PR DESCRIPTION
## What

Adds a **strict** rule to the AI coding system instructions: when an agent creates a **new** variable (or any other new identifier) for a task, the chosen name **must be unique** and must **not clash with or shadow** any existing identifier reachable in that scope.

This is the complement of the existing naming-immutability rule — that rule forbids *renaming* existing identifiers; this new rule forbids *new* identifiers from *colliding* with them.

## Where

The rule is added as a sub-rule **inside the existing naming-immutability section** of each system-instruction file, so no section numbers are renumbered (required by the §6 "section numbers must not be renumbered" invariant):

- `CLAUDE.md` — interactive Claude Code sessions (§6)
- `codex.md` — interactive Codex sessions (§6)
- `unattended_system_instructions.md` — unattended AI coding pipelines (§10)

## Consumer templates

Per the follow-up request, consumer-template coverage was verified:

- `workflow-templates/CLAUDE.md` is a **symlink → root `CLAUDE.md`**, so it inherits the rule automatically (no separate edit needed).
- Consumer repos receive `unattended_system_instructions.md` through the existing runtime fetch of the canonical file (`scripts/stage_workflow_support.sh`), so the unattended rule reaches them automatically too.
- `workflow-templates/.claude/commands/*.md` only *reference* the instruction files and carry no naming rules, so they need no change.

There is no separate consumer copy of `codex.md` / `unattended_system_instructions.md` to edit.

## Notes

- Docs-only change; no code/behavior/env/DB impact, so no `README.md` / `agents.md` / `/db/contracts/*` updates were required.
- Scope (all three system-instruction files) was confirmed with the requester before editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AF3XNQ42fYHcyE926TbqK

---
_Generated by [Claude Code](https://claude.ai/code/session_018AF3XNQ42fYHcyE926TbqK)_