### PR TITLE
fix(review_autofix): harden OS-dep install against flaky third-party apt sources

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1384,10 +1384,43 @@ jobs:
           codex_version: ${{ vars.CODEX_VERSION || 'v0.114.0' }}
 
       - name: Install OS-level dependencies
+        shell: bash
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y jq curl python3
+
+          # jq/curl/python3 are pre-installed on hosted ubuntu runners, so the
+          # common case needs no apt at all. Only reach for apt-get when a tool
+          # is genuinely missing: a bare `apt-get update` under `set -e` exits
+          # 100 whenever an unrelated pre-installed third-party apt source (e.g.
+          # packages.microsoft.com) transiently 403s, which would otherwise take
+          # the whole review pipeline down for a dependency this step never uses.
+          # Mirrors the "Install OS-level core tools" step in orchestrate.yml /
+          # orchestrate_poll.yml.
+          missing_tools=()
+          for tool in jq curl python3; do
+            command -v "$tool" >/dev/null 2>&1 || missing_tools+=("$tool")
+          done
+
+          if [ "${#missing_tools[@]}" -gt 0 ]; then
+            if ! command -v apt-get >/dev/null 2>&1; then
+              echo "Missing tools (${missing_tools[*]}), but apt-get is unavailable on this runner" >&2
+              exit 1
+            fi
+
+            apt_cmd=(apt-get)
+            if command -v sudo >/dev/null 2>&1; then
+              apt_cmd=(sudo apt-get)
+            elif [ "$(id -u)" -ne 0 ]; then
+              echo "Missing tools (${missing_tools[*]}), but sudo is unavailable and the current user is not root" >&2
+              exit 1
+            fi
+
+            "${apt_cmd[@]}" update
+            if ! "${apt_cmd[@]}" install -y "${missing_tools[@]}"; then
+              echo "apt-get install failed for: ${missing_tools[*]}" >&2
+              exit 1
+            fi
+          fi
 
       - name: Initialize runtime workspace
         run: |


### PR DESCRIPTION
## Summary

Consumer-reported failure (`shubhodeep1/binance-blessings` AI Review, run `28144533314`, job `83348768973`, PR #212) traced to **this** reusable workflow: the `review_autofix.yml@stable` step **"Install OS-level dependencies"** failed with `apt-get update … 403 Forbidden … exit code 100` when the pre-installed `packages.microsoft.com` apt sources transiently 403'd. The incident itself was environmental and self-recovered on the next run, but it surfaced a genuine latent fragility in upstream code.

### Issue verdict: VALID-UPSTREAM (environmental trigger, real latent defect)

`.github/workflows/review_autofix.yml` ran `sudo apt-get update` **unconditionally** under `set -euo pipefail`. A bare `apt-get update` exits 100 if **any** configured apt source fails — including the pre-installed Microsoft/azure-cli sources the step never uses. `jq`, `curl`, and `python3` all ship in Ubuntu's own archives (and are pre-installed on hosted `ubuntu-24.04`), so the step had no reason to depend on those third-party repos at all.

This is a shared reusable workflow, so the fragility was exposed for **every** consumer's AI Review — not just the reporting repo.

### Proposed fix verdict: CORRECT-BUT-INCOMPLETE

The consumer proposed `rm -f` of the Microsoft/azure-cli source files before `apt-get update`. That would prevent this specific failure, but it hard-codes runner-image-specific filenames that can drift, still runs `apt-get update`/`install` unnecessarily (leaving a residual network dependency — an Ubuntu archive blip would still break it), and diverges from the repo's own established hardening pattern.

### Fix applied (derived from repo convention)

Adopt the **existing** hardened pattern already used in `orchestrate.yml` and `orchestrate_poll.yml` (the "Install OS-level core tools" step): probe each tool with `command -v` and only invoke `apt-get` for genuinely missing ones. On hosted runners all three tools are present, so apt is skipped entirely and the unrelated third-party-source blip can no longer fail the run.

This is a resilience fix that **removes an unnecessary network dependency** — not a retry that masks a deterministic failure. The tool set (`jq curl python3`) and the step name are unchanged (no §6 rename).

## Changes
- `.github/workflows/review_autofix.yml:1386` — replace the unconditional `apt-get update && apt-get install` with the conditional probe-then-install pattern; add `shell: bash` (the script uses bash arrays).

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses.
- `bash -n` on the embedded script — syntax OK.
- Functional run with all tools present — apt block skipped (failure path cannot trigger).
- `pytest` on the 5 `review_autofix` contract/structure test modules — **77 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9Lz3dMbmvyF9xREFtr636

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9Lz3dMbmvyF9xREFtr636)_