### PR TITLE
fix(test): reconcile stale prompt-assembly include test with shipped renderer

### DIFF
--- a/tests/test_assemble_prompt.py
+++ b/tests/test_assemble_prompt.py
@@ -263,14 +263,16 @@ def test_render_prompt_sh_flag_true_cleans_up_assembled_temp_file() -> None:
 	assert list((repo_root / "prompts").glob(".mode-sample.txt.assembled.*")) == []
 
 
-def test_render_prompt_sh_body_with_include_line_hard_fails_without_input_already_assembled() -> None:
-	# Guards the exposure directly: a reviewer/editor BODY that embeds a raw PR
-	# diff/context line `{% include "..." %}` is parsed as a real prompt-fragment
-	# include and hard-fails with PromptAssemblyError when include-assembly runs
-	# over it. RENDER_PROMPT_SKIP_SYNTAX_VALIDATION alone does NOT prevent this —
-	# include expansion happens before the syntax gate. (tele-funtoken run
-	# 29182737982.)
-	with tempfile.TemporaryDirectory(prefix="render_prompt_body_include_unfixed_") as td:
+def test_render_prompt_sh_body_with_include_line_preserved_with_skip_syntax_validation() -> None:
+	# Guards the shipped contract via the render_prompt.sh shim: a reviewer/editor
+	# BODY that embeds a raw PR diff/context line `{% include "..." %}` must survive
+	# verbatim when RENDER_PROMPT_SKIP_SYNTAX_VALIDATION is set — the env var marks
+	# the input as an already-composed untrusted body, so include-assembly is skipped
+	# and the standalone include line is treated as the diff's own content rather than
+	# a fragment to expand. Mirrors the direct-invocation coverage in
+	# tests/test_render_prompt_foundation.py for the bash entrypoint + env-var path.
+	# (Renderer behavior locked in by PR #3647.)
+	with tempfile.TemporaryDirectory(prefix="render_prompt_body_include_skip_syntax_") as td:
 		repo_root = Path(td)
 		_copy_prompt_runtime_scripts(repo_root)
 		body_file = repo_root / "reviewer_prompt_body.txt"
@@ -295,10 +297,12 @@ def test_render_prompt_sh_body_with_include_line_hard_fails_without_input_alread
 			timeout=60,
 		)
 
-	assert proc.returncode == 1
-	assert proc.stdout == ""
-	assert "Included prompt fragment not found" in proc.stderr
-	assert "_partials/site_footer.html" in proc.stderr
+	assert proc.returncode == 0, proc.stderr
+	assert "Included prompt fragment not found" not in proc.stderr
+	# Static placeholder substitution still runs for the trusted scaffolding.
+	assert "Reviewer body. Overlay: X\n" in proc.stdout
+	# The untrusted include line survives as literal text (never expanded).
+	assert ' {% include "_partials/site_footer.html" %}\n' in proc.stdout
 
 
 def test_render_prompt_sh_input_already_assembled_keeps_include_line_literal() -> None:

--- a/tests/test_assemble_prompt.py
+++ b/tests/test_assemble_prompt.py
@@ -298,7 +298,7 @@ def test_render_prompt_sh_body_with_include_line_preserved_with_skip_syntax_vali
 		)
 
 	assert proc.returncode == 0, proc.stderr
-	assert "Included prompt fragment not found" not in proc.stderr
+	assert proc.stderr == ""
 	# Static placeholder substitution still runs for the trusted scaffolding.
 	assert "Reviewer body. Overlay: X\n" in proc.stdout
 	# The untrusted include line survives as literal text (never expanded).


### PR DESCRIPTION
## Summary

Internal AI Validate [run 29198236851](https://github.com/shubhodeep1/coding-workflows/actions/runs/29198236851) failed with `needs_fixes` on its only non-passing check, `40_repo_checks.sh`. The failure surfaced as the warning *"Validation reported fixable failures, but TRACKING_ISSUE is not set"* — the run was dispatched on `main` with `tracking_issue=0`, so the consolidated fix-up issue was correctly not created; this PR fixes the underlying defect directly.

## Root cause

A stale, contradictory regression test:

- PR #3646 (`7f7e464`) added `tests/test_assemble_prompt.py::test_render_prompt_sh_body_with_include_line_hard_fails_without_input_already_assembled`, documenting that `RENDER_PROMPT_SKIP_SYNTAX_VALIDATION=1` **alone** did not stop `{% include "..." %}` expansion (rc=1, `Included prompt fragment not found`).
- PR #3647 (`501c291`) then changed the renderer — `scripts/render_prompt.py:1057` now passes `resolve_includes=not args.skip_syntax_validation` — so `--skip-syntax-validation` disables include resolution over untrusted reviewer/editor bodies (raw PR diffs), preserving standalone include lines verbatim. It added `tests/test_render_prompt_foundation.py:603-646` to lock in the new contract but did **not** update the older `test_assemble_prompt.py` test.
- The stale assertion (`assert proc.returncode == 1`) then failed on every run, blocking `scripts/run_validation_repo_checks.sh` (runtime validation) and the `test-and-mark-stable.yml` release gate.

Reverting the renderer was not an option — PR #3647 is a deliberate security fix (untrusted include lines must not be expanded).

## Change

`tests/test_assemble_prompt.py`

- Rewrote the test to assert the shipped behavior: with `RENDER_PROMPT_SKIP_SYNTAX_VALIDATION=1`, the render succeeds (rc=0), the standalone `{% include "_partials/site_footer.html" %}` line survives verbatim, the static placeholder is still substituted, and no missing-fragment error is emitted.
- Renamed the function to `test_render_prompt_sh_body_with_include_line_preserved_with_skip_syntax_validation` and updated its docstring to match. This keeps the `render_prompt.sh` shim + env-var entrypoint coverage that the foundation suite (which calls `render_prompt.py` directly with the flag) does not exercise.

## Verification

```
PYTHONDONTWRITEBYTECODE=1 python3 tests/test_assemble_prompt.py           # OK
PYTHONDONTWRITEBYTECODE=1 python3 tests/test_render_prompt_foundation.py  # OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018XV5KDyoWp15aN5Jov1h4i)_