### PR TITLE
Add CLAUDE.md §22: DigitalOcean access via DIGITALOCEAN_ACCESS_TOKEN

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,8 @@ These instructions are mandatory and must be followed before any action.
 
 Before any task, read:
 - `README.md`
-- `agents.md`
+- `agents.md` (or `AGENTS.md` — whichever casing the repo root has; same file,
+  read it every session)
 - all `/db/contracts/*.yml` (or `.json`) relevant to collections that may be touched
 
 If any are missing or unclear: **STOP and ask using the mandatory Q/A format.**
@@ -900,6 +901,97 @@ exactly the long-running web sessions §21 exists to protect. `gh pr list`
 remains wired as a transport fallback for environments where REST is gated
 instead. The fallback is a retry of the same question on a different
 transport, never a second query.
+
+---
+
+## §22. DigitalOcean Access (MANDATORY)
+
+The session environment provides a `DIGITALOCEAN_ACCESS_TOKEN` env var — a
+DigitalOcean API token. This section applies in this repo and in every
+consumer repo that receives this file via the `@stable` sync. It splits
+DigitalOcean operations into two postures: **reads are self-serve** (act,
+do not ask), **mutations are ask-first** (always confirm before acting).
+
+### A) Read Operations — Act, Do Not Ask
+
+When a task needs data from DigitalOcean, pull it yourself with the token
+instead of asking the user to fetch it or to run commands on your behalf.
+This is an explicit carve-out from §2 for **read-only** DigitalOcean calls —
+needing DO-hosted data is not, by itself, a reason to stop and ask.
+Self-serve reads include (non-exhaustively):
+
+- listing and inspecting Apps, Droplets, managed databases, volumes, and
+  load balancers, and their specs/configuration;
+- reading deployed app-level env vars to verify that a name or value
+  matches what the code and docs expect;
+- fetching build, deploy, and runtime logs to diagnose failures;
+- checking deployment status, alert policies, and monitoring/metrics data.
+
+Transport: prefer `doctl` when installed (it honours the
+`DIGITALOCEAN_ACCESS_TOKEN` env var natively); otherwise call the REST API
+directly:
+
+```
+curl -sS -H "Authorization: Bearer ${DIGITALOCEAN_ACCESS_TOKEN}" \
+  "https://api.digitalocean.com/v2/<endpoint>"
+```
+
+Token hygiene (hard rules):
+- Never echo, log, or print the token value; reference it only via env
+  expansion (`$DIGITALOCEAN_ACCESS_TOKEN`).
+- Never write the token into committed files, PR bodies, issue comments,
+  or diagnostic output. Redact it if a tool response contains it.
+- If the token is missing or the API returns 401/403, report that to the
+  user and continue with what can be done without it — do not retry-loop
+  and do not ask the user to run the API calls manually.
+
+### B) Provisioning & Mutations — ALWAYS Ask First
+
+**Never create, modify, resize, or destroy DigitalOcean resources without
+asking first** in the §2 Q/A format — even when the need seems obvious,
+and even under §12's proactive PR-review scope (this subsection is NOT
+superseded by §12). Ask-first operations include (non-exhaustively):
+
+- spinning up new Droplets, Apps, managed databases, volumes, load
+  balancers, or any other billable resource;
+- resizing, scaling, or migrating existing resources;
+- destroying or powering off resources;
+- changing a deployed app's spec or env vars, forcing rebuilds/redeploys,
+  restoring from backups, or rotating credentials.
+
+The question must name the exact resource type, size/plan, region, and
+estimated billing impact where known, so the user approves a concrete
+action rather than an intention. After approval, perform the operation
+yourself with the token — do not hand the user a command to run (§18).
+
+### C) Resource IDs Live in the Agents File
+
+Each repo's root agents file (`agents.md` in this repo; `AGENTS.md` in
+consumer repos that use that casing) carries a `## DigitalOcean resources`
+section listing the App / database / Droplet IDs relevant to that repo,
+as a table:
+
+```md
+## DigitalOcean resources
+
+| Resource | Type | ID | Notes |
+|---|---|---|---|
+| <name> | app / db / droplet / ... | <id> | <role, environment> |
+```
+
+Rules:
+- **Look there first.** Before asking for any DigitalOcean resource ID,
+  read the repo's agents file. Use recorded IDs without re-asking.
+- **Ask when missing.** If a needed ID is not recorded, ask the user for
+  it (§2 Q/A format, free-text answer allowed for the ID itself).
+- **Save once provided.** After the user supplies an ID, verify it
+  resolves with one read API call (§22.A), then add it to the
+  `## DigitalOcean resources` section of the agents file **in the same
+  PR/commit as the work that needed it**, so it is never asked for again.
+  Create the section if the file lacks it.
+- IDs are identifiers under §6 — never remove or rewrite an existing
+  entry without the §2 ask flow; correcting a stale ID requires telling
+  the user what changed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ In your consumer repository, go to **Settings → Secrets and variables → Acti
 | `GH_PAT` | **Yes** | All workflows | GitHub Personal Access Token with `repo` scope |
 | `OPENROUTER_API_KEY` | **Yes** | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, orchestrate_clarify_respond, validate, memory_maintenance, security-audit (source repo only) | [OpenRouter](https://openrouter.ai) API key for LLM access and AI memory keyword extraction |
 | `TG_BOT_SECRET` | No | clarify, plan, implement, review_autofix, orchestrate, orchestrate_poll, orchestrate_clarify_respond, validate, issue_pr_status | Telegram bot token for notifications and message cleanup |
+| `DIGITALOCEAN_ACCESS_TOKEN` | No | Interactive Claude Code sessions only (CLAUDE.md §22) — no Actions workflow reads it | DigitalOcean API token. Set as an env var in the Claude Code session environment (not required as an Actions secret). Lets interactive sessions pull DigitalOcean data (app specs, deployed env vars, logs, deployment status) self-serve for verification and debugging; provisioning or mutating resources always requires asking the user first. Resource IDs per repo live in the `## DigitalOcean resources` section of `agents.md`/`AGENTS.md`. |
 
 #### Variables
 

--- a/agents.md
+++ b/agents.md
@@ -618,6 +618,20 @@ into poller reconciliation.
 
 ---
 
+## DigitalOcean resources
+
+Registry of DigitalOcean resource IDs relevant to this repo, per CLAUDE.md
+§22.C. Interactive Claude Code sessions read IDs from this table instead of
+asking the user; when a needed ID is missing, the session asks once and then
+records it here in the same PR/commit. Consumer repos carry the same section
+in their root `AGENTS.md`.
+
+| Resource | Type | ID | Notes |
+|---|---|---|---|
+
+_None recorded yet — this repo is workflow tooling and currently has no
+DigitalOcean-hosted app or database of its own._
+
 ## Reference
 
 Operator runbooks (env var reference, autofix retrigger/dedup internals,

--- a/changelog.d/digitalocean-token-access.md
+++ b/changelog.d/digitalocean-token-access.md
@@ -1,0 +1,17 @@
+<!-- changelog: added -->
+- **Interactive Claude Code sessions can now query DigitalOcean directly via `DIGITALOCEAN_ACCESS_TOKEN`, instead of asking the operator to fetch data by hand.** A new CLAUDE.md §22 splits DigitalOcean work into self-serve reads and ask-first mutations, and reaches every consumer repo through the existing root `CLAUDE.md` sync.
+
+Sessions previously had no standing policy for DigitalOcean, so any question about a deployed app's env vars, logs, or deployment status bounced back to the operator. §22.A makes read-only calls (app specs, deployed env vars, build/deploy/runtime logs, deployment status, metrics) an explicit carve-out from the §2 ask-first rule: the session pulls the data itself, via `doctl` or the REST API with the `DIGITALOCEAN_ACCESS_TOKEN` env var. §22.B keeps provisioning and every other mutation (creating, resizing, destroying, redeploying, spec or env var changes) behind a mandatory §2 Q/A confirmation that names the resource type, size, region, and billing impact — not superseded by §12's proactive scope. §22.C adds a per-repo `## DigitalOcean resources` registry to the root agents file (`agents.md` here, `AGENTS.md` in consumer repos): sessions read app/db IDs from the table first, ask once when an ID is missing, and record it in the same PR so it is never asked for again. The pre-task context-loading rule now names both `agents.md` and `AGENTS.md` casings so the every-session read applies in every repo.
+
+| The numbers that matter | Value |
+| --- | --- |
+| New `CLAUDE.md` section | §22 |
+| New env var | `DIGITALOCEAN_ACCESS_TOKEN` (session environment, not an Actions secret) |
+| Actions workflows that read the token | 0 |
+| New `agents.md` section | `## DigitalOcean resources` (ID registry) |
+
+What this means for operators: set `DIGITALOCEAN_ACCESS_TOKEN` in the Claude Code session environment of any repo where sessions should verify DigitalOcean state themselves; nothing else to install. The §22 rules and the registry convention arrive in consumer repos on the next `@stable` sync via the root `CLAUDE.md` mirror in `update_workflows.yml`. Sessions never print the token, and a missing or expired token degrades to "report and continue" rather than a retry loop.
+
+### For contributors
+
+The unattended pipelines read `unattended_system_instructions.md` and never see `CLAUDE.md`, so §22 governs interactive sessions only — no codex-driven phase gains DigitalOcean access from this change. Registry entries are identifiers under §6: correcting or removing a recorded ID goes through the §2 ask flow.


### PR DESCRIPTION
## Summary

Interactive Claude Code sessions now have a standing policy for DigitalOcean, keyed on the `DIGITALOCEAN_ACCESS_TOKEN` session env var. A new **CLAUDE.md §22** splits DigitalOcean work into two postures:

- **§22.A Reads are self-serve** — sessions pull data themselves (app specs, deployed env vars, build/deploy/runtime logs, deployment status, metrics) via `doctl` or the REST API, instead of asking the operator to fetch it. This is an explicit carve-out from the §2 ask-first rule for read-only calls, with token-hygiene hard rules (never print/commit the token; 401 degrades to report-and-continue, no retry loops).
- **§22.B Mutations are ask-first** — spinning up, resizing, destroying, redeploying, or changing specs/env vars of any DigitalOcean resource always requires a §2 Q/A confirmation naming resource type, size/plan, region, and billing impact. Not superseded by §12's proactive scope.
- **§22.C Resource-ID registry** — each repo's root agents file (`agents.md` here, `AGENTS.md` in consumer repos) carries a `## DigitalOcean resources` table of App/DB/Droplet IDs. Sessions read IDs from the table first, ask once when one is missing, verify it resolves, and record it in the same PR so it is never asked for again. Registry entries are §6-covered identifiers.

Because `workflow-templates/CLAUDE.md` is a symlink to the root `CLAUDE.md` and `update_workflows.yml` mirrors that file into every consumer repo's root, these rules reach all consumer repos on the next `@stable` sync with no additional wiring.

## Changes

- `CLAUDE.md` — new §22 (inserted before FINAL REMINDER; no existing section renumbered, per §6). Also updated the PRE-TASK MANDATORY CONTEXT LOADING list so the every-session agents-file read names both `agents.md` and `AGENTS.md` casings.
- `agents.md` — new `## DigitalOcean resources` registry section with the table format and an empty placeholder (this repo currently has no DO-hosted app/db of its own).
- `README.md` — documented `DIGITALOCEAN_ACCESS_TOKEN` in the secrets table, marked as read by interactive sessions only (no Actions workflow reads it; it is not required as an Actions secret).
- `changelog.d/digitalocean-token-access.md` — changelog fragment per §20.

## Notes

- Unattended pipelines read `unattended_system_instructions.md` and never see `CLAUDE.md`, so no codex-driven phase gains DigitalOcean access from this change.
- No code or workflow behavior changes — documentation/policy only.

---
_Generated by [Claude Code](https://claude.ai/code/session_019n45ZJNVxYysngQkbeuXpy)_