### PR TITLE
fix(sync-labels): dedent fallback heredoc so bash finds the PY terminator

### DIFF
--- a/.github/workflows/sync_ai_labels.yml
+++ b/.github/workflows/sync_ai_labels.yml
@@ -116,27 +116,27 @@ jobs:
           fi
 
           if [ ! -s "${RESULT_JSON}" ]; then
-            python3 - <<'PY' "${RESULT_JSON}" "${rc}"
-            import json
-            import sys
-            from pathlib import Path
+          python3 - <<'PY' "${RESULT_JSON}" "${rc}"
+          import json
+          import sys
+          from pathlib import Path
 
-            result_path = Path(sys.argv[1])
-            exit_code = int(sys.argv[2])
-            payload = {
-                "created": 0,
-                "updated": 0,
-                "unchanged": 0,
-                "errors": [
-                    {
-                        "label": "*",
-                        "action": "command",
-                        "message": f"sync-labels produced no JSON output (exit={exit_code})",
-                    }
-                ],
-            }
-            result_path.write_text(json.dumps(payload, ensure_ascii=True, sort_keys=True), encoding="utf-8")
-            PY
+          result_path = Path(sys.argv[1])
+          exit_code = int(sys.argv[2])
+          payload = {
+              "created": 0,
+              "updated": 0,
+              "unchanged": 0,
+              "errors": [
+                  {
+                      "label": "*",
+                      "action": "command",
+                      "message": f"sync-labels produced no JSON output (exit={exit_code})",
+                  }
+              ],
+          }
+          result_path.write_text(json.dumps(payload, ensure_ascii=True, sort_keys=True), encoding="utf-8")
+          PY
           fi
 
           echo "result_json=${RESULT_JSON}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary

Fixes a deterministic, **consumer-wide false failure** in the reusable `AI Sync Labels` workflow (`.github/workflows/sync_ai_labels.yml`). Reported from consumer repo `shubhodeep1/tele-funtoken-msg-scoring` (run `28219606031`, job `83597776418`), which surfaces as the alert:

> ❌ ERROR: AI label sync for shubhodeep1/tele-funtoken-msg-scoring: created=0, updated=0, unchanged=0, errors=1

**The label sync itself succeeds** — only the reporting path was broken.

## Root cause (validated against the code consumers run)

In the `Sync AI labels from contract` step, the fallback here-document sat **inside** an `if [ ! -s "${RESULT_JSON}" ]; then … fi` block and was indented to match it (12 spaces in YAML). After the `run: |` block-scalar strips the 10-space base indent, the closing `PY` lands at **column 2, not column 0**. A non-dash `<<'PY'` requires its terminator at column 0, so under `set -euo pipefail` bash reads to EOF and dies:

```
line 58: warning: here-document at line 33 delimited by end-of-file (wanted `PY')
line 59: syntax error: unexpected end of file
##[error]Process completed with exit code 2.
```

This parse error kills the step with exit 2 **after** `ai_labels.py sync-labels` has already synced the labels, so the step's trailing `result_json` / `exit_code` output writes never run. The `Summarize results` step then reads an empty result path → `OSError` → `parse_failed = True` → manufactures `created=0, updated=0, unchanged=0, errors=1`, sets `ALERT_LEVEL=ERROR` and `should_fail=true`, failing the job and firing the false Telegram alert.

## Fix

Dedent the heredoc command, body, and closing `PY` by 2 spaces so they sit at the block-scalar base indentation (column 0 after dedent) — **matching the already-correct `Summarize results` heredoc in the same file**. Indentation-only change; no logic, identifier, or behavior change beyond removing the parse error.

This also resolves a **latent secondary defect**: the previously space-indented body would have raised a Python `IndentationError` had the fallback branch ever executed (it is fed to `python3 -`).

## Verification

- `bash -n` on the reconstructed run block now exits **0** (was 2), reproducing then clearing the exact `wanted 'PY'` / `unexpected end of file` error from the run log.
- Executing the fallback branch with an empty result file writes valid, correct JSON.
- The full workflow YAML still parses (`yaml.safe_load` OK; job `sync-labels` intact).

## Blast radius

The bug is independent of label state, so it fails on **every run for every consumer** of this reusable workflow while still mutating labels correctly. Fixing this single shared file fixes all consumers.

## ⚠️ Operational follow-up — re-mark the `stable` tag after merge

This PR targets the **`stable` branch**. Consumers pin `uses: …/sync_ai_labels.yml@stable`, which resolves to the **`stable` tag**. At report time the tag (`122e65fe`) and branch (`cdf7af4d`) had **diverged**, and both carry the identical bug. **Merging this PR to the `stable` branch alone does not reach consumers** — the `stable` tag must be re-pointed to the fixed commit via the normal release path (`scripts/mark-stable.sh <version>` / the `mark-stable` workflow) before `@stable` consumers receive the fix.

- No port-to-`main` needed: `sync_ai_labels.yml` does not exist on `main` (the label-sync reusable workflow is `stable`-only; `main` and `stable` have disjoint history here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149XVdPzdBiyRnMqaNXejph

---
_Generated by [Claude Code](https://claude.ai/code/session_0149XVdPzdBiyRnMqaNXejph)_