### PR TITLE
fix(render_prompt): stop rejecting dollar-prefixed ${{ in assembled prompt bodies

### DIFF
--- a/scripts/render_prompt.py
+++ b/scripts/render_prompt.py
@@ -20,6 +20,14 @@ except ImportError:  # pragma: no cover - dependency is optional
 
 PLACEHOLDER_PATTERN = re.compile(r"\{\{([A-Za-z0-9_]+)\}\}")
 PLACEHOLDER_EXPRESSION_PATTERN = re.compile(r"\{\{(.*?)\}\}")
+# A `{{` opening delimiter that is immediately preceded by `$` (i.e. `${{`) is a
+# GitHub Actions expression / shell literal, not a template placeholder — the
+# same literal form already exempted by `_placeholder_expression_allowed_as_literal`
+# for balanced `${{ ... }}`. Assembled prompt bodies embed arbitrary PR diff text
+# that can carry a lone `${{` (e.g. a test assertion checking for the `${{`
+# prefix substring only), so the unmatched-delimiter residual check must skip
+# dollar-prefixed opens or it wrongly rejects the whole prompt.
+UNMATCHED_OPEN_DELIMITER_PATTERN = re.compile(r"(?<!\$)\{\{")
 STANDALONE_PLACEHOLDER_PATTERN = re.compile(r"^[ \t]*\{\{([A-Za-z0-9_]+)\}\}[ \t]*$")
 INCLUDE_DIRECTIVE_PATTERN = re.compile(r'^[ \t]*\{%[ \t]*include[ \t]+"([^"\n]+)"[ \t]*%\}[ \t]*$')
 VARIABLE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_]+$")
@@ -751,7 +759,7 @@ def validate_supported_template_syntax(prompt_text: str, prompt_path: Path) -> N
 
 		residual_segments.append(line[last_end:])
 		residual_text = "".join(residual_segments)
-		if "{{" in residual_text:
+		if UNMATCHED_OPEN_DELIMITER_PATTERN.search(residual_text) is not None:
 			violations.append(
 				f"{prompt_path}:{line_number}: unmatched placeholder delimiter in {line.strip()!r}"
 			)

--- a/tests/test_render_prompt_foundation.py
+++ b/tests/test_render_prompt_foundation.py
@@ -436,6 +436,45 @@ def test_render_prompt_py_allows_literal_dot_field_expression() -> None:
 	assert proc.stdout == "docker inspect --format='{{.State.ExitCode}}'\n"
 
 
+def test_render_prompt_py_allows_dollar_prefixed_unmatched_open_delimiter() -> None:
+	# Regression: assembled reviewer/editor prompt bodies embed arbitrary PR diff
+	# text, which can carry a lone `${{` with no closing `}}` on the line (e.g. a
+	# test assertion checking only for the `${{` prefix substring). Such a
+	# GitHub Actions / shell literal must not be treated as an unmatched template
+	# placeholder delimiter — otherwise render_prompt.py exits 1 and the whole
+	# reviewer step fails (observed on PR #3592).
+	with tempfile.TemporaryDirectory(prefix="render_prompt_foundation_dollar_open_") as td:
+		prompt_file = Path(td) / "prompt.txt"
+		prompt_file.write_text(
+			'assert "SVB_REASON: ${{ steps.preflight_destructive_guard.outputs.scope_violation_blocked" in text\n',
+			encoding="utf-8",
+		)
+
+		proc = _run_render_prompt_py(prompt_file)
+
+	assert proc.returncode == 0, proc.stderr
+	assert proc.stderr == ""
+	assert proc.stdout == (
+		'assert "SVB_REASON: ${{ steps.preflight_destructive_guard.outputs.scope_violation_blocked" in text\n'
+	)
+
+
+def test_render_prompt_py_rejects_bare_unmatched_open_delimiter() -> None:
+	# Complement to the dollar-prefixed exemption above: a `{{` open delimiter
+	# that is NOT dollar-prefixed and has no closing `}}` is still a genuine
+	# template-syntax error and must keep failing.
+	with tempfile.TemporaryDirectory(prefix="render_prompt_foundation_bare_open_") as td:
+		prompt_file = Path(td) / "prompt.txt"
+		prompt_file.write_text("stray {{ open delimiter with no close\n", encoding="utf-8")
+
+		proc = _run_render_prompt_py(prompt_file)
+
+	assert proc.returncode == 1
+	assert proc.stdout == ""
+	assert "Unsupported template syntax" in proc.stderr
+	assert "unmatched placeholder delimiter" in proc.stderr
+
+
 def test_render_prompt_py_allows_stray_closing_braces_in_prose() -> None:
 	with tempfile.TemporaryDirectory(prefix="render_prompt_foundation_closing_braces_") as td:
 		prompt_file = Path(td) / "prompt.txt"


### PR DESCRIPTION
## Summary

The AI Review & Autofix run for PR #3592 ([run 28864360964](https://github.com/shubhodeep1/coding-workflows/actions/runs/28864360964)) failed in the **Run reviewer models** step and posted *"AI review/autofix produced no output — will retry"*. Root cause is a false-positive in the prompt-template validator, not a defect in PR #3592.

`scripts/review_run_reviewers.sh` assembles the reviewer prompt **body** (which embeds the raw PR diff) and then runs it through `scripts/render_prompt.sh` → `render_prompt.py` to substitute `{{WORKFLOW_EDIT_RESTRICTION}}` etc. `render_prompt.py`'s `validate_supported_template_syntax` flags any residual `{{` open delimiter as an *"unmatched placeholder delimiter"* and exits 1.

PR #3592's diff contained a test assertion with a **lone** `${{` and no closing `}}` on the line:

```python
assert "SVB_REASON: ${{ steps.preflight_destructive_guard.outputs.scope_violation_blocked" in text
```

That is a GitHub Actions / shell literal, not a template placeholder. Balanced `${{ ... }}` was already exempted (`_placeholder_expression_allowed_as_literal`), but the unmatched-open residual check ignored the `$` prefix, so the whole reviewer step died.

## Root cause evidence

- Job log `review / codex-agent`, step *Run reviewer models*:
  ```
  ERROR: Unsupported template syntax:
  reviewer_prompt_body.txt:314: unmatched placeholder delimiter in 'assert "SVB_REASON: ${{ steps.preflight_destructive_guard.outputs.scope_violation_blocked" in text'
  ##[error]Process completed with exit code 1.
  ```
- `scripts/render_prompt.py:754` — `if "{{" in residual_text:` flagged the `$`-prefixed open.
- `scripts/render_prompt.py:728` — the existing balanced-expression exemption already treats `${{ ... }}` as a literal; this change closes the same gap for the unmatched-open case.
- Reproduced locally: the exact line failed before the fix, passes after; a bare `{{` open and `{{FOO|lower}}` still fail.

## Changes

- **`scripts/render_prompt.py`** — added `UNMATCHED_OPEN_DELIMITER_PATTERN = re.compile(r"(?<!\$)\{\{")` and use it in `validate_supported_template_syntax` so a dollar-prefixed `${{` open is not reported as an unmatched delimiter. Bare `{{` opens and unsupported expressions still fail.
- **`tests/test_render_prompt_foundation.py`** — added `test_render_prompt_py_allows_dollar_prefixed_unmatched_open_delimiter` (the exact PR #3592 line) and `test_render_prompt_py_rejects_bare_unmatched_open_delimiter` (guards the still-failing case).

## Verification

`pytest tests/test_render_prompt_foundation.py tests/test_assemble_prompt.py tests/test_render_prompt_core_modes.py tests/test_render_prompt_review_judge_modes.py tests/test_render_prompt_validate_analytics_modes.py` — all pass (75 tests).

Refs #3592

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKKDpDaoQdBwf2rBnSPiyv)_