### PR TITLE
fix(review_autofix): set REPOSITORY env on codex-agent force-tick steps

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -4584,6 +4584,7 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
           GH_TOKEN: ${{ secrets.GH_PAT }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           HELPER="${SUPPORT_SCRIPTS_DIR}/orchestrate_force_tick.sh"
@@ -5432,6 +5433,7 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
           GH_TOKEN: ${{ secrets.GH_PAT }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           HELPER="${SUPPORT_SCRIPTS_DIR}/orchestrate_force_tick.sh"


### PR DESCRIPTION
## Summary

The two `codex-agent` "Force orchestrate poll" steps in `review_autofix.yml` —
**"Force orchestrate poll after review-blocked exhaustion"** and **"Force
orchestrate poll after workflow failure review-blocked label"** — run
`orchestrate_force_tick.sh --repo "${REPOSITORY}"` under `set -euo pipefail`,
but neither the steps' `env:` blocks nor the `codex-agent` job-level env
(lines ~1120–1186, which sets `PR_NUMBER` but not `REPOSITORY`) defined
`REPOSITORY`. Under `set -u`, the unbound expansion aborted the step with
`REPOSITORY: unbound variable` (exit 1) on **every** review-blocked / failure
exit of the job.

The functional loss: the orchestrator force-tick never fired, so the poller
was not nudged after review-blocked exhaustion or after a workflow failure.
It also failed the whole `codex-agent` job. This was deterministic, not a
flake.

## Fix

Add `REPOSITORY: ${{ github.repository }}` to both steps' `env:` blocks,
matching the step-local convention already used by ~13 sibling steps in the
same job (e.g. lines 1364, 4314, 4498, 5349, 5369). The post-merge twin
("Force orchestrate poll after merged PR handling") never hit this because
its job, `post-merge-validate-dispatch`, sets `REPOSITORY` at the job level.

`SUPPORT_SCRIPTS_DIR` (referenced earlier in the same run blocks) survives
because `scripts/stage_workflow_support.sh` exports it to `$GITHUB_ENV`;
`REPOSITORY` had no such job-level source, which is exactly why only the
`--repo` line aborted and the error surfaced at script line 7.

## Validation

- **Issue verdict: VALID-UPSTREAM.** Confirmed against `main`: job env
  `review_autofix.yml:1120-1186` omits `REPOSITORY`; both force-tick steps
  reference `${REPOSITORY}` under `set -euo pipefail` with `env:` blocks that
  set only `GH_PAT` / `GH_TOKEN`.
- **Cross-check (open question from the report resolved):** every other
  `${REPOSITORY}` reference inside the `codex-agent` job is covered by a
  step-local `REPOSITORY` env or the gate/post-merge job-level env. These two
  force-tick steps were the only offenders.
- **Why CI missed it:** the CI `actionlint` step runs with `-shellcheck=`
  (shellcheck disabled), so this runtime `set -u` failure was not caught
  statically.
- Verified `yamllint -s`, Python YAML parse, and `actionlint -shellcheck=`
  (the CI dogfood gate) all pass after the change. Diff is exactly the two
  one-line `env:` additions; minimal, reversible, no §6 rename, no §10
  contract impact, and consistent across consumers (`github.repository`
  resolves to the caller repo in a reusable workflow, which is the intended
  force-tick target).

Repro: consumer run
https://github.com/shubhodeep1/tele-funtoken-msg-scoring/actions/runs/27870512585
(PR #3411) — both force-tick steps failed with `REPOSITORY: unbound variable`
at script line 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVRQ8aKHYcqSRLdf5mSFGj)_