### PR TITLE
Make /validate-consumer-issue default its target ref to stable

### DIFF
--- a/.claude/commands/validate-consumer-issue.md
+++ b/.claude/commands/validate-consumer-issue.md
@@ -1,14 +1,24 @@
-Given an issue **and a proposed fix reported from a consumer repo** (in `$ARGUMENTS` — an issue URL / number, pasted issue text, a PR carrying the fix, or prose describing both), determine two things about **this** upstream library (`shubhodeep1/coding-workflows`) at `main`: (1) is it a **valid issue** — real, reproducible, and correctly diagnosed as an upstream bug rather than consumer misconfiguration; and (2) is the **proposed fix** correct, complete, and safe to land here? Then **act on the verdict**: when the issue is a genuine upstream defect and the correct fix (the proposed one, or a corrected/completed version you derive from the evidence) is fully evidence-based, safe, and needs no clarification, **implement it here** — apply, verify, commit, push, open a PR — exactly as `/investigate-issue` would. Otherwise this stays a read-only verdict: report the two judgments and ask / route, never landing a flawed or ambiguous fix.
+Given an issue **and a proposed fix reported from a consumer repo** (in `$ARGUMENTS` — an issue URL / number, pasted issue text, a PR carrying the fix, or prose describing both), determine two things about **this** upstream library (`shubhodeep1/coding-workflows`) at its **[target ref](#target-ref)** (default `stable` — the ref consumers pin and actually run, not `main`): (1) is it a **valid issue** — real, reproducible, and correctly diagnosed as an upstream bug rather than consumer misconfiguration; and (2) is the **proposed fix** correct, complete, and safe to land here? Then **act on the verdict**: when the issue is a genuine upstream defect and the correct fix (the proposed one, or a corrected/completed version you derive from the evidence) is fully evidence-based, safe, and needs no clarification, **implement it here** — apply, verify, commit, push, open a PR — exactly as `/investigate-issue` would. Otherwise this stays a read-only verdict: report the two judgments and ask / route, never landing a flawed or ambiguous fix.
 
 $ARGUMENTS
 
+## Target ref
+
+Everything this command reads, traces, reproduces, branches from, and opens its PR against is the **target ref**. Pick it once, up front, and state it in the report:
+
+- **Default — `stable`.** Validate against `stable` and land the fix there. Consumers pin `@stable`, so that is the ref the failing run actually executed and the ref a fix must reach; a fix landed on `main` does not reach them until the next `main → stable` promotion. `stable` is **both a branch and a tag** — branch off the **branch**: `git fetch origin stable` then branch off `origin/stable`, and give the working branch a `-stable` suffix so the target is obvious. Open the PR with **base = `stable`**.
+- **Explicit `main`.** Use `main` only when it is explicitly selected or specified — e.g. `$ARGUMENTS` says "implement on main" / "target main" / "land on main" / "@main", or the report explicitly states the consumer's upstream ref is `main`. Then branch off, validate against, and PR into `main`.
+- **Explicit other ref.** If the report names some other pinned ref (a version tag or another branch), prefer **that** ref over the `stable` default — it is what the consumer runs.
+
+Always state in the report which target ref was chosen and why: **default-stable**, **explicit-main**, or **explicit-other**. When the fix lands on `stable` only, add the regression caveat to the report and PR body: it should also be ported to `main`, or the next `main → stable` promotion will silently revert it.
+
 ## Procedure
 
-1. **Parse `$ARGUMENTS`.** Separate the two halves: the **reported issue** (the symptom, where it surfaced, which consumer repo + which upstream ref it was running if stated) and the **proposed fix** (a diff, a `file:line` pointer, or a prose description). Fetch any referenced issue / PR via `mcp__github__issue_read` / `pull_request_read` (or `gh`). If neither a clear issue nor a fix is present, stop and ask for the missing half.
+1. **Parse `$ARGUMENTS`.** Separate the two halves: the **reported issue** (the symptom, where it surfaced, which consumer repo + which upstream ref it was running if stated) and the **proposed fix** (a diff, a `file:line` pointer, or a prose description). Fetch any referenced issue / PR via `mcp__github__issue_read` / `pull_request_read` (or `gh`). If neither a clear issue nor a fix is present, stop and ask for the missing half. Determine the **[target ref](#target-ref)** for this run (default `stable`; `main` or another ref only when explicitly selected / named).
 
-2. **Read project context.** Read `README.md`, `agents.md`, and `CLAUDE.md`. If the issue touches a MongoDB collection, read the relevant `/db/contracts/*.yml` (§10). Read the actual upstream code the report implicates — the scripts, workflows, and prompts on `main` — never reason from the report's description alone.
+2. **Read project context.** Read `README.md`, `agents.md`, and `CLAUDE.md`. If the issue touches a MongoDB collection, read the relevant `/db/contracts/*.yml` (§10). Read the actual upstream code the report implicates — the scripts, workflows, and prompts at the **[target ref](#target-ref)** (default `stable`) — never reason from the report's description alone.
 
-3. **Validate the ISSUE.** Trace it in this library's code at `main` and, where feasible, reproduce it. Decide:
+3. **Validate the ISSUE.** Trace it in this library's code at the **[target ref](#target-ref)** (default `stable`) and, where feasible, reproduce it. Decide:
    - **VALID-UPSTREAM** — a genuine defect in the library's own code / workflow / prompt. Cite the code path (`file:line`) and the repro result.
    - **CONSUMER-MISCONFIG** — not our bug. The symptom comes from the consumer's setup: a stale or wrong `@ref` pin, an unset secret / repo-var, a malformed wrapper workflow, a missing input. Identify exactly what the consumer must fix on their side.
    - **NOT-REPRODUCIBLE / INVALID** — cannot be traced or reproduced; the diagnosis does not hold against the actual code.
@@ -34,9 +44,9 @@ First settle on **the correct fix** — the change that actually resolves the va
 - **CORRECT-BUT-INCOMPLETE** → the fix is the proposal plus the missing pieces (edge cases, tests) that make it complete.
 - **INCORRECT** or **UNNECESSARY**, but the issue is **VALID-UPSTREAM** → derive the correct fix from the evidence. This is the `/investigate-issue` behaviour: find the real solution rather than landing the flawed proposal.
 
-Then classify every finding — the issue diagnosis and the fix's correctness — as **EVIDENCE-BASED** (supported by code reading at `main` plus reproduction where feasible) or **HYPOTHESIS** (plausible but unverified). Then:
+Then classify every finding — the issue diagnosis and the fix's correctness — as **EVIDENCE-BASED** (supported by code reading at the **[target ref](#target-ref)** (default `stable`) plus reproduction where feasible) or **HYPOTHESIS** (plausible but unverified). Then:
 
-- **Issue is VALID-UPSTREAM, the correct fix is fully EVIDENCE-BASED, it lands in THIS repo (`shubhodeep1/coding-workflows`), it triggers no §6/§10 hard gate and no cross-consumer break, and no missing/inaccessible resource blocks root cause or fix verification** → design the fix, branch off `stable` and apply it there, verify it (re-run the repro / failing test when feasible), commit, push, open a PR **with base = `stable`**. This command always lands its fixes on this repo's `stable` branch — never `main` or any other branch — **unless the request explicitly names a different target branch**. Do not ask. Then report using the [Output Format](#output-format) with `Fix:` = applied and the branch/PR link. Non-blocking gaps still get listed for transparency.
+- **Issue is VALID-UPSTREAM, the correct fix is fully EVIDENCE-BASED, it lands in THIS repo (`shubhodeep1/coding-workflows`), it triggers no §6/§10 hard gate and no cross-consumer break, and no missing/inaccessible resource blocks root cause or fix verification** → design the fix, branch off the **[target ref](#target-ref)** (default `stable` — `git fetch origin stable` then branch off `origin/stable`, naming the working branch with a `-stable` suffix) and apply it there, verify it (re-run the repro / failing test when feasible), commit, push, open a PR **with base = the target ref** (default `stable`). This command lands its fixes on `stable` by default — never `main` unless `main` (or another ref) is explicitly selected per [Target ref](#target-ref). Do not ask. Then report using the [Output Format](#output-format) with `Fix:` = applied, the chosen target ref + why, and the branch/PR link; when the fix landed on `stable` only, include the port-to-`main` caveat. Non-blocking gaps still get listed for transparency.
 - **Issue is CONSUMER-MISCONFIG** → do **not** edit this library; the remedy lives on the consumer's side. Report the exact configuration change the consumer must make. A code fix here would address the wrong layer — flag that.
 - **Issue is NOT-REPRODUCIBLE / INVALID** → do not edit; report and ask for what's needed to reproduce.
 - **Otherwise** — any HYPOTHESIS finding; a §6 hard gate (the only correct fix needs an unaliased rename/removal of a public identifier); a §10 hard gate (a collection/index change without its `/db/contracts/*` update); a fix that would break other consumers pinned to this library; multiple plausible fixes with material tradeoffs; or a missing/inaccessible resource that blocks root cause or fix verification → **stop before editing**. Report the two verdicts using the [Output Format](#output-format) and ask the user how to proceed (use the CLAUDE.md §2 Q/A format for a §6/§10/tradeoff decision).
@@ -46,6 +56,7 @@ Then classify every finding — the issue diagnosis and the fix's correctness �
 
 ```
 Issue: <one-line restatement; consumer repo + upstream ref if known>
+Target ref: <stable (default-stable) | main (explicit-main) | <ref> (explicit-other)> — <why>
 Issue verdict: VALID-UPSTREAM / CONSUMER-MISCONFIG / NOT-REPRODUCIBLE
 - Evidence: <file:line, code path, repro result>
 
@@ -56,6 +67,7 @@ Fix verdict: CORRECT / CORRECT-BUT-INCOMPLETE / INCORRECT / UNNECESSARY
 
 Fix: <applied | none — read-only verdict>
 - <file>:<line> — <one-line rationale; what the correct fix does>
+- Caveat (stable-only fix): also port to `main`, or the next `main → stable` promotion will silently revert it.
 
 Recommendation: <implemented here (branch/PR) | reject + the correct fix to land | return to consumer (misconfig: <what they must change>) | blocked — ask (reason)>
 Next step: <branch/PR to review when applied; else the consumer-side change, or what's needed to unblock>
@@ -65,21 +77,22 @@ Omit empty sections; every verdict carries a citation. When the fix was applied 
 
 ## Tool Access
 
-**Reads (at `main`):**
+**Reads (at the [target ref](#target-ref), default `stable`):**
 
 - **`mcp__github__*` MCP tools** — `issue_read`, `pull_request_read`, `get_file_contents`, `list_commits`, `search_issues`, `search_pull_requests` for the report, the proposed-fix PR, and the implicated code.
 - **`gh` CLI** — when `GH_TOKEN` / `GITHUB_TOKEN` is set (verify nounset-safe: `{ [ -n "${GH_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ]; } && gh auth status`). **Pass `-R <owner>/<repo>`** — Claude Code Web's remote is a local proxy; bare `gh` fails with `failed to determine base repo`. Use `shubhodeep1/coding-workflows` for upstream reads and the consumer's slug when reading the consumer's wrapper to confirm a misconfig.
-- **`Read` / `Grep` / `Glob`** — trace and reproduce against the local `main` checkout. **`Bash`** for read-only inspection / reproduction.
+- **`Read` / `Grep` / `Glob`** — trace and reproduce against the local **target-ref** checkout (default `stable`). **`Bash`** for read-only inspection / reproduction.
 
 **Writes (only when the [Decision Rule](#decision-rule) implement gate is met):**
 
-- **`Edit` / `Write`** — apply the correct fix against the local `stable` checkout (branch off `stable`), and add/extend the test that verifies it.
-- **`Bash`** — `git` (branch off `stable`, commit, `push -u origin <branch>`) and re-running the repro / failing test to verify the fix before pushing.
-- **`mcp__github__create_pull_request`** (or `gh pr create`) — open the PR ready for review against the `stable` branch (this command's default and only target; override only when the request explicitly names another branch).
+- **`Edit` / `Write`** — apply the correct fix against the local **target-ref** checkout (default `stable`; branch off `origin/stable` with a `-stable`-suffixed working branch), and add/extend the test that verifies it.
+- **`Bash`** — `git` (for the default: `git fetch origin stable` then branch off `origin/stable`; otherwise the chosen target ref — commit, `push -u origin <branch>`) and re-running the repro / failing test to verify the fix before pushing.
+- **`mcp__github__create_pull_request`** (or `gh pr create`) — open the PR ready for review against the **[target ref](#target-ref)** (default `stable`; `main` or another branch only when explicitly selected).
 
 ## Rules
 
 - **Judge, then act.** The two judgments always ship in the report. When the [Decision Rule](#decision-rule) implement gate is met, additionally apply → verify → commit → push → open a PR for the correct fix (the `/investigate-issue` behaviour). When it isn't met, stay read-only and report / ask — never land a flawed or ambiguous fix just because it was proposed.
+- **Target ref defaults to `stable`.** Read, trace, reproduce, branch, and PR against the [target ref](#target-ref) — `stable` by default (what consumers pin and run), `main` or another ref only when explicitly selected / named. State the chosen ref + why (default-stable / explicit-main / explicit-other) in the report, and when landing on `stable` only, flag that it must also be ported to `main` or the next `main → stable` promotion will silently revert it.
 - **Implement the *correct* fix, never the flawed proposal.** A CORRECT proposal is applied as-is; a CORRECT-BUT-INCOMPLETE one is completed; an INCORRECT / UNNECESSARY proposal against a real bug is replaced by the fix you derive from the evidence. Never commit a proposed change you judged INCORRECT.
 - **Two independent judgments.** A real issue can arrive with a wrong fix; an invalid issue can arrive with a tempting but pointless fix. Validate the issue and the fix separately and report both — even when you go on to implement.
 - **Watch for misconfig dressed as an upstream bug.** A wrong `@ref` pin, an unset secret/var, or a stale wrapper is **CONSUMER-MISCONFIG**, not a library defect — never gets a code fix here; tell the consumer exactly what to change.


### PR DESCRIPTION
## What & why

`/validate-consumer-issue` fixes consumer-reported defects in this upstream library. Consumers pin `@stable`, so the ref a consumer report's failing run actually executed — and the ref a fix must reach — is **`stable`**, not `main`. A fix landed on `main` doesn't reach consumers until the next `main → stable` promotion.

This change makes the command's **target ref default to `stable`** for *everything* — reading, tracing, reproducing, branching, and the PR base — not just where the fix lands. (A prior change had already moved only the *landing* to `stable`; this completes the contract.)

## New behavior contract (live command)

- **Default target ref = `stable`.** Read / trace / reproduce against `stable`; branch off the `stable` **branch** (`git fetch origin stable` → branch off `origin/stable`, with a `-stable` suffix); open the PR with base `stable`.
- **Override to `main`** only when explicitly selected/specified (e.g. `$ARGUMENTS` says "implement on main" / "target main" / "land on main" / "@main", or the report states the consumer's upstream ref is `main`).
- **Explicit other pinned ref** (version tag / branch) is preferred over the `stable` default — it's what the consumer runs.
- The run always **states which target ref was chosen and why** (`default-stable` / `explicit-main` / `explicit-other`).
- A **stable-only fix carries a port-to-`main` caveat** (else the next `main → stable` promotion silently reverts it).

## Files changed

- `.claude/commands/validate-consumer-issue.md` — added a **Target ref** section; replaced every `at main` read/trace/reproduce reference with the target ref (default `stable`); generalized the already-`stable` landing/PR-base sections to the target ref; added a `Target ref:` line + stable-only caveat to the Output Format; added a Rules bullet.

## Scope decision (confirmed with the requester)

The consumer-distributed template `workflow-templates/.claude/commands/validate-consumer-issue.md` is a **different variant** — its `main` references mostly target the *consumer's own* repo, and its `[UPSTREAM]` side already validates against the consumer's pinned ref (typically `@stable`). Per the requester's choice, only the **live** copy is changed; the template is intentionally left untouched. No parity/guardrail test enforces the two copies match (`tests/test_update_workflows_guardrails.py` covers only `.yml` templates/profiles/docs and **passes**).

## Why land on `main`

This is a dev-side change to the command's default behavior, not a consumer hotfix — so it lands on `main` via a normal PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxAk74PQ1kt2p3a8EEuz8R

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxAk74PQ1kt2p3a8EEuz8R)_