### PR TITLE
Fix e2e-smoke Phase 4 falsely matching Copilot Code Review run

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1329,6 +1329,20 @@ jobs:
             # BAIT_SHA because we dispatch with --ref "${BRANCH}" and
             # GitHub records the ref's tip SHA at dispatch time.
             #
+            # GitHub's "Running Copilot Code Review" run is excluded
+            # (event == "dynamic" / name contains "copilot"): it is a
+            # code-REVIEW agent, not the review-AND-AUTOFIX workflow, yet
+            # its name matches the broad `Review` token above. On v1.19.0
+            # (run 27926259717) the Copilot run (head=pre-bait SHA,
+            # created 02:56:26, updated 02:58:40) straddled the bait
+            # timestamp (02:58:37) so leg (b)'s created<=bait<=updated
+            # window admitted it; tier-1 preference then picked that
+            # already-completed Copilot success over the still-in-progress
+            # real autofix run, so Phase 4 declared success ~6s in and
+            # Phase 4b then failed on the unrestored canary. Excluding the
+            # Copilot reviewer keeps the loop watching the actual
+            # internal-review.yml / review_autofix.yml run instead.
+            #
             # `self-healing` is part of the regex because review_autofix.yml
             # ("Codex PR Self-Healing Semantic Agent") is dispatched directly
             # by its own post_commit_retrigger after the editor commits the
@@ -1406,10 +1420,10 @@ jobs:
               # wins over an active sibling (preserves the run-26989483268
               # fix).
               REVIEW_RUN=$(gh_api_safe_quiet_print "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&per_page=100" \
-                --jq "[.workflow_runs[] | select(.name | test(\"Review|review|autofix|self-healing\"; \"i\")) | select(.head_sha == \"${PIN_SHA}\" or (\"${BAIT_CREATED_AT:-}\" != \"\" and .created_at <= \"${BAIT_CREATED_AT:-}\" and (.updated_at >= \"${BAIT_CREATED_AT:-}\" or .status == \"in_progress\")))] as \$m | (\$m | map(select(.status == \"completed\" and .conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | map(select(.status == \"in_progress\" and \"${BAIT_CREATED_AT:-}\" != \"\" and .created_at <= \"${BAIT_CREATED_AT:-}\")) | sort_by(.created_at) | first) // (\$m | map(select(.status == \"in_progress\")) | sort_by(.created_at) | last) // (\$m | map(select(.conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | sort_by(.created_at) | last)" || echo "")
+                --jq "[.workflow_runs[] | select(.name | test(\"Review|review|autofix|self-healing\"; \"i\")) | select((.event == \"dynamic\" or (.name | test(\"copilot\"; \"i\"))) | not) | select(.head_sha == \"${PIN_SHA}\" or (\"${BAIT_CREATED_AT:-}\" != \"\" and .created_at <= \"${BAIT_CREATED_AT:-}\" and (.updated_at >= \"${BAIT_CREATED_AT:-}\" or .status == \"in_progress\")))] as \$m | (\$m | map(select(.status == \"completed\" and .conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | map(select(.status == \"in_progress\" and \"${BAIT_CREATED_AT:-}\" != \"\" and .created_at <= \"${BAIT_CREATED_AT:-}\")) | sort_by(.created_at) | first) // (\$m | map(select(.status == \"in_progress\")) | sort_by(.created_at) | last) // (\$m | map(select(.conclusion != \"cancelled\")) | sort_by(.created_at) | last) // (\$m | sort_by(.created_at) | last)" || echo "")
             else
               REVIEW_RUN=$(gh_api_safe_quiet_print "repos/${TEST_REPO}/actions/runs?branch=${PR_BRANCH}&event=pull_request&per_page=5" \
-                --jq '[.workflow_runs[] | select(.name | test("Review|review|autofix|self-healing"; "i"))] | sort_by(.created_at) | last' || echo "")
+                --jq '[.workflow_runs[] | select(.name | test("Review|review|autofix|self-healing"; "i")) | select((.event == "dynamic" or (.name | test("copilot"; "i"))) | not)] | sort_by(.created_at) | last' || echo "")
             fi
 
             # If rate-limited, skip this cycle entirely (don't corrupt state)


### PR DESCRIPTION
## Summary

Release **v1.19.0** failed on `e2e-smoke-test` ([run 27926259717](https://github.com/shubhodeep1/coding-workflows/actions/runs/27926259717)). The failing step was **Phase 4b: Verify editor restored canary** — pytest found the canary still contained the bait marker, the retry re-dispatch never got scheduled, and the step exited with `retry_timeout`.

Root cause is one step earlier: **Phase 4 ("Wait for review & autofix to complete")** selected GitHub's **"Running Copilot Code Review"** run as the review/autofix run and declared `✓ Review & autofix completed successfully` ~6 seconds in, before the real autofix run could restore the canary.

## Root cause

The review-run matcher in `test-and-mark-stable.yml` uses the name regex `test("Review|review|autofix|self-healing"; "i")`, which also matches `"Running Copilot Code Review"` (it contains "Review"). On the failing run:

- The Copilot run `27926631448` had `head_sha = de58089` (the **pre-bait** commit), `event = dynamic`, `created_at = 02:56:26`, `updated_at = 02:58:40`.
- The bait commit `f702e7f` landed at `BAIT_CREATED_AT = 02:58:37`.
- Leg (b)'s in-flight window `created_at <= bait <= updated_at` admitted the Copilot run because its lifetime straddled the bait timestamp by 3 seconds.
- Tier-1 preference (newest completed non-cancelled) then picked that **completed Copilot success** over the **still-in-progress real autofix run** `27926628655` (`Internal: AI Review & Autofix`).

Phase 4 therefore exited early with a false success; Phase 4b read the canary, found the bait still present (the real autofix never restored it), retried, and the re-dispatched review run stayed `pending` past the 25-minute window → `retry_timeout` → job failure.

## Fix

Exclude GitHub's Copilot Code Review run (`event == "dynamic"` **or** name contains `copilot`) from the candidate set, in **both** the `PIN_SHA` query and the legacy-fallback query. The wait loop now watches the actual `internal-review.yml` / `review_autofix.yml` run instead of short-circuiting on the unrelated reviewer agent. The broad positive name match is preserved (consumer repos use different workflow names), so only the specific false positive is removed.

## Verification

Replayed the failing run list through `jq`:

- **Old filter** → selects `27926631448 "Running Copilot Code Review"` (completed/success) — the bug.
- **New filter** → selects `27926628655 "Internal: AI Review & Autofix"` (in_progress) — correct.

YAML re-parses cleanly; no tab characters introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMoeyoksYKA8A6Dbh8XH2p)_