### PR TITLE
Auto-land upstream fixes from /investigate-issue when the library is attached to the session

### DIFF
--- a/changelog.d/investigate-issue-attached-upstream-autochain.md
+++ b/changelog.d/investigate-issue-attached-upstream-autochain.md
@@ -1,0 +1,18 @@
+<!-- changelog: changed -->
+- **`/investigate-issue` now lands upstream fixes itself when the library is attached to the session.** A consumer-repo session that also has `shubhodeep1/coding-workflows` checked out no longer stops at "open an upstream session" — it auto-chains into `/validate-consumer-issue` and ships the fix.
+
+Until now, an `[UPSTREAM]` root cause found from a consumer repo always ended read-only: the command emitted a proposed diff pinned to the consumer's upstream SHA and told the operator to open a separate `shubhodeep1/coding-workflows` session to apply it. That hand-off existed because a consumer session could not push to the library. When both repos are attached to the same session, that is no longer true, so `/investigate-issue` now detects a pushable upstream working tree, finishes the investigation exactly as before, then chains into `/validate-consumer-issue`, which applies, verifies, commits, pushes, and opens the upstream PR in the attached checkout. With no upstream attached, both commands behave exactly as they did — the read-only hand-off is unchanged.
+
+| The numbers that matter | Value |
+| --- | --- |
+| Command templates changed | `workflow-templates/.claude/commands/investigate-issue.md`, `workflow-templates/.claude/commands/validate-consumer-issue.md` |
+| Checks a checkout must pass to count as attached | 4 — is the library, clean tree, reachable `origin`, push permitted |
+| Default landing branch for the upstream fix | `stable` (`main` only when the consumer pins `@main`) |
+| New Evidence Ledger fields | `UPSTREAM_ATTACHED`, `UPSTREAM_CHECKOUT`, `UPSTREAM_BASE` |
+| Behaviour when upstream is not attached | unchanged |
+
+What this means for operators: attach `shubhodeep1/coding-workflows` alongside the consumer repo before running `/investigate-issue`, and an upstream defect comes back as a PR against `stable` instead of a diff to carry to another session. A `[BOTH]` root cause produces two PRs — the consumer one first, then the upstream one — never one commit spanning two repos. Nothing is attached automatically: if the library is absent, dirty, or not pushable, the run keeps the old read-only ending.
+
+### For contributors
+
+Attachment is detected, never created — the commands will not clone the library to unlock the write path, and a dirty upstream tree counts as not attached so in-flight work is never branched over. Diagnosis stays pinned to `UPSTREAM_SHA` even when a checkout is attached; the checkout is a write target only, and it sits at whatever ref it was cloned to. `UPSTREAM_BASE` resolves to `stable` for `@stable`, version-tag, and raw-SHA pins, since a tag is not a mergeable PR base — a tag-pinned fix is validated at the pinned SHA and re-verified against `stable` before push, and carries the usual port-to-`main` caveat. `/validate-consumer-issue` keeps full ownership of the decision to land: being chained grants no exemption from its `MISCONFIG` / `NOT-REPRODUCIBLE` / `INCORRECT` verdicts or the §6 and §10 gates. A rejected push restores the attached tree to its original branch and falls back to the read-only output rather than leaving a half-applied fix behind. Upstream PR bodies reference the consumer issue with `Refs owner/repo#N`; cross-repo auto-close keywords are forbidden (§19).

--- a/workflow-templates/.claude/commands/investigate-issue.md
+++ b/workflow-templates/.claude/commands/investigate-issue.md
@@ -5,7 +5,9 @@ Investigate a problem reported against this repo, identify the root cause, and e
 - **`[CONSUMER-INTERNAL]`** — the bug is in **this** repo's own code / config / workflows, unrelated to the upstream workflow library. → Investigate **this** repo at **`main`** (the local working checkout). **Read-write: ship the fix** here (apply, verify, commit, push, open a PR).
 - **`[UPSTREAM]`** — the bug is in the upstream workflow library `shubhodeep1/coding-workflows`.
   - If **this repo *is* `shubhodeep1/coding-workflows`** (it consumes its own templates), investigate it at **`main`** and **ship the fix** here (read-write) — there is no separate downstream to hand off to.
-  - Otherwise (this is a *different* consumer repo), investigate `shubhodeep1/coding-workflows` pinned to the **upstream ref this consumer is actually running** (NOT `main`), and produce a **read-only** proposed fix the user takes to a `shubhodeep1/coding-workflows` session — a different repo's session cannot commit / push to the upstream library.
+  - Otherwise (this is a *different* consumer repo), investigate `shubhodeep1/coding-workflows` pinned to the **upstream ref this consumer is actually running** (NOT `main`). What happens next depends on whether the upstream library is **attached to this session** (see [Attached upstream checkout](#attached-upstream-checkout)):
+    - **Upstream attached** (a pushable local checkout of `shubhodeep1/coding-workflows` exists in this session) → finish the investigation exactly as below, then **auto-chain into `/validate-consumer-issue`** and ship the upstream fix in that checkout (apply, verify, commit, push, open a PR). The session *can* push upstream, so the hand-off to a human is unnecessary.
+    - **Upstream not attached** → produce a **read-only** proposed fix the user takes to a `shubhodeep1/coding-workflows` session — that session cannot commit / push to the upstream library. This is the unchanged legacy behaviour.
 - **`[BOTH]`** — coordinated change spanning both; handle each side by the matching rule above.
 
 Decide the classification from the parsed leads + the user's description + the evidence you gather. If it is genuinely unclear which side owns the root cause, investigate **both** sides and surface the ambiguity under **Open Questions** rather than guessing.
@@ -37,8 +39,40 @@ $ARGUMENTS
 
    - **`[CONSUMER-INTERNAL]`** → `TARGET_REPO = THIS_REPO`, `TARGET_REF = main` (the local working checkout). **Mode = read-write** (apply the fix per the Decision Rule in Step 9).
    - **`[UPSTREAM]` and `THIS_REPO == shubhodeep1/coding-workflows`** → `TARGET_REPO = shubhodeep1/coding-workflows`, `TARGET_REF = main`. **Mode = read-write**. Resolve `TARGET_SHA` to the current `main` tip via `mcp__github__list_commits` with `sha=main` (or read files directly from the local `main` checkout). Do **not** run the stable-pinning procedure below — this repo is the upstream, and the fix lands on `main`.
-   - **`[UPSTREAM]` and `THIS_REPO != shubhodeep1/coding-workflows`** → `TARGET_REPO = shubhodeep1/coding-workflows`, pinned to the **upstream ref this consumer is actually running** (the stable-pinning procedure below). **Mode = read-only** (propose the fix; the user takes it to a `shubhodeep1/coding-workflows` session).
-   - **`[BOTH]`** → run both the consumer-internal path and the upstream path; apply only the edits the current session is allowed to push (the `[CONSUMER-INTERNAL]` side, and the upstream side only when `THIS_REPO == shubhodeep1/coding-workflows`), and propose the rest read-only.
+   - **`[UPSTREAM]` and `THIS_REPO != shubhodeep1/coding-workflows`** → `TARGET_REPO = shubhodeep1/coding-workflows`, pinned to the **upstream ref this consumer is actually running** (the stable-pinning procedure below). The mode depends on `UPSTREAM_ATTACHED`, resolved by the [Attached upstream checkout](#attached-upstream-checkout) procedure below:
+     - `UPSTREAM_ATTACHED = yes` → **Mode = read-write-attached-upstream**. Investigate read-only against `UPSTREAM_SHA` exactly as in the read-only mode, then hand the finished diagnosis to the auto-chain in Step 9, which lands the fix in `UPSTREAM_CHECKOUT`.
+     - `UPSTREAM_ATTACHED = no` → **Mode = read-only** (propose the fix; the user takes it to a `shubhodeep1/coding-workflows` session). Unchanged legacy behaviour.
+   - **`[BOTH]`** → run both the consumer-internal path and the upstream path; apply only the edits the current session is allowed to push (the `[CONSUMER-INTERNAL]` side, and the upstream side when `THIS_REPO == shubhodeep1/coding-workflows` or `UPSTREAM_ATTACHED = yes`), and propose the rest read-only.
+
+   ### Attached upstream checkout
+
+   Resolve this **only** for the `[UPSTREAM]` / `[BOTH]` path when `THIS_REPO != shubhodeep1/coding-workflows` — when this repo *is* the library there is no second checkout to find. A session can have more than one repo attached (e.g. the user added `shubhodeep1/coding-workflows` alongside this consumer repo); when the upstream library is present as a **pushable working tree**, the read-only hand-off in Step 9 is replaced by the auto-chain.
+
+   Set two fields and record both in the **Evidence Ledger**:
+
+   - `UPSTREAM_CHECKOUT` — absolute path of the local `shubhodeep1/coding-workflows` working tree, or `none`.
+   - `UPSTREAM_ATTACHED` — `yes` only when every check below passes; otherwise `no`.
+
+   Detection (local only — no network, no repo mutation):
+
+   ```bash
+   # Find candidate working trees whose remotes point at the upstream library.
+   # Claude Code Web rewrites remotes to a local proxy
+   # (http://...@127.0.0.1:PORT/git/<owner>/<repo>), so match on the slug, not the host.
+   for candidate in "$PWD" "$PWD"/* "$PWD"/.. "$PWD"/../* "$HOME" "$HOME"/*; do
+     [ -d "$candidate/.git" ] || continue
+     git -C "$candidate" remote -v 2>/dev/null | grep -q 'shubhodeep1/coding-workflows' || continue
+     git -C "$candidate" rev-parse --show-toplevel 2>/dev/null
+   done | sort -u
+   ```
+
+   Then, for the candidate you selected (skip any tree that is `THIS_REPO`'s own checkout):
+
+   - **It is really the library** — the tree contains `workflow-templates/` and `.github/ai/consumer_repos.json`. A consumer repo that merely *mentions* the slug in a wrapper YAML is not the library.
+   - **It is clean** — `git -C "$UPSTREAM_CHECKOUT" status --porcelain` is empty. A dirty tree holds someone else's in-flight work; do **not** branch over it. Record `UPSTREAM_ATTACHED = no`, note the dirty tree under **Open Questions**, and take the read-only path.
+   - **It is reachable and pushable** — `git -C "$UPSTREAM_CHECKOUT" ls-remote --heads origin >/dev/null` succeeds, and `git -C "$UPSTREAM_CHECKOUT" push --dry-run origin HEAD:refs/heads/<probe-branch>` reports no permission error (`--dry-run` contacts the server without creating anything).
+
+   If more than one candidate qualifies, prefer the one whose `origin` slug matches exactly and record the others under **Open Questions**. If zero qualify, `UPSTREAM_CHECKOUT = none`, `UPSTREAM_ATTACHED = no` — and the command behaves exactly as it did before this section existed. **Never clone, fetch-into, or otherwise attach the upstream repo yourself**: an unattached upstream is a supported, unchanged outcome, not a problem to fix.
 
    ### Stable-pinning procedure (only for `[UPSTREAM]` when `THIS_REPO != shubhodeep1/coding-workflows`)
 
@@ -63,7 +97,7 @@ $ARGUMENTS
    - Record `UPSTREAM_TAG`, `UPSTREAM_SHA`, `PREVIOUS_UPSTREAM_TAG`, `PREVIOUS_UPSTREAM_SHA` in the **Evidence Ledger**. Every later upstream tool call MUST pass `ref=<UPSTREAM_SHA>`. Every citation should be written as `<owner>/<repo>@<UPSTREAM_TAG> (<short-sha>):<file>:<line>` so the reader sees both the human label and the canonical SHA.
    - If `UPSTREAM_SHA` cannot be resolved at all after retries (see **Retry Rule**), record this under **Inaccessible Resources** and stop — this path cannot produce a pinned analysis without a SHA. Do not silently fall back to `main`.
 
-   Record the chosen classification, `THIS_REPO`, `TARGET_REPO`, `TARGET_REF`/`TARGET_SHA`, and the mode (read-write vs read-only) in the **Evidence Ledger** before proceeding.
+   Record the chosen classification, `THIS_REPO`, `TARGET_REPO`, `TARGET_REF`/`TARGET_SHA`, the mode (read-write / read-write-attached-upstream / read-only), and — for the pinned upstream path — `UPSTREAM_ATTACHED` and `UPSTREAM_CHECKOUT` in the **Evidence Ledger** before proceeding.
 
 3. **Download any logs** referenced in the input — Choose the fetch tool by URL shape; `curl` against a rendered GitHub page returns HTML, not log content.
    - **GitHub Actions run / job URLs** (e.g. `https://github.com/<owner>/<repo>/actions/runs/<id>`, `.../runs/<id>/job/<id>`, `.../runs/<id>/attempts/<n>`): use the appropriate GitHub MCP tool (e.g. `mcp__github__get_workflow_run_logs`, `mcp__github__get_job_logs`, or whichever workflow-log tool is exposed in the current session — search `mcp__github__*` for `log`). When `GH_TOKEN` is set in the session environment (the SessionStart hook installs `gh` and authenticates with it), `gh run view --log <run-id> -R <owner>/<repo>`, `gh run view --log --job <job-id> -R <owner>/<repo>`, `gh run view --log-failed <run-id> -R <owner>/<repo>` (failed-step lines only), and `gh api repos/<owner>/<repo>/actions/runs/<id>/logs` are also available — see [Tool Access](#tool-access) for why `-R` is mandatory in this environment. These return the raw log payload. Do NOT `curl` these rendered URLs.
@@ -88,7 +122,7 @@ $ARGUMENTS
    - Other recent runs of the same workflow (regression vs. flake).
 
    **For an `[UPSTREAM]` issue, in `shubhodeep1/coding-workflows`:**
-   - When `THIS_REPO == shubhodeep1/coding-workflows`, read at `main` (`ref=main` or the local checkout). When `THIS_REPO` is a *different* consumer, use `mcp__github__get_file_contents` with `ref=<UPSTREAM_SHA>` for **every** read — never read upstream files at `main` in that case, because a fix proposed against `main` may not apply against the consumer's pinned wrapper.
+   - When `THIS_REPO == shubhodeep1/coding-workflows`, read at `main` (`ref=main` or the local checkout). When `THIS_REPO` is a *different* consumer, use `mcp__github__get_file_contents` with `ref=<UPSTREAM_SHA>` for **every** read — never read upstream files at `main` in that case, because a fix proposed against `main` may not apply against the consumer's pinned wrapper. **This holds even when `UPSTREAM_ATTACHED = yes`**: the attached checkout sits at whatever ref it was cloned to (usually the default branch), which is *not* what the consumer ran. Diagnose from `UPSTREAM_SHA`; use `UPSTREAM_CHECKOUT` only for writing in Step 9.
    - Reusable workflow that the wrapper calls (under `workflow-templates/` or `.github/workflows/`).
    - Scripts invoked by that workflow (under `scripts/`).
    - Prompt files invoked by those scripts (under `prompts/`).
@@ -126,22 +160,45 @@ $ARGUMENTS
      - All findings `EVIDENCE-BASED` and no missing/inaccessible resource blocks root cause or fix verification → design the fix, apply it, verify it (re-run the repro / failing test when feasible), commit, push, and open a PR. Do not ask. Report using the **Final output structure** afterward, with the applied fix and the branch / PR link.
      - Any `HYPOTHESIS` finding, or any missing/inaccessible resource that blocks root cause or fix verification → stop before editing. Report and ask the user how to proceed.
      - Add or extend a test when fixing a defect that lacked coverage; do not ship a behaviour fix without verification.
-   - **Read-only mode** — `[UPSTREAM]` when `THIS_REPO != shubhodeep1/coding-workflows`:
-     - Do **NOT** apply fixes. A different consumer's session cannot push to the upstream library. Surface the proposed diff (as a fenced code block with `file:line` anchors at `UPSTREAM_SHA`) labeled `[UPSTREAM]` and let the user open a `shubhodeep1/coding-workflows` session to implement it.
-   - **`[BOTH]`** — apply the side this session is allowed to push (the `[CONSUMER-INTERNAL]` side, and the upstream side only when `THIS_REPO == shubhodeep1/coding-workflows`); propose the rest read-only with the matching target-repo label.
+   - **Read-write-attached-upstream mode** — `[UPSTREAM]` when `THIS_REPO != shubhodeep1/coding-workflows` **and** `UPSTREAM_ATTACHED = yes`:
+     - Produce exactly what the read-only mode produces — the evidence-based proposed diff with `file:line` anchors at `UPSTREAM_SHA` — then run the [Auto-chain](#auto-chain-to-validate-consumer-issue-read-write-attached-upstream-mode-only) below instead of stopping at the hand-off.
+     - The same gate applies before chaining: any `HYPOTHESIS` finding, or any missing/inaccessible resource that blocks root cause or fix verification → do **not** chain. Report and ask, exactly as the other read-write modes do.
+   - **Read-only mode** — `[UPSTREAM]` when `THIS_REPO != shubhodeep1/coding-workflows` **and** `UPSTREAM_ATTACHED = no`:
+     - Do **NOT** apply fixes. With no upstream checkout attached, this session cannot push to the library. Surface the proposed diff (as a fenced code block with `file:line` anchors at `UPSTREAM_SHA`) labeled `[UPSTREAM]` and let the user open a `shubhodeep1/coding-workflows` session to implement it.
+   - **`[BOTH]`** — apply the side this session is allowed to push (the `[CONSUMER-INTERNAL]` side, and the upstream side when `THIS_REPO == shubhodeep1/coding-workflows` or `UPSTREAM_ATTACHED = yes`); propose the rest read-only with the matching target-repo label. Land and report the `[CONSUMER-INTERNAL]` side **first**, then chain the upstream side — one PR per repo; never mix files from two repos into one commit.
    - **Environmental** (service down, rate limit, runner outage) → no fix; mark as **environmental / non-actionable** and recommend re-running once the environment recovers.
 
    Label every fix with its **target repo**: `[CONSUMER]` (lands in `THIS_REPO`), `[UPSTREAM]` (lands in `shubhodeep1/coding-workflows`), or `[BOTH]`.
 
+   ### Auto-chain to `/validate-consumer-issue` (read-write-attached-upstream mode only)
+
+   The investigation above is unchanged and completes in full first — parsed leads, Evidence Ledger, root causes, the proposed upstream diff, and (for `[BOTH]`) the applied-and-pushed `[CONSUMER-INTERNAL]` fix. Only then:
+
+   1. **Resolve `UPSTREAM_BASE`** — the branch the upstream fix lands on, derived from the consumer's pin (`UPSTREAM_TAG`, resolved in Step 2):
+      - `UPSTREAM_TAG = stable`, or the pin could not be resolved → `UPSTREAM_BASE = stable`. This is the default and the common case.
+      - `UPSTREAM_TAG = main` → `UPSTREAM_BASE = main`.
+      - `UPSTREAM_TAG` is a version tag (`vX.Y.Z`) or a raw SHA → `UPSTREAM_BASE = stable`. A tag is not a mergeable PR base, so the fix lands on the `stable` **branch** even though it was validated at the pinned SHA. Say so in the report and the PR body, and if `stable` has moved past the pin, re-verify the fix against `stable` before pushing — the code there may differ from what the consumer ran.
+      - Whenever `UPSTREAM_BASE = stable`, carry the standing caveat: the fix must also be ported to `main`, or the next `main → stable` promotion silently reverts it.
+   2. **Invoke `/validate-consumer-issue`** with a self-contained argument — it re-validates independently and must not have to re-derive context:
+      - the reported issue: the symptom, `THIS_REPO` as the reporting consumer, and the upstream ref it was running (`UPSTREAM_TAG` + `UPSTREAM_SHA`);
+      - the proposed fix: the diff from this investigation with its `shubhodeep1/coding-workflows@<UPSTREAM_TAG> (<short-sha>):<file>:<line>` anchors;
+      - the landing target: `UPSTREAM_BASE` and `UPSTREAM_CHECKOUT` (the attached working tree it writes in);
+      - the consumer-side PR link, when `[BOTH]` already landed one.
+   3. **Respect its verdict.** `/validate-consumer-issue` owns the decision to land: it may return `MISCONFIG`, `NOT-REPRODUCIBLE`, or judge the proposed fix `INCORRECT` and derive a different one. Never override it, and never re-apply a fix it declined. Its two verdicts and its outcome ship alongside this command's output (Step 10).
+   4. **Work inside `UPSTREAM_CHECKOUT`** — every `git` invocation passes `-C "$UPSTREAM_CHECKOUT"`, never the consumer's tree: `git -C "$UPSTREAM_CHECKOUT" fetch origin "$UPSTREAM_BASE"`, then `git -C "$UPSTREAM_CHECKOUT" checkout -B <work-branch> "origin/$UPSTREAM_BASE"`. Name the branch for the fix and suffix it with the base (e.g. `claude/<slug>-stable`) so the target is obvious. Open the PR with `base = $UPSTREAM_BASE`, ready for review.
+   5. **Link, don't auto-close.** The upstream PR body references the consumer issue as `Refs <owner>/<repo>#<N>` — never `Fixes` / `Closes` / `Resolves`. Cross-repo auto-close keywords fire on merge, and an orchestrator-tracking issue closed that way kills the state machine that owns it.
+   6. **Push failure → fall back cleanly.** If the push is rejected (no write access to `shubhodeep1/coding-workflows`, protected branch, expired auth) after the **Retry Rule** retries for transient errors, restore the attached checkout to the state you found it in — `git -C "$UPSTREAM_CHECKOUT" checkout <original-branch>` then `git -C "$UPSTREAM_CHECKOUT" branch -D <work-branch>` — and revert to the read-only mode output: the proposed diff plus the instruction to open a `shubhodeep1/coding-workflows` session. Leave nothing half-applied in a tree the user did not ask you to modify, and report the push failure and its reason explicitly.
+
 10. **Final output structure** — Always produce, in this order:
-    - **Summary** (1–3 lines, including the parsed leads from Step 1, the Step 2 classification + mode, and the target ref — `@main` or `UPSTREAM_TAG (UPSTREAM_SHA)`)
+    - **Summary** (1–3 lines, including the parsed leads from Step 1, the Step 2 classification + mode, and the target ref — `@main` or `UPSTREAM_TAG (UPSTREAM_SHA)`; in read-write-attached-upstream mode also name `UPSTREAM_CHECKOUT` and `UPSTREAM_BASE`)
     - **Evidence Ledger** (numbered)
     - **Root Cause(s)** — confidence label, plus a target-repo label only when the root cause is a code defect (`[CONSUMER]` / `[UPSTREAM]` / `[BOTH]`). Environmental root causes are marked non-actionable instead and carry no target-repo label.
     - **Fix(es)** — for read-write modes, what was **applied** (with `<file>:<line>` anchors and the branch / PR link); for read-only mode, the **proposed** diff with `<repo>@<UPSTREAM_TAG> (<short-sha>):<file>:<line>`, target-repo label, confidence label, and rationale. Environmental issues do not get a Fix entry.
+    - **Upstream hand-off** — only in read-write-attached-upstream mode: the `/validate-consumer-issue` run's two verdicts (issue + fix), its outcome (landed / declined / asked), `UPSTREAM_BASE`, the upstream branch / PR link, and the port-to-`main` caveat when it landed on `stable`. If the push failed and the run fell back to read-only, say so here with the reason.
     - **Inaccessible Resources** — exact URLs the user must open manually, with what's needed from each and what conclusion is blocked without it
     - **Reproduction Result**
     - **Open Questions** — surface remaining ambiguity rather than guessing
-    - **Next Step for the User** — for read-write modes, the branch / PR to review; for read-only mode, a one-sentence instruction to open a `shubhodeep1/coding-workflows` session plus a copy-paste-ready prompt summarising the proposed change. If the only finding is environmental, instruct the user to re-run after the environment recovers and explain why no code change is recommended.
+    - **Next Step for the User** — for read-write modes, the branch / PR to review (in read-write-attached-upstream mode, both the upstream PR and, for `[BOTH]`, the consumer PR); for read-only mode, a one-sentence instruction to open a `shubhodeep1/coding-workflows` session plus a copy-paste-ready prompt summarising the proposed change. If the only finding is environmental, instruct the user to re-run after the environment recovers and explain why no code change is recommended.
 
 11. **Cleanup** — Remove every temp log file written to `/tmp/` during Step 3 when done.
 
@@ -158,8 +215,10 @@ GitHub reads can go through either of two equivalent paths — pick whichever is
 
 ## Rules
 
-- **Mode is set by the Step 2 classification, not assumed.** Read-write (apply, verify, commit, push, PR) for `[CONSUMER-INTERNAL]` issues and for `[UPSTREAM]` issues when `THIS_REPO == shubhodeep1/coding-workflows`. Read-only (propose a fix the user takes elsewhere) for `[UPSTREAM]` issues when `THIS_REPO` is a *different* consumer — that session cannot push to the upstream library. Never edit files in a repo this session cannot push to.
-- **Ref selection by case.** `[CONSUMER-INTERNAL]` → `THIS_REPO@main`. `[UPSTREAM]` + `THIS_REPO == shubhodeep1/coding-workflows` → `shubhodeep1/coding-workflows@main`. `[UPSTREAM]` + different consumer → pin every upstream read to `UPSTREAM_SHA` (the resolved SHA from Step 2, never the bare tag name — moving tags like `stable` can shift mid-investigation). Reading upstream files at `main` in the *pinned* case is a bug — that consumer is not running `main`.
+- **Mode is set by the Step 2 classification, not assumed.** Read-write (apply, verify, commit, push, PR) for `[CONSUMER-INTERNAL]` issues and for `[UPSTREAM]` issues when `THIS_REPO == shubhodeep1/coding-workflows`. Read-write-attached-upstream for `[UPSTREAM]` issues when `THIS_REPO` is a *different* consumer **and** a pushable upstream checkout is attached (`UPSTREAM_ATTACHED = yes`) — investigate read-only against `UPSTREAM_SHA`, then auto-chain into `/validate-consumer-issue` to land the fix in `UPSTREAM_CHECKOUT`. Read-only (propose a fix the user takes elsewhere) for `[UPSTREAM]` issues when `UPSTREAM_ATTACHED = no` — that session cannot push to the upstream library. Never edit files in a repo this session cannot push to.
+- **Attachment is detected, never created.** `UPSTREAM_ATTACHED` comes from the [Attached upstream checkout](#attached-upstream-checkout) checks — a real, clean, pushable working tree of `shubhodeep1/coding-workflows` present in the session. Do not clone, attach, or otherwise acquire the upstream repo to unlock the write path: an unattached upstream keeps the legacy read-only behaviour, which is a correct outcome and not a failure. A dirty attached tree counts as *not attached* — never branch over someone else's in-flight work.
+- **One repo per commit, one PR per repo.** The consumer fix and the upstream fix are separate commits in separate trees with separate PRs. Every write to the attached upstream tree goes through `git -C "$UPSTREAM_CHECKOUT"`; never stage upstream files from the consumer's working directory or vice versa.
+- **Ref selection by case.** `[CONSUMER-INTERNAL]` → `THIS_REPO@main`. `[UPSTREAM]` + `THIS_REPO == shubhodeep1/coding-workflows` → `shubhodeep1/coding-workflows@main`. `[UPSTREAM]` + different consumer → pin every upstream read to `UPSTREAM_SHA` (the resolved SHA from Step 2, never the bare tag name — moving tags like `stable` can shift mid-investigation). Reading upstream files at `main` in the *pinned* case is a bug — that consumer is not running `main`. **An attached upstream checkout does not change the read ref**: diagnosis stays pinned to `UPSTREAM_SHA`; `UPSTREAM_CHECKOUT` is a write target, and the branch the fix lands on is `UPSTREAM_BASE` (Step 9's auto-chain), which is not necessarily the same commit.
 - **Always download the complete log.** Never truncate or skip sections. When multiple log URLs are present, this rule applies to each — download every accessible log in full before drawing conclusions.
 - **Retry Rule**: For transient HTTP/GitHub errors (5xx, 429, timeouts, connection resets, DNS failures), retry with exponential backoff (2s, 4s, 8s, 16s — up to 4 retries) before declaring failure. Applies to every fetch: the log download, GitHub MCP calls, raw HTTP follow-ups.
 - **Inaccessible resources** — If a resource is still unreachable after retries, or returns a hard failure (401, 403, 404, 410), or is auth-walled / expired / private, record it under **Inaccessible Resources**:

--- a/workflow-templates/.claude/commands/validate-consumer-issue.md
+++ b/workflow-templates/.claude/commands/validate-consumer-issue.md
@@ -1,4 +1,4 @@
-Given an issue **and a proposed fix** raised against **this** repo (in `$ARGUMENTS` — an issue URL / number, pasted issue text, a PR carrying the fix, or prose describing both), determine two things: (1) is it a **valid issue** — real, reproducible, and correctly diagnosed; and (2) is the **proposed fix** correct, complete, and safe? The root cause can live on one of two sides — **this repo's own code/config**, or the **upstream workflow library** (`shubhodeep1/coding-workflows`) this repo's wrappers call — and you decide which from the evidence; the side determines where a valid fix would land. Then **act on the verdict**: when the issue is a genuine defect and the correct fix (the proposal, or a corrected/completed version you derive from the evidence) is fully evidence-based, safe, and needs no clarification, **implement it on whichever side this session can push to** — apply, verify, commit, push, open a PR — exactly as `/investigate-issue` would. For a fix that must land upstream from a *different* consumer's session (which cannot push there), stay read-only and hand the user a proposed diff. Anything ambiguous or unsafe stays a read-only verdict + ask.
+Given an issue **and a proposed fix** raised against **this** repo (in `$ARGUMENTS` — an issue URL / number, pasted issue text, a PR carrying the fix, or prose describing both), determine two things: (1) is it a **valid issue** — real, reproducible, and correctly diagnosed; and (2) is the **proposed fix** correct, complete, and safe? The root cause can live on one of two sides — **this repo's own code/config**, or the **upstream workflow library** (`shubhodeep1/coding-workflows`) this repo's wrappers call — and you decide which from the evidence; the side determines where a valid fix would land. Then **act on the verdict**: when the issue is a genuine defect and the correct fix (the proposal, or a corrected/completed version you derive from the evidence) is fully evidence-based, safe, and needs no clarification, **implement it on whichever side this session can push to** — apply, verify, commit, push, open a PR — exactly as `/investigate-issue` would. For a fix that must land upstream from a *different* consumer's session, the deciding question is whether the upstream library is **attached to this session** as a pushable checkout (see [Attached upstream checkout](#attached-upstream-checkout)): when it is, land the fix there; when it is not, stay read-only and hand the user a proposed diff. Anything ambiguous or unsafe stays a read-only verdict + ask.
 
 $ARGUMENTS
 
@@ -10,11 +10,36 @@ $ARGUMENTS
 
 3. **Classify the side that owns the root cause.**
    - **`[CONSUMER-INTERNAL]`** — the defect is in this repo's own code / config / wrapper workflows. Validate at `THIS_REPO@main`. A valid fix lands **here** (read-write: this session can push).
-   - **`[UPSTREAM]`** — the defect is in the upstream library, reached through this repo's wrapper at the **ref this repo is pinned to**. Validate the upstream side pinned to `UPSTREAM_SHA` (procedure below). A valid fix lands **upstream**: read-write **only when `THIS_REPO == shubhodeep1/coding-workflows`** (this repo consumes its own templates, so there is no separate downstream); from any other consumer this session **cannot push upstream**, so the fix is read-only — the user takes it to a `shubhodeep1/coding-workflows` session.
+   - **`[UPSTREAM]`** — the defect is in the upstream library, reached through this repo's wrapper at the **ref this repo is pinned to**. Validate the upstream side pinned to `UPSTREAM_SHA` (procedure below). A valid fix lands **upstream**, and whether this session can land it depends on the repo it runs in:
+     - `THIS_REPO == shubhodeep1/coding-workflows` → read-write (this repo consumes its own templates, so there is no separate downstream).
+     - Any other consumer, **upstream attached** (`UPSTREAM_ATTACHED = yes`) → read-write **in the attached checkout** (`UPSTREAM_CHECKOUT`), landing on `UPSTREAM_BASE`.
+     - Any other consumer, **upstream not attached** → read-only; the user takes the proposed diff to a `shubhodeep1/coding-workflows` session.
    - **`[BOTH]`** — a coordinated defect; judge each side by its matching rule.
 
    ### Resolving the upstream pin (for the `[UPSTREAM]` / `[BOTH]` side)
    Inspect this repo's `.github/workflows/*.yml` for every `uses:` / `ref:` that references `shubhodeep1/coding-workflows`; the exact `ref` is the pin. Resolve it to `UPSTREAM_TAG` (the label) and `UPSTREAM_SHA` (the commit) — tag `@vX.Y.Z` via `get_tag` / `list_tags`; a direct SHA as-is; moving `@stable` via `list_tags`; branch `@main` to its current tip (note it may move). Pass `ref=<UPSTREAM_SHA>` on **every** upstream read. Validating an upstream report at `main` when this repo is pinned to a release is a bug — that ref may not match what this repo runs. (Exception: when `THIS_REPO == shubhodeep1/coding-workflows`, the upstream side *is* this repo and is validated at `main`; its fix lands on the `stable` branch — see the Decision Rule.)
+
+   ### Attached upstream checkout
+
+   Resolve this **only** for the `[UPSTREAM]` / `[BOTH]` side when `THIS_REPO != shubhodeep1/coding-workflows`. A session can have both this consumer repo and the upstream library attached; when it does, the upstream fix lands here instead of being handed to the user. Set three fields:
+
+   - `UPSTREAM_CHECKOUT` — absolute path of the local `shubhodeep1/coding-workflows` working tree, or `none`.
+   - `UPSTREAM_ATTACHED` — `yes` only when all checks below pass; otherwise `no`.
+   - `UPSTREAM_BASE` — the branch the fix lands on (see below).
+
+   **When `/investigate-issue` chained into this command** it passes `UPSTREAM_CHECKOUT` and `UPSTREAM_BASE` in `$ARGUMENTS` — verify them rather than re-deriving (confirm the path is a working tree of the library, and that the base branch exists on `origin`). Otherwise detect it yourself:
+
+   ```bash
+   for candidate in "$PWD" "$PWD"/* "$PWD"/.. "$PWD"/../* "$HOME" "$HOME"/*; do
+     [ -d "$candidate/.git" ] || continue
+     git -C "$candidate" remote -v 2>/dev/null | grep -q 'shubhodeep1/coding-workflows' || continue
+     git -C "$candidate" rev-parse --show-toplevel 2>/dev/null
+   done | sort -u
+   ```
+
+   A candidate qualifies only when it is the library itself (the tree contains `workflow-templates/` and `.github/ai/consumer_repos.json`), it is **clean** (`git -C "$UPSTREAM_CHECKOUT" status --porcelain` is empty — never branch over in-flight work), and it is reachable and pushable (`git -C "$UPSTREAM_CHECKOUT" ls-remote --heads origin` succeeds and `git -C "$UPSTREAM_CHECKOUT" push --dry-run origin HEAD:refs/heads/<probe-branch>` reports no permission error). Nothing qualifying → `UPSTREAM_ATTACHED = no` and the read-only path stands. **Never clone or attach the upstream repo to unlock the write path** — an unattached upstream is a supported outcome, not a problem to fix.
+
+   `UPSTREAM_BASE` follows this repo's pin: `UPSTREAM_TAG = main` → `main`; `stable`, a version tag, a raw SHA, or an unresolvable pin → `stable` (a tag is not a mergeable PR base, so a tag-pinned fix is validated at `UPSTREAM_SHA` but lands on the `stable` branch — say so in the report and PR body, and re-verify against `stable` before pushing if it has moved past the pin). Landing on `stable` always carries the port-to-`main` caveat: without it, the next `main → stable` promotion silently reverts the fix.
 
 4. **Validate the ISSUE** at the ref for its side. Trace it in the code and, where feasible, reproduce it. Decide:
    - **VALID** — a genuine defect; cite the code path (`THIS_REPO`: `file:line`; upstream: `shubhodeep1/coding-workflows@UPSTREAM_TAG (short-sha):file:line`) and the repro result. State the side.
@@ -37,19 +62,25 @@ Settle on the correct fix first (never apply a proposal you judged INCORRECT as-
 - **Read-write side** — `[CONSUMER-INTERNAL]`, and `[UPSTREAM]` when `THIS_REPO == shubhodeep1/coding-workflows`:
   - Issue **VALID**, the correct fix fully **EVIDENCE-BASED**, no §6/§10 hard gate, no cross-consumer break, and no missing/inaccessible resource blocking root cause or verification → apply the fix at `THIS_REPO@main` (or, for the self-consuming case where `THIS_REPO == shubhodeep1/coding-workflows`, at `shubhodeep1/coding-workflows@stable` — branch off `stable`), verify (re-run the repro / failing test when feasible), commit, push, open a PR. Set the PR base to `THIS_REPO`'s default branch for the consumer-internal side, and to `stable` for the self-consuming `shubhodeep1/coding-workflows` side — the latter always lands its fixes on `stable`, never `main`, unless the request explicitly names a different target branch. Do not ask. Report with `Fix:` = applied + branch/PR.
   - Any HYPOTHESIS finding, a §6 hard gate (the only correct fix needs an unaliased rename/removal of a public identifier), a §10 hard gate (a collection/index change without its `/db/contracts/*` update), a cross-consumer break, multiple plausible fixes with material tradeoffs, or a blocking inaccessible resource → stop before editing; report the verdicts and ask (CLAUDE.md §2 Q/A format for a §6/§10/tradeoff decision).
-- **Read-only side** — `[UPSTREAM]` when `THIS_REPO != shubhodeep1/coding-workflows`:
-  - Do **NOT** edit — this session cannot push to the upstream library. Surface the correct fix as a proposed diff with `shubhodeep1/coding-workflows@<UPSTREAM_TAG> (<short-sha>):file:line` anchors and tell the user to open a `shubhodeep1/coding-workflows` session (where `/validate-consumer-issue` or `/investigate-issue` can land it).
-- **`[BOTH]`** → implement the side this session can push (the `[CONSUMER-INTERNAL]` side, and the upstream side only when `THIS_REPO == shubhodeep1/coding-workflows`); propose the rest read-only with the matching target-repo label.
+- **Attached-upstream side** — `[UPSTREAM]` when `THIS_REPO != shubhodeep1/coding-workflows` **and** `UPSTREAM_ATTACHED = yes`:
+  - The same gate as the read-write side applies in full (issue **VALID**, correct fix fully **EVIDENCE-BASED**, no §6/§10 hard gate, no cross-consumer break, nothing blocking verification). Both verdicts are made independently first — a chained `/investigate-issue` diagnosis does not pre-approve anything, and a proposal judged INCORRECT is replaced by the fix derived from the evidence, never landed as-is.
+  - Gate met → work **only** through `git -C "$UPSTREAM_CHECKOUT"`: `fetch origin "$UPSTREAM_BASE"`, `checkout -B <work-branch> "origin/$UPSTREAM_BASE"` (suffix the branch with the base, e.g. `claude/<slug>-stable`), apply the fix and its test, verify (re-run the repro / failing test when feasible), commit, `push -u origin <work-branch>`, and open a PR with `base = $UPSTREAM_BASE`, ready for review. Reference the consumer issue as `Refs <owner>/<repo>#<N>` — never `Fixes` / `Closes` / `Resolves`, which auto-close across repos on merge. Report `Fix:` = applied + branch/PR, plus the port-to-`main` caveat whenever `UPSTREAM_BASE = stable`.
+  - Gate not met → exactly the read-write side's stop-and-ask behaviour; edit nothing in the attached tree.
+  - **Push rejected** (no write access, protected branch, expired auth) after retries → restore the attached checkout to the state you found it in (`git -C "$UPSTREAM_CHECKOUT" checkout <original-branch>` then `git -C "$UPSTREAM_CHECKOUT" branch -D <work-branch>`) and fall back to the read-only side's output, reporting the push failure and its reason. Never leave a half-applied fix in a tree the user did not ask you to modify.
+- **Read-only side** — `[UPSTREAM]` when `THIS_REPO != shubhodeep1/coding-workflows` **and** `UPSTREAM_ATTACHED = no`:
+  - Do **NOT** edit — without the library attached, this session cannot push to it. Surface the correct fix as a proposed diff with `shubhodeep1/coding-workflows@<UPSTREAM_TAG> (<short-sha>):file:line` anchors and tell the user to open a `shubhodeep1/coding-workflows` session (where `/validate-consumer-issue` or `/investigate-issue` can land it).
+- **`[BOTH]`** → implement the side this session can push (the `[CONSUMER-INTERNAL]` side, and the upstream side when `THIS_REPO == shubhodeep1/coding-workflows` or `UPSTREAM_ATTACHED = yes`); propose the rest read-only with the matching target-repo label. One PR per repo — never stage files from two trees into one commit.
 - **Issue MISCONFIG** → no code fix on either side; report the exact setup change (wrong `@ref` pin, unset secret/var, malformed wrapper, missing input) the user must make in this repo.
 - **Issue NOT-REPRODUCIBLE / INVALID** → no edit; report and ask for what's needed to reproduce.
 - **Environmental failure** (service down, rate limit, runner outage) → no fix; say so explicitly.
-- Always add/extend a test when landing a fix for a defect that lacked coverage; never edit files on the read-only `[UPSTREAM]` side.
+- Always add/extend a test when landing a fix for a defect that lacked coverage; never edit files on the read-only `[UPSTREAM]` side, and never edit an attached upstream tree that failed any [Attached upstream checkout](#attached-upstream-checkout) check.
 
 ## Output Format
 
 ```
 Issue: <one-line restatement>
 Side: [CONSUMER-INTERNAL] THIS_REPO@main | [UPSTREAM] shubhodeep1/coding-workflows@<UPSTREAM_TAG> (<short-sha>) | [BOTH]
+Upstream write path: attached (<UPSTREAM_CHECKOUT> → base <UPSTREAM_BASE>) | not attached (read-only) | n/a
 Issue verdict: VALID / MISCONFIG / NOT-REPRODUCIBLE
 - Evidence: <file:line or repo@ref (short-sha):file:line; repro result>
 
@@ -58,11 +89,11 @@ Fix verdict: CORRECT / CORRECT-BUT-INCOMPLETE / INCORRECT / UNNECESSARY
 - <why — file:line, §-citations>
 - Gaps: <missing tests, §6 rename, §10 contract, aimed at the wrong side>
 
-Fix: <applied (branch/PR) | proposed (read-only, upstream) | none>
+Fix: <applied (branch/PR) | applied upstream in attached checkout (branch/PR, base <UPSTREAM_BASE>) | proposed (read-only, upstream) | none>
 - <file:line — what the correct fix does>
 
 Recommendation: <implemented here (branch/PR) | reject + the correct fix to land | return as misconfig: <what to change> | blocked — ask (reason)>
-Next step: <branch/PR to review when applied; [UPSTREAM] from a different consumer: open a shubhodeep1/coding-workflows session with the proposed diff; misconfig: the setup change>
+Next step: <branch/PR to review when applied — both PRs for [BOTH]; [UPSTREAM] with no attached upstream: open a shubhodeep1/coding-workflows session with the proposed diff; misconfig: the setup change>
 ```
 
 Omit empty sections; every verdict carries a citation. When the fix was applied and pushed, the `Fix:` line and `Next step` include the branch/PR link.
@@ -77,15 +108,16 @@ Omit empty sections; every verdict carries a citation. When the fix was applied 
 
 **Writes (only on the read-write side per the [Decision Rule](#decision-rule)):**
 
-- **`Edit` / `Write`** — apply the correct fix against the local `THIS_REPO@main` checkout (or the local `shubhodeep1/coding-workflows@stable` checkout when this repo *is* the library — branch off `stable`), and add/extend the verifying test. **Never edit files on the read-only `[UPSTREAM]` side** — a different consumer's session cannot push there.
-- **`Bash`** — `git` (branch off the target ref — `main` for the consumer-internal side, `stable` for the self-consuming `shubhodeep1/coding-workflows` side — commit, `push -u origin <branch>`) and re-running the repro / failing test to verify before pushing.
-- **`mcp__github__create_pull_request`** (or `gh pr create`) — open the PR ready for review against the default branch (consumer-internal side), or against the `stable` branch for the self-consuming `shubhodeep1/coding-workflows` side (override only when the request explicitly names another branch).
+- **`Edit` / `Write`** — apply the correct fix against the local `THIS_REPO@main` checkout (the local `shubhodeep1/coding-workflows@stable` checkout when this repo *is* the library — branch off `stable`; or, on the attached-upstream side, the tree at `UPSTREAM_CHECKOUT` branched off `origin/$UPSTREAM_BASE`), and add/extend the verifying test. **Never edit files on the read-only `[UPSTREAM]` side** — with no attached upstream, this session cannot push there.
+- **`Bash`** — `git` (branch off the target ref — `main` for the consumer-internal side, `stable` for the self-consuming `shubhodeep1/coding-workflows` side, `origin/$UPSTREAM_BASE` for the attached-upstream side — commit, `push -u origin <branch>`) and re-running the repro / failing test to verify before pushing. Every command touching the attached upstream tree passes `-C "$UPSTREAM_CHECKOUT"`; a bare `git` in a chained run would hit the consumer's tree.
+- **`mcp__github__create_pull_request`** (or `gh pr create`) — open the PR ready for review against the default branch (consumer-internal side), against the `stable` branch for the self-consuming `shubhodeep1/coding-workflows` side, or against `$UPSTREAM_BASE` in `shubhodeep1/coding-workflows` for the attached-upstream side (override only when the request explicitly names another branch).
 
 ## Rules
 
-- **Judge, then act on the pushable side.** The two judgments always ship in the report. When the [Decision Rule](#decision-rule) implement gate is met on a side this session can push to, additionally apply → verify → commit → push → open a PR for the correct fix (the `/investigate-issue` behaviour). On the read-only `[UPSTREAM]` side (a different consumer's session), surface a proposed diff instead. When the gate isn't met, stay read-only and report / ask.
+- **Judge, then act on the pushable side.** The two judgments always ship in the report. When the [Decision Rule](#decision-rule) implement gate is met on a side this session can push to, additionally apply → verify → commit → push → open a PR for the correct fix (the `/investigate-issue` behaviour). On the read-only `[UPSTREAM]` side (no attached upstream), surface a proposed diff instead. When the gate isn't met, stay read-only and report / ask.
+- **Being chained from `/investigate-issue` grants no exemption.** When that command hands over a diagnosis and a proposed diff, this command still validates the issue and the fix independently at `UPSTREAM_SHA`, and still owns the decision to land. `MISCONFIG`, `NOT-REPRODUCIBLE`, an `INCORRECT` proposal, or a §6/§10 gate ends the chain with a report — the caller does not override it.
 - **Implement the *correct* fix, never the flawed proposal.** A CORRECT proposal is applied as-is; a CORRECT-BUT-INCOMPLETE one is completed; an INCORRECT / UNNECESSARY proposal against a real bug is replaced by the fix you derive from the evidence. Never commit a proposed change you judged INCORRECT.
-- **Pick the side from evidence**, and pin upstream reads to this repo's `UPSTREAM_SHA`. A fix lands where the defect lives: `[CONSUMER-INTERNAL]` here, `[UPSTREAM]` in `shubhodeep1/coding-workflows` (read-write only when this repo *is* that library; otherwise a different session). Flag any fix aimed at the wrong side, and **never edit a repo this session cannot push to**.
+- **Pick the side from evidence**, and pin upstream reads to this repo's `UPSTREAM_SHA` — an attached checkout is a write target, not a read source; it sits at whatever ref it was cloned to, which is not what this repo ran. A fix lands where the defect lives: `[CONSUMER-INTERNAL]` here, `[UPSTREAM]` in `shubhodeep1/coding-workflows` (read-write when this repo *is* that library or the library is attached and pushable; otherwise a different session). Flag any fix aimed at the wrong side, and **never edit a repo this session cannot push to**.
 - **Two independent judgments.** A real issue can arrive with a wrong fix; an invalid issue can arrive with a pointless fix. Validate the issue and the fix separately — even when you go on to implement.
 - **Watch for misconfig dressed as a code bug.** A wrong `@ref` pin, an unset secret/var, or a stale wrapper is **MISCONFIG** — name the exact setup change rather than editing code.
 - **§6 and §10 are hard gates on the fix** — a correct fix that needs an unaliased public rename/removal, or a collection/index change without its `/db/contracts/*` update, is **not** auto-applied even when functionally right; route to the §2 Q/A ask path.


### PR DESCRIPTION
## What changed

`/investigate-issue` run from a consumer repo previously ended read-only whenever the root cause was `[UPSTREAM]`: it emitted a proposed diff pinned to the consumer's `UPSTREAM_SHA` and told the operator to open a separate `shubhodeep1/coding-workflows` session. That hand-off existed because a consumer session could not push to the library — a premise that stops holding when both repos are attached to the same session.

Now, when a pushable upstream checkout is present, the command finishes the investigation exactly as before and then auto-chains into `/validate-consumer-issue`, which applies, verifies, commits, pushes, and opens the upstream PR in that checkout. **With no upstream attached, both commands behave exactly as they did.**

## Files changed

- **`workflow-templates/.claude/commands/investigate-issue.md`**
  - Header classification block — the `[UPSTREAM]` / different-consumer bullet splits into attached (auto-chain) vs not attached (unchanged read-only).
  - Step 2 — new `### Attached upstream checkout` section resolving `UPSTREAM_ATTACHED` / `UPSTREAM_CHECKOUT`, and a third mode `read-write-attached-upstream`; both fields recorded in the Evidence Ledger.
  - Step 4 — reads stay pinned to `UPSTREAM_SHA` even when a checkout is attached.
  - Step 9 — new mode bullet plus `### Auto-chain to /validate-consumer-issue`: resolve `UPSTREAM_BASE`, invoke with self-contained context, respect the callee's verdict, work only via `git -C "$UPSTREAM_CHECKOUT"`, `Refs`-not-`Fixes` linkage, and a clean fallback on push rejection.
  - Step 10 — new **Upstream hand-off** report section; Summary and Next Step updated.
  - Rules — mode selection, "attachment is detected, never created", one-repo-per-commit.
- **`workflow-templates/.claude/commands/validate-consumer-issue.md`**
  - Step 3 — `[UPSTREAM]` side split three ways; new `### Attached upstream checkout` section (accepts a caller-supplied path, otherwise detects) and the `UPSTREAM_BASE` derivation rule.
  - Decision Rule — new **Attached-upstream side** carrying the full read-write gate, the push-rejection fallback, and the `Refs` requirement; read-only side now conditioned on `UPSTREAM_ATTACHED = no`.
  - Output Format, Tool Access writes, Rules updated to match.
- **`changelog.d/investigate-issue-attached-upstream-autochain.md`** — new fragment (§20).

## Design decisions

| Decision | Behaviour |
| --- | --- |
| Detection | A candidate must be the library itself (`workflow-templates/` + `.github/ai/consumer_repos.json`), **clean**, reachable, and pushable. Matching is on the repo slug, not the host, so Claude Code Web's local git proxy resolves correctly. |
| Never auto-attach | The commands do not clone the library to unlock the write path. An unattached — or dirty — upstream keeps the legacy read-only ending. A dirty tree is treated as not attached so in-flight work is never branched over. |
| Read ref vs write target | Diagnosis stays pinned to `UPSTREAM_SHA`. The attached checkout sits at whatever ref it was cloned to, so it is a write target only. |
| Landing branch | `UPSTREAM_BASE` follows the consumer pin: `main` for `@main`; `stable` for `@stable`, version tags, and raw SHAs. A tag is not a mergeable PR base, so a tag-pinned fix is validated at the pinned SHA and re-verified against `stable` before push. Landing on `stable` carries the port-to-`main` caveat. |
| Who decides to land | `/validate-consumer-issue` keeps full ownership. Being chained grants no exemption: `MISCONFIG`, `NOT-REPRODUCIBLE`, an `INCORRECT` proposal, or a §6/§10 gate ends the chain with a report. |
| Push rejected | Restore the attached tree to its original branch, delete the work branch, fall back to the read-only output, and report the reason — never a half-applied fix in a tree the user did not ask you to modify. |
| `[BOTH]` | Consumer side lands and reports first, then the upstream chain. One PR per repo; never one commit spanning two trees. |

## Verification

- The detection snippet was smoke-tested in this container against the Claude Code Web proxy remote; it resolves this checkout correctly and mutates nothing.
- `scripts/assemble_changelog.py assemble --dry-run` picks up the new fragment (`layout=keep-a-changelog fragments=3 changed=true`) with the working tree unchanged.
- No wiring change needed (§18.B): `workflow-templates/.claude/` already mirrors to consumers via the existing `.github/workflows/update_workflows.yml` sync (daily cron + `@stable` dispatch).
- No `README.md` / `agents.md` updates: neither documents these slash commands. No new scripts or supervisors, so no `docs/scripts-pending-removal.md` entry (§18.F).

## Compliance notes

- §6 — no identifier renamed or removed. New names `UPSTREAM_ATTACHED`, `UPSTREAM_CHECKOUT`, `UPSTREAM_BASE` were checked repo-wide for collisions before use. Step numbering in both commands is unchanged; the new material is nested inside existing steps.
- §19 — no auto-close keywords in this body, and the new instructions explicitly forbid cross-repo auto-close keywords in the PR bodies they generate.
- §10 — no DB or index surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TATuA2kjJquSx526VehhoJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TATuA2kjJquSx526VehhoJ)_