### PR TITLE
fix(validate): stage prompt reference files into isolated validate workspace

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -374,7 +374,10 @@ jobs:
               "prompts/mode-validate-generate.txt",
               "prompts/mode-validate-diagnose.txt",
               "prompts/mode-validate-discover.txt",
-              "prompts/mode-validate-fix-harness.txt"
+              "prompts/mode-validate-fix-harness.txt",
+              "prompts/references/output-contract.txt",
+              "prompts/references/verification-loop.txt",
+              "prompts/references/validate-output-contract.txt"
             ],
             "optional_preserve_files_after_prompts": [
               "prompts/mode-validate-self-heal.txt",

--- a/tests/test_validate_semble_contract.py
+++ b/tests/test_validate_semble_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import sys
 import contextlib
 from pathlib import Path
@@ -39,6 +40,7 @@ OPTIONAL_PRESERVED_VALIDATE_PROMPTS = (
 )
 STAGED_VALIDATE_WORKSPACE_PROMPTS = STAGED_REQUIRED_VALIDATE_PROMPTS + OPTIONAL_PRESERVED_VALIDATE_PROMPTS
 RENDER_PROMPT_MODULE_NAME = "_validate_semble_render_prompt"
+REFERENCE_PATH_RE = re.compile(r"(?P<path>[^\s'\"]*/prompts/references/[^\s:'\"]+\.txt)")
 
 
 def _read(path: Path) -> str:
@@ -97,10 +99,10 @@ def _manifest_required_prompts() -> list[str]:
 
 
 def _missing_reference_path_from_error(error_text: str) -> Path | None:
-	_, separator, path_text = error_text.rpartition(": ")
-	if separator != ": " or "/prompts/references/" not in path_text:
+	match = REFERENCE_PATH_RE.search(error_text)
+	if match is None:
 		return None
-	return Path(path_text)
+	return Path(match.group("path"))
 
 
 def _expected_validate_reference_files() -> set[str]:
@@ -112,31 +114,35 @@ def _expected_validate_reference_files() -> set[str]:
 		render_prompt_path = workspace_root / "scripts" / "render_prompt.py"
 		render_prompt_path.parent.mkdir(parents=True, exist_ok=True)
 		render_prompt_path.write_text((SCRIPTS_DIR / "render_prompt.py").read_text(encoding="utf-8"), encoding="utf-8")
-		render_prompt = _import_render_prompt(render_prompt_path, f"{RENDER_PROMPT_MODULE_NAME}_isolated")
-		with contextlib.chdir(workspace_root):
-			for rel in STAGED_VALIDATE_WORKSPACE_PROMPTS:
-				prompt_path = workspace_root / rel
-				prompt_path.parent.mkdir(parents=True, exist_ok=True)
-				prompt_path.write_text((REPO_ROOT / rel).read_text(encoding="utf-8"), encoding="utf-8")
-				prompt_text = render_prompt.load_prompt(prompt_path)
-				mode_name = render_prompt.resolve_mode_name(prompt_path, None)
-				hydrated_values: dict[str, str] = {}
-				while True:
-					try:
-						hydrated_values = render_prompt.hydrate_reference_placeholders(
-							prompt_text=prompt_text,
-							prompt_path=prompt_path,
-							mode_name=mode_name,
-							values=hydrated_values,
-						)
-						break
-					except render_prompt.PromptLoadError as exc:
-						missing_path = _missing_reference_path_from_error(str(exc))
-						if missing_path is None:
-							raise AssertionError(f"unexpected hydration failure for {rel}: {exc}") from exc
-						expected.add(missing_path.name)
-						missing_path.parent.mkdir(parents=True, exist_ok=True)
-						missing_path.write_text(f"{missing_path.name}\n", encoding="utf-8")
+		isolated_module_name = f"{RENDER_PROMPT_MODULE_NAME}_isolated"
+		try:
+			render_prompt = _import_render_prompt(render_prompt_path, isolated_module_name)
+			with contextlib.chdir(workspace_root):
+				for rel in STAGED_VALIDATE_WORKSPACE_PROMPTS:
+					prompt_path = workspace_root / rel
+					prompt_path.parent.mkdir(parents=True, exist_ok=True)
+					prompt_path.write_text((REPO_ROOT / rel).read_text(encoding="utf-8"), encoding="utf-8")
+					prompt_text = render_prompt.load_prompt(prompt_path)
+					mode_name = render_prompt.resolve_mode_name(prompt_path, None)
+					hydrated_values: dict[str, str] = {}
+					while True:
+						try:
+							hydrated_values = render_prompt.hydrate_reference_placeholders(
+								prompt_text=prompt_text,
+								prompt_path=prompt_path,
+								mode_name=mode_name,
+								values=hydrated_values,
+							)
+							break
+						except render_prompt.PromptLoadError as exc:
+							missing_path = _missing_reference_path_from_error(str(exc))
+							if missing_path is None:
+								raise AssertionError(f"unexpected hydration failure for {rel}: {exc}") from exc
+							expected.add(missing_path.name)
+							missing_path.parent.mkdir(parents=True, exist_ok=True)
+							missing_path.write_text(f"{missing_path.name}\n", encoding="utf-8")
+		finally:
+			sys.modules.pop(isolated_module_name, None)
 	return expected
 
 

--- a/tests/test_validate_semble_contract.py
+++ b/tests/test_validate_semble_contract.py
@@ -3,9 +3,12 @@
 
 from __future__ import annotations
 
-import re
+import importlib.util
+import json
 import sys
+import contextlib
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -30,6 +33,12 @@ STAGED_REQUIRED_VALIDATE_PROMPTS = (
 	"prompts/mode-validate-discover.txt",
 	"prompts/mode-validate-fix-harness.txt",
 )
+OPTIONAL_PRESERVED_VALIDATE_PROMPTS = (
+	"prompts/mode-validate-self-heal.txt",
+	"prompts/mode-validate-self-heal-continuation.txt",
+)
+STAGED_VALIDATE_WORKSPACE_PROMPTS = STAGED_REQUIRED_VALIDATE_PROMPTS + OPTIONAL_PRESERVED_VALIDATE_PROMPTS
+RENDER_PROMPT_MODULE_NAME = "_validate_semble_render_prompt"
 
 
 def _read(path: Path) -> str:
@@ -52,39 +61,74 @@ def _self_heal_text() -> str:
 	return _read(SELF_HEAL_SCRIPT)
 
 
-def _import_render_prompt():
-	if str(SCRIPTS_DIR) not in sys.path:
-		sys.path.insert(0, str(SCRIPTS_DIR))
-	import render_prompt
-
+def _import_render_prompt(script_path: Path = SCRIPTS_DIR / "render_prompt.py", module_name: str = RENDER_PROMPT_MODULE_NAME):
+	if module_name in sys.modules:
+		return sys.modules[module_name]
+	spec = importlib.util.spec_from_file_location(module_name, script_path)
+	if spec is None or spec.loader is None:
+		raise AssertionError(f"unable to load render_prompt.py from {script_path}")
+	render_prompt = importlib.util.module_from_spec(spec)
+	sys.modules[module_name] = render_prompt
+	try:
+		spec.loader.exec_module(render_prompt)
+	except Exception:
+		sys.modules.pop(module_name, None)
+		raise
 	return render_prompt
 
 
 def _manifest_required_prompts() -> list[str]:
-	match = re.search(r'"required_prompts"\s*:\s*\[(.*?)\]', _workflow_text(), re.DOTALL)
-	assert match, "validate.yml support manifest is missing a required_prompts array"
-	return re.findall(r'"([^"]+)"', match.group(1))
+	array_lines: list[str] = []
+	for line in _workflow_text().splitlines():
+		stripped = line.strip()
+		if not array_lines and not stripped.startswith('"required_prompts"'):
+			continue
+		array_lines.append(stripped.split(":", 1)[1].strip() if not array_lines else stripped)
+		if stripped == "],":
+			return json.loads("\n".join(array_lines).removesuffix(","))
+	raise AssertionError("validate.yml support manifest is missing a complete required_prompts array")
+
+
+def _missing_reference_path_from_error(error_text: str) -> Path | None:
+	_, separator, path_text = error_text.rpartition(": ")
+	if separator != ": " or "/prompts/references/" not in path_text:
+		return None
+	return Path(path_text)
 
 
 def _expected_validate_reference_files() -> set[str]:
-	# Mirror render_prompt.py's placeholder->reference-file resolution so this
-	# guard tracks the renderer's real behaviour instead of a hand-maintained
-	# list: every {{REFERENCE_*}} placeholder maps to a prompts/references/*.txt
-	# file, and mode-validate-generate additionally appends
-	# validate-output-contract.txt for REFERENCE_OUTPUT_CONTRACT.
-	render_prompt = _import_render_prompt()
+	# Discover dependencies by exercising render_prompt.py's real reference
+	# hydration path in an isolated workspace, mirroring validate's runtime.
 	expected: set[str] = set()
-	for rel in STAGED_REQUIRED_VALIDATE_PROMPTS:
-		prompt_path = REPO_ROOT / rel
-		text = prompt_path.read_text(encoding="utf-8")
-		mode_name = prompt_path.stem
-		for placeholder in sorted(set(re.findall(r"\{\{([A-Za-z0-9_]+)\}\}", text))):
-			file_name = render_prompt._reference_file_name_for_placeholder(placeholder)
-			if file_name is None:
-				continue
-			expected.add(file_name)
-			if placeholder == "REFERENCE_OUTPUT_CONTRACT" and mode_name == "mode-validate-generate":
-				expected.add("validate-output-contract.txt")
+	with TemporaryDirectory() as tmpdir:
+		workspace_root = Path(tmpdir)
+		render_prompt_path = workspace_root / "scripts" / "render_prompt.py"
+		render_prompt_path.parent.mkdir(parents=True, exist_ok=True)
+		render_prompt_path.write_text((SCRIPTS_DIR / "render_prompt.py").read_text(encoding="utf-8"), encoding="utf-8")
+		render_prompt = _import_render_prompt(render_prompt_path, f"{RENDER_PROMPT_MODULE_NAME}_isolated")
+		with contextlib.chdir(workspace_root):
+			for rel in STAGED_VALIDATE_WORKSPACE_PROMPTS:
+				prompt_path = workspace_root / rel
+				prompt_path.parent.mkdir(parents=True, exist_ok=True)
+				prompt_path.write_text((REPO_ROOT / rel).read_text(encoding="utf-8"), encoding="utf-8")
+				prompt_text = render_prompt.load_prompt(prompt_path)
+				mode_name = render_prompt.resolve_mode_name(prompt_path, None)
+				while True:
+					try:
+						render_prompt.hydrate_reference_placeholders(
+							prompt_text=prompt_text,
+							prompt_path=prompt_path,
+							mode_name=mode_name,
+							values={},
+						)
+						break
+					except render_prompt.PromptLoadError as exc:
+						missing_path = _missing_reference_path_from_error(str(exc))
+						if missing_path is None:
+							raise AssertionError(str(exc)) from exc
+						expected.add(missing_path.name)
+						missing_path.parent.mkdir(parents=True, exist_ok=True)
+						missing_path.write_text(f"{missing_path.name}\n", encoding="utf-8")
 	return expected
 
 
@@ -251,16 +295,25 @@ def test_self_heal_includes_semble_and_serena_prompt_hooks() -> None:
 
 
 def main() -> int:
-	test_validate_manifest_stages_reference_dependencies()
-	test_validate_prompts_include_serena_placeholder()
-	test_validate_workflow_lists_semble_support_files_in_helper_manifest()
-	test_validate_workflow_lists_serena_support_files_in_helper_manifest()
-	test_validate_workflow_bootstraps_and_exports_semble_state()
-	test_shared_wrapper_script_owns_bm25_implementation()
-	test_validate_process_includes_serena_bootstrap_and_prompt_hooks()
-	test_validate_process_includes_discover_and_diagnose_semble_hooks()
-	test_self_heal_includes_semble_and_serena_prompt_hooks()
-	return 0
+	failures: list[str] = []
+	for test_fn in (
+		test_validate_manifest_stages_reference_dependencies,
+		test_validate_prompts_include_serena_placeholder,
+		test_validate_workflow_lists_semble_support_files_in_helper_manifest,
+		test_validate_workflow_lists_serena_support_files_in_helper_manifest,
+		test_validate_workflow_bootstraps_and_exports_semble_state,
+		test_shared_wrapper_script_owns_bm25_implementation,
+		test_validate_process_includes_serena_bootstrap_and_prompt_hooks,
+		test_validate_process_includes_discover_and_diagnose_semble_hooks,
+		test_self_heal_includes_semble_and_serena_prompt_hooks,
+	):
+		try:
+			test_fn()
+		except Exception as exc:
+			failures.append(f"{test_fn.__name__}: {exc}")
+	for failure in failures:
+		print(failure, file=sys.stderr)
+	return 1 if failures else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_semble_contract.py
+++ b/tests/test_validate_semble_contract.py
@@ -78,15 +78,22 @@ def _import_render_prompt(script_path: Path = SCRIPTS_DIR / "render_prompt.py", 
 
 
 def _manifest_required_prompts() -> list[str]:
-	array_lines: list[str] = []
-	for line in _workflow_text().splitlines():
-		stripped = line.strip()
-		if not array_lines and not stripped.startswith('"required_prompts"'):
-			continue
-		array_lines.append(stripped.split(":", 1)[1].strip() if not array_lines else stripped)
-		if stripped == "],":
-			return json.loads("\n".join(array_lines).removesuffix(","))
-	raise AssertionError("validate.yml support manifest is missing a complete required_prompts array")
+	workflow_text = _workflow_text()
+	key = '"required_prompts"'
+	key_index = workflow_text.find(key)
+	if key_index == -1:
+		raise AssertionError("validate.yml support manifest is missing a required_prompts array")
+	field_start = workflow_text.find(":", key_index + len(key))
+	array_start = workflow_text.find("[", field_start)
+	if field_start == -1 or array_start == -1:
+		raise AssertionError("validate.yml support manifest is missing a required_prompts array")
+	try:
+		required_prompts, _ = json.JSONDecoder().raw_decode(workflow_text[array_start:])
+	except json.JSONDecodeError as exc:
+		raise AssertionError("validate.yml support manifest contains an invalid required_prompts array") from exc
+	if not isinstance(required_prompts, list) or not all(isinstance(item, str) for item in required_prompts):
+		raise AssertionError("validate.yml support manifest required_prompts must be a string array")
+	return required_prompts
 
 
 def _missing_reference_path_from_error(error_text: str) -> Path | None:
@@ -113,19 +120,20 @@ def _expected_validate_reference_files() -> set[str]:
 				prompt_path.write_text((REPO_ROOT / rel).read_text(encoding="utf-8"), encoding="utf-8")
 				prompt_text = render_prompt.load_prompt(prompt_path)
 				mode_name = render_prompt.resolve_mode_name(prompt_path, None)
+				hydrated_values: dict[str, str] = {}
 				while True:
 					try:
-						render_prompt.hydrate_reference_placeholders(
+						hydrated_values = render_prompt.hydrate_reference_placeholders(
 							prompt_text=prompt_text,
 							prompt_path=prompt_path,
 							mode_name=mode_name,
-							values={},
+							values=hydrated_values,
 						)
 						break
 					except render_prompt.PromptLoadError as exc:
 						missing_path = _missing_reference_path_from_error(str(exc))
 						if missing_path is None:
-							raise AssertionError(str(exc)) from exc
+							raise AssertionError(f"unexpected hydration failure for {rel}: {exc}") from exc
 						expected.add(missing_path.name)
 						missing_path.parent.mkdir(parents=True, exist_ok=True)
 						missing_path.write_text(f"{missing_path.name}\n", encoding="utf-8")
@@ -143,6 +151,9 @@ def test_validate_manifest_stages_reference_dependencies() -> None:
 	required_prompts = _manifest_required_prompts()
 	expected_references = _expected_validate_reference_files()
 	assert expected_references, "expected at least one validate reference dependency"
+	assert "validate-output-contract.txt" in expected_references, (
+		"mode-validate-generate should require the validate-output-contract append reference"
+	)
 	for file_name in sorted(expected_references):
 		manifest_entry = f"prompts/references/{file_name}"
 		assert manifest_entry in required_prompts, (
@@ -312,7 +323,7 @@ def main() -> int:
 		except Exception as exc:
 			failures.append(f"{test_fn.__name__}: {exc}")
 	for failure in failures:
-		print(failure, file=sys.stderr)
+		print(f"::error::{failure}", file=sys.stderr)
 	return 1 if failures else 0
 
 

--- a/tests/test_validate_semble_contract.py
+++ b/tests/test_validate_semble_contract.py
@@ -3,10 +3,13 @@
 
 from __future__ import annotations
 
+import re
+import sys
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
 VALIDATE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "validate.yml"
 STAGE_WORKFLOW_SUPPORT = REPO_ROOT / "scripts" / "stage_workflow_support.sh"
 VALIDATE_PROCESS = REPO_ROOT / "scripts" / "validate_process.sh"
@@ -17,6 +20,16 @@ VALIDATE_PROMPTS = [
 	REPO_ROOT / "prompts" / "mode-validate-fix-harness.txt",
 	REPO_ROOT / "prompts" / "mode-validate-self-heal.txt",
 ]
+# The validate-mode prompts the support manifest stages into the isolated
+# per-project validate workspace via `required_prompts`. render_prompt.py
+# hydrates their {{REFERENCE_*}} placeholders from prompts/references/*.txt,
+# so those reference files must be staged alongside them or render aborts.
+STAGED_REQUIRED_VALIDATE_PROMPTS = (
+	"prompts/mode-validate-generate.txt",
+	"prompts/mode-validate-diagnose.txt",
+	"prompts/mode-validate-discover.txt",
+	"prompts/mode-validate-fix-harness.txt",
+)
 
 
 def _read(path: Path) -> str:
@@ -37,6 +50,64 @@ def _validate_process_text() -> str:
 
 def _self_heal_text() -> str:
 	return _read(SELF_HEAL_SCRIPT)
+
+
+def _import_render_prompt():
+	if str(SCRIPTS_DIR) not in sys.path:
+		sys.path.insert(0, str(SCRIPTS_DIR))
+	import render_prompt
+
+	return render_prompt
+
+
+def _manifest_required_prompts() -> list[str]:
+	match = re.search(r'"required_prompts"\s*:\s*\[(.*?)\]', _workflow_text(), re.DOTALL)
+	assert match, "validate.yml support manifest is missing a required_prompts array"
+	return re.findall(r'"([^"]+)"', match.group(1))
+
+
+def _expected_validate_reference_files() -> set[str]:
+	# Mirror render_prompt.py's placeholder->reference-file resolution so this
+	# guard tracks the renderer's real behaviour instead of a hand-maintained
+	# list: every {{REFERENCE_*}} placeholder maps to a prompts/references/*.txt
+	# file, and mode-validate-generate additionally appends
+	# validate-output-contract.txt for REFERENCE_OUTPUT_CONTRACT.
+	render_prompt = _import_render_prompt()
+	expected: set[str] = set()
+	for rel in STAGED_REQUIRED_VALIDATE_PROMPTS:
+		prompt_path = REPO_ROOT / rel
+		text = prompt_path.read_text(encoding="utf-8")
+		mode_name = prompt_path.stem
+		for placeholder in sorted(set(re.findall(r"\{\{([A-Za-z0-9_]+)\}\}", text))):
+			file_name = render_prompt._reference_file_name_for_placeholder(placeholder)
+			if file_name is None:
+				continue
+			expected.add(file_name)
+			if placeholder == "REFERENCE_OUTPUT_CONTRACT" and mode_name == "mode-validate-generate":
+				expected.add("validate-output-contract.txt")
+	return expected
+
+
+def test_validate_manifest_stages_reference_dependencies() -> None:
+	# Regression guard for the infinite redispatch loop: the validate job runs
+	# in an isolated workspace with no .codex-workflow-src checkout, so every
+	# prompts/references/*.txt file a staged validate prompt depends on must be
+	# listed in the manifest's required_prompts. If one is missing,
+	# render_prompt.py aborts ("Reference file ... not found"), the validate run
+	# exits before applying a result label, and the orchestrate poller keeps
+	# redispatching the same cycle forever.
+	required_prompts = _manifest_required_prompts()
+	expected_references = _expected_validate_reference_files()
+	assert expected_references, "expected at least one validate reference dependency"
+	for file_name in sorted(expected_references):
+		manifest_entry = f"prompts/references/{file_name}"
+		assert manifest_entry in required_prompts, (
+			f"validate manifest required_prompts is missing {manifest_entry}; "
+			"staged validate prompts depend on it at render time"
+		)
+		assert (REPO_ROOT / "prompts" / "references" / file_name).is_file(), (
+			f"prompts/references/{file_name} is staged by the manifest but does not exist on disk"
+		)
 
 
 def test_validate_prompts_include_serena_placeholder() -> None:
@@ -180,6 +251,7 @@ def test_self_heal_includes_semble_and_serena_prompt_hooks() -> None:
 
 
 def main() -> int:
+	test_validate_manifest_stages_reference_dependencies()
 	test_validate_prompts_include_serena_placeholder()
 	test_validate_workflow_lists_semble_support_files_in_helper_manifest()
 	test_validate_workflow_lists_serena_support_files_in_helper_manifest()


### PR DESCRIPTION
## Summary

Fixes the **infinite validation redispatch loop** a consumer repo reported — a notifier bot repeating `🧪 Validation dispatched for project #N (cycle 1)` forever, because every AI Validate run fails at prompt-render time and never applies a result label.

### Root cause (verified upstream, affects every consumer)

The validate support manifest in `.github/workflows/validate.yml` stages the four `mode-validate-*.txt` prompts into the isolated per-project workspace via `required_prompts`, but **never stages the `prompts/references/*.txt` files those prompts depend on**.

- All four validate prompts use `{{REFERENCE_OUTPUT_CONTRACT}}`; `generate`/`fix-harness` also use `{{REFERENCE_VERIFICATION_LOOP}}`; `generate` appends `validate-output-contract.txt` (`scripts/render_prompt.py:247-248`).
- The validate job runs in an isolated workspace (`/home/runner/work/_temp/workspaces/...`) with **no `.codex-workflow-src` checkout**, so none of `render_prompt.py`'s `discover_reference_path` candidates (`scripts/render_prompt.py:195-209`) resolve, and rendering aborts:
  ```
  ERROR: Reference file for placeholder 'REFERENCE_OUTPUT_CONTRACT' not found: prompts/references/output-contract.txt
  ```
- The validate run exits before applying a result label, so the orchestrate poller treats it as "stale, no label" and redispatches the same cycle indefinitely.

Other workflows (implement, review, …) don't hit this because they render from the main checkout, where `cwd/.codex-workflow-src/prompts/references/` resolves. Only validate renders from the isolated workspace.

### Fix

Add the three reference files to the validate manifest's `required_prompts`, so `stage_required_entry` (`scripts/stage_workflow_support.sh:611`) copies them to `<workspace>/prompts/references/` and `discover_reference_path` candidate #1 resolves. Strictly additive — no rename/removal (§6 clean), no DB/contract surface (§10 N/A).

### Verification

- **Reproduced** the exact production error in a simulated isolated workspace (validate prompts staged, references absent) → render aborts with the reported message.
- **After the fix**, all four required prompts plus both optional self-heal prompts render cleanly with no unresolved `REFERENCE_` placeholders.
- Added a **regression guard** in `tests/test_validate_semble_contract.py` that derives each staged validate prompt's reference dependencies via `render_prompt.py`'s own placeholder→filename mapping and asserts the manifest stages every one. Confirmed it **fails on the pre-fix manifest** and **passes on the fixed one**.
- Related contract / parity suites pass (`test_validate_process_template_mode.py`, `test_validate_harness_rpc.py`, `test_phase_prompt_untrusted_context_contract.py`, `prompt_size_budget.py`, `inventory_parity.py`).

### Out of scope (noted, not addressed here)

- **Consumer-side:** the reporting branch declares `type: python-repo-checks` for a Node/Next.js project; that's a consumer config issue on their branch, not an upstream defect.
- **Poller robustness:** a deterministically-failing validate harness is redispatched without a cap (cycle never advances toward `MAX_VALIDATE_CYCLES`). Worth hardening separately, but it has design tradeoffs and is not needed once render succeeds — left out to keep this change minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPoGSHuPhuU91oMpbEoKU5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPoGSHuPhuU91oMpbEoKU5)_