### PR TITLE
Add merged-PR commit guard as a PreToolUse hook (CLAUDE.md §21)

### DIFF
--- a/.claude/hooks/pr_merge_status_guard.py
+++ b/.claude/hooks/pr_merge_status_guard.py
@@ -67,10 +67,11 @@ GIT_GLOBAL_OPTS_WITH_VALUE = frozenset(
 	{"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--super-prefix", "--exec-path"}
 )
 
-# Shell operators that separate independent commands within one Bash call.
-_SEGMENT_SPLIT_RE = re.compile(r"(?:\|\||&&|[;&|\n])")
+# Shell punctuation we treat as command separators when tokenizing a Bash line.
+_SHELL_PUNCTUATION_CHARS = ";&|\n"
 
 _SLUG_RE = re.compile(r"^[A-Za-z0-9_-]+/[A-Za-z0-9._-]+$")
+_REMOTE_HEAD_BRANCH_RE = re.compile(r"^ref:\s+refs/heads/([^\s]+)\s+HEAD$", re.MULTILINE)
 
 _CACHE_TTL_SECONDS = 300
 _CACHE_DIR_NAME = "claude-pr-merge-guard"
@@ -113,6 +114,29 @@ def _run(argv: list[str], cwd: str | None, timeout: int) -> tuple[int, str, str]
 	return proc.returncode, proc.stdout, proc.stderr
 
 
+def _shell_segments(command: str) -> list[list[str]]:
+	"""Tokenize a shell command into command-sized segments.
+
+	Uses `shlex` over the full command so quoted separators such as `"a; b"`
+	stay inside their argument instead of splitting the command early.
+	"""
+	lexer = shlex.shlex(command, posix=True, punctuation_chars=_SHELL_PUNCTUATION_CHARS)
+	lexer.whitespace = " \t\r"
+	lexer.whitespace_split = True
+	segments: list[list[str]] = []
+	current_segment: list[str] = []
+	for token in lexer:
+		if token and set(token) <= set(_SHELL_PUNCTUATION_CHARS):
+			if current_segment:
+				segments.append(current_segment)
+				current_segment = []
+			continue
+		current_segment.append(token)
+	if current_segment:
+		segments.append(current_segment)
+	return segments
+
+
 def git_subcommands(command: str) -> set[str]:
 	"""Return the set of git subcommands invoked by a shell command string.
 
@@ -123,16 +147,12 @@ def git_subcommands(command: str) -> set[str]:
 	since a false block is more disruptive than a missed check on a rare form.
 	"""
 	found: set[str] = set()
-	for segment in _SEGMENT_SPLIT_RE.split(command):
-		segment = segment.strip()
-		if not segment:
-			continue
-		try:
-			tokens = shlex.split(segment)
-		except ValueError:
-			# Unbalanced quotes — the segment is not something we can read.
-			continue
-
+	try:
+		segments = _shell_segments(command)
+	except ValueError:
+		# Unbalanced quotes — the command is not something we can read.
+		return found
+	for tokens in segments:
 		# Drop leading environment assignments (`GIT_DIR=... git commit`).
 		index = 0
 		while index < len(tokens) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", tokens[index]):
@@ -210,7 +230,7 @@ def current_branch(cwd: str) -> str:
 
 
 def default_branch(cwd: str) -> str:
-	"""Best-effort default branch name; falls back to `main`."""
+	"""Best-effort default branch name; returns "" when it cannot be determined."""
 	code, out, _ = _run(
 		["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"], cwd, _GIT_TIMEOUT_SECONDS
 	)
@@ -228,7 +248,12 @@ def default_branch(cwd: str) -> str:
 		)
 		if code == 0:
 			return candidate
-	return "main"
+	code, out, _ = _run(["git", "ls-remote", "--symref", "origin", "HEAD"], cwd, _GIT_TIMEOUT_SECONDS)
+	if code == 0:
+		match = _REMOTE_HEAD_BRANCH_RE.search(out)
+		if match:
+			return match.group(1)
+	return ""
 
 
 def repo_slug(cwd: str) -> str:
@@ -415,6 +440,21 @@ def blocking_pull_request(pull_requests: list[dict], cwd: str) -> dict | None:
 
 def _block_message(pr: dict, branch: str, base: str) -> str:
 	number = pr.get("number")
+	reset_commands = (
+		f"  git fetch origin {base}\n"
+		f"  git checkout -B {branch} origin/{base}\n"
+	)
+	default_branch_note = ""
+	if not base:
+		reset_commands = (
+			f"  git fetch origin <default-branch>\n"
+			f"  git checkout -B {branch} origin/<default-branch>\n"
+		)
+		default_branch_note = (
+			f"The guard could not determine the default branch automatically; "
+			f"replace `<default-branch>` with your repo's real default branch.\n"
+			f"\n"
+		)
 	return (
 		f"BLOCKED by the merged-PR guard (CLAUDE.md §21).\n"
 		f"\n"
@@ -430,9 +470,9 @@ def _block_message(pr: dict, branch: str, base: str) -> str:
 		f"reused. Restart the branch from the default branch, keeping the same "
 		f"name, then redo the commit and open a NEW pull request:\n"
 		f"\n"
-		f"  git fetch origin {base}\n"
-		f"  git checkout -B {branch} origin/{base}\n"
+		f"{reset_commands}"
 		f"\n"
+		f"{default_branch_note}"
 		f"If the branch carries unmerged commits beyond the merged history, "
 		f"rebase them onto the new base instead of discarding them. Stash or "
 		f"re-apply any uncommitted work as needed, then retry.\n"
@@ -470,11 +510,6 @@ def evaluate(payload: dict) -> tuple[int, str]:
 		# Detached HEAD, or not a git repo — nothing branch-shaped to check.
 		return 0, ""
 
-	base = default_branch(cwd)
-	if branch == base:
-		# Committing on the default branch is not the stranded-work scenario.
-		return 0, ""
-
 	slug = repo_slug(cwd)
 	if not slug:
 		_warn(f"could not derive <owner>/<repo> from the git remote (branch `{branch}`)")
@@ -504,6 +539,11 @@ def evaluate(payload: dict) -> tuple[int, str]:
 		_write_cache(slug, branch, pull_requests)
 
 	if offender is None:
+		return 0, ""
+
+	base = default_branch(cwd)
+	if base and branch == base:
+		# Committing on the default branch is not the stranded-work scenario.
 		return 0, ""
 	return 2, _block_message(offender, branch, base)
 

--- a/.claude/hooks/pr_merge_status_guard.py
+++ b/.claude/hooks/pr_merge_status_guard.py
@@ -240,14 +240,6 @@ def default_branch(cwd: str) -> str:
 			ref = ref[len("origin/") :]
 		if ref:
 			return ref
-	for candidate in ("main", "master"):
-		code, _, _ = _run(
-			["git", "rev-parse", "--verify", f"refs/remotes/origin/{candidate}"],
-			cwd,
-			_GIT_TIMEOUT_SECONDS,
-		)
-		if code == 0:
-			return candidate
 	code, out, _ = _run(["git", "ls-remote", "--symref", "origin", "HEAD"], cwd, _GIT_TIMEOUT_SECONDS)
 	if code == 0:
 		match = _REMOTE_HEAD_BRANCH_RE.search(out)

--- a/.claude/hooks/pr_merge_status_guard.py
+++ b/.claude/hooks/pr_merge_status_guard.py
@@ -509,6 +509,10 @@ def evaluate(payload: dict) -> tuple[int, str]:
 	if not branch:
 		# Detached HEAD, or not a git repo — nothing branch-shaped to check.
 		return 0, ""
+	base = default_branch(cwd)
+	if base and branch == base:
+		# Committing on the default branch is not the stranded-work scenario.
+		return 0, ""
 
 	slug = repo_slug(cwd)
 	if not slug:
@@ -539,11 +543,6 @@ def evaluate(payload: dict) -> tuple[int, str]:
 		_write_cache(slug, branch, pull_requests)
 
 	if offender is None:
-		return 0, ""
-
-	base = default_branch(cwd)
-	if base and branch == base:
-		# Committing on the default branch is not the stranded-work scenario.
 		return 0, ""
 	return 2, _block_message(offender, branch, base)
 

--- a/.claude/hooks/pr_merge_status_guard.py
+++ b/.claude/hooks/pr_merge_status_guard.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""PreToolUse guard — refuse commits/pushes that stack on an already-merged PR.
+
+Implements CLAUDE.md §21.
+
+Long-lived Claude Code sessions (days to weeks) outlive the PRs they open. When
+the PR for the working branch merges mid-session, further commits to that same
+branch land on history that is already in the default branch and no longer has
+an open PR carrying it anywhere — the work is silently stranded. Prose
+instructions do not survive that timescale; this hook does, because the harness
+runs it on every Bash tool call regardless of what the model remembers.
+
+Detection rule — all three conditions must hold before the command is blocked:
+
+  1. A *merged* PR exists whose head ref is the current branch, AND
+  2. no *open* PR exists for the current branch, AND
+  3. that merged PR's head commit is an ancestor of HEAD — i.e. the pending
+     commit would literally stack on already-merged history.
+
+Condition 3 is what makes the guard self-clearing. The branch name is reused
+after a `git checkout -B <branch> origin/<default>` reset, so the merged PR
+keeps matching `--head <branch>` forever; ancestry is what actually
+distinguishes "stacking on a corpse" from "fresh work that happens to reuse the
+name". It also means the guard stops firing the moment the branch is reset,
+without needing a manual override flag or a new PR to exist yet.
+
+Fail-open by design (CLAUDE.md §21): any inability to answer the question —
+no `gh`, expired token, network failure, unparseable payload, not a git repo —
+allows the command and emits a warning. A guard that hard-blocks every commit
+whenever a token lapses would be worse than the bug it prevents.
+
+PR state is read over REST (`gh api repos/<slug>/pulls`) rather than
+`gh pr list`, because the latter is GraphQL-backed and Claude Code Web's agent
+proxy serves only a pinned set of GraphQL operations — the guard would fail open
+on every commit in precisely the sessions it exists to protect. `gh pr list`
+remains as a transport fallback.
+
+Exit codes (Claude Code hook protocol):
+  0 — allow the command. A warning may be emitted via `systemMessage`.
+  2 — block the command; stderr is fed back to Claude as the reason.
+
+Escape hatch: set CLAUDE_PR_MERGE_GUARD=off to disable the check entirely.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+# Guarded git subcommands. `push` is included alongside `commit` because
+# amend/rebase flows reach the remote without issuing a fresh `git commit`.
+GUARDED_SUBCOMMANDS = frozenset({"commit", "push"})
+
+# git global options that consume a following argument when not given as
+# `--opt=value`. Needed so `git -C /repo commit` resolves to `commit` rather
+# than to the path.
+GIT_GLOBAL_OPTS_WITH_VALUE = frozenset(
+	{"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--super-prefix", "--exec-path"}
+)
+
+# Shell operators that separate independent commands within one Bash call.
+_SEGMENT_SPLIT_RE = re.compile(r"(?:\|\||&&|[;&|\n])")
+
+_SLUG_RE = re.compile(r"^[A-Za-z0-9_-]+/[A-Za-z0-9._-]+$")
+
+_CACHE_TTL_SECONDS = 300
+_CACHE_DIR_NAME = "claude-pr-merge-guard"
+
+# Ceilings, not expected durations — every one of these completes in well under
+# a second in practice. They are sized so a pathological run still lands inside
+# the hook timeout in .claude/settings.json; overshooting it anyway is safe,
+# because a killed hook is a non-blocking failure and so fails open like every
+# other unanswerable case.
+_GH_TIMEOUT_SECONDS = 15
+_GIT_TIMEOUT_SECONDS = 5
+
+
+class LookupUnavailable(Exception):
+	"""Raised when PR state cannot be determined; callers must fail open."""
+
+
+def _run(argv: list[str], cwd: str | None, timeout: int) -> tuple[int, str, str]:
+	"""Run a subprocess, returning (returncode, stdout, stderr).
+
+	Never raises for process-level failures — a missing binary or a timeout is
+	reported as a non-zero return code so every caller funnels into the same
+	fail-open path.
+	"""
+	try:
+		proc = subprocess.run(
+			argv,
+			cwd=cwd,
+			capture_output=True,
+			text=True,
+			timeout=timeout,
+			check=False,
+		)
+	except FileNotFoundError:
+		return 127, "", f"{argv[0]}: not found"
+	except subprocess.TimeoutExpired:
+		return 124, "", f"{argv[0]}: timed out after {timeout}s"
+	except OSError as exc:
+		return 126, "", f"{argv[0]}: {exc}"
+	return proc.returncode, proc.stdout, proc.stderr
+
+
+def git_subcommands(command: str) -> set[str]:
+	"""Return the set of git subcommands invoked by a shell command string.
+
+	Only counts `git` when it is the first real token of a shell segment, after
+	any leading `VAR=value` assignments. That keeps `man git commit` and
+	`echo "git commit"` from tripping the guard, at the cost of missing
+	wrapper-prefixed invocations like `sudo git commit` — an acceptable trade,
+	since a false block is more disruptive than a missed check on a rare form.
+	"""
+	found: set[str] = set()
+	for segment in _SEGMENT_SPLIT_RE.split(command):
+		segment = segment.strip()
+		if not segment:
+			continue
+		try:
+			tokens = shlex.split(segment)
+		except ValueError:
+			# Unbalanced quotes — the segment is not something we can read.
+			continue
+
+		# Drop leading environment assignments (`GIT_DIR=... git commit`).
+		index = 0
+		while index < len(tokens) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", tokens[index]):
+			index += 1
+		if index >= len(tokens):
+			continue
+
+		executable = tokens[index]
+		if executable != "git" and not executable.endswith("/git"):
+			continue
+
+		# Walk past git's global options to the subcommand.
+		index += 1
+		while index < len(tokens):
+			token = tokens[index]
+			if not token.startswith("-"):
+				found.add(token)
+				break
+			if token in GIT_GLOBAL_OPTS_WITH_VALUE:
+				index += 2
+				continue
+			index += 1
+	return found
+
+
+def extract_repo_slug(url: str) -> str:
+	"""Derive `<owner>/<repo>` from a git remote URL, or "" when it is not
+	derivable.
+
+	Mirrors `extract_repo_slug` in .claude/hooks/session-start.sh, including its
+	exact host whitelist: only github.com, plus Claude Code Web's local git
+	proxy on 127.0.0.1/localhost where the path must start with `git/`. A
+	lookalike host such as `evilgithub.com` must not yield a slug, because the
+	slug is passed straight to `gh -R` and would otherwise aim the query at an
+	unrelated github.com repo.
+	"""
+	url = url.strip()
+	for suffix in ("/", ".git", "/"):
+		if url.endswith(suffix):
+			url = url[: -len(suffix)]
+
+	if "://" in url:
+		rest = url.split("://", 1)[1]
+		if "@" in rest:
+			rest = rest.rsplit("@", 1)[1]
+		if "/" not in rest:
+			return ""
+		host, path = rest.split("/", 1)
+		host = host.split(":", 1)[0]
+	elif "@" in url and ":" in url.split("@", 1)[1]:
+		rest = url.rsplit("@", 1)[1]
+		host, path = rest.split(":", 1)
+	else:
+		return ""
+
+	if host in ("127.0.0.1", "localhost"):
+		if not path.startswith("git/"):
+			return ""
+		path = path[len("git/") :]
+	elif host != "github.com":
+		return ""
+
+	if not _SLUG_RE.match(path):
+		return ""
+	return path
+
+
+def current_branch(cwd: str) -> str:
+	"""Return the checked-out branch name, or "" when detached or not a repo."""
+	code, out, _ = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd, _GIT_TIMEOUT_SECONDS)
+	if code != 0:
+		return ""
+	branch = out.strip()
+	return "" if branch in ("", "HEAD") else branch
+
+
+def default_branch(cwd: str) -> str:
+	"""Best-effort default branch name; falls back to `main`."""
+	code, out, _ = _run(
+		["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"], cwd, _GIT_TIMEOUT_SECONDS
+	)
+	if code == 0:
+		ref = out.strip()
+		if ref.startswith("origin/"):
+			ref = ref[len("origin/") :]
+		if ref:
+			return ref
+	for candidate in ("main", "master"):
+		code, _, _ = _run(
+			["git", "rev-parse", "--verify", f"refs/remotes/origin/{candidate}"],
+			cwd,
+			_GIT_TIMEOUT_SECONDS,
+		)
+		if code == 0:
+			return candidate
+	return "main"
+
+
+def repo_slug(cwd: str) -> str:
+	code, out, _ = _run(["git", "config", "--get", "remote.origin.url"], cwd, _GIT_TIMEOUT_SECONDS)
+	if code != 0:
+		return ""
+	return extract_repo_slug(out)
+
+
+def is_ancestor(sha: str, cwd: str) -> bool:
+	"""True when `sha` is an ancestor of (or equal to) HEAD.
+
+	A commit absent from the local object database cannot be an ancestor of
+	HEAD, so `git merge-base` erroring out is a legitimate False rather than an
+	unknown — no fetch is attempted.
+	"""
+	if not sha:
+		return False
+	code, _, _ = _run(
+		["git", "merge-base", "--is-ancestor", sha, "HEAD"], cwd, _GIT_TIMEOUT_SECONDS
+	)
+	return code == 0
+
+
+def _cache_path(slug: str, branch: str) -> Path:
+	digest = hashlib.sha256(f"{slug}\n{branch}".encode("utf-8")).hexdigest()[:32]
+	return Path(tempfile.gettempdir()) / _CACHE_DIR_NAME / f"{digest}.json"
+
+
+def _read_cache(slug: str, branch: str) -> list[dict] | None:
+	path = _cache_path(slug, branch)
+	try:
+		raw = json.loads(path.read_text(encoding="utf-8"))
+	except (OSError, ValueError):
+		return None
+	if not isinstance(raw, dict):
+		return None
+	stamped = raw.get("fetched_at")
+	if not isinstance(stamped, (int, float)) or time.time() - stamped > _CACHE_TTL_SECONDS:
+		return None
+	entries = raw.get("pull_requests")
+	return entries if isinstance(entries, list) else None
+
+
+def _write_cache(slug: str, branch: str, pull_requests: list[dict]) -> None:
+	path = _cache_path(slug, branch)
+	try:
+		path.parent.mkdir(parents=True, exist_ok=True)
+		path.write_text(
+			json.dumps({"fetched_at": time.time(), "pull_requests": pull_requests}),
+			encoding="utf-8",
+		)
+	except OSError:
+		# A cache we cannot write is a performance loss, never a correctness one.
+		pass
+
+
+def _normalize_rest_pull(entry: dict) -> dict:
+	"""Reshape a REST pull object into the `gh pr list --json` field names."""
+	head = entry.get("head")
+	head_sha = head.get("sha") if isinstance(head, dict) else None
+	return {
+		"number": entry.get("number"),
+		"state": entry.get("state"),
+		"url": entry.get("html_url"),
+		"title": entry.get("title"),
+		"mergedAt": entry.get("merged_at"),
+		"headRefOid": head_sha,
+	}
+
+
+def _query_via_rest(slug: str, branch: str, cwd: str) -> list[dict]:
+	"""One `gh api` REST call listing every PR whose head ref is `branch`.
+
+	Preferred over `gh pr list` because Claude Code Web's agent proxy serves
+	only a pinned set of GraphQL operations and rejects the rest — and
+	`gh pr list` is GraphQL-backed, so it fails there with HTTP 403 while REST
+	continues to work. Without this path the guard would fail open on every
+	commit in exactly the long-running web sessions it exists to protect.
+
+	The `head` filter wants `<head-owner>:<branch>`; the owner is taken from
+	the slug, which is correct for same-repo branches (the only kind this
+	guard's remediation produces). A fork-owned head ref simply returns no
+	match, which fails open — the safe direction.
+	"""
+	owner = slug.split("/", 1)[0]
+	code, out, err = _run(
+		[
+			"gh",
+			"api",
+			"-X",
+			"GET",
+			f"repos/{slug}/pulls",
+			"-f",
+			"state=all",
+			"-f",
+			f"head={owner}:{branch}",
+			"-f",
+			"per_page=20",
+		],
+		cwd,
+		_GH_TIMEOUT_SECONDS,
+	)
+	if code != 0:
+		raise LookupUnavailable((err or out).strip() or f"gh api exited {code}")
+	try:
+		parsed = json.loads(out)
+	except ValueError as exc:
+		raise LookupUnavailable(f"unparseable gh api output: {exc}") from exc
+	if not isinstance(parsed, list):
+		raise LookupUnavailable("unexpected gh api output shape")
+	return [_normalize_rest_pull(entry) for entry in parsed if isinstance(entry, dict)]
+
+
+def _query_via_pr_list(slug: str, branch: str, cwd: str) -> list[dict]:
+	"""Fallback for environments where `gh api` is gated but GraphQL is not."""
+	code, out, err = _run(
+		[
+			"gh",
+			"pr",
+			"list",
+			"-R",
+			slug,
+			"--head",
+			branch,
+			"--state",
+			"all",
+			"--json",
+			"number,state,url,title,mergedAt,headRefOid",
+			"--limit",
+			"20",
+		],
+		cwd,
+		_GH_TIMEOUT_SECONDS,
+	)
+	if code != 0:
+		raise LookupUnavailable((err or out).strip() or f"gh pr list exited {code}")
+	try:
+		parsed = json.loads(out)
+	except ValueError as exc:
+		raise LookupUnavailable(f"unparseable gh output: {exc}") from exc
+	if not isinstance(parsed, list):
+		raise LookupUnavailable("unexpected gh output shape")
+	return parsed
+
+
+def query_pull_requests(slug: str, branch: str, cwd: str) -> list[dict]:
+	"""Fetch every PR whose head ref is `branch`.
+
+	Batching contract (CLAUDE.md §15):
+	  - Input:  `<owner>/<repo>` slug + head branch name.
+	  - Output: list of dicts with `number`, `state`, `url`, `title`,
+	            `mergedAt`, `headRefOid` — REST responses are normalized to
+	            these `gh pr list --json` names so callers see one shape.
+	  - Cost:   one API call. A single `state=all` request serves both the
+	            merged and open questions the caller asks; splitting them
+	            would double the cost for no extra information. A second call
+	            is issued only when the REST path itself errors, as a
+	            transport fallback — never as a second query.
+	  - Fail-open: raises LookupUnavailable when neither transport can answer,
+	            and every caller allows the command on that exception.
+	"""
+	try:
+		return _query_via_rest(slug, branch, cwd)
+	except LookupUnavailable as rest_error:
+		try:
+			return _query_via_pr_list(slug, branch, cwd)
+		except LookupUnavailable as graphql_error:
+			raise LookupUnavailable(f"REST: {rest_error}; GraphQL: {graphql_error}") from None
+
+
+def blocking_pull_request(pull_requests: list[dict], cwd: str) -> dict | None:
+	"""Apply the three-condition detection rule; return the offending PR or None."""
+	merged = [pr for pr in pull_requests if pr.get("mergedAt")]
+	if not merged:
+		return None
+	if any(str(pr.get("state", "")).upper() == "OPEN" for pr in pull_requests):
+		return None
+	for pr in merged:
+		if is_ancestor(str(pr.get("headRefOid") or ""), cwd):
+			return pr
+	return None
+
+
+def _block_message(pr: dict, branch: str, base: str) -> str:
+	number = pr.get("number")
+	return (
+		f"BLOCKED by the merged-PR guard (CLAUDE.md §21).\n"
+		f"\n"
+		f"Branch `{branch}` already had PR #{number} merged at "
+		f"{pr.get('mergedAt')}, no open PR now carries this branch, and HEAD "
+		f"still contains that merged history. Committing or pushing here would "
+		f"strand the work on a dead branch.\n"
+		f"\n"
+		f"  merged PR: {pr.get('url')}\n"
+		f"  title:     {pr.get('title')}\n"
+		f"\n"
+		f"A merged PR is finished — it cannot track new work and must not be "
+		f"reused. Restart the branch from the default branch, keeping the same "
+		f"name, then redo the commit and open a NEW pull request:\n"
+		f"\n"
+		f"  git fetch origin {base}\n"
+		f"  git checkout -B {branch} origin/{base}\n"
+		f"\n"
+		f"If the branch carries unmerged commits beyond the merged history, "
+		f"rebase them onto the new base instead of discarding them. Stash or "
+		f"re-apply any uncommitted work as needed, then retry.\n"
+		f"\n"
+		f"To bypass this guard for one session, set CLAUDE_PR_MERGE_GUARD=off."
+	)
+
+
+def _warn(reason: str) -> None:
+	"""Emit a non-blocking warning to the user and allow the command."""
+	print(json.dumps({"systemMessage": f"merged-PR guard skipped: {reason}"}))
+
+
+def evaluate(payload: dict) -> tuple[int, str]:
+	"""Core decision. Returns (exit_code, message_for_stderr)."""
+	if os.environ.get("CLAUDE_PR_MERGE_GUARD", "").strip().lower() == "off":
+		return 0, ""
+
+	if payload.get("tool_name") != "Bash":
+		return 0, ""
+
+	tool_input = payload.get("tool_input")
+	command = tool_input.get("command", "") if isinstance(tool_input, dict) else ""
+	if not isinstance(command, str) or not command.strip():
+		return 0, ""
+	if not (git_subcommands(command) & GUARDED_SUBCOMMANDS):
+		return 0, ""
+
+	cwd = payload.get("cwd") or os.getcwd()
+	if not isinstance(cwd, str) or not os.path.isdir(cwd):
+		cwd = os.getcwd()
+
+	branch = current_branch(cwd)
+	if not branch:
+		# Detached HEAD, or not a git repo — nothing branch-shaped to check.
+		return 0, ""
+
+	base = default_branch(cwd)
+	if branch == base:
+		# Committing on the default branch is not the stranded-work scenario.
+		return 0, ""
+
+	slug = repo_slug(cwd)
+	if not slug:
+		_warn(f"could not derive <owner>/<repo> from the git remote (branch `{branch}`)")
+		return 0, ""
+
+	cached = _read_cache(slug, branch)
+	try:
+		pull_requests = cached if cached is not None else query_pull_requests(slug, branch, cwd)
+	except LookupUnavailable as exc:
+		_warn(f"could not reach GitHub to check PR status for `{branch}` ({exc})")
+		return 0, ""
+
+	offender = blocking_pull_request(pull_requests, cwd)
+
+	# Re-verify a block against live data. Cheap allows may come from cache;
+	# blocks may not, so that opening a new PR clears the guard immediately
+	# rather than after the TTL expires.
+	if offender is not None and cached is not None:
+		try:
+			pull_requests = query_pull_requests(slug, branch, cwd)
+		except LookupUnavailable as exc:
+			_warn(f"could not re-verify PR status for `{branch}` ({exc})")
+			return 0, ""
+		_write_cache(slug, branch, pull_requests)
+		offender = blocking_pull_request(pull_requests, cwd)
+	elif cached is None:
+		_write_cache(slug, branch, pull_requests)
+
+	if offender is None:
+		return 0, ""
+	return 2, _block_message(offender, branch, base)
+
+
+def main() -> int:
+	try:
+		raw = sys.stdin.read()
+	except (OSError, ValueError):
+		return 0
+	try:
+		payload = json.loads(raw) if raw.strip() else {}
+	except ValueError:
+		return 0
+	if not isinstance(payload, dict):
+		return 0
+
+	try:
+		code, message = evaluate(payload)
+	except Exception as exc:  # noqa: BLE001 - the guard must never break the session
+		_warn(f"internal error ({exc})")
+		return 0
+
+	if message:
+		print(message, file=sys.stderr)
+	return code
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,18 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pr_merge_status_guard.py",
+            "timeout": 60
+          }
+        ]
+      }
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -824,6 +824,85 @@ rules, and audience split.
 
 ---
 
+## §21. Merged-PR Commit Guard (MANDATORY)
+
+**Never commit or push onto a branch whose pull request has already
+merged.** A merged PR is finished — it cannot track new work. Commits
+stacked on top of already-merged history land on a branch no open PR
+carries, so the work is stranded: it never reaches the default branch and
+is lost when the branch is deleted.
+
+This is a real failure mode for long-lived interactive sessions. A session
+that runs for days or weeks outlives the PR it opened; the PR merges
+mid-session and the model, working from context that predates the merge,
+keeps committing to the same branch.
+
+### A) The rule
+
+Before every `git commit` and `git push` in an interactive session, confirm
+the current branch is not sitting on a merged PR. If it is:
+
+1. Restart the branch from the latest default branch, **keeping the same
+   branch name**:
+   `git fetch origin <default> && git checkout -B <branch> origin/<default>`
+2. Re-apply the pending work and commit it there.
+3. Open a **new** pull request. The merged PR is not reusable, and §12.A's
+   single-PR rule does not apply across a merge boundary — the merged PR is
+   closed history, so the follow-up work is a new PR, not a split of an
+   existing one.
+
+If the branch carries unmerged commits beyond the merged history, rebase
+them onto the new base rather than discarding them.
+
+### B) Enforcement
+
+The rule is enforced deterministically by `.claude/hooks/pr_merge_status_guard.py`,
+wired as a `PreToolUse` hook on `Bash` in `.claude/settings.json`. Prose alone
+cannot enforce this — the instruction is furthest from the context window's live
+edge exactly when the session has run long enough for the merge to happen.
+
+The guard blocks a command only when all three conditions hold:
+
+1. A **merged** PR exists whose head ref is the current branch, **and**
+2. no **open** PR exists for the current branch, **and**
+3. that merged PR's head commit is an ancestor of `HEAD`.
+
+Condition 3 is what makes the guard self-clearing. Branch names are reused
+after the reset in §21.A, so the merged PR matches `--head <branch>`
+forever; ancestry is what separates "stacking on merged history" from
+"fresh work that reuses the name". No override flag is needed, and the
+guard goes quiet as soon as the branch is reset — before the new PR exists.
+
+### C) Fail-open contract
+
+Any inability to answer the question — `gh` missing, token expired or
+unauthenticated, network failure, unparseable hook payload, detached HEAD,
+not a git repo, undeterminable `<owner>/<repo>` — **allows** the command and
+emits a warning naming the branch. A guard that hard-blocks every commit
+whenever a token lapses would cost more than the bug it prevents.
+
+The guard is skipped entirely on the default branch, and when
+`CLAUDE_PR_MERGE_GUARD=off` is set (default: unset, i.e. enabled).
+
+### D) API-call budget
+
+Per §15, the guard issues **one** API call per guarded command — a single
+`state=all` request answers both the merged and the open question — and
+caches the result for 300 seconds keyed on `<slug>/<branch>`. Cached data may
+satisfy an *allow*; a *block* is always re-verified against a live call first,
+so opening a new PR clears the guard immediately instead of after the TTL.
+
+The call goes over REST (`gh api repos/<slug>/pulls`), **not** `gh pr list`.
+Claude Code Web's agent proxy serves only a pinned set of GraphQL operations
+and rejects the rest with HTTP 403, and `gh pr list` is GraphQL-backed — using
+it as the primary transport would make the guard fail open on every commit in
+exactly the long-running web sessions §21 exists to protect. `gh pr list`
+remains wired as a transport fallback for environments where REST is gated
+instead. The fallback is a retry of the same question on a different
+transport, never a second query.
+
+---
+
 ## FINAL REMINDER
 
 If uncertainty exists: **ASK (multiple-choice). DO NOT EXECUTE.**

--- a/changelog.d/merged-pr-commit-guard.md
+++ b/changelog.d/merged-pr-commit-guard.md
@@ -1,0 +1,21 @@
+<!-- changelog: added -->
+- **Commits and pushes onto a branch whose pull request already merged are now blocked before they happen, instead of silently stranding the work.** A new `PreToolUse` hook checks PR merge status on every `git commit` and `git push` in an interactive Claude Code session.
+
+Sessions that run for days or weeks outlive the PRs they open. When the PR for the working branch merges mid-session, further commits land on history that is already in the default branch and that no open PR carries anywhere, so the work never ships and disappears when the branch is deleted. The rule against this existed only as prose in `CLAUDE.md`, which is furthest from the model's live context exactly when a session has run long enough for the merge to happen. `.claude/hooks/pr_merge_status_guard.py` now enforces it deterministically: the harness runs it on every Bash tool call regardless of what the model remembers, and a block is reported back with the `git checkout -B <branch> origin/<default>` remediation already filled in.
+
+The guard blocks only when all three conditions hold: a merged PR exists for the current branch, no open PR exists for it, and that merged PR's head commit is an ancestor of `HEAD`. The third condition is what makes it self-clearing. Branch names are reused after the reset, so the merged PR keeps matching the branch forever, and ancestry is what separates stacking on merged history from fresh work that reuses the name. The guard goes quiet the moment the branch is reset, before the replacement PR exists, so no override flag is needed to commit the fix.
+
+| The numbers that matter | Value |
+| --- | --- |
+| Consumer repos reached | 12 (`.github/ai/consumer_repos.json`) |
+| Conditions required before a command is blocked | 3 |
+| Guarded git subcommands | `commit`, `push` |
+| GitHub API calls per guarded command | 1, cached 300s per `<slug>/<branch>` |
+| New env var | `CLAUDE_PR_MERGE_GUARD` (unset = enabled; `off` disables) |
+| New `CLAUDE.md` section | §21 |
+
+What this means for operators: nothing to install. The hook, its `PreToolUse` wiring in `.claude/settings.json`, and the §21 rule that documents it all arrive in consumer repos on the next `@stable` sync, through the existing `workflow-templates/.claude/` mirror in `update_workflows.yml`. Every failure mode allows the command and prints a warning naming the branch, so a lapsed token degrades the guard to a no-op rather than blocking all committing.
+
+### For contributors
+
+PR state is read over REST (`gh api repos/<slug>/pulls?state=all`), not `gh pr list`. Claude Code Web's agent proxy serves only a pinned set of GraphQL operations and rejects the rest with HTTP 403, and `gh pr list` is GraphQL-backed, so using it as the primary transport would have made the guard fail open on every commit in exactly the long-running web sessions it exists to protect. `gh pr list` stays wired as a transport fallback for environments where REST is gated instead; it retries the same question rather than issuing a second query, so the §15 budget of one call per guarded command holds. Cached data can satisfy an allow, but a block is always re-verified against a live call first, so opening a new PR clears the guard immediately rather than after the TTL. The hook is invoked as `python3 .claude/hooks/pr_merge_status_guard.py` rather than relying on its executable bit, because the consumer sync copies with plain `cp`, which leaves an existing destination's mode untouched. `tests/test_pr_merge_status_guard.py` covers the detection rule, the fail-open contract, both transports, and the block-then-reset-then-allow sequence end to end against a real git repository.

--- a/tests/test_pr_merge_status_guard.py
+++ b/tests/test_pr_merge_status_guard.py
@@ -405,7 +405,12 @@ def test_skipped_on_detached_head(monkeypatch, tmp_path: Path) -> None:
 
 
 def test_skipped_on_default_branch(monkeypatch, tmp_path: Path) -> None:
-	assert _evaluate(monkeypatch, tmp_path, current_branch=lambda cwd: "main")[0] == 0
+	assert _evaluate(
+		monkeypatch,
+		tmp_path,
+		current_branch=lambda cwd: "main",
+		repo_slug=lambda cwd: pytest.fail("default branch should skip before repo lookup"),
+	)[0] == 0
 
 
 def test_escape_hatch_disables_the_guard(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_pr_merge_status_guard.py
+++ b/tests/test_pr_merge_status_guard.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python3
+"""Behaviour and wiring contract for the merged-PR commit guard (CLAUDE.md §21).
+
+Covers the three pieces that can silently detach the mechanism:
+  1. Command parsing — which Bash calls are guarded at all.
+  2. The three-condition detection rule, including its self-clearing property.
+  3. The fail-open contract, plus the settings.json / template-parity wiring.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GUARD_PATH = REPO_ROOT / ".claude" / "hooks" / "pr_merge_status_guard.py"
+TEMPLATE_GUARD_PATH = REPO_ROOT / "workflow-templates" / ".claude" / "hooks" / "pr_merge_status_guard.py"
+SETTINGS_PATH = REPO_ROOT / ".claude" / "settings.json"
+TEMPLATE_SETTINGS_PATH = REPO_ROOT / "workflow-templates" / ".claude" / "settings.json"
+CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+TEMPLATE_CLAUDE_MD = REPO_ROOT / "workflow-templates" / "CLAUDE.md"
+
+
+def _load_guard():
+	spec = importlib.util.spec_from_file_location("pr_merge_status_guard", GUARD_PATH)
+	assert spec is not None and spec.loader is not None
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+guard = _load_guard()
+
+
+# ──────────────────────────────────────────────────────────────────
+# Command parsing
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+	"command",
+	[
+		"git commit -m 'wip'",
+		'git commit -m "message with the word push in it"',
+		"git push -u origin feature",
+		"cd /repo && git commit --amend --no-edit",
+		"git add -A; git commit -m x",
+		"git -C /some/repo commit -m x",
+		"git -c user.name=bot commit -m x",
+		"GIT_AUTHOR_NAME=bot git commit -m x",
+		"/usr/bin/git push origin HEAD",
+	],
+)
+def test_guarded_commands_are_detected(command: str) -> None:
+	assert guard.git_subcommands(command) & guard.GUARDED_SUBCOMMANDS
+
+
+@pytest.mark.parametrize(
+	"command",
+	[
+		"git status",
+		"git log --oneline -5",
+		"git fetch origin main",
+		"echo 'git commit -m x'",
+		"man git commit",
+		"grep -rn 'git push' scripts/",
+		"ls -la",
+		"",
+	],
+)
+def test_unguarded_commands_are_ignored(command: str) -> None:
+	assert not (guard.git_subcommands(command) & guard.GUARDED_SUBCOMMANDS)
+
+
+def test_unbalanced_quotes_do_not_raise() -> None:
+	assert guard.git_subcommands("git commit -m 'unterminated") == set()
+
+
+# ──────────────────────────────────────────────────────────────────
+# Repo slug extraction — mirrors session-start.sh's host whitelist
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+	"url,expected",
+	[
+		("https://github.com/owner/repo.git", "owner/repo"),
+		("https://github.com/owner/repo", "owner/repo"),
+		("git@github.com:owner/repo.git", "owner/repo"),
+		("ssh://git@github.com/owner/repo.git", "owner/repo"),
+		("https://x-access-token:tok@github.com/owner/repo.git", "owner/repo"),
+		("http://user:pw@127.0.0.1:8080/git/owner/repo", "owner/repo"),
+		("http://localhost:9000/git/owner/repo.git", "owner/repo"),
+		("https://github.com/owner/repo/", "owner/repo"),
+		("git@github.com:owner/repo", "owner/repo"),
+	],
+)
+def test_slug_extracted_from_supported_remotes(url: str, expected: str) -> None:
+	assert guard.extract_repo_slug(url) == expected
+
+
+@pytest.mark.parametrize(
+	"url",
+	[
+		"https://evilgithub.com/owner/repo.git",
+		"https://github.com.evil.com/owner/repo",
+		"https://gitlab.com/owner/repo.git",
+		"http://localhost:9000/notgit/owner/repo",
+		"https://github.com/owner/repo/tree/main",
+		"https://github.com/owner",
+		"https://github.com//repo",
+		# Owner names are GitHub-username-shaped: no dots. Only the repo half
+		# may carry one.
+		"https://github.com/ow.ner/repo",
+		"not a url",
+		"",
+	],
+)
+def test_lookalike_and_malformed_remotes_yield_no_slug(url: str) -> None:
+	"""A bogus slug would be handed straight to `gh -R` and query the wrong repo."""
+	assert guard.extract_repo_slug(url) == ""
+
+
+def test_slug_extraction_matches_the_bash_implementation_it_mirrors() -> None:
+	"""Parity with `extract_repo_slug` in session-start.sh, verified by running it.
+
+	The two implementations encode the same host whitelist. If they drift, the
+	guard could accept a remote the session-start probe rejects (or vice versa),
+	and the whitelist is what stops a lookalike host from aiming `gh -R` at an
+	unrelated github.com repo.
+	"""
+	session_start = REPO_ROOT / ".claude" / "hooks" / "session-start.sh"
+	urls = [
+		"https://github.com/owner/repo.git",
+		"git@github.com:owner/repo.git",
+		"ssh://git@github.com/owner/repo.git",
+		"http://user:pw@127.0.0.1:8080/git/owner/repo",
+		"http://localhost:9000/git/owner/repo.git",
+		"https://evilgithub.com/owner/repo.git",
+		"https://github.com.evil.com/owner/repo",
+		"https://gitlab.com/owner/repo.git",
+		"http://localhost:9000/notgit/owner/repo",
+		"https://github.com/owner/repo/tree/main",
+		"https://github.com/owner",
+		"https://github.com//repo",
+		"https://github.com/ow.ner/repo",
+		"not a url",
+	]
+	script = f'source "{session_start}"\n' + "\n".join(
+		f'extract_repo_slug "{url}"; echo ""' for url in urls
+	)
+	proc = subprocess.run(
+		["bash", "-c", script], capture_output=True, text=True, timeout=60, check=True
+	)
+	# Each URL emits its slug (or nothing) followed by a delimiter newline.
+	bash_results = proc.stdout.split("\n\n")[: len(urls)]
+	for url, bash_slug in zip(urls, bash_results):
+		assert guard.extract_repo_slug(url) == bash_slug.strip(), f"drift on {url}"
+
+
+# ──────────────────────────────────────────────────────────────────
+# Detection rule
+# ──────────────────────────────────────────────────────────────────
+
+
+MERGED_PR = {
+	"number": 41,
+	"state": "MERGED",
+	"url": "https://github.com/o/r/pull/41",
+	"title": "the merged one",
+	"mergedAt": "2026-07-01T10:00:00Z",
+	"headRefOid": "deadbeef",
+}
+OPEN_PR = {
+	"number": 42,
+	"state": "OPEN",
+	"url": "https://github.com/o/r/pull/42",
+	"title": "the live one",
+	"mergedAt": None,
+	"headRefOid": "cafebabe",
+}
+
+
+def _with_ancestry(monkeypatch, ancestors: set[str]) -> None:
+	monkeypatch.setattr(guard, "is_ancestor", lambda sha, cwd: sha in ancestors)
+
+
+def test_blocks_when_merged_pr_is_ancestor_and_no_open_pr(monkeypatch) -> None:
+	_with_ancestry(monkeypatch, {"deadbeef"})
+	assert guard.blocking_pull_request([MERGED_PR], "/repo") == MERGED_PR
+
+
+def test_allows_when_an_open_pr_exists(monkeypatch) -> None:
+	"""Condition 2 — commits still land somewhere live."""
+	_with_ancestry(monkeypatch, {"deadbeef"})
+	assert guard.blocking_pull_request([MERGED_PR, OPEN_PR], "/repo") is None
+
+
+def test_allows_when_branch_was_reset_off_merged_history(monkeypatch) -> None:
+	"""Condition 3 — the self-clearing property.
+
+	After `git checkout -B <branch> origin/<default>` the merged PR still
+	matches `--head <branch>` and no new PR exists yet, so conditions 1 and 2
+	both hold. Only ancestry distinguishes this from the stranded case, and it
+	must allow — otherwise the remediation in §21.A could never be committed.
+	"""
+	_with_ancestry(monkeypatch, set())
+	assert guard.blocking_pull_request([MERGED_PR], "/repo") is None
+
+
+def test_allows_when_no_pr_ever_existed(monkeypatch) -> None:
+	_with_ancestry(monkeypatch, {"deadbeef"})
+	assert guard.blocking_pull_request([], "/repo") is None
+
+
+def test_allows_when_only_a_closed_unmerged_pr_exists(monkeypatch) -> None:
+	closed = dict(OPEN_PR, state="CLOSED", mergedAt=None, headRefOid="deadbeef")
+	_with_ancestry(monkeypatch, {"deadbeef"})
+	assert guard.blocking_pull_request([closed], "/repo") is None
+
+
+# ──────────────────────────────────────────────────────────────────
+# Transport — REST first, GraphQL fallback
+# ──────────────────────────────────────────────────────────────────
+
+
+REST_PULL = {
+	"number": 41,
+	"state": "closed",
+	"html_url": "https://github.com/o/r/pull/41",
+	"title": "the merged one",
+	"merged_at": "2026-07-01T10:00:00Z",
+	"head": {"sha": "deadbeef"},
+}
+
+
+def test_rest_response_is_normalized_to_gh_pr_list_field_names() -> None:
+	"""`state` is passed through verbatim and intentionally diverges: REST calls a
+	merged PR `closed`, GraphQL calls it `MERGED`. The detection rule never reads
+	that value for mergedness — `mergedAt` decides — and only tests it for `OPEN`,
+	which both transports spell the same way modulo case.
+	"""
+	assert guard._normalize_rest_pull(REST_PULL) == dict(MERGED_PR, state="closed")
+
+
+def test_normalized_rest_state_survives_the_open_check(monkeypatch) -> None:
+	"""REST returns lowercase `open`; the detection rule must still see it."""
+	rest_open = guard._normalize_rest_pull(
+		dict(REST_PULL, number=42, state="open", merged_at=None, head={"sha": "cafebabe"})
+	)
+	_with_ancestry(monkeypatch, {"deadbeef"})
+	merged = guard._normalize_rest_pull(REST_PULL)
+	assert guard.blocking_pull_request([merged, rest_open], "/repo") is None
+
+
+def test_rest_is_tried_first_and_graphql_is_not_called(monkeypatch) -> None:
+	monkeypatch.setattr(guard, "_query_via_rest", lambda slug, branch, cwd: [MERGED_PR])
+	monkeypatch.setattr(
+		guard,
+		"_query_via_pr_list",
+		lambda slug, branch, cwd: pytest.fail("GraphQL must not run when REST succeeds"),
+	)
+	assert guard.query_pull_requests("o/r", "feature/x", "/repo") == [MERGED_PR]
+
+
+def test_graphql_fallback_runs_when_rest_is_gated(monkeypatch) -> None:
+	def _gated(slug, branch, cwd):
+		raise guard.LookupUnavailable("HTTP 403")
+
+	monkeypatch.setattr(guard, "_query_via_rest", _gated)
+	monkeypatch.setattr(guard, "_query_via_pr_list", lambda slug, branch, cwd: [OPEN_PR])
+	assert guard.query_pull_requests("o/r", "feature/x", "/repo") == [OPEN_PR]
+
+
+def test_both_transports_failing_raises_with_both_reasons(monkeypatch) -> None:
+	def _rest(slug, branch, cwd):
+		raise guard.LookupUnavailable("rest boom")
+
+	def _graphql(slug, branch, cwd):
+		raise guard.LookupUnavailable("graphql boom")
+
+	monkeypatch.setattr(guard, "_query_via_rest", _rest)
+	monkeypatch.setattr(guard, "_query_via_pr_list", _graphql)
+	with pytest.raises(guard.LookupUnavailable) as excinfo:
+		guard.query_pull_requests("o/r", "feature/x", "/repo")
+	assert "rest boom" in str(excinfo.value)
+	assert "graphql boom" in str(excinfo.value)
+
+
+def test_rest_call_targets_the_pulls_endpoint_with_one_request(monkeypatch) -> None:
+	"""§15 — one call, `state=all`, not separate merged/open queries."""
+	seen: list[list[str]] = []
+
+	def _fake_run(argv, cwd, timeout):
+		seen.append(argv)
+		return 0, "[]", ""
+
+	monkeypatch.setattr(guard, "_run", _fake_run)
+	guard._query_via_rest("o/r", "feature/x", "/repo")
+	assert len(seen) == 1
+	argv = seen[0]
+	assert argv[:2] == ["gh", "api"]
+	assert "repos/o/r/pulls" in argv
+	assert "state=all" in argv
+	assert "head=o:feature/x" in argv
+
+
+# ──────────────────────────────────────────────────────────────────
+# Fail-open contract
+# ──────────────────────────────────────────────────────────────────
+
+
+def _evaluate(monkeypatch, tmp_path: Path, **overrides) -> tuple[int, str]:
+	defaults = {
+		"current_branch": lambda cwd: "feature/x",
+		"default_branch": lambda cwd: "main",
+		"repo_slug": lambda cwd: "o/r",
+		"query_pull_requests": lambda slug, branch, cwd: [MERGED_PR],
+		"is_ancestor": lambda sha, cwd: True,
+		"_read_cache": lambda slug, branch: None,
+		"_write_cache": lambda slug, branch, prs: None,
+	}
+	defaults.update(overrides)
+	for name, value in defaults.items():
+		monkeypatch.setattr(guard, name, value)
+	monkeypatch.delenv("CLAUDE_PR_MERGE_GUARD", raising=False)
+	payload = {
+		"tool_name": "Bash",
+		"tool_input": {"command": "git commit -m x"},
+		"cwd": str(tmp_path),
+	}
+	return guard.evaluate(payload)
+
+
+def test_blocks_end_to_end(monkeypatch, tmp_path: Path) -> None:
+	code, message = _evaluate(monkeypatch, tmp_path)
+	assert code == 2
+	assert "§21" in message
+	assert "git checkout -B feature/x origin/main" in message
+	assert "https://github.com/o/r/pull/41" in message
+
+
+def test_fails_open_when_gh_is_unavailable(monkeypatch, tmp_path: Path, capsys) -> None:
+	def _unavailable(slug, branch, cwd):
+		raise guard.LookupUnavailable("gh: not found")
+
+	code, message = _evaluate(monkeypatch, tmp_path, query_pull_requests=_unavailable)
+	assert code == 0
+	assert message == ""
+	assert "feature/x" in json.loads(capsys.readouterr().out)["systemMessage"]
+
+
+def test_fails_open_when_slug_is_underivable(monkeypatch, tmp_path: Path, capsys) -> None:
+	code, _ = _evaluate(monkeypatch, tmp_path, repo_slug=lambda cwd: "")
+	assert code == 0
+	assert "systemMessage" in json.loads(capsys.readouterr().out)
+
+
+def test_skipped_on_detached_head(monkeypatch, tmp_path: Path) -> None:
+	assert _evaluate(monkeypatch, tmp_path, current_branch=lambda cwd: "")[0] == 0
+
+
+def test_skipped_on_default_branch(monkeypatch, tmp_path: Path) -> None:
+	assert _evaluate(monkeypatch, tmp_path, current_branch=lambda cwd: "main")[0] == 0
+
+
+def test_escape_hatch_disables_the_guard(monkeypatch, tmp_path: Path) -> None:
+	monkeypatch.setenv("CLAUDE_PR_MERGE_GUARD", "off")
+	monkeypatch.setattr(guard, "current_branch", lambda cwd: pytest.fail("must not run"))
+	assert guard.evaluate(
+		{"tool_name": "Bash", "tool_input": {"command": "git commit -m x"}}
+	) == (0, "")
+
+
+def test_non_bash_tools_are_ignored() -> None:
+	assert guard.evaluate({"tool_name": "Edit", "tool_input": {"command": "git commit"}}) == (0, "")
+
+
+def test_block_is_reverified_live_before_firing(monkeypatch, tmp_path: Path) -> None:
+	"""A cached block must not outlive the PR that justified it (§21.D)."""
+	calls: list[str] = []
+
+	def _fresh(slug, branch, cwd):
+		calls.append(branch)
+		return [MERGED_PR, OPEN_PR]
+
+	code, _ = _evaluate(
+		monkeypatch,
+		tmp_path,
+		_read_cache=lambda slug, branch: [MERGED_PR],
+		query_pull_requests=_fresh,
+	)
+	assert calls == ["feature/x"], "a cache-derived block must trigger one live re-check"
+	assert code == 0, "the freshly-opened PR must clear the guard immediately"
+
+
+def test_cached_allow_issues_no_api_call(monkeypatch, tmp_path: Path) -> None:
+	def _must_not_run(slug, branch, cwd):
+		pytest.fail("cached allow must not hit the GitHub API (§15)")
+
+	code, _ = _evaluate(
+		monkeypatch,
+		tmp_path,
+		_read_cache=lambda slug, branch: [MERGED_PR, OPEN_PR],
+		query_pull_requests=_must_not_run,
+	)
+	assert code == 0
+
+
+# ──────────────────────────────────────────────────────────────────
+# Process-level contract
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("payload", ["", "not json", "[]", "null"])
+def test_malformed_stdin_exits_zero(payload: str) -> None:
+	proc = subprocess.run(
+		[sys.executable, str(GUARD_PATH)],
+		input=payload,
+		capture_output=True,
+		text=True,
+		timeout=30,
+	)
+	assert proc.returncode == 0
+
+
+def test_unguarded_command_exits_zero_without_touching_git() -> None:
+	proc = subprocess.run(
+		[sys.executable, str(GUARD_PATH)],
+		input=json.dumps({"tool_name": "Bash", "tool_input": {"command": "ls -la"}}),
+		capture_output=True,
+		text=True,
+		timeout=30,
+	)
+	assert proc.returncode == 0
+	assert proc.stdout.strip() == ""
+
+
+# ──────────────────────────────────────────────────────────────────
+# End-to-end against a real git repository
+# ──────────────────────────────────────────────────────────────────
+
+
+def _git(repo: Path, *args: str) -> str:
+	proc = subprocess.run(
+		["git", *args], cwd=repo, capture_output=True, text=True, check=True, timeout=30
+	)
+	return proc.stdout.strip()
+
+
+@pytest.fixture()
+def merged_branch_repo(tmp_path: Path):
+	"""A repo whose `feature/x` branch has a merged PR and no open one.
+
+	Returns (repo_path, stub_bin_path). The stub `gh` answers the REST pulls
+	query with a merged PR whose head sha is the branch tip, reproducing the
+	exact stranded-work state §21 exists to catch.
+	"""
+	repo = tmp_path / "repo"
+	repo.mkdir()
+	_git(repo, "init", "-b", "main")
+	_git(repo, "config", "user.email", "test@example.com")
+	_git(repo, "config", "user.name", "Test")
+	_git(repo, "remote", "add", "origin", "https://github.com/o/r.git")
+	(repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+	_git(repo, "add", "-A")
+	_git(repo, "commit", "-m", "seed")
+
+	_git(repo, "checkout", "-b", "feature/x")
+	(repo / "work.txt").write_text("work\n", encoding="utf-8")
+	_git(repo, "add", "-A")
+	_git(repo, "commit", "-m", "merged work")
+	merged_sha = _git(repo, "rev-parse", "HEAD")
+
+	payload = json.dumps(
+		[
+			{
+				"number": 41,
+				"state": "closed",
+				"html_url": "https://github.com/o/r/pull/41",
+				"title": "the merged one",
+				"merged_at": "2026-07-01T10:00:00Z",
+				"head": {"sha": merged_sha},
+			}
+		]
+	)
+	stub_bin = tmp_path / "bin"
+	stub_bin.mkdir()
+	stub = stub_bin / "gh"
+	stub.write_text(f"#!/bin/sh\ncat <<'EOF'\n{payload}\nEOF\n", encoding="utf-8")
+	stub.chmod(0o755)
+	return repo, stub_bin
+
+
+def _run_hook(repo: Path, stub_bin: Path, command: str) -> subprocess.CompletedProcess:
+	import os
+
+	env = dict(os.environ)
+	env["PATH"] = f"{stub_bin}{os.pathsep}{env.get('PATH', '')}"
+	env["PYTHONDONTWRITEBYTECODE"] = "1"
+	env.pop("CLAUDE_PR_MERGE_GUARD", None)
+	# A cold cache per run: the guard keys its TTL cache on slug+branch, which
+	# every case in this fixture shares.
+	env["TMPDIR"] = str(repo.parent / "cache")
+	(repo.parent / "cache").mkdir(exist_ok=True)
+	return subprocess.run(
+		[sys.executable, str(GUARD_PATH)],
+		input=json.dumps(
+			{"tool_name": "Bash", "tool_input": {"command": command}, "cwd": str(repo)}
+		),
+		capture_output=True,
+		text=True,
+		env=env,
+		timeout=60,
+	)
+
+
+def test_e2e_blocks_commit_stacked_on_merged_history(merged_branch_repo) -> None:
+	repo, stub_bin = merged_branch_repo
+	(repo / "more.txt").write_text("more\n", encoding="utf-8")
+	_git(repo, "add", "-A")
+	_git(repo, "commit", "-m", "follow-up that would be stranded")
+
+	proc = _run_hook(repo, stub_bin, "git commit -m 'next'")
+	assert proc.returncode == 2, proc.stdout + proc.stderr
+	assert "git checkout -B feature/x origin/main" in proc.stderr
+	assert "pull/41" in proc.stderr
+
+
+def test_e2e_allows_after_branch_is_reset_off_merged_history(merged_branch_repo) -> None:
+	"""The §21.A remediation must actually clear the guard, with the same branch
+	name and before any new PR exists."""
+	repo, stub_bin = merged_branch_repo
+	_git(repo, "checkout", "-B", "feature/x", "main")
+	(repo / "fresh.txt").write_text("fresh\n", encoding="utf-8")
+	_git(repo, "add", "-A")
+	_git(repo, "commit", "-m", "fresh work on a rebuilt branch")
+
+	proc = _run_hook(repo, stub_bin, "git commit -m 'next'")
+	assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_e2e_allows_unguarded_commands_on_a_stranded_branch(merged_branch_repo) -> None:
+	repo, stub_bin = merged_branch_repo
+	assert _run_hook(repo, stub_bin, "git status").returncode == 0
+
+
+def test_e2e_guards_push_as_well_as_commit(merged_branch_repo) -> None:
+	repo, stub_bin = merged_branch_repo
+	proc = _run_hook(repo, stub_bin, "git push -u origin feature/x")
+	assert proc.returncode == 2, proc.stdout + proc.stderr
+
+
+# ──────────────────────────────────────────────────────────────────
+# Wiring — the parts that only exist as config / instruction text
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("path", [SETTINGS_PATH, TEMPLATE_SETTINGS_PATH])
+def test_guard_is_wired_as_a_pretooluse_bash_hook(path: Path) -> None:
+	settings = json.loads(path.read_text(encoding="utf-8"))
+	entries = settings["hooks"]["PreToolUse"]
+	matched = [entry for entry in entries if entry.get("matcher") == "Bash"]
+	assert matched, f"{path} has no PreToolUse hook matching Bash"
+	commands = [hook["command"] for entry in matched for hook in entry["hooks"]]
+	assert any("pr_merge_status_guard.py" in command for command in commands)
+	# Invoked through `python3` rather than relying on the executable bit:
+	# the consumer sync copies with plain `cp`, which leaves an existing
+	# destination's mode untouched.
+	assert any(
+		command.startswith("python3 ")
+		for command in commands
+		if "pr_merge_status_guard.py" in command
+	)
+
+
+@pytest.mark.parametrize("path", [SETTINGS_PATH, TEMPLATE_SETTINGS_PATH])
+def test_session_start_hook_is_preserved(path: Path) -> None:
+	"""§6 — adding PreToolUse must not displace the existing SessionStart hook."""
+	settings = json.loads(path.read_text(encoding="utf-8"))
+	commands = [
+		hook["command"]
+		for entry in settings["hooks"]["SessionStart"]
+		for hook in entry["hooks"]
+	]
+	assert any("session-start.sh" in command for command in commands)
+
+
+def test_template_copies_are_identical() -> None:
+	"""Consumer repos receive the guard via the workflow-templates/.claude mirror."""
+	assert TEMPLATE_GUARD_PATH.read_text(encoding="utf-8") == GUARD_PATH.read_text(encoding="utf-8")
+	assert TEMPLATE_SETTINGS_PATH.read_text(encoding="utf-8") == SETTINGS_PATH.read_text(
+		encoding="utf-8"
+	)
+	assert TEMPLATE_CLAUDE_MD.read_text(encoding="utf-8") == CLAUDE_MD.read_text(encoding="utf-8")
+
+
+def test_claude_md_documents_the_guard() -> None:
+	text = CLAUDE_MD.read_text(encoding="utf-8")
+	assert "## §21. Merged-PR Commit Guard (MANDATORY)" in text
+	assert ".claude/hooks/pr_merge_status_guard.py" in text
+	assert "CLAUDE_PR_MERGE_GUARD=off" in text

--- a/tests/test_pr_merge_status_guard.py
+++ b/tests/test_pr_merge_status_guard.py
@@ -342,6 +342,38 @@ def test_default_branch_uses_remote_head_when_local_refs_are_missing(monkeypatch
 	assert guard.default_branch("/repo") == "trunk"
 
 
+def test_default_branch_does_not_guess_local_main_over_remote_head(monkeypatch) -> None:
+	def _fake_run(argv, cwd, timeout):
+		lookup = {
+			("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): (1, "", ""),
+			("git", "ls-remote", "--symref", "origin", "HEAD"): (
+				0,
+				"ref: refs/heads/trunk\tHEAD\n0123456789abcdef\tHEAD\n",
+				"",
+			),
+		}
+		result = lookup.get(tuple(argv))
+		assert result is not None, f"unexpected argv: {argv}"
+		return result
+
+	monkeypatch.setattr(guard, "_run", _fake_run)
+	assert guard.default_branch("/repo") == "trunk"
+
+
+def test_default_branch_returns_empty_when_only_local_main_exists(monkeypatch) -> None:
+	def _fake_run(argv, cwd, timeout):
+		lookup = {
+			("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): (1, "", ""),
+			("git", "ls-remote", "--symref", "origin", "HEAD"): (1, "", ""),
+		}
+		result = lookup.get(tuple(argv))
+		assert result is not None, f"unexpected argv: {argv}"
+		return result
+
+	monkeypatch.setattr(guard, "_run", _fake_run)
+	assert guard.default_branch("/repo") == ""
+
+
 # ──────────────────────────────────────────────────────────────────
 # Fail-open contract
 # ──────────────────────────────────────────────────────────────────

--- a/tests/test_pr_merge_status_guard.py
+++ b/tests/test_pr_merge_status_guard.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -38,6 +39,13 @@ def _load_guard():
 guard = _load_guard()
 
 
+def _git_env() -> dict[str, str]:
+	env = dict(os.environ)
+	for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR"):
+		env.pop(key, None)
+	return env
+
+
 # ──────────────────────────────────────────────────────────────────
 # Command parsing
 # ──────────────────────────────────────────────────────────────────
@@ -48,6 +56,7 @@ guard = _load_guard()
 	[
 		"git commit -m 'wip'",
 		'git commit -m "message with the word push in it"',
+		'git commit -m "message with ; && | operators"',
 		"git push -u origin feature",
 		"cd /repo && git commit --amend --no-edit",
 		"git add -A; git commit -m x",
@@ -311,6 +320,28 @@ def test_rest_call_targets_the_pulls_endpoint_with_one_request(monkeypatch) -> N
 	assert "head=o:feature/x" in argv
 
 
+def test_default_branch_uses_remote_head_when_local_refs_are_missing(monkeypatch) -> None:
+	def _fake_run(argv, cwd, timeout):
+		lookup = {
+			("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): (1, "", ""),
+			("git", "rev-parse", "--verify", "refs/remotes/origin/main"): (1, "", ""),
+			("git", "rev-parse", "--verify", "refs/remotes/origin/master"): (1, "", ""),
+			(
+				"git",
+				"ls-remote",
+				"--symref",
+				"origin",
+				"HEAD",
+			): (0, "ref: refs/heads/trunk\tHEAD\n0123456789abcdef\tHEAD\n", ""),
+		}
+		result = lookup.get(tuple(argv))
+		assert result is not None, f"unexpected argv: {argv}"
+		return result
+
+	monkeypatch.setattr(guard, "_run", _fake_run)
+	assert guard.default_branch("/repo") == "trunk"
+
+
 # ──────────────────────────────────────────────────────────────────
 # Fail-open contract
 # ──────────────────────────────────────────────────────────────────
@@ -344,6 +375,13 @@ def test_blocks_end_to_end(monkeypatch, tmp_path: Path) -> None:
 	assert "§21" in message
 	assert "git checkout -B feature/x origin/main" in message
 	assert "https://github.com/o/r/pull/41" in message
+
+
+def test_block_message_uses_a_placeholder_when_default_branch_is_unknown(monkeypatch, tmp_path: Path) -> None:
+	code, message = _evaluate(monkeypatch, tmp_path, default_branch=lambda cwd: "")
+	assert code == 2
+	assert "git fetch origin <default-branch>" in message
+	assert "could not determine the default branch automatically" in message
 
 
 def test_fails_open_when_gh_is_unavailable(monkeypatch, tmp_path: Path, capsys) -> None:
@@ -449,7 +487,13 @@ def test_unguarded_command_exits_zero_without_touching_git() -> None:
 
 def _git(repo: Path, *args: str) -> str:
 	proc = subprocess.run(
-		["git", *args], cwd=repo, capture_output=True, text=True, check=True, timeout=30
+		["git", *args],
+		cwd=repo,
+		capture_output=True,
+		text=True,
+		check=True,
+		env=_git_env(),
+		timeout=30,
 	)
 	return proc.stdout.strip()
 
@@ -471,6 +515,9 @@ def merged_branch_repo(tmp_path: Path):
 	(repo / "seed.txt").write_text("seed\n", encoding="utf-8")
 	_git(repo, "add", "-A")
 	_git(repo, "commit", "-m", "seed")
+	seed_sha = _git(repo, "rev-parse", "HEAD")
+	_git(repo, "update-ref", "refs/remotes/origin/main", seed_sha)
+	_git(repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
 
 	_git(repo, "checkout", "-b", "feature/x")
 	(repo / "work.txt").write_text("work\n", encoding="utf-8")
@@ -499,9 +546,7 @@ def merged_branch_repo(tmp_path: Path):
 
 
 def _run_hook(repo: Path, stub_bin: Path, command: str) -> subprocess.CompletedProcess:
-	import os
-
-	env = dict(os.environ)
+	env = _git_env()
 	env["PATH"] = f"{stub_bin}{os.pathsep}{env.get('PATH', '')}"
 	env["PYTHONDONTWRITEBYTECODE"] = "1"
 	env.pop("CLAUDE_PR_MERGE_GUARD", None)

--- a/workflow-templates/.claude/hooks/pr_merge_status_guard.py
+++ b/workflow-templates/.claude/hooks/pr_merge_status_guard.py
@@ -67,10 +67,11 @@ GIT_GLOBAL_OPTS_WITH_VALUE = frozenset(
 	{"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--super-prefix", "--exec-path"}
 )
 
-# Shell operators that separate independent commands within one Bash call.
-_SEGMENT_SPLIT_RE = re.compile(r"(?:\|\||&&|[;&|\n])")
+# Shell punctuation we treat as command separators when tokenizing a Bash line.
+_SHELL_PUNCTUATION_CHARS = ";&|\n"
 
 _SLUG_RE = re.compile(r"^[A-Za-z0-9_-]+/[A-Za-z0-9._-]+$")
+_REMOTE_HEAD_BRANCH_RE = re.compile(r"^ref:\s+refs/heads/([^\s]+)\s+HEAD$", re.MULTILINE)
 
 _CACHE_TTL_SECONDS = 300
 _CACHE_DIR_NAME = "claude-pr-merge-guard"
@@ -113,6 +114,29 @@ def _run(argv: list[str], cwd: str | None, timeout: int) -> tuple[int, str, str]
 	return proc.returncode, proc.stdout, proc.stderr
 
 
+def _shell_segments(command: str) -> list[list[str]]:
+	"""Tokenize a shell command into command-sized segments.
+
+	Uses `shlex` over the full command so quoted separators such as `"a; b"`
+	stay inside their argument instead of splitting the command early.
+	"""
+	lexer = shlex.shlex(command, posix=True, punctuation_chars=_SHELL_PUNCTUATION_CHARS)
+	lexer.whitespace = " \t\r"
+	lexer.whitespace_split = True
+	segments: list[list[str]] = []
+	current_segment: list[str] = []
+	for token in lexer:
+		if token and set(token) <= set(_SHELL_PUNCTUATION_CHARS):
+			if current_segment:
+				segments.append(current_segment)
+				current_segment = []
+			continue
+		current_segment.append(token)
+	if current_segment:
+		segments.append(current_segment)
+	return segments
+
+
 def git_subcommands(command: str) -> set[str]:
 	"""Return the set of git subcommands invoked by a shell command string.
 
@@ -123,16 +147,12 @@ def git_subcommands(command: str) -> set[str]:
 	since a false block is more disruptive than a missed check on a rare form.
 	"""
 	found: set[str] = set()
-	for segment in _SEGMENT_SPLIT_RE.split(command):
-		segment = segment.strip()
-		if not segment:
-			continue
-		try:
-			tokens = shlex.split(segment)
-		except ValueError:
-			# Unbalanced quotes — the segment is not something we can read.
-			continue
-
+	try:
+		segments = _shell_segments(command)
+	except ValueError:
+		# Unbalanced quotes — the command is not something we can read.
+		return found
+	for tokens in segments:
 		# Drop leading environment assignments (`GIT_DIR=... git commit`).
 		index = 0
 		while index < len(tokens) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", tokens[index]):
@@ -210,7 +230,7 @@ def current_branch(cwd: str) -> str:
 
 
 def default_branch(cwd: str) -> str:
-	"""Best-effort default branch name; falls back to `main`."""
+	"""Best-effort default branch name; returns "" when it cannot be determined."""
 	code, out, _ = _run(
 		["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"], cwd, _GIT_TIMEOUT_SECONDS
 	)
@@ -228,7 +248,12 @@ def default_branch(cwd: str) -> str:
 		)
 		if code == 0:
 			return candidate
-	return "main"
+	code, out, _ = _run(["git", "ls-remote", "--symref", "origin", "HEAD"], cwd, _GIT_TIMEOUT_SECONDS)
+	if code == 0:
+		match = _REMOTE_HEAD_BRANCH_RE.search(out)
+		if match:
+			return match.group(1)
+	return ""
 
 
 def repo_slug(cwd: str) -> str:
@@ -415,6 +440,21 @@ def blocking_pull_request(pull_requests: list[dict], cwd: str) -> dict | None:
 
 def _block_message(pr: dict, branch: str, base: str) -> str:
 	number = pr.get("number")
+	reset_commands = (
+		f"  git fetch origin {base}\n"
+		f"  git checkout -B {branch} origin/{base}\n"
+	)
+	default_branch_note = ""
+	if not base:
+		reset_commands = (
+			f"  git fetch origin <default-branch>\n"
+			f"  git checkout -B {branch} origin/<default-branch>\n"
+		)
+		default_branch_note = (
+			f"The guard could not determine the default branch automatically; "
+			f"replace `<default-branch>` with your repo's real default branch.\n"
+			f"\n"
+		)
 	return (
 		f"BLOCKED by the merged-PR guard (CLAUDE.md §21).\n"
 		f"\n"
@@ -430,9 +470,9 @@ def _block_message(pr: dict, branch: str, base: str) -> str:
 		f"reused. Restart the branch from the default branch, keeping the same "
 		f"name, then redo the commit and open a NEW pull request:\n"
 		f"\n"
-		f"  git fetch origin {base}\n"
-		f"  git checkout -B {branch} origin/{base}\n"
+		f"{reset_commands}"
 		f"\n"
+		f"{default_branch_note}"
 		f"If the branch carries unmerged commits beyond the merged history, "
 		f"rebase them onto the new base instead of discarding them. Stash or "
 		f"re-apply any uncommitted work as needed, then retry.\n"
@@ -470,11 +510,6 @@ def evaluate(payload: dict) -> tuple[int, str]:
 		# Detached HEAD, or not a git repo — nothing branch-shaped to check.
 		return 0, ""
 
-	base = default_branch(cwd)
-	if branch == base:
-		# Committing on the default branch is not the stranded-work scenario.
-		return 0, ""
-
 	slug = repo_slug(cwd)
 	if not slug:
 		_warn(f"could not derive <owner>/<repo> from the git remote (branch `{branch}`)")
@@ -504,6 +539,11 @@ def evaluate(payload: dict) -> tuple[int, str]:
 		_write_cache(slug, branch, pull_requests)
 
 	if offender is None:
+		return 0, ""
+
+	base = default_branch(cwd)
+	if base and branch == base:
+		# Committing on the default branch is not the stranded-work scenario.
 		return 0, ""
 	return 2, _block_message(offender, branch, base)
 

--- a/workflow-templates/.claude/hooks/pr_merge_status_guard.py
+++ b/workflow-templates/.claude/hooks/pr_merge_status_guard.py
@@ -240,14 +240,6 @@ def default_branch(cwd: str) -> str:
 			ref = ref[len("origin/") :]
 		if ref:
 			return ref
-	for candidate in ("main", "master"):
-		code, _, _ = _run(
-			["git", "rev-parse", "--verify", f"refs/remotes/origin/{candidate}"],
-			cwd,
-			_GIT_TIMEOUT_SECONDS,
-		)
-		if code == 0:
-			return candidate
 	code, out, _ = _run(["git", "ls-remote", "--symref", "origin", "HEAD"], cwd, _GIT_TIMEOUT_SECONDS)
 	if code == 0:
 		match = _REMOTE_HEAD_BRANCH_RE.search(out)

--- a/workflow-templates/.claude/hooks/pr_merge_status_guard.py
+++ b/workflow-templates/.claude/hooks/pr_merge_status_guard.py
@@ -509,6 +509,10 @@ def evaluate(payload: dict) -> tuple[int, str]:
 	if not branch:
 		# Detached HEAD, or not a git repo — nothing branch-shaped to check.
 		return 0, ""
+	base = default_branch(cwd)
+	if base and branch == base:
+		# Committing on the default branch is not the stranded-work scenario.
+		return 0, ""
 
 	slug = repo_slug(cwd)
 	if not slug:
@@ -539,11 +543,6 @@ def evaluate(payload: dict) -> tuple[int, str]:
 		_write_cache(slug, branch, pull_requests)
 
 	if offender is None:
-		return 0, ""
-
-	base = default_branch(cwd)
-	if base and branch == base:
-		# Committing on the default branch is not the stranded-work scenario.
 		return 0, ""
 	return 2, _block_message(offender, branch, base)
 

--- a/workflow-templates/.claude/hooks/pr_merge_status_guard.py
+++ b/workflow-templates/.claude/hooks/pr_merge_status_guard.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""PreToolUse guard — refuse commits/pushes that stack on an already-merged PR.
+
+Implements CLAUDE.md §21.
+
+Long-lived Claude Code sessions (days to weeks) outlive the PRs they open. When
+the PR for the working branch merges mid-session, further commits to that same
+branch land on history that is already in the default branch and no longer has
+an open PR carrying it anywhere — the work is silently stranded. Prose
+instructions do not survive that timescale; this hook does, because the harness
+runs it on every Bash tool call regardless of what the model remembers.
+
+Detection rule — all three conditions must hold before the command is blocked:
+
+  1. A *merged* PR exists whose head ref is the current branch, AND
+  2. no *open* PR exists for the current branch, AND
+  3. that merged PR's head commit is an ancestor of HEAD — i.e. the pending
+     commit would literally stack on already-merged history.
+
+Condition 3 is what makes the guard self-clearing. The branch name is reused
+after a `git checkout -B <branch> origin/<default>` reset, so the merged PR
+keeps matching `--head <branch>` forever; ancestry is what actually
+distinguishes "stacking on a corpse" from "fresh work that happens to reuse the
+name". It also means the guard stops firing the moment the branch is reset,
+without needing a manual override flag or a new PR to exist yet.
+
+Fail-open by design (CLAUDE.md §21): any inability to answer the question —
+no `gh`, expired token, network failure, unparseable payload, not a git repo —
+allows the command and emits a warning. A guard that hard-blocks every commit
+whenever a token lapses would be worse than the bug it prevents.
+
+PR state is read over REST (`gh api repos/<slug>/pulls`) rather than
+`gh pr list`, because the latter is GraphQL-backed and Claude Code Web's agent
+proxy serves only a pinned set of GraphQL operations — the guard would fail open
+on every commit in precisely the sessions it exists to protect. `gh pr list`
+remains as a transport fallback.
+
+Exit codes (Claude Code hook protocol):
+  0 — allow the command. A warning may be emitted via `systemMessage`.
+  2 — block the command; stderr is fed back to Claude as the reason.
+
+Escape hatch: set CLAUDE_PR_MERGE_GUARD=off to disable the check entirely.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+# Guarded git subcommands. `push` is included alongside `commit` because
+# amend/rebase flows reach the remote without issuing a fresh `git commit`.
+GUARDED_SUBCOMMANDS = frozenset({"commit", "push"})
+
+# git global options that consume a following argument when not given as
+# `--opt=value`. Needed so `git -C /repo commit` resolves to `commit` rather
+# than to the path.
+GIT_GLOBAL_OPTS_WITH_VALUE = frozenset(
+	{"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--super-prefix", "--exec-path"}
+)
+
+# Shell operators that separate independent commands within one Bash call.
+_SEGMENT_SPLIT_RE = re.compile(r"(?:\|\||&&|[;&|\n])")
+
+_SLUG_RE = re.compile(r"^[A-Za-z0-9_-]+/[A-Za-z0-9._-]+$")
+
+_CACHE_TTL_SECONDS = 300
+_CACHE_DIR_NAME = "claude-pr-merge-guard"
+
+# Ceilings, not expected durations — every one of these completes in well under
+# a second in practice. They are sized so a pathological run still lands inside
+# the hook timeout in .claude/settings.json; overshooting it anyway is safe,
+# because a killed hook is a non-blocking failure and so fails open like every
+# other unanswerable case.
+_GH_TIMEOUT_SECONDS = 15
+_GIT_TIMEOUT_SECONDS = 5
+
+
+class LookupUnavailable(Exception):
+	"""Raised when PR state cannot be determined; callers must fail open."""
+
+
+def _run(argv: list[str], cwd: str | None, timeout: int) -> tuple[int, str, str]:
+	"""Run a subprocess, returning (returncode, stdout, stderr).
+
+	Never raises for process-level failures — a missing binary or a timeout is
+	reported as a non-zero return code so every caller funnels into the same
+	fail-open path.
+	"""
+	try:
+		proc = subprocess.run(
+			argv,
+			cwd=cwd,
+			capture_output=True,
+			text=True,
+			timeout=timeout,
+			check=False,
+		)
+	except FileNotFoundError:
+		return 127, "", f"{argv[0]}: not found"
+	except subprocess.TimeoutExpired:
+		return 124, "", f"{argv[0]}: timed out after {timeout}s"
+	except OSError as exc:
+		return 126, "", f"{argv[0]}: {exc}"
+	return proc.returncode, proc.stdout, proc.stderr
+
+
+def git_subcommands(command: str) -> set[str]:
+	"""Return the set of git subcommands invoked by a shell command string.
+
+	Only counts `git` when it is the first real token of a shell segment, after
+	any leading `VAR=value` assignments. That keeps `man git commit` and
+	`echo "git commit"` from tripping the guard, at the cost of missing
+	wrapper-prefixed invocations like `sudo git commit` — an acceptable trade,
+	since a false block is more disruptive than a missed check on a rare form.
+	"""
+	found: set[str] = set()
+	for segment in _SEGMENT_SPLIT_RE.split(command):
+		segment = segment.strip()
+		if not segment:
+			continue
+		try:
+			tokens = shlex.split(segment)
+		except ValueError:
+			# Unbalanced quotes — the segment is not something we can read.
+			continue
+
+		# Drop leading environment assignments (`GIT_DIR=... git commit`).
+		index = 0
+		while index < len(tokens) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", tokens[index]):
+			index += 1
+		if index >= len(tokens):
+			continue
+
+		executable = tokens[index]
+		if executable != "git" and not executable.endswith("/git"):
+			continue
+
+		# Walk past git's global options to the subcommand.
+		index += 1
+		while index < len(tokens):
+			token = tokens[index]
+			if not token.startswith("-"):
+				found.add(token)
+				break
+			if token in GIT_GLOBAL_OPTS_WITH_VALUE:
+				index += 2
+				continue
+			index += 1
+	return found
+
+
+def extract_repo_slug(url: str) -> str:
+	"""Derive `<owner>/<repo>` from a git remote URL, or "" when it is not
+	derivable.
+
+	Mirrors `extract_repo_slug` in .claude/hooks/session-start.sh, including its
+	exact host whitelist: only github.com, plus Claude Code Web's local git
+	proxy on 127.0.0.1/localhost where the path must start with `git/`. A
+	lookalike host such as `evilgithub.com` must not yield a slug, because the
+	slug is passed straight to `gh -R` and would otherwise aim the query at an
+	unrelated github.com repo.
+	"""
+	url = url.strip()
+	for suffix in ("/", ".git", "/"):
+		if url.endswith(suffix):
+			url = url[: -len(suffix)]
+
+	if "://" in url:
+		rest = url.split("://", 1)[1]
+		if "@" in rest:
+			rest = rest.rsplit("@", 1)[1]
+		if "/" not in rest:
+			return ""
+		host, path = rest.split("/", 1)
+		host = host.split(":", 1)[0]
+	elif "@" in url and ":" in url.split("@", 1)[1]:
+		rest = url.rsplit("@", 1)[1]
+		host, path = rest.split(":", 1)
+	else:
+		return ""
+
+	if host in ("127.0.0.1", "localhost"):
+		if not path.startswith("git/"):
+			return ""
+		path = path[len("git/") :]
+	elif host != "github.com":
+		return ""
+
+	if not _SLUG_RE.match(path):
+		return ""
+	return path
+
+
+def current_branch(cwd: str) -> str:
+	"""Return the checked-out branch name, or "" when detached or not a repo."""
+	code, out, _ = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd, _GIT_TIMEOUT_SECONDS)
+	if code != 0:
+		return ""
+	branch = out.strip()
+	return "" if branch in ("", "HEAD") else branch
+
+
+def default_branch(cwd: str) -> str:
+	"""Best-effort default branch name; falls back to `main`."""
+	code, out, _ = _run(
+		["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"], cwd, _GIT_TIMEOUT_SECONDS
+	)
+	if code == 0:
+		ref = out.strip()
+		if ref.startswith("origin/"):
+			ref = ref[len("origin/") :]
+		if ref:
+			return ref
+	for candidate in ("main", "master"):
+		code, _, _ = _run(
+			["git", "rev-parse", "--verify", f"refs/remotes/origin/{candidate}"],
+			cwd,
+			_GIT_TIMEOUT_SECONDS,
+		)
+		if code == 0:
+			return candidate
+	return "main"
+
+
+def repo_slug(cwd: str) -> str:
+	code, out, _ = _run(["git", "config", "--get", "remote.origin.url"], cwd, _GIT_TIMEOUT_SECONDS)
+	if code != 0:
+		return ""
+	return extract_repo_slug(out)
+
+
+def is_ancestor(sha: str, cwd: str) -> bool:
+	"""True when `sha` is an ancestor of (or equal to) HEAD.
+
+	A commit absent from the local object database cannot be an ancestor of
+	HEAD, so `git merge-base` erroring out is a legitimate False rather than an
+	unknown — no fetch is attempted.
+	"""
+	if not sha:
+		return False
+	code, _, _ = _run(
+		["git", "merge-base", "--is-ancestor", sha, "HEAD"], cwd, _GIT_TIMEOUT_SECONDS
+	)
+	return code == 0
+
+
+def _cache_path(slug: str, branch: str) -> Path:
+	digest = hashlib.sha256(f"{slug}\n{branch}".encode("utf-8")).hexdigest()[:32]
+	return Path(tempfile.gettempdir()) / _CACHE_DIR_NAME / f"{digest}.json"
+
+
+def _read_cache(slug: str, branch: str) -> list[dict] | None:
+	path = _cache_path(slug, branch)
+	try:
+		raw = json.loads(path.read_text(encoding="utf-8"))
+	except (OSError, ValueError):
+		return None
+	if not isinstance(raw, dict):
+		return None
+	stamped = raw.get("fetched_at")
+	if not isinstance(stamped, (int, float)) or time.time() - stamped > _CACHE_TTL_SECONDS:
+		return None
+	entries = raw.get("pull_requests")
+	return entries if isinstance(entries, list) else None
+
+
+def _write_cache(slug: str, branch: str, pull_requests: list[dict]) -> None:
+	path = _cache_path(slug, branch)
+	try:
+		path.parent.mkdir(parents=True, exist_ok=True)
+		path.write_text(
+			json.dumps({"fetched_at": time.time(), "pull_requests": pull_requests}),
+			encoding="utf-8",
+		)
+	except OSError:
+		# A cache we cannot write is a performance loss, never a correctness one.
+		pass
+
+
+def _normalize_rest_pull(entry: dict) -> dict:
+	"""Reshape a REST pull object into the `gh pr list --json` field names."""
+	head = entry.get("head")
+	head_sha = head.get("sha") if isinstance(head, dict) else None
+	return {
+		"number": entry.get("number"),
+		"state": entry.get("state"),
+		"url": entry.get("html_url"),
+		"title": entry.get("title"),
+		"mergedAt": entry.get("merged_at"),
+		"headRefOid": head_sha,
+	}
+
+
+def _query_via_rest(slug: str, branch: str, cwd: str) -> list[dict]:
+	"""One `gh api` REST call listing every PR whose head ref is `branch`.
+
+	Preferred over `gh pr list` because Claude Code Web's agent proxy serves
+	only a pinned set of GraphQL operations and rejects the rest — and
+	`gh pr list` is GraphQL-backed, so it fails there with HTTP 403 while REST
+	continues to work. Without this path the guard would fail open on every
+	commit in exactly the long-running web sessions it exists to protect.
+
+	The `head` filter wants `<head-owner>:<branch>`; the owner is taken from
+	the slug, which is correct for same-repo branches (the only kind this
+	guard's remediation produces). A fork-owned head ref simply returns no
+	match, which fails open — the safe direction.
+	"""
+	owner = slug.split("/", 1)[0]
+	code, out, err = _run(
+		[
+			"gh",
+			"api",
+			"-X",
+			"GET",
+			f"repos/{slug}/pulls",
+			"-f",
+			"state=all",
+			"-f",
+			f"head={owner}:{branch}",
+			"-f",
+			"per_page=20",
+		],
+		cwd,
+		_GH_TIMEOUT_SECONDS,
+	)
+	if code != 0:
+		raise LookupUnavailable((err or out).strip() or f"gh api exited {code}")
+	try:
+		parsed = json.loads(out)
+	except ValueError as exc:
+		raise LookupUnavailable(f"unparseable gh api output: {exc}") from exc
+	if not isinstance(parsed, list):
+		raise LookupUnavailable("unexpected gh api output shape")
+	return [_normalize_rest_pull(entry) for entry in parsed if isinstance(entry, dict)]
+
+
+def _query_via_pr_list(slug: str, branch: str, cwd: str) -> list[dict]:
+	"""Fallback for environments where `gh api` is gated but GraphQL is not."""
+	code, out, err = _run(
+		[
+			"gh",
+			"pr",
+			"list",
+			"-R",
+			slug,
+			"--head",
+			branch,
+			"--state",
+			"all",
+			"--json",
+			"number,state,url,title,mergedAt,headRefOid",
+			"--limit",
+			"20",
+		],
+		cwd,
+		_GH_TIMEOUT_SECONDS,
+	)
+	if code != 0:
+		raise LookupUnavailable((err or out).strip() or f"gh pr list exited {code}")
+	try:
+		parsed = json.loads(out)
+	except ValueError as exc:
+		raise LookupUnavailable(f"unparseable gh output: {exc}") from exc
+	if not isinstance(parsed, list):
+		raise LookupUnavailable("unexpected gh output shape")
+	return parsed
+
+
+def query_pull_requests(slug: str, branch: str, cwd: str) -> list[dict]:
+	"""Fetch every PR whose head ref is `branch`.
+
+	Batching contract (CLAUDE.md §15):
+	  - Input:  `<owner>/<repo>` slug + head branch name.
+	  - Output: list of dicts with `number`, `state`, `url`, `title`,
+	            `mergedAt`, `headRefOid` — REST responses are normalized to
+	            these `gh pr list --json` names so callers see one shape.
+	  - Cost:   one API call. A single `state=all` request serves both the
+	            merged and open questions the caller asks; splitting them
+	            would double the cost for no extra information. A second call
+	            is issued only when the REST path itself errors, as a
+	            transport fallback — never as a second query.
+	  - Fail-open: raises LookupUnavailable when neither transport can answer,
+	            and every caller allows the command on that exception.
+	"""
+	try:
+		return _query_via_rest(slug, branch, cwd)
+	except LookupUnavailable as rest_error:
+		try:
+			return _query_via_pr_list(slug, branch, cwd)
+		except LookupUnavailable as graphql_error:
+			raise LookupUnavailable(f"REST: {rest_error}; GraphQL: {graphql_error}") from None
+
+
+def blocking_pull_request(pull_requests: list[dict], cwd: str) -> dict | None:
+	"""Apply the three-condition detection rule; return the offending PR or None."""
+	merged = [pr for pr in pull_requests if pr.get("mergedAt")]
+	if not merged:
+		return None
+	if any(str(pr.get("state", "")).upper() == "OPEN" for pr in pull_requests):
+		return None
+	for pr in merged:
+		if is_ancestor(str(pr.get("headRefOid") or ""), cwd):
+			return pr
+	return None
+
+
+def _block_message(pr: dict, branch: str, base: str) -> str:
+	number = pr.get("number")
+	return (
+		f"BLOCKED by the merged-PR guard (CLAUDE.md §21).\n"
+		f"\n"
+		f"Branch `{branch}` already had PR #{number} merged at "
+		f"{pr.get('mergedAt')}, no open PR now carries this branch, and HEAD "
+		f"still contains that merged history. Committing or pushing here would "
+		f"strand the work on a dead branch.\n"
+		f"\n"
+		f"  merged PR: {pr.get('url')}\n"
+		f"  title:     {pr.get('title')}\n"
+		f"\n"
+		f"A merged PR is finished — it cannot track new work and must not be "
+		f"reused. Restart the branch from the default branch, keeping the same "
+		f"name, then redo the commit and open a NEW pull request:\n"
+		f"\n"
+		f"  git fetch origin {base}\n"
+		f"  git checkout -B {branch} origin/{base}\n"
+		f"\n"
+		f"If the branch carries unmerged commits beyond the merged history, "
+		f"rebase them onto the new base instead of discarding them. Stash or "
+		f"re-apply any uncommitted work as needed, then retry.\n"
+		f"\n"
+		f"To bypass this guard for one session, set CLAUDE_PR_MERGE_GUARD=off."
+	)
+
+
+def _warn(reason: str) -> None:
+	"""Emit a non-blocking warning to the user and allow the command."""
+	print(json.dumps({"systemMessage": f"merged-PR guard skipped: {reason}"}))
+
+
+def evaluate(payload: dict) -> tuple[int, str]:
+	"""Core decision. Returns (exit_code, message_for_stderr)."""
+	if os.environ.get("CLAUDE_PR_MERGE_GUARD", "").strip().lower() == "off":
+		return 0, ""
+
+	if payload.get("tool_name") != "Bash":
+		return 0, ""
+
+	tool_input = payload.get("tool_input")
+	command = tool_input.get("command", "") if isinstance(tool_input, dict) else ""
+	if not isinstance(command, str) or not command.strip():
+		return 0, ""
+	if not (git_subcommands(command) & GUARDED_SUBCOMMANDS):
+		return 0, ""
+
+	cwd = payload.get("cwd") or os.getcwd()
+	if not isinstance(cwd, str) or not os.path.isdir(cwd):
+		cwd = os.getcwd()
+
+	branch = current_branch(cwd)
+	if not branch:
+		# Detached HEAD, or not a git repo — nothing branch-shaped to check.
+		return 0, ""
+
+	base = default_branch(cwd)
+	if branch == base:
+		# Committing on the default branch is not the stranded-work scenario.
+		return 0, ""
+
+	slug = repo_slug(cwd)
+	if not slug:
+		_warn(f"could not derive <owner>/<repo> from the git remote (branch `{branch}`)")
+		return 0, ""
+
+	cached = _read_cache(slug, branch)
+	try:
+		pull_requests = cached if cached is not None else query_pull_requests(slug, branch, cwd)
+	except LookupUnavailable as exc:
+		_warn(f"could not reach GitHub to check PR status for `{branch}` ({exc})")
+		return 0, ""
+
+	offender = blocking_pull_request(pull_requests, cwd)
+
+	# Re-verify a block against live data. Cheap allows may come from cache;
+	# blocks may not, so that opening a new PR clears the guard immediately
+	# rather than after the TTL expires.
+	if offender is not None and cached is not None:
+		try:
+			pull_requests = query_pull_requests(slug, branch, cwd)
+		except LookupUnavailable as exc:
+			_warn(f"could not re-verify PR status for `{branch}` ({exc})")
+			return 0, ""
+		_write_cache(slug, branch, pull_requests)
+		offender = blocking_pull_request(pull_requests, cwd)
+	elif cached is None:
+		_write_cache(slug, branch, pull_requests)
+
+	if offender is None:
+		return 0, ""
+	return 2, _block_message(offender, branch, base)
+
+
+def main() -> int:
+	try:
+		raw = sys.stdin.read()
+	except (OSError, ValueError):
+		return 0
+	try:
+		payload = json.loads(raw) if raw.strip() else {}
+	except ValueError:
+		return 0
+	if not isinstance(payload, dict):
+		return 0
+
+	try:
+		code, message = evaluate(payload)
+	except Exception as exc:  # noqa: BLE001 - the guard must never break the session
+		_warn(f"internal error ({exc})")
+		return 0
+
+	if message:
+		print(message, file=sys.stderr)
+	return code
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/workflow-templates/.claude/settings.json
+++ b/workflow-templates/.claude/settings.json
@@ -9,6 +9,18 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pr_merge_status_guard.py",
+            "timeout": 60
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Problem

Long-lived interactive sessions outlive the PRs they open. When the PR for the working branch merges mid-session, further commits land on history that is already in the default branch and that no open PR carries anywhere. The work never ships, and disappears when the branch is deleted.

The rule against this already existed, but only as prose (the remote-session system prompt, and `CLAUDE.md` §12.A). Prose is furthest from the model's live context at exactly the moment a session has run long enough for the merge to happen, which is why it kept failing.

## What changed

`.claude/hooks/pr_merge_status_guard.py`, wired as a `PreToolUse` hook on `Bash` in `.claude/settings.json`. The harness runs it on every Bash tool call regardless of what the model remembers, so the check cannot be forgotten.

### Detection rule

A command is blocked only when **all three** conditions hold:

1. A **merged** PR exists whose head ref is the current branch, **and**
2. no **open** PR exists for the current branch, **and**
3. that merged PR's head commit is an ancestor of `HEAD`.

Condition 3 is what makes the guard self-clearing. Branch names are reused after the `git checkout -B <branch> origin/<default>` reset, so the merged PR keeps matching the branch forever; ancestry is what separates "stacking on merged history" from "fresh work that reuses the name". The guard goes quiet the moment the branch is reset — before the replacement PR exists — so no override flag is needed to commit the remediation. `tests/test_pr_merge_status_guard.py` pins the block → reset → allow sequence end to end against a real git repository.

### REST, not `gh pr list`

PR state is read over `gh api repos/<slug>/pulls?state=all`. Claude Code Web's agent proxy serves only a pinned set of GraphQL operations and rejects the rest with HTTP 403 — verified in this session — and `gh pr list` is GraphQL-backed. Using it as the primary transport would have made the guard fail open on every commit in exactly the long-running web sessions it exists to protect. `gh pr list` remains wired as a transport fallback for environments where REST is gated instead.

### Fail-open contract

Any unanswerable case — `gh` missing, token expired, network failure, unparseable payload, detached HEAD, not a git repo, underivable `<owner>/<repo>` — allows the command and emits a warning naming the branch. A guard that hard-blocks every commit whenever a token lapses would cost more than the bug it prevents. `CLAUDE_PR_MERGE_GUARD=off` disables it entirely; default unset means enabled.

## Files changed

| File | Change |
| --- | --- |
| `.claude/hooks/pr_merge_status_guard.py` | New. The guard (command parsing, slug extraction, detection rule, both transports, TTL cache). |
| `.claude/settings.json` | Adds the `PreToolUse` / `Bash` entry. `SessionStart` untouched. |
| `CLAUDE.md` | New §21. No existing section renumbered (§6). |
| `tests/test_pr_merge_status_guard.py` | New. 73 tests. |
| `changelog.d/merged-pr-commit-guard.md` | New fragment (§20). |
| `workflow-templates/.claude/{settings.json,hooks/pr_merge_status_guard.py}` | Mirrors, so consumer repos receive it. |

`workflow-templates/CLAUDE.md` is a symlink to `../CLAUDE.md`, so §21 propagates with no separate edit.

## Consumer propagation

All 12 repos in `.github/ai/consumer_repos.json` receive the hook, its wiring, and §21 on the next `@stable` sync, via the existing `workflow-templates/.claude/` mirror in `update_workflows.yml` (daily 04:00 UTC cron plus the `@stable` `repository_dispatch`). Two properties of that sync shaped the implementation:

- It copies with plain `cp`, which leaves an **existing** destination's mode untouched. The hook is therefore invoked as `python3 <path>` rather than relying on its executable bit.
- `settings.json` is overwritten wholesale on every sync, so any consumer-local hand-edit to that file is lost. That is pre-existing documented behaviour of the sync, not introduced here, but it is worth knowing before a consumer customizes its hooks.

## §15 API budget

One API call per guarded command — a single `state=all` request answers both the merged and the open question — cached 300s keyed on `<slug>/<branch>`. Cached data may satisfy an *allow*; a *block* is always re-verified against a live call first, so opening a new PR clears the guard immediately rather than after the TTL. The GraphQL fallback is a retry of the same question on a different transport, never a second query.

## Verification

**New tests:** `tests/test_pr_merge_status_guard.py` — 73 passed. Covers command parsing (including `git -C`, env-prefixed, and `echo "git commit"` negatives), the detection rule, both transports, the fail-open contract, and the end-to-end block → reset → allow sequence against a real git repository.

Slug extraction is differentially tested against the bash `extract_repo_slug` in `session-start.sh` by executing it — the two share a security-relevant host whitelist (`evilgithub.com`, `github.com.evil.com`, and non-`git/` localhost paths must all yield no slug) and would otherwise drift silently.

**Full suite (local, Python 3.11):** 2372 passed, 113 failed, 3 skipped. **Every one of the 113 failures is pre-existing and unrelated to this PR.** Verified rather than assumed: a `git worktree` at `origin/main` produces an identical failure set. For the five heaviest failing files the comparison was exact —

```
$ diff <baseline failures> <this branch's failures>
IDENTICAL — no failure introduced   (35 failures each)
```

The failures cluster in `test_review_reject_verify.py`, `test_validation_*.py`, and `test_workflow_retro_fanout.py` — codex/validation pipeline tests that touch nothing in this diff.

Separately, `tests/test_workflow_retro.py` fails to *collect* on Python 3.11: `scripts/workflow_retro.py:794` puts a backslash inside an f-string expression, which requires 3.12+. Also untouched by this PR, but it means the local suite cannot be run to completion on a 3.11 interpreter without `--ignore`.

Contract tests reading `CLAUDE.md` / `settings.json` re-run clean: `test_changelog_fragment_contract`, `test_session_start_extract_repo_slug`, `test_repo_root_helper`, `test_lint_pr_body_auto_close`, `test_assemble_changelog` — 69 passed.

## Note for reviewers

Claude Code snapshots hooks at session start, so the guard activates in the **next** session, not the one that authored this PR.