### PR TITLE
fix(test): cherry-pick #3656 to stable — reconcile stale prompt-assembly include test

### DIFF
--- a/tests/test_assemble_prompt.py
+++ b/tests/test_assemble_prompt.py
@@ -263,14 +263,16 @@ def test_render_prompt_sh_flag_true_cleans_up_assembled_temp_file() -> None:
 	assert list((repo_root / "prompts").glob(".mode-sample.txt.assembled.*")) == []
 
 
-def test_render_prompt_sh_body_with_include_line_hard_fails_without_input_already_assembled() -> None:
-	# Guards the exposure directly: a reviewer/editor BODY that embeds a raw PR
-	# diff/context line `{% include "..." %}` is parsed as a real prompt-fragment
-	# include and hard-fails with PromptAssemblyError when include-assembly runs
-	# over it. RENDER_PROMPT_SKIP_SYNTAX_VALIDATION alone does NOT prevent this —
-	# include expansion happens before the syntax gate. (tele-funtoken run
-	# 29182737982.)
-	with tempfile.TemporaryDirectory(prefix="render_prompt_body_include_unfixed_") as td:
+def test_render_prompt_sh_body_with_include_line_preserved_with_skip_syntax_validation() -> None:
+	# Guards the shipped contract via the render_prompt.sh shim: a reviewer/editor
+	# BODY that embeds a raw PR diff/context line `{% include "..." %}` must survive
+	# verbatim when RENDER_PROMPT_SKIP_SYNTAX_VALIDATION is set — the env var marks
+	# the input as an already-composed untrusted body, so include-assembly is skipped
+	# and the standalone include line is treated as the diff's own content rather than
+	# a fragment to expand. Mirrors the direct-invocation coverage in
+	# tests/test_render_prompt_foundation.py for the bash entrypoint + env-var path.
+	# (Renderer behavior locked in by PR #3647.)
+	with tempfile.TemporaryDirectory(prefix="render_prompt_body_include_skip_syntax_") as td:
 		repo_root = Path(td)
 		_copy_prompt_runtime_scripts(repo_root)
 		body_file = repo_root / "reviewer_prompt_body.txt"
@@ -295,10 +297,12 @@ def test_render_prompt_sh_body_with_include_line_hard_fails_without_input_alread
 			timeout=60,
 		)
 
-	assert proc.returncode == 1
-	assert proc.stdout == ""
-	assert "Included prompt fragment not found" in proc.stderr
-	assert "_partials/site_footer.html" in proc.stderr
+	assert proc.returncode == 0, proc.stderr
+	assert proc.stderr == ""
+	# Static placeholder substitution still runs for the trusted scaffolding.
+	assert "Reviewer body. Overlay: X\n" in proc.stdout
+	# The untrusted include line survives as literal text (never expanded).
+	assert ' {% include "_partials/site_footer.html" %}\n' in proc.stdout
 
 
 def test_render_prompt_sh_input_already_assembled_keeps_include_line_literal() -> None:


### PR DESCRIPTION
## What & why

The **Test & Mark Stable Release** gate (run [29198217777](https://github.com/shubhodeep1/coding-workflows/actions/runs/29198217777), the v1.21.0 attempt) failed on `validate-scripts` because of a stale test on the `stable` branch:

```
tests/test_assemble_prompt.py:298 (on stable) — assert proc.returncode == 1  → AssertionError
```

`test_render_prompt_sh_body_with_include_line_hard_fails_without_input_already_assembled` still asserts the **pre-#3647** contract (`rc=1`, "Included prompt fragment not found") for a standalone `{% include "..." %}` line rendered with `RENDER_PROMPT_SKIP_SYNTAX_VALIDATION=1`.

The renderer changes from **#3646/#3647** already reached `stable` (via the `stable`→`main` forward-merge that produced `f6fa71e`): `render_prompt.py` now sets `resolve_includes = not args.skip_syntax_validation`, so include-assembly is skipped over untrusted reviewer/editor bodies and the include line is preserved verbatim (`rc=0`). That made the old assertion fail.

**#3656** reconciled the test on `main` (rewrote it to assert the shipped `rc=0` behavior and renamed it to `..._preserved_with_skip_syntax_validation`). But `main → stable` is not auto-propagated — only `stable → main` is (`forward-merge-stable-to-main.yml`). So the fix never reached the `stable` branch and the release gate stayed red.

This PR cherry-picks #3656 (`6890c57`) onto the `stable` branch so the release gate can pass. Once merged, `forward-merge-stable-to-main.yml` reconciles `main` automatically (already has the same change, so it's a no-op there).

## Change

- Cherry-pick of `6890c57` — **1 file, +16/−12**, `tests/test_assemble_prompt.py` only. Replaces the stale `rc=1` test with the shipped-contract `rc=0` test (include line preserved verbatim, placeholder still substituted, no missing-fragment error), exercising the `render_prompt.sh` + `RENDER_PROMPT_SKIP_SYNTAX_VALIDATION` entrypoint.

## Verification

- `python3 tests/test_assemble_prompt.py` → `OK: shared-prelude assembly path is byte-stable and flag-gated` (previously `AssertionError`).
- Stale test name absent; new `..._preserved_with_skip_syntax_validation` test present.
- Diff vs `stable` is exactly #3656 (no other changes).

After merge, re-run **Test & Mark Stable Release** with `--ref stable` to cut the release on the stable line.

Refs #3656

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018WoQKVhhqu1VRbEgyNbVkr)_