### PR TITLE
fix(e2e): don't age out healthy long review steps in smoke-test poller (stable)

### DIFF
--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -73,9 +73,27 @@ name: Test & Mark Stable Release
           lock (cancel-in-progress: false) for ~37m on a slow reviewer
           LLM step (~29m), serialising the bait review behind it; the
           extra headroom absorbs that contention.
+          Raised 40→60 after run 28282500673 (v1.20.1): a healthy review
+          whose single "Run reviewer models" step ran 41m aged out the
+          40m timer because GitHub does not stream in-progress step logs
+          (see review_step_timeout below for the structural guard).
         required: false
         type: number
-        default: 40
+        default: 60
+      review_step_timeout:
+        description: >
+          Max minutes a single in-progress step of the review run may take
+          before the wait loop treats it as a genuine stall. GitHub's
+          /actions/jobs/{id}/logs endpoint does not stream an in-progress
+          step's output, so a long LLM step (reviewer models / editor)
+          freezes every cached activity signal the loop watches. While the
+          review run is in_progress and its current step has been running
+          for less than this cap, the loop defers the inactivity-stall
+          check; a step that exceeds the cap still fails, preserving
+          stuck-run detection. Defaults to review_timeout (or 50).
+        required: false
+        type: number
+        default: 50
       review_workflow_file:
         description: >
           Filename (under .github/workflows/ in TEST_REPO) of the
@@ -328,7 +346,22 @@ jobs:
       TEST_REPO: ${{ inputs.test_repo || github.repository }}
       PHASE_TIMEOUT: ${{ inputs.phase_timeout || 30 }}
       PLAN_PHASE_TIMEOUT: ${{ inputs.plan_timeout || inputs.phase_timeout || 60 }}
-      REVIEW_TIMEOUT: ${{ inputs.review_timeout || inputs.phase_timeout || 40 }}
+      REVIEW_TIMEOUT: ${{ inputs.review_timeout || inputs.phase_timeout || 60 }}
+      # Per-step wall-clock cap (minutes) for the review run's currently
+      # in-progress step. GitHub's /actions/jobs/{id}/logs endpoint does NOT
+      # stream an in-progress step's output, so during a single long LLM step
+      # (e.g. "Run reviewer models" can run >40m for 6 two-pass reviewers)
+      # every cached activity signal the wait loop watches (log byte size,
+      # step name, review-comment count) freezes and the global inactivity
+      # timer would age out a perfectly healthy review — the v1.20.1 release
+      # failure on run 28282500673, where the reviewer step ran 41m, log_sz
+      # was pinned at 52333b the whole time, and the run nonetheless completed
+      # success ~6m after the poller gave up. While the run is in_progress and
+      # its current step has been running for less than this cap, the loop
+      # treats the silence as a healthy long step and defers the stall check;
+      # a genuinely hung step still trips once it exceeds the cap, so
+      # stuck-run detection is preserved.
+      REVIEW_STEP_TIMEOUT: ${{ inputs.review_step_timeout || inputs.review_timeout || inputs.phase_timeout || 50 }}
       POLL_INTERVAL: 10
       # Wrapper-workflow filename used by the smoke gate to dispatch
       # / poll review_autofix runs. Defaults to the source repo's
@@ -1275,6 +1308,16 @@ jobs:
           fi
           echo "Inactivity timeout: ${REVIEW_TIMEOUT} minutes"
           INACTIVITY_LIMIT=$((REVIEW_TIMEOUT * 60))
+          # Per-step wall-clock cap (see REVIEW_STEP_TIMEOUT env above):
+          # a single in-progress review step may run this long before the
+          # inactivity check treats it as a stall, since GitHub does not
+          # stream in-progress step logs and the cached activity signals
+          # freeze for the step's whole duration. Fall back to 50m when the
+          # env is unset/non-numeric so the arithmetic below never errors.
+          REVIEW_STEP_TIMEOUT="${REVIEW_STEP_TIMEOUT:-50}"
+          [[ "$REVIEW_STEP_TIMEOUT" =~ ^[0-9]+$ ]] && [ "$REVIEW_STEP_TIMEOUT" -gt 0 ] || REVIEW_STEP_TIMEOUT=50
+          STEP_INACTIVITY_LIMIT=$((REVIEW_STEP_TIMEOUT * 60))
+          echo "Per-step stall cap: ${REVIEW_STEP_TIMEOUT} minutes"
           LAST_ACTIVITY=$(date +%s)
           PREV_STATE=""
           ELAPSED=0
@@ -1641,14 +1684,23 @@ jobs:
             # Beyond run status/conclusion, probe deeper indicators
             # that the review workflow is genuinely making progress.
 
-            # 1) Current step name — reuse JOBS_JSON if already fetched
+            # 1) Current step name — reuse JOBS_JSON if already fetched.
+            #    Also capture the in-progress step's started_at so the
+            #    inactivity check can tell a healthy long step (whose logs
+            #    GitHub does not stream) apart from a genuinely hung run —
+            #    see the REVIEW_STEP_TIMEOUT guard below.
             CURRENT_STEP=""
+            CURRENT_STEP_STARTED_AT=""
             if [ "$RUN_ID" != "unknown" ]; then
               if [ -n "${JOBS_JSON:-}" ]; then
                 CURRENT_STEP=$(echo "$JOBS_JSON" | jq -r '[.jobs[].steps[] | select(.status == "in_progress")] | last | .name // ""' 2>/dev/null || echo "")
+                CURRENT_STEP_STARTED_AT=$(echo "$JOBS_JSON" | jq -r '[.jobs[].steps[] | select(.status == "in_progress")] | last | .started_at // ""' 2>/dev/null || echo "")
               else
-                CURRENT_STEP=$(gh_api_safe_quiet_print "repos/${TEST_REPO}/actions/runs/${RUN_ID}/jobs?per_page=10" \
-                  --jq '[.jobs[].steps[] | select(.status == "in_progress")] | last | .name // ""' || echo "")
+                JOBS_STEP_JSON=$(gh_api_safe_quiet_print "repos/${TEST_REPO}/actions/runs/${RUN_ID}/jobs?per_page=10" || echo "")
+                if [ -n "$JOBS_STEP_JSON" ]; then
+                  CURRENT_STEP=$(echo "$JOBS_STEP_JSON" | jq -r '[.jobs[].steps[] | select(.status == "in_progress")] | last | .name // ""' 2>/dev/null || echo "")
+                  CURRENT_STEP_STARTED_AT=$(echo "$JOBS_STEP_JSON" | jq -r '[.jobs[].steps[] | select(.status == "in_progress")] | last | .started_at // ""' 2>/dev/null || echo "")
+                fi
               fi
             fi
 
@@ -1697,6 +1749,30 @@ jobs:
             # review-run inventory for the branch so the diagnosis
             # doesn't require an out-of-band gh api call.
             if [ $IDLE -ge $INACTIVITY_LIMIT ]; then
+              # Structural guard against GitHub not streaming in-progress
+              # step logs: when the pinned review run is still in_progress
+              # and its current step has been running for less than the
+              # per-step cap, the inactivity silence is explained by one
+              # long healthy step (e.g. "Run reviewer models", which ran
+              # 41m on v1.20.1 run 28282500673 with log_sz frozen at
+              # 52333b) rather than a genuine stall. Defer the stall check
+              # and keep polling. A step that exceeds the cap falls through
+              # to the normal stall path below, so a truly-hung run still
+              # fails — just bounded by REVIEW_STEP_TIMEOUT instead of the
+              # global inactivity window.
+              if [ "${RUN_STATUS:-}" = "in_progress" ] && [ -n "${CURRENT_STEP_STARTED_AT:-}" ]; then
+                STEP_STARTED_EPOCH=$(date -d "${CURRENT_STEP_STARTED_AT}" +%s 2>/dev/null || echo 0)
+                if [ "$STEP_STARTED_EPOCH" -gt 0 ]; then
+                  STEP_ELAPSED=$((NOW - STEP_STARTED_EPOCH))
+                  if [ "$STEP_ELAPSED" -ge 0 ] && [ "$STEP_ELAPSED" -lt "$STEP_INACTIVITY_LIMIT" ]; then
+                    STEP_REMAINING=$(( (STEP_INACTIVITY_LIMIT - STEP_ELAPSED + 59) / 60 ))
+                    echo "  ⏳ idle ${IDLE}s ≥ ${REVIEW_TIMEOUT}m, but review run ${RUN_ID} step '${CURRENT_STEP:-?}' has only run ${STEP_ELAPSED}s (< ${REVIEW_STEP_TIMEOUT}m cap; GitHub does not stream in-progress step logs) — deferring stall check (~${STEP_REMAINING}m of step budget left)"
+                    sleep "$POLL_INTERVAL"
+                    ELAPSED=$((ELAPSED + POLL_INTERVAL))
+                    continue
+                  fi
+                fi
+              fi
               # jq's `last` on an empty array yields the literal string
               # "null" rather than empty, so both branches are needed.
               if [ -n "${BAIT_SHA:-}" ] && { [ -z "${REVIEW_RUN:-}" ] || [ "${REVIEW_RUN}" = "null" ]; }; then

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -90,7 +90,9 @@ name: Test & Mark Stable Release
           review run is in_progress and its current step has been running
           for less than this cap, the loop defers the inactivity-stall
           check; a step that exceeds the cap still fails, preserving
-          stuck-run detection. Defaults to review_timeout (or 50).
+          stuck-run detection. Defaults to 50 minutes for
+          workflow_dispatch; set it explicitly if you want a different
+          cap than review_timeout.
         required: false
         type: number
         default: 50
@@ -348,7 +350,10 @@ jobs:
       PLAN_PHASE_TIMEOUT: ${{ inputs.plan_timeout || inputs.phase_timeout || 60 }}
       REVIEW_TIMEOUT: ${{ inputs.review_timeout || inputs.phase_timeout || 60 }}
       # Per-step wall-clock cap (minutes) for the review run's currently
-      # in-progress step. GitHub's /actions/jobs/{id}/logs endpoint does NOT
+      # in-progress step. For normal workflow_dispatch runs this comes from
+      # review_step_timeout (default 50); the review_timeout/phase_timeout
+      # fallbacks below are only a defensive backstop for unexpected
+      # falsey/missing values. GitHub's /actions/jobs/{id}/logs endpoint does NOT
       # stream an in-progress step's output, so during a single long LLM step
       # (e.g. "Run reviewer models" can run >40m for 6 two-pass reviewers)
       # every cached activity signal the wait loop watches (log byte size,


### PR DESCRIPTION
## Summary

Backport to **`stable`** of the e2e smoke-test poller fix landing on `main` in #3554.

Release v1.20.1 ([run 28282500673](https://github.com/shubhodeep1/coding-workflows/actions/runs/28282500673)) failed on `e2e-smoke-test` only because the review phase aged out: the `review_autofix` run was **healthy** (all 6 reviewers succeeded, run completed `success` ~6 min after the poller gave up), but its single "Run reviewer models" step ran ~41 min — just over the 40 min `REVIEW_TIMEOUT`. GitHub's `/actions/jobs/{id}/logs` endpoint does not stream an in-progress step's output, so for the step's whole duration every cached activity signal the wait loop watches froze (`log_sz` pinned at 52333b), the inactivity timer never reset, and the poller failed with `Review phase stalled`.

`stable` carries the identical pre-fix poller (`REVIEW_TIMEOUT` default 40, same wait-review loop), so it is exposed to the same spurious-timeout failure. This cherry-picks the fix so a stable-channel release does not hit it.

## Changes

`.github/workflows/test-and-mark-stable.yml` (cherry-pick of the #3554 commit, applies cleanly — `stable`'s file matches the pre-fix base in every edited region):

- **Robust per-step liveness (structural fix).** Capture the in-progress step's `started_at`; before declaring a stall, defer the check while the review run is `in_progress` **and** its current step has run less than a new `REVIEW_STEP_TIMEOUT` cap (default 50 min). A step exceeding the cap still trips the existing stall path, so genuinely-hung runs are still caught — bounded by the per-step cap instead of a frozen global timer.
- **Raise `REVIEW_TIMEOUT` default 40 → 60** for immediate headroom.
- New `review_step_timeout` `workflow_dispatch` input (default 50); both knobs remain overridable.

## Scope note

Only the poller fix is backported. The `assemble_prompt.sh` merge done on the `main` PR (#3554) was branch-staleness specific to that feature branch and does not apply to `stable`.

## Verification

- `yaml.safe_load(...)` → workflow parses.
- `bash -n` on the extracted `wait-review` step script → clean.
- Diff vs `stable` touches only `.github/workflows/test-and-mark-stable.yml` (+81/-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194x7PWK97pGP3jteEFymFt

---
_Generated by [Claude Code](https://claude.ai/code/session_0194x7PWK97pGP3jteEFymFt)_