### PR TITLE
fix(audit): drop self-repo from consumer wrapper drift registry

### DIFF
--- a/.github/ai/consumer_repos.json
+++ b/.github/ai/consumer_repos.json
@@ -8,7 +8,6 @@
   "shubhodeep1/mongo-explorer",
   "shubhodeep1/multi-user-ai-agent",
   "shubhodeep1/fbc_shutdown",
-  "shubhodeep1/coding-workflows",
   "shubhodeep1/bitsafe.io",
   "shubhodeep1/hylifegroup.com",
   "shubhodeep1/radateeree-resort.com"


### PR DESCRIPTION
## Summary

The weekly **Audit Consumer Drift** run ([run 28362702354](https://github.com/shubhodeep1/coding-workflows/actions/runs/28362702354)) fired a `WARNING` alert: `Processed=13 Match=0 Drift=13 Error=0 DriftItems=79`.

Investigating the full per-repo log, the single largest and structurally-permanent contributor is that **`shubhodeep1/coding-workflows` — the upstream library itself — is listed in `.github/ai/consumer_repos.json`**. It has been there since the file was created (#3297), but it is not a consumer:

- It hosts the **reusable** workflows (`clarify.yml`, `implement.yml`, `check_failure_triage.yml`, …) and carries **zero** `ai-*.yml` thin wrapper files.
- It has **no** `repository_dispatch` listener for `coding-workflows-stable-released`.

So the auditor compares all 14 templates against the upstream repo's `.github/workflows/` and reports every one as `missing` — **14 phantom drift items every run** (of the 79 reported), and a permanent WARNING regardless of true consumer state. The `mark-stable` release job also fired a no-op self `repository_dispatch` on every `@stable` tag, and `validation-refresh` swept the upstream repo as if it were a consumer.

## Fix

Remove `"shubhodeep1/coding-workflows"` from `.github/ai/consumer_repos.json`, so the registry matches its documented purpose (CLAUDE.md §14: repos that copy workflow templates from `workflow-templates/`).

- `.github/ai/consumer_repos.json` — drop the self-entry (12 entries remain).

## Verification

- `tests/test_audit_consumer_drift.py` and `tests/test_drift_audit_job.py` pass (no test asserts the registry contains the source repo).
- The 3 `tests/test_validation_refresh_runner.py` failures are **pre-existing** (a `git fetch`/`git checkout -B` command-sequence expectation) and reproduce on clean `main` — unrelated to this data change.

## Not addressed here (consumer-internal, not fixable upstream)

These remaining drift items are not defects in this repo and resolve via normal distribution:

- `ai-check-failure-triage.yml` missing across all consumers — brand-new template (#3555), awaiting `@stable` release propagation. 7 of the 13 repos match every other template, confirming the audit normalization is correct.
- `btc_sweeper`, `atlas-bridge.gd`, `mongo-explorer`, `fbc_shutdown` carry outdated/incomplete wrappers; `radateeree-resort.com` has a minor `ai-update-workflows.yml` drift. These are consumer-repo state and resolve via the dispatch + `ai-update-workflows` update path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZgcTNXuCMVvx3yGsgJKjv)_