### PR TITLE
Add partial-clone promisor recovery to review_autofix's late merge precheck

### DIFF
--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3227,6 +3227,7 @@ jobs:
           merge_exit=0
           merge_promisor_fetch_failure_seen=false
           merge_promisor_initial_stderr=""
+          merge_promisor_retry_stderr_matches=false
           git merge --no-commit --no-ff "origin/${BASE_BRANCH}" 2> "${MERGE_STDERR_FILE}" || merge_exit=$?
           if [ -s "${MERGE_STDERR_FILE}" ]; then
             sed 's/^/git merge stderr: /' "${MERGE_STDERR_FILE}"
@@ -3260,10 +3261,14 @@ jobs:
               echo "::warning::blob-backfill refetch failed during pre-review merge gate; retrying the merge anyway. git fetch stderr: ${_refetch_stderr}"
             fi
             merge_exit=0
+            merge_promisor_retry_stderr_matches=false
             : > "${MERGE_STDERR_FILE}"
             git merge --no-commit --no-ff "origin/${BASE_BRANCH}" 2> "${MERGE_STDERR_FILE}" || merge_exit=$?
             if [ -s "${MERGE_STDERR_FILE}" ]; then
               sed 's/^/git merge stderr (after blob backfill): /' "${MERGE_STDERR_FILE}"
+            fi
+            if grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${MERGE_STDERR_FILE}" 2>/dev/null; then
+              merge_promisor_retry_stderr_matches=true
             fi
           fi
 
@@ -3289,11 +3294,16 @@ jobs:
                   exit 0
                 fi
               elif [ "${merge_exit}" -eq 128 ]; then
-                if [ "${merge_promisor_fetch_failure_seen}" = "true" ] \
-                   || grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${MERGE_STDERR_FILE}" 2>/dev/null; then
+                if [ "${merge_promisor_retry_stderr_matches}" = "true" ] \
+                   || { [ "${merge_promisor_fetch_failure_seen}" = "true" ] \
+                        && [ "${_merge_stderr_oneline}" = "<git merge produced no stderr>" ]; }; then
                   # A partial-clone promisor fetch failure that survived the
                   # blob-backfill retry above is an infrastructure error, not
-                  # a deterministic stale base. Fail OPEN so the reviewer +
+                  # a deterministic stale base. Use the retry probe's own
+                  # promisor signature when it is still present; fall back to
+                  # the initial probe only when the retry produced no stderr
+                  # at all. Any other retry-side exit-128 cause keeps the hard
+                  # error path below. Fail OPEN so the reviewer +
                   # conflict-resolver path still runs (the resolver runs its
                   # own merge with its own backfill) rather than skipping it.
                   echo "::warning::Pre-review merge topology gate: exit 128 from a partial-clone promisor fetch failure that survived the blob-backfill retry. Failing open to the reviewer/resolver path. git stderr: ${_merge_stderr_oneline}"
@@ -4512,6 +4522,7 @@ jobs:
           merge_exit=0
           merge_promisor_fetch_failure_seen=false
           merge_promisor_initial_stderr=""
+          merge_promisor_retry_stderr_matches=false
           # Capture git merge stderr so the failure annotation can surface
           # the real cause (e.g. "refusing to merge unrelated histories",
           # "Untracked working tree file … would be overwritten by merge").
@@ -4568,10 +4579,14 @@ jobs:
               echo "::warning::blob-backfill refetch failed during merge precheck; retrying the merge anyway. git fetch stderr: ${_merge_refetch_stderr}"
             fi
             merge_exit=0
+            merge_promisor_retry_stderr_matches=false
             : > "${MERGE_STDERR_FILE}"
             git merge --no-commit --no-ff "origin/${BASE_BRANCH}" 2> "${MERGE_STDERR_FILE}" || merge_exit=$?
             if [ -s "${MERGE_STDERR_FILE}" ]; then
               sed 's/^/git merge stderr (after blob backfill): /' "${MERGE_STDERR_FILE}"
+            fi
+            if grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${MERGE_STDERR_FILE}" 2>/dev/null; then
+              merge_promisor_retry_stderr_matches=true
             fi
           fi
 
@@ -4606,11 +4621,16 @@ jobs:
                 _base_sha="$(git rev-parse --short "origin/${BASE_BRANCH}" 2>/dev/null || echo unknown)"
                 echo "::error::Merge precheck failed (exit ${merge_exit}): HEAD (${_head_sha}) and origin/${BASE_BRANCH} (${_base_sha}) have no common ancestor. This PR's branch was likely force-pushed to an orphan root, or ${BASE_BRANCH} was force-pushed since this branch diverged. Manual repair required: rebase the PR branch onto a current ${BASE_BRANCH} ancestor, or recreate the branch from ${BASE_BRANCH} and re-apply the changes. git stderr: ${_merge_stderr_oneline}"
               elif [ "${merge_exit}" -eq 128 ]; then
-                if [ "${merge_promisor_fetch_failure_seen}" = "true" ] \
-                   || grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${MERGE_STDERR_FILE}" 2>/dev/null; then
+                if [ "${merge_promisor_retry_stderr_matches}" = "true" ] \
+                   || { [ "${merge_promisor_fetch_failure_seen}" = "true" ] \
+                        && [ "${_merge_stderr_oneline}" = "<git merge produced no stderr>" ]; }; then
                   # A partial-clone promisor fetch failure that survived the
                   # blob-backfill retry above is an infrastructure error, not
-                  # a merge outcome. Downgrade to a ::warning:: so the run's
+                  # a merge outcome. Use the retry probe's own promisor
+                  # signature when it is still present; fall back to the
+                  # initial probe only when the retry produced no stderr at
+                  # all. Any other retry-side exit-128 cause keeps the hard
+                  # error path below. Downgrade to a ::warning:: so the run's
                   # annotations stay honest, and fail OPEN into the resolver
                   # path with MERGE_CONFLICT=true:
                   # scripts/review_conflict_prepare.sh runs its own merge

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -3276,6 +3276,7 @@ jobs:
             if [ "${merge_exit}" -ne 0 ] && [ ! -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
               _merge_stderr_oneline="$(tr '\n' ' ' < "${MERGE_STDERR_FILE}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
               _merge_stderr_oneline="${_merge_stderr_oneline:-<git merge produced no stderr>}"
+              _merge_classifier_stderr_oneline="${_merge_stderr_oneline}"
               if [ "${merge_promisor_fetch_failure_seen}" = "true" ] && [ -n "${merge_promisor_initial_stderr}" ] \
                  && [ "${merge_promisor_initial_stderr}" != "${_merge_stderr_oneline}" ]; then
                 _merge_stderr_oneline="${_merge_stderr_oneline} | initial promisor stderr: ${merge_promisor_initial_stderr}"
@@ -3296,7 +3297,7 @@ jobs:
               elif [ "${merge_exit}" -eq 128 ]; then
                 if [ "${merge_promisor_retry_stderr_matches}" = "true" ] \
                    || { [ "${merge_promisor_fetch_failure_seen}" = "true" ] \
-                        && [ "${_merge_stderr_oneline}" = "<git merge produced no stderr>" ]; }; then
+                        && [ "${_merge_classifier_stderr_oneline}" = "<git merge produced no stderr>" ]; }; then
                   # A partial-clone promisor fetch failure that survived the
                   # blob-backfill retry above is an infrastructure error, not
                   # a deterministic stale base. Use the retry probe's own
@@ -4611,6 +4612,7 @@ jobs:
               # annotation (::error:: notations cannot span newlines).
               _merge_stderr_oneline="$(tr '\n' ' ' < "${MERGE_STDERR_FILE}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
               _merge_stderr_oneline="${_merge_stderr_oneline:-<git merge produced no stderr>}"
+              _merge_classifier_stderr_oneline="${_merge_stderr_oneline}"
               if [ "${merge_promisor_fetch_failure_seen}" = "true" ] && [ -n "${merge_promisor_initial_stderr}" ] \
                  && [ "${merge_promisor_initial_stderr}" != "${_merge_stderr_oneline}" ]; then
                 _merge_stderr_oneline="${_merge_stderr_oneline} | initial promisor stderr: ${merge_promisor_initial_stderr}"
@@ -4623,7 +4625,7 @@ jobs:
               elif [ "${merge_exit}" -eq 128 ]; then
                 if [ "${merge_promisor_retry_stderr_matches}" = "true" ] \
                    || { [ "${merge_promisor_fetch_failure_seen}" = "true" ] \
-                        && [ "${_merge_stderr_oneline}" = "<git merge produced no stderr>" ]; }; then
+                        && [ "${_merge_classifier_stderr_oneline}" = "<git merge produced no stderr>" ]; }; then
                   # A partial-clone promisor fetch failure that survived the
                   # blob-backfill retry above is an infrastructure error, not
                   # a merge outcome. Use the retry probe's own promisor

--- a/.github/workflows/review_autofix.yml
+++ b/.github/workflows/review_autofix.yml
@@ -4510,6 +4510,8 @@ jobs:
           echo "====================================="
 
           merge_exit=0
+          merge_promisor_fetch_failure_seen=false
+          merge_promisor_initial_stderr=""
           # Capture git merge stderr so the failure annotation can surface
           # the real cause (e.g. "refusing to merge unrelated histories",
           # "Untracked working tree file … would be overwritten by merge").
@@ -4523,6 +4525,54 @@ jobs:
           # even when we wrap it in an annotation below.
           if [ -s "${MERGE_STDERR_FILE}" ]; then
             sed 's/^/git merge stderr: /' "${MERGE_STDERR_FILE}"
+          fi
+          if grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${MERGE_STDERR_FILE}" 2>/dev/null; then
+            merge_promisor_fetch_failure_seen=true
+            merge_promisor_initial_stderr="$(tr '\n' ' ' < "${MERGE_STDERR_FILE}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
+            merge_promisor_initial_stderr="${merge_promisor_initial_stderr:-<git merge produced no stderr>}"
+          fi
+
+          # Blobless partial clone recovery (the codex-agent checkout uses
+          # `filter: blob:none`): the 3-way merge lazy-fetches blob content
+          # from the promisor remote, and that batched on-demand fetch fails
+          # hard (exit 128) when any single OID in the batch is unreachable
+          # server-side ("not our ref" / "could not fetch ... from promisor
+          # remote") — even though the merge itself is well-formed. On that
+          # signature, drop the partial filter, refetch the merge inputs so
+          # every blob is materialised locally, and retry the merge once.
+          # Without this the step misreads an infrastructure fetch failure as
+          # a merge outcome: it emits a hard ::error:: on an otherwise green
+          # run and sets MERGE_CONFLICT=true, firing the Codex resolver on a
+          # PR that may have no conflict at all — exactly the cascade this
+          # step's header comment warns about.
+          #
+          # Mirrors the pre-review merge-topology gate above and the merge
+          # replay in scripts/review_conflict_prepare.sh; the refspec list is
+          # rebuilt here rather than reusing _merge_base_refspecs, which is
+          # only defined inside the shallow-clone branch above and would be
+          # unset under `set -u` on a full clone.
+          if [ "${merge_exit}" -ne 0 ] && [ ! -f "$(git rev-parse --git-dir)/MERGE_HEAD" ] \
+             && [ "${merge_promisor_fetch_failure_seen}" = "true" ]; then
+            echo "::warning::Merge precheck hit a partial-clone promisor fetch failure; backfilling blobs and retrying the merge once."
+            git reset --hard HEAD >/dev/null 2>&1 || true
+            git config --unset-all remote.origin.partialclonefilter 2>/dev/null || true
+            _merge_backfill_refspecs=("refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}")
+            if [ -n "${TARGET_BRANCH:-}" ]; then
+              _merge_backfill_refspecs+=("refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}")
+            fi
+            _merge_refetch_rc=0
+            _merge_refetch_stderr="$(git fetch --no-tags --prune --refetch origin "${_merge_backfill_refspecs[@]}" 2>&1 >/dev/null)" || _merge_refetch_rc=$?
+            if [ "${_merge_refetch_rc}" -ne 0 ]; then
+              _merge_refetch_stderr="$(printf '%s' "${_merge_refetch_stderr}" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
+              _merge_refetch_stderr="${_merge_refetch_stderr:-<git fetch produced no stderr>}"
+              echo "::warning::blob-backfill refetch failed during merge precheck; retrying the merge anyway. git fetch stderr: ${_merge_refetch_stderr}"
+            fi
+            merge_exit=0
+            : > "${MERGE_STDERR_FILE}"
+            git merge --no-commit --no-ff "origin/${BASE_BRANCH}" 2> "${MERGE_STDERR_FILE}" || merge_exit=$?
+            if [ -s "${MERGE_STDERR_FILE}" ]; then
+              sed 's/^/git merge stderr (after blob backfill): /' "${MERGE_STDERR_FILE}"
+            fi
           fi
 
           # Restore the stashed dirs so later steps have them available.
@@ -4546,13 +4596,30 @@ jobs:
               # annotation (::error:: notations cannot span newlines).
               _merge_stderr_oneline="$(tr '\n' ' ' < "${MERGE_STDERR_FILE}" 2>/dev/null | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')"
               _merge_stderr_oneline="${_merge_stderr_oneline:-<git merge produced no stderr>}"
+              if [ "${merge_promisor_fetch_failure_seen}" = "true" ] && [ -n "${merge_promisor_initial_stderr}" ] \
+                 && [ "${merge_promisor_initial_stderr}" != "${_merge_stderr_oneline}" ]; then
+                _merge_stderr_oneline="${_merge_stderr_oneline} | initial promisor stderr: ${merge_promisor_initial_stderr}"
+              fi
               _merge_stderr_oneline="$(printf '%s' "${_merge_stderr_oneline}" | sed 's/%/%25/g; s/\r/%0D/g')"
               if grep -qi 'refusing to merge unrelated histories' "${MERGE_STDERR_FILE}" 2>/dev/null; then
                 _head_sha="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
                 _base_sha="$(git rev-parse --short "origin/${BASE_BRANCH}" 2>/dev/null || echo unknown)"
                 echo "::error::Merge precheck failed (exit ${merge_exit}): HEAD (${_head_sha}) and origin/${BASE_BRANCH} (${_base_sha}) have no common ancestor. This PR's branch was likely force-pushed to an orphan root, or ${BASE_BRANCH} was force-pushed since this branch diverged. Manual repair required: rebase the PR branch onto a current ${BASE_BRANCH} ancestor, or recreate the branch from ${BASE_BRANCH} and re-apply the changes. git stderr: ${_merge_stderr_oneline}"
               elif [ "${merge_exit}" -eq 128 ]; then
-                echo "::error::Merge precheck failed (exit 128): git merge aborted before entering merge state. See pre-merge diagnostics above. git stderr: ${_merge_stderr_oneline}"
+                if [ "${merge_promisor_fetch_failure_seen}" = "true" ] \
+                   || grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack' "${MERGE_STDERR_FILE}" 2>/dev/null; then
+                  # A partial-clone promisor fetch failure that survived the
+                  # blob-backfill retry above is an infrastructure error, not
+                  # a merge outcome. Downgrade to a ::warning:: so the run's
+                  # annotations stay honest, and fail OPEN into the resolver
+                  # path with MERGE_CONFLICT=true:
+                  # scripts/review_conflict_prepare.sh runs its own merge
+                  # replay with its own blob backfill and clears
+                  # MERGE_CONFLICT when that replay finds nothing to resolve.
+                  echo "::warning::Merge precheck: exit 128 from a partial-clone promisor fetch failure that survived the blob-backfill retry. Failing open to the conflict-resolver path, which re-runs the merge with its own backfill. git stderr: ${_merge_stderr_oneline}"
+                else
+                  echo "::error::Merge precheck failed (exit 128): git merge aborted before entering merge state. See pre-merge diagnostics above. git stderr: ${_merge_stderr_oneline}"
+                fi
               else
                 echo "::warning::git merge exited ${merge_exit} without entering merge state — treating as conflict. git stderr: ${_merge_stderr_oneline}"
               fi

--- a/changelog.d/3738-merge-precheck-promisor-recovery.md
+++ b/changelog.d/3738-merge-precheck-promisor-recovery.md
@@ -1,0 +1,18 @@
+<!-- changelog: fixed -->
+- **The AI review workflow no longer reports a partial-clone blob-fetch failure as a merge conflict.** `review_autofix.yml`'s `Detect merge conflicts` step now backfills blobs and retries the merge once on the promisor-fetch signature, and downgrades a surviving failure from a hard `::error::` to a `::warning::` fail-open.
+
+The `codex-agent` checkout uses `filter: blob:none`, so the merge precheck's 3-way merge lazy-fetches blob content from the promisor remote. That batched fetch fails hard with exit 128 when any single object in the batch is unreachable server-side, even though the merge itself is well-formed. The step had no recovery for it, so a green run still showed `::error::Merge precheck failed (exit 128)` in its annotations, and `MERGE_CONFLICT=true` came from an infrastructure failure rather than a merge outcome. In the three observed runs the conflicts happened to be real — `scripts/review_conflict_prepare.sh`'s replay found 3, 8, and 6 unmerged paths on the same inputs the precheck had just failed on — so the harm was a false red annotation on successful runs plus a latent path to invoking the Codex resolver on a PR with nothing to resolve. The two sibling merge probes, the pre-review merge-topology gate in the same workflow and that same replay in `review_conflict_prepare.sh`, already carried this recovery; the late precheck was the only one left without it.
+
+| The numbers that matter | Value |
+| --- | --- |
+| Merge probes with promisor recovery | 2 of 3 → 3 of 3 |
+| Merge retries on the promisor signature | 1 |
+| Exit-128 causes that keep the hard `::error::` | all except a surviving promisor fetch failure |
+| Consumer runs observed with the signature | 3 (`tele-funtoken-msg-scoring` 31303907566, 31305600310, 31312967313 — all concluded `success`) |
+| New contract tests | 7 in `tests/test_review_autofix_merge_precheck.py` |
+
+What this means for operators: a review run whose merge precheck trips over a lazy blob fetch now recovers silently instead of printing a red annotation on a successful run, and the Codex conflict resolver stops being invoked on infrastructure noise. Genuine exit-128 causes — untracked-file collisions, a corrupt index, unrelated histories — still fail loudly with the same annotations as before.
+
+### For contributors
+
+`MERGE_CONFLICT=true` is deliberately kept on the fail-open path: `scripts/review_conflict_prepare.sh` runs its own merge replay with its own blob backfill and clears the flag when that replay finds nothing to resolve, so the resolver step remains the single place that decides whether a conflict is real. The retry builds its own `_merge_backfill_refspecs` array rather than reusing `_merge_base_refspecs`, which is defined only inside the shallow-clone deepen branch and would be unset under `set -u` on a full clone.

--- a/tests/test_review_autofix_merge_precheck.py
+++ b/tests/test_review_autofix_merge_precheck.py
@@ -424,6 +424,42 @@ def test_initial_promisor_stderr_preserved_in_annotation():
     )
 
 
+def test_retry_exit_128_classifier_requires_retry_evidence():
+    """A retry-side exit 128 must not be downgraded just because the initial
+    probe saw the promisor signature; the retry must either repeat the
+    signature or emit no stderr at all."""
+    pre_review_step = _section(
+        "- name: Pre-review deterministic merge-topology gate",
+        "\n      - name: Run reviewer models",
+    )
+    detect_step = _detect_step()
+    for label, section in (
+        ("pre-review merge-topology gate", pre_review_step),
+        ("late detect-conflicts step", detect_step),
+    ):
+        classifier = section.split('elif [ "${merge_exit}" -eq 128 ]; then', 1)[1]
+        assert "merge_promisor_retry_stderr_matches=false" in section, (
+            f"Expected the {label} to track whether the retry itself still "
+            "matched the promisor signature"
+        )
+        assert "merge_promisor_retry_stderr_matches=true" in section, (
+            f"Expected the {label} to record a promisor-signature match from "
+            "the retry stderr"
+        )
+        assert '[ "${merge_promisor_retry_stderr_matches}" = "true" ]' in classifier, (
+            f"Expected the {label} exit-128 classifier to key off the retry's "
+            "own promisor signature"
+        )
+        assert '[ "${_merge_stderr_oneline}" = "<git merge produced no stderr>" ]' in classifier, (
+            f"Expected the {label} to fall back to the initial promisor signal "
+            "only when the retry produced no stderr"
+        )
+        assert '|| grep -qiE \'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack\'' not in classifier, (
+            f"The {label} must not treat the initial promisor flag alone as "
+            "enough to downgrade an unrelated retry-side exit 128"
+        )
+
+
 def test_all_merge_probes_share_the_promisor_recovery():
     """Both merge probes in review_autofix.yml must carry the recovery — a probe
     without it misreads a lazy-fetch failure as a merge outcome."""

--- a/tests/test_review_autofix_merge_precheck.py
+++ b/tests/test_review_autofix_merge_precheck.py
@@ -286,3 +286,163 @@ def test_merge_conflict_env_var_set_on_exit_128():
         "Expected 'MERGE_CONFLICT=true' to be written to GITHUB_ENV after the "
         "exit-128 error annotation"
     )
+
+
+# ---------------------------------------------------------------------------
+# Fix 5: blobless partial-clone promisor-fetch recovery in the late detect step
+#
+# The codex-agent checkout uses `filter: blob:none`, so the 3-way merge
+# lazy-fetches blobs from the promisor remote and can fail with exit 128 on a
+# "not our ref" / "could not fetch ... from promisor remote" signature even
+# when the merge itself is well-formed.  The pre-review merge-topology gate and
+# scripts/review_conflict_prepare.sh already backfill and retry on that
+# signature; the late detect step must do the same, and must not report an
+# infrastructure failure as a hard ::error:: merge outcome.
+# ---------------------------------------------------------------------------
+
+PROMISOR_SIGNATURE_GREP = (
+    "grep -qiE 'promisor remote|not our ref|could not fetch|fetch-pack|"
+    "remote error: upload-pack'"
+)
+
+
+def _detect_step() -> str:
+    return _section(
+        "- name: Detect merge conflicts",
+        "\n      - name: Prepare merge-conflict resolver prompt and pre-snapshot",
+    )
+
+
+def test_detect_step_detects_promisor_fetch_failure_signature():
+    """The late detect step must classify the promisor-fetch stderr signature
+    instead of treating it as an ordinary merge failure."""
+    step = _detect_step()
+    assert "merge_promisor_fetch_failure_seen=false" in step, (
+        "Expected the detect step to initialise merge_promisor_fetch_failure_seen "
+        "before the merge probe"
+    )
+    assert PROMISOR_SIGNATURE_GREP in step, (
+        "Expected the detect step to grep git merge stderr for the partial-clone "
+        "promisor fetch failure signature"
+    )
+
+
+def test_detect_step_backfills_blobs_and_retries_merge_once():
+    """On the promisor signature the detect step must drop the partial filter,
+    refetch the merge inputs, and retry the merge exactly once."""
+    step = _detect_step()
+    assert "git config --unset-all remote.origin.partialclonefilter" in step, (
+        "Expected the detect step to unset remote.origin.partialclonefilter "
+        "before refetching blobs"
+    )
+    assert "git fetch --no-tags --prune --refetch origin" in step, (
+        "Expected the detect step to run a --refetch blob backfill"
+    )
+    # Exactly two merge invocations: the initial probe and the single retry.
+    merge_cmd = 'git merge --no-commit --no-ff "origin/${BASE_BRANCH}"'
+    assert step.count(merge_cmd) == 2, (
+        "Expected exactly two git merge invocations in the detect step (initial "
+        f"probe + one blob-backfill retry), found {step.count(merge_cmd)}"
+    )
+    assert "git merge stderr (after blob backfill): " in step, (
+        "Expected the retry to label its stderr so the two probes are "
+        "distinguishable in the raw CI log"
+    )
+
+
+def test_detect_step_backfill_refspecs_defined_outside_shallow_branch():
+    """The backfill refspec array must be built inside the recovery block, not
+    reused from the shallow-clone deepen path — `_merge_base_refspecs` is only
+    defined when .git/shallow exists and would be unset under `set -u`."""
+    step = _detect_step()
+    array_init = '_merge_backfill_refspecs=("refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}")'
+    assert array_init in step, (
+        "Expected the recovery block to build its own _merge_backfill_refspecs array"
+    )
+    assert '"${_merge_backfill_refspecs[@]}"' in step, (
+        "Expected the --refetch call to expand _merge_backfill_refspecs"
+    )
+    assert '"${_merge_base_refspecs[@]}"' not in step.split(array_init)[1], (
+        "The blob-backfill refetch must not reuse the shallow-only "
+        "_merge_base_refspecs array"
+    )
+
+
+def test_surviving_promisor_failure_downgraded_to_warning():
+    """A promisor fetch failure that survives the retry is infrastructure, not a
+    merge outcome: it must produce a ::warning:: fail-open, while every other
+    exit-128 cause keeps its hard ::error::."""
+    step = _detect_step()
+    warning = "::warning::Merge precheck: exit 128 from a partial-clone promisor fetch failure"
+    error = "::error::Merge precheck failed (exit 128)"
+    warn_pos = step.find(warning)
+    err_pos = step.find(error)
+    assert warn_pos != -1, (
+        "Expected a ::warning:: fail-open for a promisor fetch failure surviving "
+        "the blob-backfill retry"
+    )
+    assert err_pos != -1, (
+        "The hard ::error:: must be preserved for non-promisor exit-128 causes"
+    )
+    # The warning is the guarded branch; the error is its else.
+    assert warn_pos < err_pos, (
+        "Expected the promisor ::warning:: branch to be evaluated before falling "
+        "back to the generic exit-128 ::error::"
+    )
+    assert step.count(PROMISOR_SIGNATURE_GREP) >= 2, (
+        "Expected the exit-128 classifier to re-check the promisor signature in "
+        "addition to the post-merge detection"
+    )
+
+
+def test_surviving_promisor_failure_still_sets_merge_conflict_true():
+    """Fail-open here means handing the run to the conflict resolver, which runs
+    its own merge replay with its own backfill and clears MERGE_CONFLICT when
+    that replay finds nothing to resolve — so MERGE_CONFLICT must stay true."""
+    step = _detect_step()
+    warn_pos = step.find(
+        "::warning::Merge precheck: exit 128 from a partial-clone promisor fetch failure"
+    )
+    assert warn_pos != -1, "promisor fail-open warning not found"
+    conflict_pos = step.find('echo "MERGE_CONFLICT=true" >> "$GITHUB_ENV"', warn_pos)
+    assert conflict_pos != -1, (
+        "Expected MERGE_CONFLICT=true to still be written after the promisor "
+        "fail-open warning so scripts/review_conflict_prepare.sh gets the run"
+    )
+
+
+def test_initial_promisor_stderr_preserved_in_annotation():
+    """After a retry the second probe's stderr may not carry the signature, so
+    the original promisor stderr must be appended to the annotation."""
+    step = _detect_step()
+    assert 'merge_promisor_initial_stderr=""' in step, (
+        "Expected the detect step to initialise merge_promisor_initial_stderr"
+    )
+    assert "| initial promisor stderr: ${merge_promisor_initial_stderr}" in step, (
+        "Expected the annotation to append the initial promisor stderr when the "
+        "retry produced a different message"
+    )
+
+
+def test_all_merge_probes_share_the_promisor_recovery():
+    """Both merge probes in review_autofix.yml must carry the recovery — a probe
+    without it misreads a lazy-fetch failure as a merge outcome."""
+    wf = _workflow()
+    pre_review_step = _section(
+        "- name: Pre-review deterministic merge-topology gate",
+        "\n      - name: Run reviewer models",
+    )
+    detect_step = _detect_step()
+    for label, section in (
+        ("pre-review merge-topology gate", pre_review_step),
+        ("late detect-conflicts step", detect_step),
+    ):
+        assert "git config --unset-all remote.origin.partialclonefilter" in section, (
+            f"Expected the {label} to carry the partial-clone promisor recovery"
+        )
+    # No third, unguarded probe has crept in elsewhere in the workflow.
+    assert wf.count('git merge --no-commit --no-ff "origin/${BASE_BRANCH}"') == 4, (
+        "Expected exactly four merge invocations in review_autofix.yml (initial "
+        "probe + backfill retry, in each of the two merge-performing steps). A "
+        "new probe must carry the promisor recovery too."
+    )

--- a/tests/test_review_autofix_merge_precheck.py
+++ b/tests/test_review_autofix_merge_precheck.py
@@ -438,6 +438,11 @@ def test_retry_exit_128_classifier_requires_retry_evidence():
         ("late detect-conflicts step", detect_step),
     ):
         classifier = section.split('elif [ "${merge_exit}" -eq 128 ]; then', 1)[1]
+        classifier_copy = '_merge_classifier_stderr_oneline="${_merge_stderr_oneline}"'
+        append_line = (
+            '_merge_stderr_oneline="${_merge_stderr_oneline} | initial promisor '
+            'stderr: ${merge_promisor_initial_stderr}"'
+        )
         assert "merge_promisor_retry_stderr_matches=false" in section, (
             f"Expected the {label} to track whether the retry itself still "
             "matched the promisor signature"
@@ -446,13 +451,25 @@ def test_retry_exit_128_classifier_requires_retry_evidence():
             f"Expected the {label} to record a promisor-signature match from "
             "the retry stderr"
         )
+        assert classifier_copy in section, (
+            f"Expected the {label} to snapshot the retry stderr before "
+            "appending the initial promisor stderr"
+        )
+        assert section.find(classifier_copy) < section.find(append_line), (
+            f"Expected the {label} to preserve an unmutated retry-stderr copy "
+            "for the exit-128 classifier"
+        )
         assert '[ "${merge_promisor_retry_stderr_matches}" = "true" ]' in classifier, (
             f"Expected the {label} exit-128 classifier to key off the retry's "
             "own promisor signature"
         )
-        assert '[ "${_merge_stderr_oneline}" = "<git merge produced no stderr>" ]' in classifier, (
+        assert '[ "${_merge_classifier_stderr_oneline}" = "<git merge produced no stderr>" ]' in classifier, (
             f"Expected the {label} to fall back to the initial promisor signal "
             "only when the retry produced no stderr"
+        )
+        assert '[ "${_merge_stderr_oneline}" = "<git merge produced no stderr>" ]' not in classifier, (
+            f"Expected the {label} classifier to avoid comparing against the "
+            "mutated annotation string"
         )
         assert '|| grep -qiE \'promisor remote|not our ref|could not fetch|fetch-pack|remote error: upload-pack\'' not in classifier, (
             f"The {label} must not treat the initial promisor flag alone as "


### PR DESCRIPTION
## What this fixes

The `Detect merge conflicts` step in `.github/workflows/review_autofix.yml` ran its `git merge --no-commit --no-ff "origin/${BASE_BRANCH}"` probe with **no blobless-partial-clone recovery**, unlike the two other merge probes in the same flow:

| Merge probe | Promisor recovery before this PR |
| --- | --- |
| Pre-review merge-topology gate (`review_autofix.yml`) | yes |
| Merge replay (`scripts/review_conflict_prepare.sh`) | yes |
| `Detect merge conflicts` (`review_autofix.yml`) | **no** |

The `codex-agent` checkout uses `filter: blob:none`, so the 3-way merge lazy-fetches blob content from the promisor remote. That batched on-demand fetch fails hard with exit 128 when any single OID in the batch is unreachable server-side, even though the merge itself is well-formed. The step then emitted a hard `::error::Merge precheck failed (exit 128)` on a run that concluded `success`, and set `MERGE_CONFLICT=true` from an infrastructure failure rather than a merge outcome — the exact cascade the step's own header comment warns about.

## Evidence

All three reported runs in `shubhodeep1/tele-funtoken-msg-scoring` were verified from their raw logs. Each concluded `success` and each referenced `coding-workflows/.github/workflows/review_autofix.yml@stable` at `830c8e9c` — the annotated tag object for `refs/heads/stable` at `f1667f4`, so the report's SHA and this PR's base are the same tree.

| Run | Precheck annotation | Resolver replay on the same inputs |
| --- | --- | --- |
| `31303907566` | `##[error]Merge precheck failed (exit 128) … not our ref f35ee68f … could not fetch 25238192 from promisor remote` | `git merge exit=1`, 3 unmerged paths |
| `31305600310` | same signature, `not our ref 544f956f` | `git merge exit=1`, 8 unmerged paths |
| `31312967313` | same signature, `not our ref eaf89854` | `git merge exit=1`, 6 unmerged paths |

The step immediately after the failing precheck — `review_conflict_prepare.sh`'s merge replay, which *does* carry the recovery — merged the same inputs successfully every time. The failure was in the probe, not the merge.

In these three runs the conflicts happened to be real, so the observed harm was a red `::error::` on green runs. The latent hazard is the other direction: `MERGE_CONFLICT=true` derived from a fetch failure would invoke the Codex resolver on a PR with nothing to resolve.

## The change

`.github/workflows/review_autofix.yml`

- **Detection** (after the merge probe): set `merge_promisor_fetch_failure_seen` / `merge_promisor_initial_stderr` on the `not our ref` / `could not fetch … from promisor remote` signature, using the same grep as the two sibling call sites.
- **Backfill and retry once**: unset `remote.origin.partialclonefilter`, `git fetch --no-tags --prune --refetch` the merge inputs, re-run the merge exactly once, and label the retry's stderr so the two probes stay distinguishable in the raw log.
- **Exit-128 classification**: a promisor failure that survives the retry is downgraded from `::error::` to a `::warning::` fail-open, matching the pre-review gate's wording. `MERGE_CONFLICT=true` is kept so `scripts/review_conflict_prepare.sh` receives the run and clears it after its own replay finds nothing to resolve. Every other exit-128 cause — untracked-file collision, corrupt index, unrelated histories — keeps its hard `::error::` unchanged.
- The retry's refspec array is built locally as `_merge_backfill_refspecs` rather than reusing `_merge_base_refspecs`, which is only defined inside the shallow-clone deepen branch and would be unset under `set -u` on a full clone.

`tests/test_review_autofix_merge_precheck.py` — seven new contract tests covering signature detection, the single-retry backfill, the refspec-scoping bug above, the warning/error split, `MERGE_CONFLICT=true` on fail-open, initial-stderr preservation, and a guard that no third unguarded merge probe creeps in.

`changelog.d/3738-merge-precheck-promisor-recovery.md` — §20 fragment; the change alters an observable failure mode.

## Verification

- `python3 -m pytest tests/test_review_autofix_merge_precheck.py` — 21 passed (14 pre-existing + 7 new).
- All 7 new tests fail against the pre-fix workflow at `origin/stable` and pass after, so none is vacuous.
- The workflow parses (`yaml.safe_load`) and the modified step body parses under `bash -n`.
- Functional simulation of the step's control flow with a stubbed `git` across six scenarios:

| Scenario | Result |
| --- | --- |
| Promisor failure, retry merges clean | one retry warning, no error, `MERGE_CONFLICT` unset |
| Promisor failure, retry finds real conflicts | normal conflict path |
| Promisor failure survives retry | `::warning::` fail-open, `MERGE_CONFLICT=true` |
| Promisor failure + refetch itself fails | extra warning, still fails open |
| Exit 128 from untracked-file collision | hard `::error::` preserved, no retry |
| Exit 128 from unrelated histories | dedicated `::error::` preserved, no retry |

## Compatibility

No identifier renamed or removed (§6); the new names (`merge_promisor_fetch_failure_seen`, `merge_promisor_initial_stderr`, `_merge_backfill_refspecs`, `_merge_refetch_rc`, `_merge_refetch_stderr`) were checked for collisions within the step's scope. No DB or contract surface touched (§10). The `MERGE_CONFLICT` contract is unchanged in both directions. Cross-consumer blast radius is a strict improvement: the recovery only fires on a signature that previously produced a guaranteed hard failure.

## Note for reviewers

`tests/test_review_autofix_merge_precheck.py` is not currently invoked by any workflow — it is one of ~48 of the 190 files in `tests/` that no CI step names. That is pre-existing and out of scope here; wiring it up would need pytest in `ci.yml`, which is a separate change. The new tests were run locally as described above.

## Target ref

Opened against `stable`, the ref consumers pin and the ref the failing runs executed. `mark-stable.yml` cuts the release tag from the `stable` branch, so this reaches consumers on the next release. The same gap exists on `main` at the identical line; `forward-merge-stable-to-main.yml` (triggered on push to `stable`) should carry this over, but if that forward-merge does not land, the next `main → stable` promotion will silently revert this fix — worth confirming after merge.