### PR TITLE
feat(check-triage): enable check-failure triage by default (land the flip on main)

### DIFF
--- a/.github/workflows/check_failure_triage.yml
+++ b/.github/workflows/check_failure_triage.yml
@@ -49,7 +49,7 @@ env:
 jobs:
   derive_check_name_key:
     if: >-
-      vars.CHECK_FAILURE_TRIAGE_ENABLED != 'false' &&
+      !contains(fromJson('["false"]'), vars.CHECK_FAILURE_TRIAGE_ENABLED) &&
       inputs.pr_number != '' &&
       contains(fromJson('["failure","timed_out"]'), inputs.check_conclusion) &&
       !contains(inputs.check_name, 'Check Failure Triage')
@@ -78,7 +78,7 @@ jobs:
     # name for direct callers that omit check_run_id.
     if: >-
       always() &&
-      vars.CHECK_FAILURE_TRIAGE_ENABLED != 'false' &&
+      !contains(fromJson('["false"]'), vars.CHECK_FAILURE_TRIAGE_ENABLED) &&
       inputs.pr_number != '' &&
       contains(fromJson('["failure","timed_out"]'), inputs.check_conclusion) &&
       !contains(inputs.check_name, 'Check Failure Triage')

--- a/.github/workflows/check_failure_triage.yml
+++ b/.github/workflows/check_failure_triage.yml
@@ -49,7 +49,7 @@ env:
 jobs:
   derive_check_name_key:
     if: >-
-      vars.CHECK_FAILURE_TRIAGE_ENABLED == 'true' &&
+      vars.CHECK_FAILURE_TRIAGE_ENABLED != 'false' &&
       inputs.pr_number != '' &&
       contains(fromJson('["failure","timed_out"]'), inputs.check_conclusion) &&
       !contains(inputs.check_name, 'Check Failure Triage')
@@ -69,15 +69,16 @@ jobs:
 
   triage:
     needs: derive_check_name_key
-    # Cost gate: do nothing unless the consumer repo has explicitly opted in,
-    # and only for genuine failure conclusions on a real PR. The job is skipped
-    # (no checkout / no codex install) when disabled. always() preserves the
+    # Cost gate: enabled by default; a consumer opts OUT via
+    # CHECK_FAILURE_TRIAGE_ENABLED=false. Only genuine failure conclusions on a
+    # real PR proceed. The job is skipped (no checkout / no codex install) when
+    # disabled. always() preserves the
     # triage run if the hash-only dependency fails transiently; the
     # concurrency key then falls back to the check-run id, then the raw check
     # name for direct callers that omit check_run_id.
     if: >-
       always() &&
-      vars.CHECK_FAILURE_TRIAGE_ENABLED == 'true' &&
+      vars.CHECK_FAILURE_TRIAGE_ENABLED != 'false' &&
       inputs.pr_number != '' &&
       contains(fromJson('["failure","timed_out"]'), inputs.check_conclusion) &&
       !contains(inputs.check_name, 'Check Failure Triage')
@@ -100,7 +101,7 @@ jobs:
       MODEL_REASONING_EFFORT: ${{ vars.THINKING_LEVEL_CHECK_TRIAGE || 'xhigh' }}
       MODEL_VERBOSITY: ${{ vars.VERBOSITY_CHECK_TRIAGE || 'low' }}
       OPENROUTER_PROMPT_CACHE_DISABLED: ${{ vars.OPENROUTER_PROMPT_CACHE_DISABLED || 'false' }}
-      CHECK_FAILURE_TRIAGE_ENABLED: ${{ vars.CHECK_FAILURE_TRIAGE_ENABLED || 'false' }}
+      CHECK_FAILURE_TRIAGE_ENABLED: ${{ vars.CHECK_FAILURE_TRIAGE_ENABLED || 'true' }}
       CHECK_FAILURE_TRIAGE_MAX_LINEAGE_DEPTH: ${{ vars.CHECK_FAILURE_TRIAGE_MAX_LINEAGE_DEPTH || '3' }}
       TG_BOT_SECRET: ${{ secrets.TG_BOT_SECRET }}
       TG_ADMIN_CHAT_ID: ${{ vars.TG_ADMIN_CHAT_ID }}

--- a/.github/workflows/internal-check-failure-triage.yml
+++ b/.github/workflows/internal-check-failure-triage.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   triage:
     if: >-
-      vars.CHECK_FAILURE_TRIAGE_ENABLED != 'false' &&
+      !contains(fromJson('["false"]'), vars.CHECK_FAILURE_TRIAGE_ENABLED) &&
       (github.event.check_run.conclusion == 'failure' ||
        github.event.check_run.conclusion == 'timed_out') &&
       github.event.check_run.pull_requests[0] != null &&

--- a/.github/workflows/internal-check-failure-triage.yml
+++ b/.github/workflows/internal-check-failure-triage.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   triage:
     if: >-
-      vars.CHECK_FAILURE_TRIAGE_ENABLED == 'true' &&
+      vars.CHECK_FAILURE_TRIAGE_ENABLED != 'false' &&
       (github.event.check_run.conclusion == 'failure' ||
        github.event.check_run.conclusion == 'timed_out') &&
       github.event.check_run.pull_requests[0] != null &&

--- a/README.md
+++ b/README.md
@@ -922,7 +922,7 @@ See [`workflow-templates/`](workflow-templates/) in this repository for ready-to
 | `orchestrate_poll.yml` | `schedule` (every ~5 min) | Orchestrator progress poller + judge + auto-recovery. Polling cadence is driven entirely by the wrapper workflow's cron schedule; the legacy self-retrigger path (cooldown sleep + `workflow_dispatch` at end-of-run) and its rate-limit circuit-breaker gate have been removed. |
 | `update_workflows.yml` | `schedule` (daily), `repository_dispatch`, `workflow_dispatch` | Auto-updates existing and creates new workflow wrappers from upstream templates |
 | `workflow-log-analysis.yml` | `workflow_dispatch` (typically called from comprehensive-test-and-release / test-and-mark-stable smoke gates) | Periodic Codex audit of workflow runs (analyze, deep-audit, api-redundancy passes); see [`probably_unnecessary_but_read_if_stuck.md`](probably_unnecessary_but_read_if_stuck.md) for the runbook |
-| `check_failure_triage.yml` | `check_run.completed` (failure) | LLM diagnoses a failing PR check and opens an `ai:check-triage` issue for the pipeline to fix. Opt-in via `CHECK_FAILURE_TRIAGE_ENABLED`; see "Check Failure Triage Phase" below |
+| `check_failure_triage.yml` | `check_run.completed` (failure) | LLM diagnoses a failing PR check and opens an `ai:check-triage` issue for the pipeline to fix. On by default; disable via `CHECK_FAILURE_TRIAGE_ENABLED=false`; see "Check Failure Triage Phase" below |
 
 <!-- §Workflow Log Analysis And Improvement and §Workflow Log Analysis moved to ./probably_unnecessary_but_read_if_stuck.md — read it there if you need workflow-log-analysis pipeline runbook details (collector/analyzer contracts, phase behavior, env vars). -->
 
@@ -941,9 +941,9 @@ the way to a fix PR without human action.
 - **Trigger:** `check_run: completed` with a `failure` or `timed_out`
   conclusion, on a check associated with an open PR. The workflow file lives
   on the default branch (required for `check_run` events).
-- **Opt-in:** disabled unless the repo variable `CHECK_FAILURE_TRIAGE_ENABLED`
-  is `true`. While disabled the wrapper job is skipped immediately (no checkout
-  / no model call).
+- **On by default:** runs unless the repo variable `CHECK_FAILURE_TRIAGE_ENABLED`
+  is set to `false`. While disabled the wrapper job is skipped immediately (no
+  checkout / no model call).
 - **Same-repo guard:** fork-origin PRs are skipped before checkout / model
   execution, so `GH_PAT` and model credentials are never exposed to untrusted
   fork code.
@@ -1158,7 +1158,7 @@ the way to a fix PR without human action.
 | `SECURITY_AUDIT_FP_EXCLUSIONS` | `scripts/security_audit_fp_exclusions.json` | Editable JSON catalog of false-positive suppression rules for the security audit |
 | `REVIEW_DIATAXIS_LENS_ENABLED` | `true` | Documentation-only contract row for the advisory `DOCS COVERAGE (DIATAXIS)` consolidator lens. Current branch behavior is prompt-defined only (no separate workflow toggle yet): keep it `low` severity and name only still-missing `Reference` / `How-to` / `Tutorial` / `Explanation` updates. |
 | `REVIEW_AGENTS_MD_MATERIALITY_CHECK_ENABLED` | `true` | Enable the consolidator-side companion `AGENTS.md` materiality finding. Unlike `AGENTS_MD_MATERIALITY_ENABLED`, which controls the separate advisory comment helper, this flag only controls whether `review_consolidate.sh` passes the helper JSON into Lens 7 (`NAMING / BACKWARD COMPATIBILITY`). |
-| `CHECK_FAILURE_TRIAGE_ENABLED` | `false` | Opt-in switch for the check-failure triage workflow. When `true`, a failing PR check is analysed by the diagnosis model, which opens an `ai:check-triage` issue for the pipeline to fix. Off by default. |
+| `CHECK_FAILURE_TRIAGE_ENABLED` | `true` | Switch for the check-failure triage workflow. On by default: a failing PR check is analysed by the diagnosis model, which opens an `ai:check-triage` issue for the pipeline to fix. Set to `false` to disable per repo. |
 | `CHECK_FAILURE_TRIAGE_MAX_LINEAGE_DEPTH` | `3` | Max auto-fix generations in a single failure lineage before the chain is escalated (`ai:check-triage-escalated` + Telegram) instead of opening another issue. |
 | `WORKFLOW_CHECK_TRIAGE_MODEL` | `WORKFLOW_EDITOR_MODEL` (`openai/gpt-5.4`) | Diagnosis model for check-failure triage. |
 | `THINKING_LEVEL_CHECK_TRIAGE` | `xhigh` | Reasoning effort for the check-failure triage diagnosis call. |

--- a/agents.md
+++ b/agents.md
@@ -52,8 +52,9 @@ Phases of the unattended pipeline (each is a separate workflow file under
     completed` failures on a PR; the diagnosis model analyses the failing
     check's logs and opens a GitHub issue (label `ai:check-triage`) describing
     the root cause + suggested fix, which the clarify→…→review pipeline then
-    picks up. Opt-in per repo via `CHECK_FAILURE_TRIAGE_ENABLED`; never pushes
-    code itself. De-dupes one in-flight triage per repo+PR+check and caps the
+    picks up. On by default; disable per repo via
+    `CHECK_FAILURE_TRIAGE_ENABLED=false`; never pushes code itself. De-dupes one
+    in-flight triage per repo+PR+check and caps the
     auto-fix lineage at `CHECK_FAILURE_TRIAGE_MAX_LINEAGE_DEPTH` generations
     (escalates with `ai:check-triage-escalated` + Telegram at the cap).
 

--- a/docs/scripts-pending-removal.md
+++ b/docs/scripts-pending-removal.md
@@ -120,7 +120,7 @@ Copy this block when adding a new entry:
   - `rg -n 'check_failure_triage\.sh' .github/workflows/check_failure_triage.yml` shows the reusable workflow still stages and invokes the script.
   - `rg -n 'check_failure_triage\.yml' .github/workflows/internal-check-failure-triage.yml workflow-templates/ai-check-failure-triage.yml` shows both the self-hosting (`@main`) and consumer (`@stable`) wrappers still call the reusable workflow.
   - `PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_workflow_script_refs.py` returns `All workflow script references resolve to existing files.`
-  - For every consumer in `.github/ai/consumer_repos.json`, `gh variable list --repo <consumer>` shows `CHECK_FAILURE_TRIAGE_ENABLED` is unset or `false` (no repo still relies on the feature) before removing it.
+  - The feature is on by default, so removal requires confirming no consumer still wants it: for every consumer in `.github/ai/consumer_repos.json`, `gh variable list --repo <consumer>` shows `CHECK_FAILURE_TRIAGE_ENABLED` is explicitly `false` (the repo has opted out) before removing it.
 - **Owner:** @shubhodeep1
 
 ### `.github/workflows/workspace-cache-maintenance.yml`

--- a/scripts/check_failure_triage.sh
+++ b/scripts/check_failure_triage.sh
@@ -109,7 +109,7 @@ RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${REPO}/actions/runs/${GITHUB_
 
 # --- Gates -----------------------------------------------------------------
 
-if [ "${ENABLED}" = "false" ]; then
+if [ "${ENABLED,,}" = "false" ]; then
 	log "skip reason=disabled (CHECK_FAILURE_TRIAGE_ENABLED=false) repo=${REPO}"
 	exit 0
 fi

--- a/scripts/check_failure_triage.sh
+++ b/scripts/check_failure_triage.sh
@@ -38,7 +38,7 @@
 #   CHECK_TRIAGE_CHECK_RUN_ID    check-run id
 #
 # Optional env (have defaults):
-#   CHECK_FAILURE_TRIAGE_ENABLED             "true" to act; anything else = no-op
+#   CHECK_FAILURE_TRIAGE_ENABLED             "false" to disable; default on
 #   CHECK_FAILURE_TRIAGE_MAX_LINEAGE_DEPTH   max auto-fix generations (default 3)
 #   MODEL_EDITOR                             diagnosis model (default openai/gpt-5.4)
 #   MODEL_VERBOSITY                          codex verbosity (default low)
@@ -82,7 +82,7 @@ type tg_send_msg >/dev/null 2>&1 || tg_send_msg() { :; }
 
 # --- Config ----------------------------------------------------------------
 
-ENABLED="${CHECK_FAILURE_TRIAGE_ENABLED:-false}"
+ENABLED="${CHECK_FAILURE_TRIAGE_ENABLED:-true}"
 MAX_DEPTH="${CHECK_FAILURE_TRIAGE_MAX_LINEAGE_DEPTH:-3}"
 case "${MAX_DEPTH}" in
 	''|*[!0-9]*)
@@ -109,8 +109,8 @@ RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${REPO}/actions/runs/${GITHUB_
 
 # --- Gates -----------------------------------------------------------------
 
-if [ "${ENABLED}" != "true" ]; then
-	log "skip reason=disabled (set CHECK_FAILURE_TRIAGE_ENABLED=true to enable) repo=${REPO}"
+if [ "${ENABLED}" = "false" ]; then
+	log "skip reason=disabled (CHECK_FAILURE_TRIAGE_ENABLED=false) repo=${REPO}"
 	exit 0
 fi
 

--- a/workflow-templates/ai-check-failure-triage.yml
+++ b/workflow-templates/ai-check-failure-triage.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   triage:
     if: >-
-      vars.CHECK_FAILURE_TRIAGE_ENABLED != 'false' &&
+      !contains(fromJson('["false"]'), vars.CHECK_FAILURE_TRIAGE_ENABLED) &&
       (github.event.check_run.conclusion == 'failure' ||
        github.event.check_run.conclusion == 'timed_out') &&
       github.event.check_run.pull_requests[0] != null &&

--- a/workflow-templates/ai-check-failure-triage.yml
+++ b/workflow-templates/ai-check-failure-triage.yml
@@ -2,11 +2,11 @@
 # automatically when upstream templates change. To opt out of auto-updates,
 # set the ALLOW_WORKFLOW_EDITS repository variable to 'false'.
 #
-# This workflow is a no-op until you set the repository variable
-# CHECK_FAILURE_TRIAGE_ENABLED to 'true'. When enabled, a failing check on a
-# pull request is analysed by an LLM, which opens a GitHub issue describing the
-# failure and its root cause; the normal AI pipeline (clarify -> plan ->
-# implement -> review) then picks that issue up automatically.
+# This workflow is ENABLED BY DEFAULT. A failing check on a pull request is
+# analysed by an LLM, which opens a GitHub issue describing the failure and its
+# root cause; the normal AI pipeline (clarify -> plan -> implement -> review)
+# then picks that issue up automatically. To disable it for this repository,
+# set the repository variable CHECK_FAILURE_TRIAGE_ENABLED to 'false'.
 name: AI Check Failure Triage
 on:
   check_run:
@@ -18,7 +18,7 @@ permissions:
 jobs:
   triage:
     if: >-
-      vars.CHECK_FAILURE_TRIAGE_ENABLED == 'true' &&
+      vars.CHECK_FAILURE_TRIAGE_ENABLED != 'false' &&
       (github.event.check_run.conclusion == 'failure' ||
        github.event.check_run.conclusion == 'timed_out') &&
       github.event.check_run.pull_requests[0] != null &&


### PR DESCRIPTION
## Why this PR exists

The earlier default-on PR **#3569** was based on the feature branch `claude/llm-pr-check-resolution-7vjfvi`. But **#3555** had already merged that feature branch into `main` *before* #3569 merged, and the branch wasn't deleted — so GitHub never retargeted #3569 to `main`. #3569's changes landed back on the (now-stale) feature branch, which has **no remaining path to `main`**.

Result: `main` shipped the check-failure triage feature in its **opt-in** form (`CHECK_FAILURE_TRIAGE_ENABLED == 'true'`, default off). The default-on flip never reached `main`. This PR re-applies it directly against `main`.

## What changed

Re-applies the default-on flip against **main's current content** (the review pipeline hardened #3555 during merge with a fork-PR origin guard and a two-job structure — `derive_check_name_key` + `triage` — both of which are handled here):

- `.github/workflows/check_failure_triage.yml` — **both** var-gated jobs `== 'true'` → `!= 'false'`; env default `'false'` → `'true'`; comment updated.
- `workflow-templates/ai-check-failure-triage.yml` — wrapper gate `== 'true'` → `!= 'false'`; header comment → "enabled by default".
- `scripts/check_failure_triage.sh` — `ENABLED` default `false` → `true`; gate now skips only on an explicit `false`.
- Docs: README env-var row + Reusable Workflows row + phase section, `agents.md` architecture line, and the `docs/scripts-pending-removal.md` preflight.

A repo now opts **out** by setting `CHECK_FAILURE_TRIAGE_ENABLED=false`.

## Effect once merged

- **This repo:** the internal wrapper (`check_run: completed`) is already on `main`; after this merges, a failing PR check will auto-file an `ai:check-triage` issue with no variable needed.
- **Consumers:** picked up after the next `@stable` release + wrapper sync (the template ships in the default `full` profile). Then it's on by default there too.

All existing safeguards are unchanged: never pushes code, per-`repo+PR+check` dedup, lineage-depth cap (default 3) with escalation, self-loop guard, and environmental-failure handling in the prompt. The blast-radius caveat from #3569 still applies (flaky/environmental reds can mint issues + auto-PRs across all consumers; any repo can opt out).

## Validation

- `bash -n scripts/check_failure_triage.sh` — OK
- YAML parse of both workflows — OK
- `tests/test_ai_labels.py` — pass
- Grep confirms no residual `== 'true'` / `:-false` / "opt-in / off by default" references for this feature

Refs #3569

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QT2HariphFgZcc5p8audY

---
_Generated by [Claude Code](https://claude.ai/code/session_011QT2HariphFgZcc5p8audY)_