### PR TITLE
fix(review): size reviewer embed budget under codex 1MB stdin cap

### DIFF
--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -1869,14 +1869,52 @@ fi
 
 # Initialise the prompt-input running-budget tracker.  Keeps cumulative
 # bytes across every _embed_input_file invocation in the heredoc below
-# under _PROMPT_BUDGET_TOTAL_BYTES (default 800KB ≈ 200k tokens at
-# ~4 bytes/token) so a single oversized input artifact (e.g. a 500KB
-# PR diff) can't blow past the reviewer model's context window. The
-# current default gpt-5.4 has a 272k standard context (lower than the
-# legacy editor default's 400k); 200k of inputs leaves room for the
-# static prefix (~10k tokens) and response budget (~30k tokens)
-# within the 272k window.
-_init_prompt_budget
+# under the budget passed to _init_prompt_budget so a single oversized
+# input artifact (e.g. a 500KB PR diff) can't blow past either the
+# reviewer model's context window OR codex-cli's hard stdin cap.
+#
+# codex-cli's `turn/start` imposes a hard 1,048,576-character stdin cap on
+# the WHOLE prompt.  The assembled reviewer prompt (see
+# assemble_reviewer_prompt) is `pre_assembled_static.txt` (unattended
+# system instructions + agents.md + trimmed README — ~190KB today and
+# growing) PLUS this reviewer template, the checklist, and memory/semble
+# context, all wrapped OUTSIDE the _embed_input_file budget, PLUS the
+# budgeted body.  The historical flat 800KB embed budget was sized against
+# a stale "static prefix ~10k tokens (~40KB)" assumption; once the static
+# prefix grew past ~190KB the assembled prompt for a large PR overshot the
+# 1,048,576-char cap and EVERY reviewer failed with
+# "turn/start ... Input exceeds the maximum length of 1048576 characters"
+# (run 29181029369 / PR #3643 — all 6 reviewers, ~100 min, then exit 1).
+#
+# Size the embed budget from the hard cap MINUS the measured static prefix
+# MINUS a reserve for the non-embedded scaffolding, so the total assembled
+# prompt stays under the cap regardless of how large the static docs grow.
+# Only ever tighten below the historical default — never widen past it.
+REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES="${REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES:-1048576}"
+REVIEWER_PROMPT_SCAFFOLD_RESERVE_BYTES="${REVIEWER_PROMPT_SCAFFOLD_RESERVE_BYTES:-175000}"
+REVIEWER_PROMPT_EMBED_BUDGET_FLOOR_BYTES="${REVIEWER_PROMPT_EMBED_BUDGET_FLOOR_BYTES:-200000}"
+reviewer_static_prefix_bytes=0
+if [ -f ./pre_assembled_static.txt ]; then
+  reviewer_static_prefix_bytes="$(wc -c < ./pre_assembled_static.txt 2>/dev/null | tr -d '[:space:]' || printf '0')"
+fi
+if ! [[ "${reviewer_static_prefix_bytes}" =~ ^[0-9]+$ ]]; then
+  reviewer_static_prefix_bytes=0
+fi
+# Fail-safe: if the static prefix could not be measured, assume a
+# conservative large prefix so the budget still tightens rather than
+# silently reverting to the oversized flat default.
+if [ "${reviewer_static_prefix_bytes}" -le 0 ]; then
+  reviewer_static_prefix_bytes=200000
+fi
+reviewer_embed_budget_bytes=$(( REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES - reviewer_static_prefix_bytes - REVIEWER_PROMPT_SCAFFOLD_RESERVE_BYTES ))
+if [ "${reviewer_embed_budget_bytes}" -lt "${REVIEWER_PROMPT_EMBED_BUDGET_FLOOR_BYTES}" ]; then
+  reviewer_embed_budget_bytes="${REVIEWER_PROMPT_EMBED_BUDGET_FLOOR_BYTES}"
+fi
+if [ "${reviewer_embed_budget_bytes}" -gt "${_PROMPT_BUDGET_TOTAL_BYTES:-800000}" ]; then
+  reviewer_embed_budget_bytes="${_PROMPT_BUDGET_TOTAL_BYTES:-800000}"
+fi
+echo "Reviewer prompt embed budget: ${reviewer_embed_budget_bytes} bytes (codex stdin cap ${REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES}, measured static prefix ${reviewer_static_prefix_bytes}, scaffold reserve ${REVIEWER_PROMPT_SCAFFOLD_RESERVE_BYTES})."
+_init_prompt_budget "${reviewer_embed_budget_bytes}"
 {
   cat <<__REVIEWER_PROMPT__
 ${ITERATION_CONTEXT_BLOCK}
@@ -2462,6 +2500,25 @@ assemble_reviewer_prompt() {
 
 # Assemble the default (pass 1 / single-pass) prompt.
 assemble_reviewer_prompt "${REVIEWER_PROMPT_FILE}" "${REVIEWER_PROMPT_BODY_FILE}"
+
+# Safety net: log the assembled reviewer prompt size and warn if it is at or
+# over codex-cli's hard `turn/start` stdin cap. The dynamic embed budget
+# above is sized to keep the total under the cap, but memory/semble context
+# and the untrusted-input blocks ride outside that budget, so surface any
+# residual overshoot here for diagnosis instead of only discovering it as
+# an opaque "Input exceeds the maximum length of 1048576 characters" per-
+# reviewer failure (run 29181029369 / PR #3643). Mirrors the equivalent
+# guard in scripts/review_rb_judge.sh.
+if [ -f "${REVIEWER_PROMPT_FILE}" ]; then
+  reviewer_prompt_assembled_bytes="$(wc -c < "${REVIEWER_PROMPT_FILE}" 2>/dev/null | tr -d '[:space:]' || printf '0')"
+  if ! [[ "${reviewer_prompt_assembled_bytes}" =~ ^[0-9]+$ ]]; then
+    reviewer_prompt_assembled_bytes=0
+  fi
+  echo "Reviewer prompt assembled size: ${reviewer_prompt_assembled_bytes} bytes (codex stdin cap: ${REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES})."
+  if [ "${reviewer_prompt_assembled_bytes}" -ge "${REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES}" ]; then
+    echo "::warning::Reviewer prompt is ${reviewer_prompt_assembled_bytes} bytes, at or over codex's ${REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES}-character turn/start stdin cap. Reviewers will fail with 'Input exceeds the maximum length'. Lower REVIEWER_PROMPT_SCAFFOLD_RESERVE_BYTES headroom or shrink pre_assembled_static.txt / memory / semble context."
+  fi
+fi
 
 # ── Reviewer failback / health helpers ──────────────────────────────
 REVIEWER_FAILBACK_CHAINS_FILE="${REVIEWER_FAILBACK_CHAINS_FILE:-${SUPPORT_SCRIPTS_DIR:-scripts}/reviewer_failback_chains.json}"

--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -1890,9 +1890,10 @@ fi
 # MINUS a reserve for the non-embedded scaffolding, so the total assembled
 # prompt stays under the cap regardless of how large the static docs grow.
 # Only ever tighten below the historical default — never widen past it.
-REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES="${REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES:-1048576}"
-REVIEWER_PROMPT_SCAFFOLD_RESERVE_BYTES="${REVIEWER_PROMPT_SCAFFOLD_RESERVE_BYTES:-175000}"
-REVIEWER_PROMPT_EMBED_BUDGET_FLOOR_BYTES="${REVIEWER_PROMPT_EMBED_BUDGET_FLOOR_BYTES:-200000}"
+REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES="$(reviewer_parse_positive_int_env REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES 1048576)"
+REVIEWER_PROMPT_SCAFFOLD_RESERVE_BYTES="$(reviewer_parse_positive_int_env REVIEWER_PROMPT_SCAFFOLD_RESERVE_BYTES 175000)"
+REVIEWER_PROMPT_EMBED_BUDGET_FLOOR_BYTES="$(reviewer_parse_positive_int_env REVIEWER_PROMPT_EMBED_BUDGET_FLOOR_BYTES 200000)"
+_PROMPT_BUDGET_TOTAL_BYTES="$(reviewer_parse_positive_int_env _PROMPT_BUDGET_TOTAL_BYTES 800000)"
 reviewer_static_prefix_bytes=0
 if [ -f ./pre_assembled_static.txt ]; then
   reviewer_static_prefix_bytes="$(wc -c < ./pre_assembled_static.txt 2>/dev/null | tr -d '[:space:]' || printf '0')"
@@ -1907,11 +1908,14 @@ if [ "${reviewer_static_prefix_bytes}" -le 0 ]; then
   reviewer_static_prefix_bytes=200000
 fi
 reviewer_embed_budget_bytes=$(( REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES - reviewer_static_prefix_bytes - REVIEWER_PROMPT_SCAFFOLD_RESERVE_BYTES ))
-if [ "${reviewer_embed_budget_bytes}" -lt "${REVIEWER_PROMPT_EMBED_BUDGET_FLOOR_BYTES}" ]; then
-  reviewer_embed_budget_bytes="${REVIEWER_PROMPT_EMBED_BUDGET_FLOOR_BYTES}"
+if [ "${reviewer_embed_budget_bytes}" -lt 0 ]; then
+  echo "::warning::Reviewer prompt static prefix (${reviewer_static_prefix_bytes}) plus scaffold reserve (${REVIEWER_PROMPT_SCAFFOLD_RESERVE_BYTES}) leaves negative embed headroom (${reviewer_embed_budget_bytes}) under codex stdin cap ${REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES}; forcing embed budget to 0." >&2
+  reviewer_embed_budget_bytes=0
+elif [ "${reviewer_embed_budget_bytes}" -lt "${REVIEWER_PROMPT_EMBED_BUDGET_FLOOR_BYTES}" ]; then
+  echo "::warning::Reviewer embed budget floor ${REVIEWER_PROMPT_EMBED_BUDGET_FLOOR_BYTES} exceeds cap-safe headroom ${reviewer_embed_budget_bytes}; continuing with reduced embed budget to stay under codex stdin cap." >&2
 fi
-if [ "${reviewer_embed_budget_bytes}" -gt "${_PROMPT_BUDGET_TOTAL_BYTES:-800000}" ]; then
-  reviewer_embed_budget_bytes="${_PROMPT_BUDGET_TOTAL_BYTES:-800000}"
+if [ "${reviewer_embed_budget_bytes}" -gt "${_PROMPT_BUDGET_TOTAL_BYTES}" ]; then
+  reviewer_embed_budget_bytes="${_PROMPT_BUDGET_TOTAL_BYTES}"
 fi
 echo "Reviewer prompt embed budget: ${reviewer_embed_budget_bytes} bytes (codex stdin cap ${REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES}, measured static prefix ${reviewer_static_prefix_bytes}, scaffold reserve ${REVIEWER_PROMPT_SCAFFOLD_RESERVE_BYTES})."
 _init_prompt_budget "${reviewer_embed_budget_bytes}"
@@ -2516,7 +2520,7 @@ if [ -f "${REVIEWER_PROMPT_FILE}" ]; then
   fi
   echo "Reviewer prompt assembled size: ${reviewer_prompt_assembled_bytes} bytes (codex stdin cap: ${REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES})."
   if [ "${reviewer_prompt_assembled_bytes}" -ge "${REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES}" ]; then
-    echo "::warning::Reviewer prompt is ${reviewer_prompt_assembled_bytes} bytes, at or over codex's ${REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES}-character turn/start stdin cap. Reviewers will fail with 'Input exceeds the maximum length'. Lower REVIEWER_PROMPT_SCAFFOLD_RESERVE_BYTES headroom or shrink pre_assembled_static.txt / memory / semble context."
+    echo "::warning::Reviewer prompt is ${reviewer_prompt_assembled_bytes} bytes, at or over codex's ${REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES}-character turn/start stdin cap. Reviewers will fail with 'Input exceeds the maximum length'. Raise REVIEWER_PROMPT_SCAFFOLD_RESERVE_BYTES to tighten the embed budget or shrink pre_assembled_static.txt / memory / semble context."
   fi
 fi
 


### PR DESCRIPTION
## Summary

The **Run reviewer models** step of the AI review/autofix pipeline failed for [PR #3643](https://github.com/shubhodeep1/coding-workflows/pull/3643) ([run 29181029369](https://github.com/shubhodeep1/coding-workflows/actions/runs/29181029369)). All six reviewer models failed identically with:

```
Error: turn/start: turn/start failed: Input exceeds the maximum length of 1048576 characters.
```

Each was retried 3× over **~100 minutes**, then the step exited 1 and the whole autofix job failed (the editor never ran; the downstream "Post editor summary comment" no-op path then also exited 1).

## Root cause

The assembled reviewer prompt exceeded codex-cli's hard **1,048,576-character `turn/start` stdin cap**. The reviewer prompt is:

- `pre_assembled_static.txt` — unattended system instructions (~29 KB) + `agents.md` (~61 KB) + trimmed `README.md` (~98 KB) ≈ **~190 KB**, and growing
- the reviewer template heredoc (~16 KB), checklist (~7 KB), and memory/semble context — all wrapped **outside** the `_embed_input_file` budget
- the budgeted embedded body (diffs)

`_embed_input_file`'s cumulative budget was a flat **800 KB** (`_PROMPT_BUDGET_TOTAL_BYTES`), sized against a stale comment assumption of a "~10k-token / ~40 KB static prefix". Once the static docs grew past ~190 KB, `800 KB` of embedded diffs + ~250 KB of scaffolding overshot the 1 MB cap for a large PR (this one: 79 files, +6933/−161). No reviewer could ever succeed regardless of retries.

## Fix

`scripts/review_run_reviewers.sh`:

- Size the reviewer embed budget dynamically = codex stdin cap − measured `pre_assembled_static.txt` size − a scaffold reserve, clamped to a floor and never widened above the historical 800 KB default. This keeps the total assembled prompt under the cap regardless of how large the static docs grow.
- Add a post-assembly size log + over-cap `::warning::` mirroring the existing guard in `scripts/review_rb_judge.sh`, so any residual overshoot (from memory/semble context riding outside the budget) is diagnosable instead of surfacing only as an opaque per-reviewer `turn/start` failure.
- Three new thresholds (`REVIEWER_PROMPT_CODEX_STDIN_CAP_BYTES`, `REVIEWER_PROMPT_SCAFFOLD_RESERVE_BYTES`, `REVIEWER_PROMPT_EMBED_BUDGET_FLOOR_BYTES`) are env-overridable with defaults.

With the measured ~190 KB static prefix, the embed budget resolves to ~684 KB and the assembled prompt lands comfortably under the 1,048,576 cap.

## Verification

- `bash -n scripts/review_run_reviewers.sh` passes.
- Budget math simulated against real doc sizes: static ≈ 189,781 B → embed budget = 683,795 B; worst-case total (embedded budget fully saturated + scaffolding == full reserve) = exactly the 1,048,576 cap, and real scaffolding (~110 KB) is well under the 175 KB reserve, so actual totals land strictly under the cap.

## Files changed

- `scripts/review_run_reviewers.sh` — dynamic embed-budget sizing before `_init_prompt_budget` (~line 1870) and post-assembly size guard after `assemble_reviewer_prompt` (~line 2500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoFG385jWHkEqFB1rPG5EV

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoFG385jWHkEqFB1rPG5EV)_