### PR TITLE
fix(review_autofix): stage judge prompt reference assets into runtime bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,6 +421,11 @@ jobs:
           set -euo pipefail
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_rb_judge_label_propagation.py
 
+      - name: Review-blocked judge reference staging regression tests
+        run: |
+          set -euo pipefail
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_review_rb_judge_reference_staging.py
+
       - name: Review-blocked judge self-run exclusion regression tests
         run: |
           set -euo pipefail

--- a/scripts/stage_workflow_support.sh
+++ b/scripts/stage_workflow_support.sh
@@ -254,8 +254,9 @@ fi
 # checkout does not exist. Stage the reference assets here; without them the
 # review-blocked / interim judges fail with "Reference file for placeholder
 # 'REFERENCE_OUTPUT_CONTRACT' not found" and degrade to the recovery path.
-# Warn (do not exit 1) when a reference is unavailable so older support refs
-# keep degrading gracefully instead of hard-failing the whole bundle.
+# Warn (do not exit 1) when a reference is unavailable so bundle staging still
+# completes; if the staged prompt still requires the asset, the downstream
+# judge render will fail with the concrete missing-reference error.
 for reference_asset in output-contract.txt severity-classification.txt; do
   if [ ! -f "${SUPPORT_PROMPTS_DIR}/references/${reference_asset}" ]; then
     src=".codex-workflow-src/prompts/references/${reference_asset}"
@@ -266,7 +267,7 @@ for reference_asset in output-contract.txt severity-classification.txt; do
       mkdir -p "${SUPPORT_PROMPTS_DIR}/references"
       install -m 0644 "${src}" "${SUPPORT_PROMPTS_DIR}/references/${reference_asset}"
     else
-      echo "::warning::prompts/references/${reference_asset} not found in checked-out support sources for ${SCRIPT_REF}; review-blocked/interim judge will degrade (REFERENCE_* placeholder left unhydrated)."
+      echo "::warning::prompts/references/${reference_asset} not found in checked-out support sources for ${SCRIPT_REF}; bundle staging will continue, but downstream review-blocked/interim judge render will fail with a missing REFERENCE_* error if the staged prompt still requires this asset."
     fi
   fi
 done

--- a/scripts/stage_workflow_support.sh
+++ b/scripts/stage_workflow_support.sh
@@ -244,6 +244,32 @@ if [ ! -f "${SUPPORT_PROMPTS_DIR}/mode-judge-interim.txt" ]; then
   fi
   install -m 0644 "${src}" "${SUPPORT_PROMPTS_DIR}/mode-judge-interim.txt"
 fi
+# The judge / reviewer prompts staged into the runtime bundle embed REFERENCE_*
+# placeholders (REFERENCE_OUTPUT_CONTRACT, REFERENCE_SEVERITY_CLASSIFICATION)
+# that render_prompt.py hydrates from <prompt-root>/prompts/references/<name>.txt.
+# review_rb_judge.sh and review_run_judge_interim.sh cd into SUPPORT_ROOT_DIR
+# before rendering, so the prompt root is SUPPORT_ROOT_DIR and the only path
+# render_prompt.py can resolve is SUPPORT_PROMPTS_DIR/references/ — the cwd /
+# .codex-workflow-src fallbacks point under SUPPORT_ROOT_DIR, where the support
+# checkout does not exist. Stage the reference assets here; without them the
+# review-blocked / interim judges fail with "Reference file for placeholder
+# 'REFERENCE_OUTPUT_CONTRACT' not found" and degrade to the recovery path.
+# Warn (do not exit 1) when a reference is unavailable so older support refs
+# keep degrading gracefully instead of hard-failing the whole bundle.
+for reference_asset in output-contract.txt severity-classification.txt; do
+  if [ ! -f "${SUPPORT_PROMPTS_DIR}/references/${reference_asset}" ]; then
+    src=".codex-workflow-src/prompts/references/${reference_asset}"
+    if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/prompts/references/${reference_asset}" ]; then
+      src=".codex-workflow-src-main/prompts/references/${reference_asset}"
+    fi
+    if [ -f "${src}" ]; then
+      mkdir -p "${SUPPORT_PROMPTS_DIR}/references"
+      install -m 0644 "${src}" "${SUPPORT_PROMPTS_DIR}/references/${reference_asset}"
+    else
+      echo "::warning::prompts/references/${reference_asset} not found in checked-out support sources for ${SCRIPT_REF}; review-blocked/interim judge will degrade (REFERENCE_* placeholder left unhydrated)."
+    fi
+  fi
+done
 if [ ! -f "${SUPPORT_PROMPTS_DIR}/behavioural-smoke-synthesise.txt" ]; then
   src=".codex-workflow-src/prompts/behavioural-smoke-synthesise.txt"
   if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/prompts/behavioural-smoke-synthesise.txt" ]; then

--- a/tests/test_review_rb_judge_reference_staging.py
+++ b/tests/test_review_rb_judge_reference_staging.py
@@ -2,7 +2,7 @@
 """Regression guard: judge prompt reference assets are staged into the bundle.
 
 Reported from consumer run 28009116022 (shubhodeep1/tele-funtoken-msg-scoring,
-PR #3434): the review-blocked judge degraded with
+PR #3434): the review-blocked judge failed with
 
   ERROR: Reference file for placeholder 'REFERENCE_OUTPUT_CONTRACT' not found:
   .../coding-workflows-runtime-.../prompts/references/output-contract.txt
@@ -24,7 +24,8 @@ Two tests pin the fix:
    output-contract.txt and severity-classification.txt into
    ${SUPPORT_PROMPTS_DIR}/references/ with the .codex-workflow-src ->
    .codex-workflow-src-main fallback, and warns (does not exit 1) when a
-   reference is unavailable so older support refs degrade gracefully.
+   reference is unavailable so bundle staging continues while any later
+   missing-reference failure is reported by render_prompt.py itself.
 
 2. A behavioural test that reproduces the bundle layout review_rb_judge.sh
    builds, renders the review-blocked prompt the same way (cd SUPPORT_ROOT_DIR
@@ -85,9 +86,10 @@ def test_stage_workflow_support_stages_judge_reference_assets() -> None:
 		'install -m 0644 "${src}" "${SUPPORT_PROMPTS_DIR}/references/${reference_asset}"'
 		in stage_helper
 	)
-	# Graceful degrade (warn, never exit 1) so older support refs still bootstrap.
+	# Warn, never exit 1, so bundle staging continues until render_prompt.py can
+	# surface any concrete missing-reference failure.
 	assert (
-		"review-blocked/interim judge will degrade (REFERENCE_* placeholder left unhydrated)"
+		"downstream review-blocked/interim judge render will fail with a missing REFERENCE_* error"
 		in stage_helper
 	)
 
@@ -130,6 +132,13 @@ def _render_review_blocked_prompt(*, stage_references: bool) -> subprocess.Compl
 
 		env = os.environ.copy()
 		env["PYTHONDONTWRITEBYTECODE"] = "1"
+		# The workflow judge path explicitly `cd`s into SUPPORT_ROOT_DIR before
+		# rendering. Local editor/review shells can export BASH_ENV/WORKSPACE_PATH
+		# helpers that auto-cd nested bash processes back to the repo root, which
+		# would let render_prompt.py fall back to the source-tree references and
+		# mask the missing-bundle regression this test is meant to catch.
+		env.pop("BASH_ENV", None)
+		env.pop("WORKSPACE_PATH", None)
 		return subprocess.run(
 			[
 				"bash",
@@ -167,3 +176,20 @@ def test_review_blocked_prompt_fails_without_staged_references() -> None:
 		"Reference file for placeholder 'REFERENCE_OUTPUT_CONTRACT' not found"
 		in result.stderr
 	)
+
+
+def main() -> int:
+	"""Keep this file runnable via `python3 tests/<file>.py`.
+
+	The repo's CI uses explicit direct-run allowlists rather than pytest
+	discovery, so this module must provide its own entrypoint.
+	"""
+	test_stage_workflow_support_stages_judge_reference_assets()
+	test_review_blocked_prompt_hydrates_references_from_bundle_layout()
+	test_review_blocked_prompt_fails_without_staged_references()
+	print("OK: review-blocked judge reference staging regression tests passed")
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_review_rb_judge_reference_staging.py
+++ b/tests/test_review_rb_judge_reference_staging.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Regression guard: judge prompt reference assets are staged into the bundle.
+
+Reported from consumer run 28009116022 (shubhodeep1/tele-funtoken-msg-scoring,
+PR #3434): the review-blocked judge degraded with
+
+  ERROR: Reference file for placeholder 'REFERENCE_OUTPUT_CONTRACT' not found:
+  .../coding-workflows-runtime-.../prompts/references/output-contract.txt
+
+`mode-judge-review-blocked.txt` (and `mode-judge-interim.txt`,
+`review-consolidator.txt`, `review-reviewer-checklist.txt`) embed REFERENCE_*
+placeholders that render_prompt.py hydrates from
+`<prompt-root>/prompts/references/<name>.txt`. review_rb_judge.sh and
+review_run_judge_interim.sh `cd "${SUPPORT_ROOT_DIR}"` before rendering, so the
+prompt root is SUPPORT_ROOT_DIR and the only location render_prompt.py can
+resolve is SUPPORT_PROMPTS_DIR/references/ — the cwd / .codex-workflow-src
+fallbacks resolve under SUPPORT_ROOT_DIR, where the support checkout does not
+exist. stage_review_runtime_support() never staged that subdirectory, so every
+review-blocked / interim judge render hit the unhydrated-reference error.
+
+Two tests pin the fix:
+
+1. A static contract on scripts/stage_workflow_support.sh: it stages
+   output-contract.txt and severity-classification.txt into
+   ${SUPPORT_PROMPTS_DIR}/references/ with the .codex-workflow-src ->
+   .codex-workflow-src-main fallback, and warns (does not exit 1) when a
+   reference is unavailable so older support refs degrade gracefully.
+
+2. A behavioural test that reproduces the bundle layout review_rb_judge.sh
+   builds, renders the review-blocked prompt the same way (cd SUPPORT_ROOT_DIR
+   then render_prompt.sh), and asserts the REFERENCE_OUTPUT_CONTRACT placeholder
+   is hydrated when references/ is staged — with a negative control proving the
+   exact consumer error fires when it is absent.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+STAGE_HELPER = REPO_ROOT / "scripts" / "stage_workflow_support.sh"
+RENDER_PROMPT_PY = REPO_ROOT / "scripts" / "render_prompt.py"
+RENDER_PROMPT_SH = REPO_ROOT / "scripts" / "render_prompt.sh"
+REVIEW_BLOCKED_PROMPT = REPO_ROOT / "prompts" / "mode-judge-review-blocked.txt"
+REVIEW_BLOCKED_CONTRACT = REPO_ROOT / "prompts" / "contracts" / "mode-judge-review-blocked.yml"
+REFERENCES_DIR = REPO_ROOT / "prompts" / "references"
+JUDGE_REFERENCE_ASSETS = ("output-contract.txt", "severity-classification.txt")
+
+
+def _stage_helper_text() -> str:
+	return STAGE_HELPER.read_text(encoding="utf-8")
+
+
+def test_stage_workflow_support_stages_judge_reference_assets() -> None:
+	"""stage_review_runtime_support() must stage the judge REFERENCE_* assets."""
+	stage_helper = _stage_helper_text()
+
+	# The reference files the staged judge / reviewer prompts hydrate must exist.
+	for reference_asset in JUDGE_REFERENCE_ASSETS:
+		assert (REFERENCES_DIR / reference_asset).is_file(), (
+			f"missing reference asset prompts/references/{reference_asset}"
+		)
+
+	# The staging loop pins both assets and the standard ref -> main fallback.
+	assert (
+		"for reference_asset in output-contract.txt severity-classification.txt; do"
+		in stage_helper
+	)
+	assert (
+		'if [ ! -f "${SUPPORT_PROMPTS_DIR}/references/${reference_asset}" ]; then'
+		in stage_helper
+	)
+	assert (
+		'src=".codex-workflow-src/prompts/references/${reference_asset}"' in stage_helper
+	)
+	assert (
+		'src=".codex-workflow-src-main/prompts/references/${reference_asset}"'
+		in stage_helper
+	)
+	assert (
+		'install -m 0644 "${src}" "${SUPPORT_PROMPTS_DIR}/references/${reference_asset}"'
+		in stage_helper
+	)
+	# Graceful degrade (warn, never exit 1) so older support refs still bootstrap.
+	assert (
+		"review-blocked/interim judge will degrade (REFERENCE_* placeholder left unhydrated)"
+		in stage_helper
+	)
+
+
+def _render_review_blocked_prompt(*, stage_references: bool) -> subprocess.CompletedProcess[str]:
+	"""Render the review-blocked prompt the way review_rb_judge.sh does.
+
+	Builds the runtime bundle layout (scripts/ + prompts/, optionally
+	prompts/references/), cds into the bundle root, and renders the staged
+	prompt — mirroring review_rb_judge.sh:960-961.
+	"""
+	with tempfile.TemporaryDirectory(prefix="rb-judge-reference-staging-") as td:
+		support_root = Path(td) / "coding-workflows-runtime-1-1"
+		scripts_dir = support_root / "scripts"
+		prompts_dir = support_root / "prompts"
+		contracts_dir = prompts_dir / "contracts"
+		scripts_dir.mkdir(parents=True)
+		prompts_dir.mkdir(parents=True)
+		contracts_dir.mkdir(parents=True)
+
+		# Stage the renderer + prompt + contract exactly as the bundle does.
+		for src in (RENDER_PROMPT_PY, RENDER_PROMPT_SH):
+			(scripts_dir / src.name).write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+		(scripts_dir / "render_prompt.sh").chmod(0o755)
+		(prompts_dir / REVIEW_BLOCKED_PROMPT.name).write_text(
+			REVIEW_BLOCKED_PROMPT.read_text(encoding="utf-8"), encoding="utf-8"
+		)
+		(contracts_dir / REVIEW_BLOCKED_CONTRACT.name).write_text(
+			REVIEW_BLOCKED_CONTRACT.read_text(encoding="utf-8"), encoding="utf-8"
+		)
+
+		if stage_references:
+			references_dir = prompts_dir / "references"
+			references_dir.mkdir()
+			for reference_asset in JUDGE_REFERENCE_ASSETS:
+				(references_dir / reference_asset).write_text(
+					(REFERENCES_DIR / reference_asset).read_text(encoding="utf-8"),
+					encoding="utf-8",
+				)
+
+		env = os.environ.copy()
+		env["PYTHONDONTWRITEBYTECODE"] = "1"
+		return subprocess.run(
+			[
+				"bash",
+				str(scripts_dir / "render_prompt.sh"),
+				str(prompts_dir / REVIEW_BLOCKED_PROMPT.name),
+			],
+			cwd=str(support_root),
+			env=env,
+			capture_output=True,
+			text=True,
+			timeout=120,
+		)
+
+
+def test_review_blocked_prompt_hydrates_references_from_bundle_layout() -> None:
+	"""With references staged, the review-blocked render hydrates the placeholder."""
+	result = _render_review_blocked_prompt(stage_references=True)
+	assert result.returncode == 0, (
+		f"render failed unexpectedly: rc={result.returncode}\nstderr={result.stderr}"
+	)
+	assert "Reference file for placeholder" not in result.stderr
+	# Placeholder must be hydrated (no literal {{REFERENCE_OUTPUT_CONTRACT}} left).
+	assert "{{REFERENCE_OUTPUT_CONTRACT}}" not in result.stdout
+
+
+def test_review_blocked_prompt_fails_without_staged_references() -> None:
+	"""Negative control: the exact consumer error fires when references are absent.
+
+	This proves the behavioural test above is load-bearing — if a regression
+	drops the references staging, the render fails with the reported error.
+	"""
+	result = _render_review_blocked_prompt(stage_references=False)
+	assert result.returncode != 0
+	assert (
+		"Reference file for placeholder 'REFERENCE_OUTPUT_CONTRACT' not found"
+		in result.stderr
+	)


### PR DESCRIPTION
## Summary

Validated a consumer-reported upstream issue (`/validate-consumer-issue`) from **`shubhodeep1/tele-funtoken-msg-scoring` PR #3434**, Actions run `28009116022`, banner `❌ ERROR: PR autofix failed`, running `review_autofix.yml@stable (97ffa4e)`.

The report raised **two** upstream defects. This PR lands the **second** (the first was already fixed):

| # | Defect | Status |
|---|--------|--------|
| Fix 1 (primary) | Two `orchestrate_force_tick.sh` steps referenced `${REPOSITORY}` under `set -u` without binding it in `env:` → `REPOSITORY: unbound variable` → red job | **Already fixed on `main`/`stable`** by `cef5db6` (#3459). No action. |
| Fix 2 (secondary) | `review_rb_judge.sh` degraded with `Reference file for placeholder 'REFERENCE_OUTPUT_CONTRACT' not found: …/prompts/references/output-contract.txt` | **Fixed here.** |

## Root cause (Fix 2)

The review-blocked / interim judge prompts (`mode-judge-review-blocked.txt`, `mode-judge-interim.txt`) — plus the reviewer consolidator/checklist prompts — embed `REFERENCE_*` placeholders (`REFERENCE_OUTPUT_CONTRACT`, `REFERENCE_SEVERITY_CLASSIFICATION`) that `render_prompt.py` hydrates from `<prompt-root>/prompts/references/<name>.txt`.

`review_rb_judge.sh:960-961` and `review_run_judge_interim.sh:250-251` `cd "${SUPPORT_ROOT_DIR}"` before rendering, so the prompt root is `SUPPORT_ROOT_DIR` and the only path `render_prompt.py` can resolve is `SUPPORT_PROMPTS_DIR/references/`. All other candidates (`cwd`, `.codex-workflow-src`, `.codex-workflow-src-main`) resolve **under** `SUPPORT_ROOT_DIR`, where the support checkout does not exist.

`stage_review_runtime_support()` staged the prompts but **never staged `prompts/references/`**, so on the review-blocked / failure path the judge crashed with the missing-reference error and degraded to the `ai:review-blocked` recovery path (`review_rb_judge.sh` exited 1). The `validate.yml` path already stages these references via its manifest (`validate.yml:378-380`); this brings the `review_autofix` runtime bundle in line.

## Reproduction

- **Without** `prompts/references/` staged → exact consumer error, `rc=1`.
- **With** it staged → both review-blocked and interim judges render `rc=0`, placeholder hydrated, no leftover `{{REFERENCE_OUTPUT_CONTRACT}}`.

## Fix

`scripts/stage_workflow_support.sh` — in `stage_review_runtime_support()`, stage `output-contract.txt` and `severity-classification.txt` into `SUPPORT_PROMPTS_DIR/references/` with the standard `.codex-workflow-src` → `.codex-workflow-src-main` fallback. Warns (never `exit 1`) when a reference is unavailable, so older support refs keep degrading gracefully instead of hard-failing the whole bundle bootstrap. The change is additive and purely beneficial across consumers.

## Tests

`tests/test_review_rb_judge_reference_staging.py` (new):
- static contract pinning the staging block + ref→main fallback;
- behavioural test reproducing the bundle layout and render (asserts hydration);
- **negative control** proving the exact consumer error fires when references are absent.

`71 passed` across the new file + `test_review_autofix_review_pipeline_contract.py` + `test_render_prompt_review_judge_modes.py` + `test_review_autofix_force_tick_repository_env.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL5fuxCouMT8xccByD9DdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SL5fuxCouMT8xccByD9DdN)_