### PR TITLE
test(orchestrate_poll): sync bootstrap-list assertions with render_prompt.py main-primary move

### DIFF
--- a/tests/test_orchestrate_poll_process.py
+++ b/tests/test_orchestrate_poll_process.py
@@ -12995,14 +12995,17 @@ def test_review_autofix_workflow_wires_optional_verifier_bootstrap_and_gate():
 	assert '.codex-workflow-src-main/scripts/stage_workflow_support.sh' in wf_body
 	assert (
 		'MAIN_PRIMARY_BOOTSTRAP_SCRIPTS="verify_integration_fingerprints.py review_conflict_resolve.sh '
-		'review_conflict_prepare.sh"'
+		'review_conflict_prepare.sh render_prompt.py"'
 	) in stage_helper_body
 	assert 'SUPPORT_ROOT_DIR="${RUNNER_TEMP}/coding-workflows-runtime-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"' in stage_helper_body
 	assert 'SUPPORT_SCRIPTS_DIR="${SUPPORT_ROOT_DIR}/scripts"' in stage_helper_body
 	assert 'SUPPORT_SCRIPTS_DIR="scripts"' not in stage_helper_body
-	# render_prompt.py is staged optionally on main so shim branches resolve
-	# their backend (PR #3057); keep this list in sync with review_autofix.yml.
-	assert 'OPTIONAL_BOOTSTRAP_SCRIPTS="install_semble.sh build_semble_wrapper.sh semble_helpers.sh render_prompt.py"' in stage_helper_body
+	# render_prompt.py was moved out of OPTIONAL_BOOTSTRAP_SCRIPTS into
+	# MAIN_PRIMARY_BOOTSTRAP_SCRIPTS by PR #3594 so main-side validator fixes
+	# reach wedged branches (see the dedicated contract test in
+	# tests/test_review_autofix_review_pipeline_contract.py); keep this list in
+	# sync with review_autofix.yml and stage_workflow_support.sh.
+	assert 'OPTIONAL_BOOTSTRAP_SCRIPTS="install_semble.sh build_semble_wrapper.sh semble_helpers.sh"' in stage_helper_body
 	assert "for f in ${MAIN_PRIMARY_BOOTSTRAP_SCRIPTS}; do" in stage_helper_body
 	assert "Bootstrapped ${f} from main snapshot (branch copy ignored)." in stage_helper_body
 	# The bootstrap still enumerates the script name in review_autofix.yml


### PR DESCRIPTION
## Summary

The `validate-scripts` job failed the **v1.21.0** release ([run 29154978313](https://github.com/shubhodeep1/coding-workflows/actions/runs/29154978313)) with `287 passed, 1 failed` — the sole failure was `test_review_autofix_workflow_wires_optional_verifier_bootstrap_and_gate` in `tests/test_orchestrate_poll_process.py`.

## Root cause

PR #3594 (commit `3468edd`) moved `render_prompt.py` out of `OPTIONAL_BOOTSTRAP_SCRIPTS` into `MAIN_PRIMARY_BOOTSTRAP_SCRIPTS` in `scripts/stage_workflow_support.sh` so that main-side validator fixes reach wedged PR branches, and added a dedicated contract test in `tests/test_review_autofix_review_pipeline_contract.py`.

That PR did **not** update the pre-existing bootstrap-list assertions in `test_review_autofix_workflow_wires_optional_verifier_bootstrap_and_gate`, which still:
- ended the `MAIN_PRIMARY_BOOTSTRAP_SCRIPTS` string at `review_conflict_prepare.sh"` (no `render_prompt.py`), and
- asserted `render_prompt.py` was in `OPTIONAL_BOOTSTRAP_SCRIPTS`.

These stale assertions directly contradicted the new contract test and the shipped script, so the test failed deterministically. No production code is at fault — the script state (main-primary) is intentional and correct.

## Change

- `tests/test_orchestrate_poll_process.py` — update the two stale assertions to match the authoritative script: `render_prompt.py` now trails the `MAIN_PRIMARY_BOOTSTRAP_SCRIPTS` list and is absent from `OPTIONAL_BOOTSTRAP_SCRIPTS`. Refresh the accompanying comment to cite PR #3594 and the main-primary rationale instead of the superseded #3057 optional placement, and point at the dedicated contract test.

## Verification

- Extracted and executed every assertion in the previously-failing test against the current tree — all pass.
- Confirmed the authoritative contract in `scripts/stage_workflow_support.sh`: `render_prompt.py` is present in `MAIN_PRIMARY_BOOTSTRAP_SCRIPTS`, absent from both `OPTIONAL_BOOTSTRAP_SCRIPTS` and `REQUIRED_BOOTSTRAP_SCRIPTS` (the `render_prompt.sh` shim remains required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GdRbwP3p8tfpn3HHoV7ab

---
_Generated by [Claude Code](https://claude.ai/code/session_012GdRbwP3p8tfpn3HHoV7ab)_