### PR TITLE
fix(clarify): exclude ai:retro / ai:security-audit issues from the stable clarify guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,6 +447,7 @@ jobs:
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_ai_memory_push_retry_backoff.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_ai_memory_git_env_isolation.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_plan_clarify_blocked_output.py
+          PYTHONDONTWRITEBYTECODE=1 python3 tests/test_clarify_workflow_guard.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_plan_clarify_header_prompt_staging.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_plan_auto_approve_safe_state_fetch.py
           PYTHONDONTWRITEBYTECODE=1 python3 tests/test_workflow_gh_retry_fallback_contract.py

--- a/.github/workflows/clarify.yml
+++ b/.github/workflows/clarify.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   clarify:
     if: >-
-      (github.event_name == 'issues' && github.event.action == 'opened' && !contains(toJson(github.event.issue.labels.*.name), 'ai:orchestrator-tracking')) ||
+      (github.event_name == 'issues' && github.event.action == 'opened' && !contains(toJson(github.event.issue.labels.*.name), 'ai:orchestrator-tracking') && !contains(toJson(github.event.issue.labels.*.name), 'ai:security-audit') && !contains(toJson(github.event.issue.labels.*.name), 'ai:retro')) ||
       (github.event_name == 'issue_comment' && github.event.action == 'created' && github.event.issue.pull_request == null && github.event.comment.user.type == 'User' && contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && startsWith(github.event.comment.body, '/reclarify'))
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/tests/test_clarify_workflow_guard.py
+++ b/tests/test_clarify_workflow_guard.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Regression checks for the consumer-facing clarify.yml job trigger guard.
+
+Consumers pin ``clarify.yml@stable`` and delegate every ``issues.opened`` /
+``issue_comment`` event to it. Central, main-run producers (the retro fan-out
+in ``workflow-log-analysis.yml`` and the security-audit fan-out) create
+informational tracker issues in every consumer, labeled ``ai:retro`` /
+``ai:security-audit`` at creation time. Those issues must never enter the
+clarify pipeline — otherwise they get an ``ai:clarification`` label and a
+stall marker and nag forever.
+
+The clarify job ``if:`` guard is the only thing standing between those
+labeled issues and a clarify run, so it must exclude every fan-out label.
+This test pins that invariant so a future edit (or a stale ``stable`` that
+drifted from ``main``) cannot silently drop an exclusion.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CLARIFY_WF = REPO_ROOT / ".github" / "workflows" / "clarify.yml"
+
+# Labels applied at issue-creation time by central fan-out producers. An issue
+# carrying any of these is informational and must be skipped by the clarify
+# job's issues.opened branch.
+EXCLUDED_OPEN_LABELS = (
+	"ai:orchestrator-tracking",
+	"ai:security-audit",
+	"ai:retro",
+)
+
+
+def _clarify_if_guard() -> str:
+	"""Return the folded ``if:`` expression of the ``clarify`` job."""
+	text = CLARIFY_WF.read_text(encoding="utf-8")
+	# The guard is a folded scalar: `if: >-` followed by indented lines up to
+	# the next same-or-lower-indent key (`runs-on:`).
+	match = re.search(
+		r"\n    if: >-\n(?P<body>(?:      .*\n)+)",
+		text,
+	)
+	assert match, "could not locate the clarify job `if: >-` guard in clarify.yml"
+	return match.group("body")
+
+
+def test_clarify_open_guard_excludes_all_fanout_labels() -> None:
+	guard = _clarify_if_guard()
+	for label in EXCLUDED_OPEN_LABELS:
+		needle = f"!contains(toJson(github.event.issue.labels.*.name), '{label}')"
+		assert needle in guard, (
+			f"clarify.yml job guard must exclude '{label}'-labeled issues from "
+			f"the issues.opened branch (missing: {needle}). Fan-out tracker "
+			f"issues would otherwise trigger a consumer clarify run and stall."
+		)
+
+
+def test_clarify_open_branch_still_gates_on_opened_action() -> None:
+	# Guard must still only fire on the `opened` action for the issues branch,
+	# so re-labeling an existing tracker (issues.labeled) never triggers clarify.
+	guard = _clarify_if_guard()
+	assert "github.event_name == 'issues'" in guard
+	assert "github.event.action == 'opened'" in guard
+
+
+def main() -> int:
+	tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+	for test in tests:
+		test()
+	print(f"{len(tests)} passed")
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())


### PR DESCRIPTION
## What & why

Consumers pin `clarify.yml@stable` and delegate every `issues.opened` event to it. Central, **`main`-run** fan-out producers create informational tracker issues in every consumer, labeled `ai:retro` / `ai:security-audit` **at creation time** (`gh issue create ... --label`, so the label is in the `issues.opened` payload):
- retro fan-out — `.github/workflows/workflow-log-analysis.yml` + `scripts/workflow_retro_fanout.sh`
- security-audit fan-out

The clarify job `if:` guard on `stable` only excluded `ai:orchestrator-tracking`, so those tracker issues passed the guard and started a clarify run in every `@stable` consumer. The run then stamped `ai:clarification` + a stall marker, so the informational issue nagged forever.

Reported from consumer `shubhodeep1/tele-funtoken-msg-scoring#3529` ("AI Workflow Weekly Retro"), which is stuck in `ai:clarification`.

### Root cause — release-coordination gap
PR #3575 added **both** halves in one change: the producer (retro/security-audit fan-out) **and** the protector (this `clarify.yml:20` exclusion). The producer half went live the moment it merged to `main`; the protector half only reached `main`, never `stable`. Consumers run the `stable` guard — so the producer reached them but the protector didn't. This lands the protector on `stable`.

## Changes
- **`.github/workflows/clarify.yml`** (line 20) — add `!contains(..., 'ai:security-audit')` and `!contains(..., 'ai:retro')` to the `issues.opened` branch of the clarify job guard. Identical to the guard already on `main`.
- **`tests/test_clarify_workflow_guard.py`** (new) — regression test: asserts the clarify job guard excludes every fan-out label (`ai:orchestrator-tracking`, `ai:security-audit`, `ai:retro`) and still gates on the `opened` action. Verified it fails on the pre-fix guard and passes on the fixed guard.
- **`.github/workflows/ci.yml`** — register the new test.

## Verification
- New test passes with the fix; reverting the guard makes it fail with a targeted message → it catches the regression.
- `python3 -m py_compile` on the test, `yaml.safe_load` + `yamllint -s` on both edited workflows → clean.

## Target ref & scope
- **Target ref: `stable` (default-stable)** — consumers pin and run `@stable`; a fix on `main` alone never reaches them.
- Scope kept minimal (§5): only the guard clause is ported. The other two `clarify.yml` hunks that differ between `stable` and `main` belong to an unrelated prompt-prelude refactor and are intentionally **not** included.
- No `§6` rename / removal and no `§10` DB or contract change. Cross-consumer blast radius is strictly positive: informational `ai:retro` / `ai:security-audit` issues stop triggering clarify for all consumers; nothing relied on clarify running on them.

## Caveat (stable-targeted)
The **guard** already exists on `main`, so the next `main → stable` promotion will **not** revert it. The **regression test** (`tests/test_clarify_workflow_guard.py`) and its `ci.yml` registration are new here and are not yet on `main` — they should also be added to `main` so they survive the next promotion.

## Follow-ups (not code, out of scope for this PR)
- Already-stuck consumer issues (e.g. `tele-funtoken-msg-scoring#3529`) are not retroactively un-stuck by this guard — they still carry `ai:clarification` + a stall marker and need manual cleanup.
- Other `@stable` consumers likely have the same stuck retro issue this week, since the fan-out is default-on for all repos.

Refs shubhodeep1/tele-funtoken-msg-scoring#3529, #3575

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjGQGS75nCagbMEC9D4dQz)_