### PR TITLE
fix(review_autofix): backfill preflight-required bootstrap scripts on staging-helper skew

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -1348,6 +1348,35 @@ jobs:
 
           SUPPORT_ROOT_DIR="${RUNNER_TEMP}/coding-workflows-runtime-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           SUPPORT_PROMPTS_DIR="${SUPPORT_ROOT_DIR}/prompts"
+          SUPPORT_SCRIPTS_DIR="${SUPPORT_ROOT_DIR}/scripts"
+
+          # Backfill preflight-required bootstrap scripts that the branch-pinned
+          # staging helper did not stage.  review_autofix.yml runs @main and its
+          # preflight (the "Preflight: Verify required files" step) defines the
+          # required asset set, but stage_workflow_support.sh is sourced from the
+          # PR branch checkout (SCRIPT_REF).  When the PR branch predates a commit
+          # that introduced a new required bootstrap script (e.g. assemble_prompt.sh,
+          # added in #3501), the stale helper's REQUIRED_BOOTSTRAP_SCRIPTS list does
+          # not include it, so it is never copied — and the main-snapshot fallback
+          # in the helper is also skipped because the helper itself never iterates
+          # the new name.  The main snapshot is already checked out here and holds
+          # the current required set, so re-stage any preflight-required script that
+          # is still missing.  Prefer the branch copy (consistent with the helper's
+          # branch-first policy) and fall back to the main snapshot.
+          for f in codex_helpers.sh codex_stall_guard.sh watchdog_helpers.sh review_run_reviewers.sh render_prompt.sh assemble_prompt.sh render_prompt.py; do
+            if [ -f "${SUPPORT_SCRIPTS_DIR}/${f}" ]; then
+              continue
+            fi
+            backfill_src=".codex-workflow-src/scripts/${f}"
+            if [ ! -f "${backfill_src}" ] && [ -f ".codex-workflow-src-main/scripts/${f}" ]; then
+              backfill_src=".codex-workflow-src-main/scripts/${f}"
+            fi
+            if [ -f "${backfill_src}" ]; then
+              install -m 0755 "${backfill_src}" "${SUPPORT_SCRIPTS_DIR}/${f}"
+              echo "::notice::Backfilled ${f} into the runtime support bundle from ${backfill_src} (branch-pinned stage_workflow_support.sh at ${SCRIPT_REF} did not stage it)."
+            fi
+          done
+
           if [ ! -f "${SUPPORT_PROMPTS_DIR}/integration-sync-conflict-resolver-retry-timeout-prelude.txt" ]; then
             src=".codex-workflow-src/prompts/integration-sync-conflict-resolver-retry-timeout-prelude.txt"
             if [ ! -f "${src}" ] && [ -f ".codex-workflow-src-main/prompts/integration-sync-conflict-resolver-retry-timeout-prelude.txt" ]; then

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -201,6 +201,14 @@ env:
   FINGERPRINT_QUARANTINE_RUNS_M: ${{ vars.FINGERPRINT_QUARANTINE_RUNS_M || '3' }}
   SEMBLE_ENABLED: ${{ vars.SEMBLE_ENABLED || 'true' }}
   SERENA_ENABLED: ${{ vars.SERENA_ENABLED || 'false' }}
+  # Shared source of truth for the scripts the later preflight checks under
+  # SUPPORT_SCRIPTS_DIR. Keep the hard-required and soft-checked sets separate
+  # so the staging backfill and preflight stay in sync without conflating them.
+  REVIEW_PREFLIGHT_REQUIRED_SUPPORT_SCRIPTS: >-
+    codex_helpers.sh codex_stall_guard.sh watchdog_helpers.sh
+    review_run_reviewers.sh render_prompt.sh assemble_prompt.sh
+  REVIEW_PREFLIGHT_SOFT_SUPPORT_SCRIPTS: >-
+    render_prompt.py
 
 jobs:
   gate:
@@ -1350,20 +1358,16 @@ jobs:
           SUPPORT_PROMPTS_DIR="${SUPPORT_ROOT_DIR}/prompts"
           SUPPORT_SCRIPTS_DIR="${SUPPORT_ROOT_DIR}/scripts"
 
-          # Backfill preflight-required bootstrap scripts that the branch-pinned
-          # staging helper did not stage.  review_autofix.yml runs @main and its
-          # preflight (the "Preflight: Verify required files" step) defines the
-          # required asset set, but stage_workflow_support.sh is sourced from the
-          # PR branch checkout (SCRIPT_REF).  When the PR branch predates a commit
-          # that introduced a new required bootstrap script (e.g. assemble_prompt.sh,
-          # added in #3501), the stale helper's REQUIRED_BOOTSTRAP_SCRIPTS list does
-          # not include it, so it is never copied — and the main-snapshot fallback
-          # in the helper is also skipped because the helper itself never iterates
-          # the new name.  The main snapshot is already checked out here and holds
-          # the current required set, so re-stage any preflight-required script that
-          # is still missing.  Prefer the branch copy (consistent with the helper's
-          # branch-first policy) and fall back to the main snapshot.
-          for f in codex_helpers.sh codex_stall_guard.sh watchdog_helpers.sh review_run_reviewers.sh render_prompt.sh assemble_prompt.sh render_prompt.py; do
+          # Backfill the preflight-checked SUPPORT_SCRIPTS_DIR subset that the
+          # branch-pinned staging helper did not stage. review_autofix.yml runs
+          # @main, but stage_workflow_support.sh is sourced from the PR branch
+          # checkout (SCRIPT_REF). When the PR branch predates a commit that
+          # introduced a new preflight-checked script (e.g. assemble_prompt.sh,
+          # added in #3501), the stale helper never iterates that name, so it is
+          # never copied — and the helper's own main-snapshot fallback is skipped
+          # for the same reason. The shared REVIEW_PREFLIGHT_*_SUPPORT_SCRIPTS env
+          # vars are the single source of truth for this checked subset.
+          for f in ${REVIEW_PREFLIGHT_REQUIRED_SUPPORT_SCRIPTS} ${REVIEW_PREFLIGHT_SOFT_SUPPORT_SCRIPTS}; do
             if [ -f "${SUPPORT_SCRIPTS_DIR}/${f}" ]; then
               continue
             fi
@@ -1374,6 +1378,8 @@ jobs:
             if [ -f "${backfill_src}" ]; then
               install -m 0755 "${backfill_src}" "${SUPPORT_SCRIPTS_DIR}/${f}"
               echo "::notice::Backfilled ${f} into the runtime support bundle from ${backfill_src} (branch-pinned stage_workflow_support.sh at ${SCRIPT_REF} did not stage it)."
+            else
+              echo "::warning::Preflight support script ${f} was not staged and could not be backfilled from .codex-workflow-src/scripts or .codex-workflow-src-main/scripts; the later preflight step will report whether this is a hard or soft miss."
             fi
           done
 
@@ -2672,13 +2678,12 @@ jobs:
           check_required_dir "${SUPPORT_SCRIPTS_DIR}"
           check_required_dir "${SUPPORT_PROMPTS_DIR}"
 
-          check_required_file "${SUPPORT_SCRIPTS_DIR}/codex_helpers.sh"
-          check_required_file "${SUPPORT_SCRIPTS_DIR}/codex_stall_guard.sh"
-          check_required_file "${SUPPORT_SCRIPTS_DIR}/watchdog_helpers.sh"
-          check_required_file "${SUPPORT_SCRIPTS_DIR}/review_run_reviewers.sh"
-          check_required_file "${SUPPORT_SCRIPTS_DIR}/render_prompt.sh"
-          check_required_file "${SUPPORT_SCRIPTS_DIR}/assemble_prompt.sh"
-          check_soft_file "${SUPPORT_SCRIPTS_DIR}/render_prompt.py"
+          for f in ${REVIEW_PREFLIGHT_REQUIRED_SUPPORT_SCRIPTS}; do
+            check_required_file "${SUPPORT_SCRIPTS_DIR}/${f}"
+          done
+          for f in ${REVIEW_PREFLIGHT_SOFT_SUPPORT_SCRIPTS}; do
+            check_soft_file "${SUPPORT_SCRIPTS_DIR}/${f}"
+          done
           check_required_nonempty_file "${SUPPORT_INSTRUCTIONS_FILE}"
           check_required_file "./pre_assembled_static.txt"
           check_required_file "${PR_DIFF_FILE}"

--- a/tests/test_review_semble_contract.py
+++ b/tests/test_review_semble_contract.py
@@ -152,9 +152,17 @@ def test_workflow_bootstrap_and_runtime_defaults_wire_semble_and_serena() -> Non
 	assert "assemble_prompt.sh" in required_bootstrap_line
 	assert "render_prompt.py" not in required_bootstrap_line
 	assert 'OPTIONAL_BOOTSTRAP_SCRIPTS="install_semble.sh build_semble_wrapper.sh semble_helpers.sh render_prompt.py"' in stage_helper
-	assert 'check_required_file "${SUPPORT_SCRIPTS_DIR}/render_prompt.sh"' in preflight_block
-	assert 'check_required_file "${SUPPORT_SCRIPTS_DIR}/assemble_prompt.sh"' in preflight_block
-	assert 'check_soft_file "${SUPPORT_SCRIPTS_DIR}/render_prompt.py"' in preflight_block
+	assert (
+		"REVIEW_PREFLIGHT_REQUIRED_SUPPORT_SCRIPTS: >-\n"
+		"    codex_helpers.sh codex_stall_guard.sh watchdog_helpers.sh\n"
+		"    review_run_reviewers.sh render_prompt.sh assemble_prompt.sh"
+	) in workflow
+	assert "REVIEW_PREFLIGHT_SOFT_SUPPORT_SCRIPTS: >-\n    render_prompt.py" in workflow
+	assert "for f in ${REVIEW_PREFLIGHT_REQUIRED_SUPPORT_SCRIPTS} ${REVIEW_PREFLIGHT_SOFT_SUPPORT_SCRIPTS}; do" in stage_step_block
+	assert 'for f in ${REVIEW_PREFLIGHT_REQUIRED_SUPPORT_SCRIPTS}; do' in preflight_block
+	assert 'check_required_file "${SUPPORT_SCRIPTS_DIR}/${f}"' in preflight_block
+	assert 'for f in ${REVIEW_PREFLIGHT_SOFT_SUPPORT_SCRIPTS}; do' in preflight_block
+	assert 'check_soft_file "${SUPPORT_SCRIPTS_DIR}/${f}"' in preflight_block
 	assert "for f in setup_serena.sh serena_stats_emit.py mcp_handshake_probe.py; do" in stage_helper
 	assert 'Optional Serena support asset ${f} is unavailable in checked-out support sources; Serena bootstrap remains disabled.' in stage_helper
 	assert 'mkdir -p "${SUPPORT_SCRIPTS_DIR}/templates"' in stage_helper


### PR DESCRIPTION
## Summary

Fixes the recurring `review_autofix` ("Internal: AI Review & Autofix") hard failure where the preflight step aborts with:

```
Preflight check FAILED: 1 required file(s) missing:
  .../scripts/assemble_prompt.sh
```

surfaced to the operator as **"PR autofix failed"** (e.g. run [28342102542](https://github.com/shubhodeep1/coding-workflows/actions/runs/28342102542) on PR #3569; the analysis doc records five earlier runs failing identically).

## Root cause

`review_autofix.yml` runs at `@main`, so its **preflight** step (`Preflight: Verify required files before reviewer invocation`) defines the required runtime-bundle asset set — including `scripts/assemble_prompt.sh`, introduced in #3501.

But the **staging helper** `stage_workflow_support.sh` is sourced from the PR branch checkout (`.codex-workflow-src` at `SCRIPT_REF` = the PR head SHA), not from main. When the PR branch predates #3501, that stale helper's `REQUIRED_BOOTSTRAP_SCRIPTS` list does **not** include `assemble_prompt.sh`, so the helper never copies it. The helper's own main-snapshot fallback is also skipped, because the helper never iterates the new name at all. The already-checked-out main snapshot (`.codex-workflow-src-main`) *does* contain the file, but nothing copies it. Result: main's preflight hard-fails.

Verified: branch head `26b5be90` does not contain `scripts/assemble_prompt.sh`, its `stage_workflow_support.sh` has zero references to it, and `0b0791f` (#3501, which added the file) is not an ancestor of the branch.

## The fix

In the `Stage workflow support files` step, after the branch-pinned helper runs, backfill any preflight-required bootstrap script still missing from the runtime support bundle (`codex_helpers.sh`, `codex_stall_guard.sh`, `watchdog_helpers.sh`, `review_run_reviewers.sh`, `render_prompt.sh`, `assemble_prompt.sh`, `render_prompt.py`). It prefers the branch copy (consistent with the helper's branch-first policy) and falls back to the already-checked-out main snapshot, emitting a `::notice::` when it backfills.

This makes the workflow resilient to staging-helper version skew for the full preflight-required script set, not just `assemble_prompt.sh` — the same skew will recur for any future newly-required bootstrap asset whenever a branch predates its introduction.

The change mirrors the existing in-step backfill pattern (the `integration-sync-conflict-resolver-retry-timeout-prelude.txt` block immediately below it), recomputing `SUPPORT_SCRIPTS_DIR` locally exactly as the step already recomputes `SUPPORT_ROOT_DIR`/`SUPPORT_PROMPTS_DIR`.

## Files changed

- `.github/workflows/review_autofix.yml` — backfill loop added in the `Stage workflow support files` step (+29 lines).

## Verification

- `yaml.safe_load` parses the workflow.
- `bash -n` on the extracted step script passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwnonXRywpXJEG8tfDLopt)_