### PR TITLE
Add partial-clone promisor recovery to the late merge-conflict precheck

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -4510,6 +4510,8 @@ jobs:
           echo "====================================="
 
           merge_exit=0
+          merge_promisor_fetch_failure_seen=false
+          merge_promisor_initial_stderr=""
           # Capture git merge stderr so the failure annotation can surface
           # the real cause (e.g. "refusing to merge unrelated histories",
           # "Untracked working tree file … would be overwritten by merge").
@@ -4523,6 +4525,51 @@ jobs:
           # even when we wrap it in an annotation below.
           if [ -s "${MERGE_STDERR_FILE}" ]; then
             sed 's/^/git merge stderr: /' "${MERGE_STDERR_FILE}"
+          fi
+          if grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${MERGE_STDERR_FILE}" 2>/dev/null; then
+            merge_promisor_fetch_failure_seen=true
+            merge_promisor_initial_stderr="$(tr '\n' ' ' < "${MERGE_STDERR_FILE}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
+            merge_promisor_initial_stderr="${merge_promisor_initial_stderr:-<git merge produced no stderr>}"
+          fi
+
+          # Blobless partial clone recovery (the codex-agent checkout uses
+          # `filter: blob:none`): the 3-way merge lazy-fetches blob content
+          # from the promisor remote, and that batched on-demand fetch fails
+          # hard (exit 128) when any single OID in the batch is unreachable
+          # server-side ("not our ref" / "could not fetch ... from promisor
+          # remote") — even though the merge itself is well-formed. On that
+          # signature, drop the partial filter, refetch the merge inputs so
+          # every blob is materialised locally, and retry the merge once.
+          # Without this the step misreads an infrastructure fetch failure as
+          # a merge outcome and sets MERGE_CONFLICT=true off a hard
+          # ::error:: annotation on an otherwise-successful run.
+          #
+          # This mirrors the pre-review merge topology gate and
+          # scripts/review_conflict_prepare.sh; the refspec array is built
+          # locally because the deepen block above only defines
+          # _merge_base_refspecs on shallow clones.
+          if [ "${merge_exit}" -ne 0 ] && [ ! -f "$(git rev-parse --git-dir)/MERGE_HEAD" ] \
+             && [ "${merge_promisor_fetch_failure_seen}" = "true" ]; then
+            echo "::warning::Merge precheck hit a partial-clone promisor fetch failure; backfilling blobs and retrying the merge once."
+            git reset --hard HEAD >/dev/null 2>&1 || true
+            git config --unset-all remote.origin.partialclonefilter 2>/dev/null || true
+            _merge_backfill_refspecs=("refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}")
+            if [ -n "${TARGET_BRANCH:-}" ]; then
+              _merge_backfill_refspecs+=("refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}")
+            fi
+            _refetch_rc=0
+            _refetch_stderr="$(git fetch --no-tags --prune --refetch origin "${_merge_backfill_refspecs[@]}" 2>&1 >/dev/null)" || _refetch_rc=$?
+            if [ "${_refetch_rc}" -ne 0 ]; then
+              _refetch_stderr="$(printf '%s' "${_refetch_stderr}" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
+              _refetch_stderr="${_refetch_stderr:-<git fetch produced no stderr>}"
+              echo "::warning::blob-backfill refetch failed during merge precheck; retrying the merge anyway. git fetch stderr: ${_refetch_stderr}"
+            fi
+            merge_exit=0
+            : > "${MERGE_STDERR_FILE}"
+            git merge --no-commit --no-ff "origin/${BASE_BRANCH}" 2> "${MERGE_STDERR_FILE}" || merge_exit=$?
+            if [ -s "${MERGE_STDERR_FILE}" ]; then
+              sed 's/^/git merge stderr (after blob backfill): /' "${MERGE_STDERR_FILE}"
+            fi
           fi
 
           # Restore the stashed dirs so later steps have them available.
@@ -4546,13 +4593,30 @@ jobs:
               # annotation (::error:: notations cannot span newlines).
               _merge_stderr_oneline="$(tr '\n' ' ' < "${MERGE_STDERR_FILE}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
               _merge_stderr_oneline="${_merge_stderr_oneline:-<git merge produced no stderr>}"
+              if [ "${merge_promisor_fetch_failure_seen}" = "true" ] && [ -n "${merge_promisor_initial_stderr}" ] \
+                 && [ "${merge_promisor_initial_stderr}" != "${_merge_stderr_oneline}" ]; then
+                _merge_stderr_oneline="${_merge_stderr_oneline} | initial promisor stderr: ${merge_promisor_initial_stderr}"
+              fi
               _merge_stderr_oneline="$(printf '%s' "${_merge_stderr_oneline}" | sed 's/%/%25/g; s/\r/%0D/g')"
               if grep -qi 'refusing to merge unrelated histories' "${MERGE_STDERR_FILE}" 2>/dev/null; then
                 _head_sha="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
                 _base_sha="$(git rev-parse --short "origin/${BASE_BRANCH}" 2>/dev/null || echo unknown)"
                 echo "::error::Merge precheck failed (exit ${merge_exit}): HEAD (${_head_sha}) and origin/${BASE_BRANCH} (${_base_sha}) have no common ancestor. This PR's branch was likely force-pushed to an orphan root, or ${BASE_BRANCH} was force-pushed since this branch diverged. Manual repair required: rebase the PR branch onto a current ${BASE_BRANCH} ancestor, or recreate the branch from ${BASE_BRANCH} and re-apply the changes. git stderr: ${_merge_stderr_oneline}"
               elif [ "${merge_exit}" -eq 128 ]; then
-                echo "::error::Merge precheck failed (exit 128): git merge aborted before entering merge state. See pre-merge diagnostics above. git stderr: ${_merge_stderr_oneline}"
+                if [ "${merge_promisor_fetch_failure_seen}" = "true" ] \
+                   || grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${MERGE_STDERR_FILE}" 2>/dev/null; then
+                  # A partial-clone promisor fetch failure that survived the
+                  # blob-backfill retry above is an infrastructure error, not
+                  # a merge outcome. Fail OPEN with a ::warning:: so a run
+                  # that otherwise concludes success is not annotated as a
+                  # hard error. MERGE_CONFLICT stays true so the conflict
+                  # resolver still runs — review_conflict_prepare.sh replays
+                  # the merge with its own blob backfill and clears the flag
+                  # when the replay finds nothing to resolve.
+                  echo "::warning::Merge precheck: exit 128 from a partial-clone promisor fetch failure that survived the blob-backfill retry. Failing open to the conflict-resolver path. git stderr: ${_merge_stderr_oneline}"
+                else
+                  echo "::error::Merge precheck failed (exit 128): git merge aborted before entering merge state. See pre-merge diagnostics above. git stderr: ${_merge_stderr_oneline}"
+                fi
               else
                 echo "::warning::git merge exited ${merge_exit} without entering merge state — treating as conflict. git stderr: ${_merge_stderr_oneline}"
               fi

--- a/changelog.d/merge-precheck-promisor-recovery.md
+++ b/changelog.d/merge-precheck-promisor-recovery.md
@@ -1,0 +1,20 @@
+<!-- changelog: fixed -->
+- **The late merge-conflict precheck in `review_autofix.yml` no longer turns a blobless-clone fetch failure into a hard `::error::` and a phantom merge conflict.** It now backfills blobs and retries the merge once, the same way the pre-review merge topology gate and `scripts/review_conflict_prepare.sh` already did.
+
+The `Detect merge conflicts` step runs `git merge --no-commit --no-ff origin/<base>` against a checkout made with `filter: blob:none`. That 3-way merge lazy-fetches blob content from the promisor remote, and the batched on-demand fetch fails with exit 128 when any single OID in the batch is unreachable server-side, emitting `not our ref` / `could not fetch … from promisor remote`. The step read that as a merge outcome: it printed `::error::Merge precheck failed (exit 128)` on runs that otherwise concluded `success`, then set `MERGE_CONFLICT=true` off an infrastructure failure and fired the Codex conflict resolver against a PR with no conflict. The step's own header comment already named this as the hazard to avoid. Observed on `shubhodeep1/tele-funtoken-msg-scoring` runs 31303907566, 31305600310, and 31312967313, all of them green.
+
+On that stderr signature the step now unsets `remote.origin.partialclonefilter`, runs `git fetch --no-tags --prune --refetch origin` against the base branch (plus `TARGET_BRANCH` when it is set), and retries the merge once so every blob is materialised locally. A promisor failure that survives the retry is downgraded from `::error::` to a `::warning::` fail-open, matching the wording the pre-review gate already uses. `MERGE_CONFLICT` stays `true` in that case, so the conflict-resolver path still runs and `review_conflict_prepare.sh` clears the flag after its own replay finds nothing to resolve.
+
+| The numbers that matter | Value |
+| --- | --- |
+| Merge retries after blob backfill | 1 |
+| Refs refetched | base branch, plus `TARGET_BRANCH` when set |
+| Config key unset before the retry | `remote.origin.partialclonefilter` |
+| Annotation on a surviving promisor failure | `::warning::` (was `::error::`) |
+| `MERGE_CONFLICT` on a surviving promisor failure | `true`, cleared later by `review_conflict_prepare.sh` |
+
+What this means for operators: review-autofix runs on repos with blobless checkouts stop showing a red merge-precheck annotation on green runs, and stop spending a Codex resolver invocation on a conflict that does not exist. Genuine exit-128 aborts and `refusing to merge unrelated histories` still surface as `::error::` exactly as before.
+
+### For contributors
+
+The backfill block sits between the initial merge and the `MERGE_STASH` restore loop, so the retry runs against the same clean working tree the first merge saw. It builds its own `_merge_backfill_refspecs` array rather than reusing `_merge_base_refspecs`, which the deepen block above only defines on shallow clones and would be unset under `set -u` otherwise. The initial promisor stderr is captured before the retry and appended to the annotation when the post-retry stderr differs, so the log keeps both halves of the failure.


### PR DESCRIPTION
## Problem

The `Detect merge conflicts` step in `.github/workflows/review_autofix.yml` runs `git merge --no-commit --no-ff "origin/${BASE_BRANCH}"` against a checkout made with `filter: blob:none`, with **no** partial-clone promisor-fetch recovery. Two other call sites in this repo already have it:

- the pre-review merge topology gate in the same workflow (`.github/workflows/review_autofix.yml:3228-3300`)
- `scripts/review_conflict_prepare.sh:121-171`

Both detect the `not our ref` / `could not fetch … from promisor remote` signature, unset `remote.origin.partialclonefilter`, `git fetch --refetch` the merge inputs, and retry the merge once.

Without it, the 3-way merge's batched lazy blob fetch fails with exit 128 when any single OID in the batch is unreachable server-side. The step then:

1. emitted a hard `::error::Merge precheck failed (exit 128)` on runs that concluded `success`, and
2. set `MERGE_CONFLICT=true` from an infrastructure failure rather than a merge outcome, firing the Codex conflict resolver against a PR with no conflict.

That is the exact hazard the step's own header comment at lines 4349-4352 warns about.

Observed in `shubhodeep1/tele-funtoken-msg-scoring` runs 31303907566, 31305600310 and 31312967313 — all of which concluded `success` — against `coding-workflows@stable` 830c8e9c6ca897d1d491a1fbcc160937e248a972.

## Changes

**`.github/workflows/review_autofix.yml`** (+65/-1), all inside the `Detect merge conflicts` step:

| Lines | Change |
| --- | --- |
| 4512-4514, 4529-4533 | Declare `merge_promisor_fetch_failure_seen` / `merge_promisor_initial_stderr` and set them from the initial merge's stderr on the promisor signature. |
| 4535-4573 | Backfill-and-retry block, ported from the two existing call sites: `git reset --hard HEAD`, `git config --unset-all remote.origin.partialclonefilter`, `git fetch --no-tags --prune --refetch origin <refspecs>`, then one merge retry with its stderr re-captured and echoed under a `(after blob backfill)` prefix. Placed between the initial merge and the `MERGE_STASH` restore loop so the retry sees the same clean working tree the first merge did. |
| 4596-4599 | Append the initial promisor stderr to the annotation when the post-retry stderr differs, matching line 3274-3277. |
| 4607-4619 | At the `merge_exit -eq 128` branch, downgrade a **surviving** promisor failure from `::error::` to a `::warning::` fail-open, with wording matching line 3299. Genuine exit-128 aborts still get `::error::`. |

`MERGE_CONFLICT=true` is deliberately kept on the fail-open path: `scripts/review_conflict_prepare.sh:215-231` replays the merge with its own blob backfill and writes `MERGE_CONFLICT=false` when the replay yields no unmerged paths, so the flag clears itself one step later instead of being cleared here on a guess.

The refspec array is built locally as `_merge_backfill_refspecs` rather than reusing `_merge_base_refspecs`, which the deepen block above defines only on shallow clones and would be unset under `set -u`. The name does not collide with any identifier in the step (CLAUDE.md §6).

**`changelog.d/merge-precheck-promisor-recovery.md`** — new fragment (CLAUDE.md §20; failure-mode change an operator would notice).

## Verification

- `yaml.safe_load` parses the workflow, and the `Detect merge conflicts` step still resolves as a single step.
- The step's extracted `run:` body passes `bash -n`.
- No `workflow-templates/` mirror of this file exists — `Detect merge conflicts` appears only in `.github/workflows/review_autofix.yml`, so consumer repos pick the fix up through the existing reusable-workflow call.
- No behavioural test exists for this step; the change is a line-for-line port of a block already exercised by the two sibling call sites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpjRsAudaLxth47UBbHnGP)_