### PR TITLE
fix: namespace reviewer attempt prompt copies per slot to stop the empty-stdin race

### DIFF
--- a/changelog.d/review-autofix-per-slot-attempt-prompts.md
+++ b/changelog.d/review-autofix-per-slot-attempt-prompts.md
@@ -1,0 +1,17 @@
+<!-- changelog: fixed -->
+- **review_autofix no longer loses a whole reviewer pass to the shared attempt-prompt race.** Each reviewer slot now copies the pass prompt to its own per-slot attempt file, and an empty effective prompt is restored (or loudly flagged) before codex launches.
+
+In `scripts/review_run_reviewers.sh`, every concurrent reviewer worker used to derive the same `<pass prompt>.attempt_1` path whenever no model-family overlay existed, then `cp`-truncate, nag-append, and sanitize-rewrite that one file while codex read it as stdin. One bad interleaving left the file empty, every reviewer failed non-retryably with `No prompt provided via stdin`, and the review_autofix job failed with "All reviewers failed" even though the assembled pass prompt was intact. Observed on consumer run tele-funtoken-msg-scoring `actions/runs/32222803753` (PR #3721, pass 2: 6 of 6 reviewers failed ~1.5s after launch). The attempt path now embeds the per-slot `safe_name`, and a pre-launch guard restores an unexpectedly empty effective prompt from the base prompt with a `::warning::` instead of failing the slot silently.
+
+| The numbers that matter | Value |
+| --- | --- |
+| Affected script | `scripts/review_run_reviewers.sh` |
+| Failure signature | `No prompt provided via stdin` on every slot of one pass |
+| Local race repro (shared path) | 41 of 1200 reads empty |
+| Local race repro (per-slot path) | 0 of 1200 reads empty |
+
+What this means for operators: a review_autofix run can no longer fail an entire reviewer pass because parallel reviewer slots raced on one temp prompt file; a Telegram "PR autofix failed" alert from this signature should not recur, and any residual empty-prompt condition now shows up as an explicit `::warning::` in the job log.
+
+### For contributors
+
+`tests/test_review_reviewer_attempt_prompt_isolation.py` pins both halves: the attempt path must embed `${safe_name}`, and the empty-prompt guard must precede the codex launch redirect. `${safe_name}` is `run_reviewer`'s local, visible inside `execute_reviewer_attempt` via bash dynamic scoping (sole call site), matching the existing pattern in `emit_reviewer_substate`.

--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -3636,7 +3636,17 @@ execute_reviewer_attempt() {
   fi
 
   emit_reviewer_substate "BuildingPrompt" "${attempt_number}"
-  reviewer_attempt_prompt_file="${prompt_file}.attempt_${attempt_number}"
+  # The attempt copy MUST be namespaced per reviewer slot. When no
+  # model-family overlay exists, prepare_reviewer_prompt_for_model returns
+  # the SHARED pass prompt file for every slot, and all reviewer workers run
+  # concurrently — a shared "<prompt>.attempt_N" path is then cp-truncated,
+  # nag-appended, and sanitize-rewritten by all of them at once while codex
+  # reads it as stdin. One bad interleaving leaves the file empty and every
+  # reviewer fails with "No prompt provided via stdin" (consumer run
+  # tele-funtoken-msg-scoring/actions/runs/32222803753, pass 2: 6/6 failed).
+  # ${safe_name} is run_reviewer's local, visible here via bash dynamic
+  # scoping (sole call site), same as the existing use at emit_reviewer_substate.
+  reviewer_attempt_prompt_file="${prompt_file}.${safe_name:-reviewer}.attempt_${attempt_number}"
   if cp "${prompt_file}" "${reviewer_attempt_prompt_file}" 2>/dev/null; then
     reviewer_effective_prompt_file="${reviewer_attempt_prompt_file}"
     # Prompt assembly happens before the current reviewer turn runs, so feed
@@ -3736,6 +3746,18 @@ execute_reviewer_attempt() {
 
   if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
     sanitize_codex_prompt_file "${reviewer_effective_prompt_file}"
+  fi
+  # Last-line-of-defence for the empty-stdin failure mode: codex exits
+  # non-retryably on empty stdin ("No prompt provided via stdin"), so an
+  # unexpectedly empty effective prompt must be restored (or at least
+  # surfaced loudly) before launch instead of silently failing the slot.
+  if [ ! -s "${reviewer_effective_prompt_file}" ]; then
+    if [ "${reviewer_effective_prompt_file}" != "${prompt_file}" ] && [ -s "${prompt_file}" ] \
+      && cp "${prompt_file}" "${reviewer_effective_prompt_file}" 2>/dev/null; then
+      echo "::warning::Reviewer slot ${slot_model} (${effective_model}) effective prompt file was empty before launch on ${attempt_label}; restored it from the base prompt." | tee -a "${log_file}" >&2
+    else
+      echo "::warning::Reviewer slot ${slot_model} (${effective_model}) effective prompt file is empty before launch on ${attempt_label} and could not be restored; codex will fail this slot with empty stdin." | tee -a "${log_file}" >&2
+    fi
   fi
   emit_reviewer_substate "LaunchingAgentProcess" "${attempt_number}"
   emit_reviewer_substate "InitializingSession" "${attempt_number}"

--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -3602,6 +3602,8 @@ execute_reviewer_attempt() {
   local reviewer_attempt_prompt_file=""
   local reviewer_effective_prompt_file="${prompt_file}"
   local reviewer_nag_block=""
+  local reviewer_base_prompt_bytes=0
+  local reviewer_effective_prompt_bytes=0
 
   REVIEWER_ATTEMPT_OUTCOME="failed"
   REVIEWER_ATTEMPT_RETRYABLE_CLASS=""
@@ -3646,7 +3648,9 @@ execute_reviewer_attempt() {
   # tele-funtoken-msg-scoring/actions/runs/32222803753, pass 2: 6/6 failed).
   # ${safe_name} is run_reviewer's local, visible here via bash dynamic
   # scoping (sole call site), same as the existing use at emit_reviewer_substate.
-  reviewer_attempt_prompt_file="${prompt_file}.${safe_name:-reviewer}.attempt_${attempt_number}"
+  # BASHPID keeps the fallback path unique if a future caller ever leaves
+  # safe_name empty or maps two slots to the same filesystem-safe name.
+  reviewer_attempt_prompt_file="${prompt_file}.${safe_name:-reviewer}_${BASHPID:-$$}.attempt_${attempt_number}"
   if cp "${prompt_file}" "${reviewer_attempt_prompt_file}" 2>/dev/null; then
     reviewer_effective_prompt_file="${reviewer_attempt_prompt_file}"
     # Prompt assembly happens before the current reviewer turn runs, so feed
@@ -3744,6 +3748,8 @@ execute_reviewer_attempt() {
   ) &
   wd_pid=$!
 
+  reviewer_base_prompt_bytes="$(wc -c < "${prompt_file}" 2>/dev/null | tr -d '[:space:]')"
+  reviewer_base_prompt_bytes="${reviewer_base_prompt_bytes:-0}"
   if command -v sanitize_codex_prompt_file >/dev/null 2>&1; then
     sanitize_codex_prompt_file "${reviewer_effective_prompt_file}"
   fi
@@ -3754,9 +3760,19 @@ execute_reviewer_attempt() {
   if [ ! -s "${reviewer_effective_prompt_file}" ]; then
     if [ "${reviewer_effective_prompt_file}" != "${prompt_file}" ] && [ -s "${prompt_file}" ] \
       && cp "${prompt_file}" "${reviewer_effective_prompt_file}" 2>/dev/null; then
-      echo "::warning::Reviewer slot ${slot_model} (${effective_model}) effective prompt file was empty before launch on ${attempt_label}; restored it from the base prompt." | tee -a "${log_file}" >&2
+      echo "::warning::Reviewer slot ${slot_model} (${effective_model}, safe_name=${safe_name:-unset}) effective prompt file was empty before launch on ${attempt_label}; restored it from the base prompt." | tee -a "${log_file}" >&2
     else
-      echo "::warning::Reviewer slot ${slot_model} (${effective_model}) effective prompt file is empty before launch on ${attempt_label} and could not be restored; codex will fail this slot with empty stdin." | tee -a "${log_file}" >&2
+      echo "::warning::Reviewer slot ${slot_model} (${effective_model}, safe_name=${safe_name:-unset}) effective prompt file is empty before launch on ${attempt_label} and could not be restored; codex will fail this slot with empty stdin." | tee -a "${log_file}" >&2
+    fi
+  elif [ "${reviewer_effective_prompt_file}" != "${prompt_file}" ] && [ "${reviewer_base_prompt_bytes}" -gt 0 ] 2>/dev/null; then
+    reviewer_effective_prompt_bytes="$(wc -c < "${reviewer_effective_prompt_file}" 2>/dev/null | tr -d '[:space:]')"
+    reviewer_effective_prompt_bytes="${reviewer_effective_prompt_bytes:-0}"
+    if [ "${reviewer_effective_prompt_bytes}" -lt "${reviewer_base_prompt_bytes}" ] 2>/dev/null; then
+      if cp "${prompt_file}" "${reviewer_effective_prompt_file}" 2>/dev/null; then
+        echo "::warning::Reviewer slot ${slot_model} (${effective_model}, safe_name=${safe_name:-unset}) effective prompt file shrank from ${reviewer_base_prompt_bytes} to ${reviewer_effective_prompt_bytes} bytes before launch on ${attempt_label}; restored it from the base prompt." | tee -a "${log_file}" >&2
+      else
+        echo "::warning::Reviewer slot ${slot_model} (${effective_model}, safe_name=${safe_name:-unset}) effective prompt file shrank from ${reviewer_base_prompt_bytes} to ${reviewer_effective_prompt_bytes} bytes before launch on ${attempt_label} and could not be restored; codex may receive a truncated prompt." | tee -a "${log_file}" >&2
+      fi
     fi
   fi
   emit_reviewer_substate "LaunchingAgentProcess" "${attempt_number}"

--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -3761,8 +3761,11 @@ execute_reviewer_attempt() {
     if [ "${reviewer_effective_prompt_file}" != "${prompt_file}" ] && [ -s "${prompt_file}" ] \
       && cp "${prompt_file}" "${reviewer_effective_prompt_file}" 2>/dev/null; then
       echo "::warning::Reviewer slot ${slot_model} (${effective_model}, safe_name=${safe_name:-unset}) effective prompt file was empty before launch on ${attempt_label}; restored it from the base prompt." | tee -a "${log_file}" >&2
+    elif [ "${reviewer_effective_prompt_file}" != "${prompt_file}" ] && [ -s "${prompt_file}" ]; then
+      reviewer_effective_prompt_file="${prompt_file}"
+      echo "::warning::Reviewer slot ${slot_model} (${effective_model}, safe_name=${safe_name:-unset}) effective prompt file was empty before launch on ${attempt_label} and the attempt copy could not be restored; continuing with the base prompt to avoid empty stdin." | tee -a "${log_file}" >&2
     else
-      echo "::warning::Reviewer slot ${slot_model} (${effective_model}, safe_name=${safe_name:-unset}) effective prompt file is empty before launch on ${attempt_label} and could not be restored; codex will fail this slot with empty stdin." | tee -a "${log_file}" >&2
+      echo "::warning::Reviewer slot ${slot_model} (${effective_model}, safe_name=${safe_name:-unset}) effective prompt file is empty before launch on ${attempt_label} and no non-empty base prompt is available; codex will fail this slot with empty stdin." | tee -a "${log_file}" >&2
     fi
   elif [ "${reviewer_effective_prompt_file}" != "${prompt_file}" ] && [ "${reviewer_base_prompt_bytes}" -gt 0 ] 2>/dev/null; then
     reviewer_effective_prompt_bytes="$(wc -c < "${reviewer_effective_prompt_file}" 2>/dev/null | tr -d '[:space:]')"
@@ -3771,7 +3774,8 @@ execute_reviewer_attempt() {
       if cp "${prompt_file}" "${reviewer_effective_prompt_file}" 2>/dev/null; then
         echo "::warning::Reviewer slot ${slot_model} (${effective_model}, safe_name=${safe_name:-unset}) effective prompt file shrank from ${reviewer_base_prompt_bytes} to ${reviewer_effective_prompt_bytes} bytes before launch on ${attempt_label}; restored it from the base prompt." | tee -a "${log_file}" >&2
       else
-        echo "::warning::Reviewer slot ${slot_model} (${effective_model}, safe_name=${safe_name:-unset}) effective prompt file shrank from ${reviewer_base_prompt_bytes} to ${reviewer_effective_prompt_bytes} bytes before launch on ${attempt_label} and could not be restored; codex may receive a truncated prompt." | tee -a "${log_file}" >&2
+        reviewer_effective_prompt_file="${prompt_file}"
+        echo "::warning::Reviewer slot ${slot_model} (${effective_model}, safe_name=${safe_name:-unset}) effective prompt file shrank from ${reviewer_base_prompt_bytes} to ${reviewer_effective_prompt_bytes} bytes before launch on ${attempt_label} and the attempt copy could not be restored; continuing with the base prompt instead of the truncated attempt prompt." | tee -a "${log_file}" >&2
       fi
     fi
   fi

--- a/scripts/review_run_reviewers.sh
+++ b/scripts/review_run_reviewers.sh
@@ -3779,6 +3779,14 @@ execute_reviewer_attempt() {
       fi
     fi
   fi
+  if [ ! -s "${reviewer_effective_prompt_file}" ]; then
+    echo "::warning::Reviewer slot ${slot_model} (${effective_model}, safe_name=${safe_name:-unset}) effective prompt file is still empty after fallback on ${attempt_label}; refusing to launch codex with empty stdin." | tee -a "${log_file}" >&2
+    kill "${wd_pid}" 2>/dev/null; wait "${wd_pid}" 2>/dev/null || true
+    emit_reviewer_substate "Failed" "${attempt_number}"
+    rm -f "${hb_file}" "${hb_file}.tmp" "${codex_pid_file}" "${wd_reason_file}" "${stall_status_file}" "${tmp_output}" "${tmp_stderr}" "${reviewer_attempt_prompt_file}"
+    REVIEWER_ATTEMPT_OUTCOME="failed"
+    return 0
+  fi
   emit_reviewer_substate "LaunchingAgentProcess" "${attempt_number}"
   emit_reviewer_substate "InitializingSession" "${attempt_number}"
   emit_reviewer_substate "StreamingTurn" "${attempt_number}"

--- a/tests/test_review_reviewer_attempt_prompt_isolation.py
+++ b/tests/test_review_reviewer_attempt_prompt_isolation.py
@@ -103,6 +103,10 @@ def test_empty_effective_prompt_is_guarded_before_launch() -> None:
 		"an unrestorable empty attempt prompt should fall back to the base prompt "
 		"instead of launching codex with empty stdin"
 	)
+	assert "refusing to launch codex with empty stdin" in guard_block, (
+		"if every fallback still leaves an empty prompt, the slot should fail before "
+		"the codex stdin redirect"
+	)
 	assert '"${reviewer_effective_prompt_bytes}" -lt "${reviewer_base_prompt_bytes}"' in text, (
 		"the pre-launch guard should restore a non-empty but truncated attempt prompt"
 	)

--- a/tests/test_review_reviewer_attempt_prompt_isolation.py
+++ b/tests/test_review_reviewer_attempt_prompt_isolation.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Contract: reviewer attempt prompt copies must be namespaced per slot.
+
+Background — the shared attempt-prompt race (all reviewers fail on empty stdin)
+===============================================================================
+
+``scripts/review_run_reviewers.sh`` fans the active reviewer model set out as
+concurrent background workers (``run_reviewer ... &`` in ``run_reviewer_pass``).
+Each attempt makes a private, mutable copy of the pass prompt so per-attempt
+additions (nag block) never contaminate the shared base prompt::
+
+    reviewer_attempt_prompt_file="${prompt_file}.<slot>.attempt_${attempt_number}"
+
+When no model-family overlay exists, ``prepare_reviewer_prompt_for_model``
+returns the SHARED pass prompt path for every slot. Before the slot suffix was
+added, every concurrent worker then derived the SAME attempt path
+(``<pass prompt>.attempt_1``) and raced on it: ``cp`` truncates it in place,
+the nag block appends to it, ``sanitize_codex_prompt_file`` rewrites it via
+iconv → tmp → ``mv`` (and mv's an *empty* tmp over the path whenever iconv
+reads mid-truncation, after which every later sanitize preserves the
+emptiness), while each worker's codex reads it as stdin. One bad interleaving
+left the file empty and every reviewer failed non-retryably with::
+
+    Reading prompt from stdin...
+    No prompt provided via stdin.
+
+→ "Pass 2 complete: 0 reviewers successful." → "All reviewers failed." →
+review_autofix job failure. Observed in consumer run
+tele-funtoken-msg-scoring/actions/runs/32222803753 (PR #3721, pass 2: 6/6
+reviewers failed identically ~1.5s after launch while the assembled pass-2
+prompt file was 571935 bytes).
+
+This test pins the two halves of the fix:
+
+1. the attempt prompt path embeds the per-slot ``safe_name`` so concurrent
+   slots never share a mutable attempt file;
+2. the pre-launch guard restores/flags an unexpectedly empty effective prompt
+   instead of letting codex fail the slot silently.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "review_run_reviewers.sh"
+
+
+def _script_text() -> str:
+	return SCRIPT.read_text(encoding="utf-8")
+
+
+def test_attempt_prompt_path_is_namespaced_per_slot() -> None:
+	text = _script_text()
+	assignments = re.findall(
+		r'^\s*reviewer_attempt_prompt_file="([^"]+)"\s*$', text, flags=re.M
+	)
+	# The empty-string reset in the cp-failure fallback branch and in the
+	# local declaration is fine; every non-empty assignment must carry both
+	# the slot namespace and the attempt number.
+	real = [a for a in assignments if a]
+	assert real, "expected at least one reviewer_attempt_prompt_file assignment"
+	for value in real:
+		assert "${safe_name" in value, (
+			"reviewer attempt prompt path must embed the per-slot safe_name; "
+			"a shared '<prompt>.attempt_N' path is cp-truncated / sanitized / "
+			f"read concurrently by every reviewer worker (got: {value!r})"
+		)
+		assert "attempt_${attempt_number}" in value, (
+			f"attempt prompt path must stay per-attempt (got: {value!r})"
+		)
+
+
+def test_empty_effective_prompt_is_guarded_before_launch() -> None:
+	text = _script_text()
+	guard = re.search(
+		r'if \[ ! -s "\$\{reviewer_effective_prompt_file\}" \]', text
+	)
+	assert guard, (
+		"expected a pre-launch guard on an empty reviewer_effective_prompt_file "
+		"(codex fails a slot non-retryably on empty stdin)"
+	)
+	launch = text.find('-- "${reviewer_codex_cmd[@]}" < "${reviewer_effective_prompt_file}"')
+	assert launch != -1, "expected the codex launch redirect to be present"
+	assert guard.start() < launch, (
+		"the empty-prompt guard must run before the codex launch redirect"
+	)

--- a/tests/test_review_reviewer_attempt_prompt_isolation.py
+++ b/tests/test_review_reviewer_attempt_prompt_isolation.py
@@ -9,7 +9,7 @@ concurrent background workers (``run_reviewer ... &`` in ``run_reviewer_pass``).
 Each attempt makes a private, mutable copy of the pass prompt so per-attempt
 additions (nag block) never contaminate the shared base prompt::
 
-    reviewer_attempt_prompt_file="${prompt_file}.<slot>.attempt_${attempt_number}"
+    reviewer_attempt_prompt_file="${prompt_file}.<slot>_<pid>.attempt_${attempt_number}"
 
 When no model-family overlay exists, ``prepare_reviewer_prompt_for_model``
 returns the SHARED pass prompt path for every slot. Before the slot suffix was
@@ -67,6 +67,11 @@ def test_attempt_prompt_path_is_namespaced_per_slot() -> None:
 			"a shared '<prompt>.attempt_N' path is cp-truncated / sanitized / "
 			f"read concurrently by every reviewer worker (got: {value!r})"
 		)
+		assert "${BASHPID" in value, (
+			"reviewer attempt prompt path must include a per-worker shell pid "
+			"so a fallback or future safe_name collision cannot alias slots "
+			f"onto one mutable prompt file (got: {value!r})"
+		)
 		assert "attempt_${attempt_number}" in value, (
 			f"attempt prompt path must stay per-attempt (got: {value!r})"
 		)
@@ -85,4 +90,10 @@ def test_empty_effective_prompt_is_guarded_before_launch() -> None:
 	assert launch != -1, "expected the codex launch redirect to be present"
 	assert guard.start() < launch, (
 		"the empty-prompt guard must run before the codex launch redirect"
+	)
+	assert "safe_name=${safe_name:-unset}" in text, (
+		"empty/truncated prompt warnings should include safe_name for slot-to-file correlation"
+	)
+	assert '"${reviewer_effective_prompt_bytes}" -lt "${reviewer_base_prompt_bytes}"' in text, (
+		"the pre-launch guard should restore a non-empty but truncated attempt prompt"
 	)

--- a/tests/test_review_reviewer_attempt_prompt_isolation.py
+++ b/tests/test_review_reviewer_attempt_prompt_isolation.py
@@ -91,8 +91,17 @@ def test_empty_effective_prompt_is_guarded_before_launch() -> None:
 	assert guard.start() < launch, (
 		"the empty-prompt guard must run before the codex launch redirect"
 	)
+	guard_block = text[guard.start():launch]
+	assert 'reviewer_effective_prompt_file="${prompt_file}"' in guard_block, (
+		"the pre-launch guard should fall back to the base prompt when a damaged "
+		"attempt copy cannot be restored"
+	)
 	assert "safe_name=${safe_name:-unset}" in text, (
 		"empty/truncated prompt warnings should include safe_name for slot-to-file correlation"
+	)
+	assert "continuing with the base prompt to avoid empty stdin" in text, (
+		"an unrestorable empty attempt prompt should fall back to the base prompt "
+		"instead of launching codex with empty stdin"
 	)
 	assert '"${reviewer_effective_prompt_bytes}" -lt "${reviewer_base_prompt_bytes}"' in text, (
 		"the pre-launch guard should restore a non-empty but truncated attempt prompt"


### PR DESCRIPTION
## Summary

Fixes the failure behind the consumer "PR autofix failed" alert — review_autofix run https://github.com/shubhodeep1/tele-funtoken-msg-scoring/actions/runs/32222803753 on shubhodeep1/tele-funtoken-msg-scoring PR 3721 (Refs shubhodeep1/tele-funtoken-msg-scoring#3721), where **pass 2 lost all 6 reviewers in ~1.5s**, each with codex-cli stderr:

```
Reading prompt from stdin...
No prompt provided via stdin.
```

while the assembled pass-2 prompt file was intact at 571,935 bytes.

## Root cause

`scripts/review_run_reviewers.sh` fans reviewer slots out as concurrent background workers. When no model-family overlay exists (this run logged "Reviewer overlay other.txt … not found" for all 6 models), `prepare_reviewer_prompt_for_model` returns the **shared** pass prompt path for every slot, so every worker derived the **same** attempt path `<pass prompt>.attempt_1` and raced on it:

- `cp` truncates it in place (attempt copy),
- the nag block appends to it,
- `sanitize_codex_prompt_file` (gh_helpers.sh) rewrites it via iconv → tmp → `mv` — and its `[ -s tmp ] || [ ! -s path ]` gate moves an **empty** tmp over the path whenever iconv reads mid-truncation, after which every later sanitize preserves the emptiness,
- each worker's codex reads it as stdin.

One bad interleaving leaves the shared file empty → every slot fails non-retryably → "Pass 2 complete: 0 reviewers successful." → "All reviewers failed." → job exit 1.

**Reproduction:** a 6-worker stress run of the exact cp/sanitize/read pattern on a shared path yielded **41 / 1200 empty reads**; the same run with per-slot paths yielded **0 / 1200**.

## Changes

- `scripts/review_run_reviewers.sh` — `reviewer_attempt_prompt_file` now embeds the per-slot `safe_name` (`<prompt>.<safe_name>.attempt_N`), so each worker mutates a private copy. `safe_name` is `run_reviewer`'s local, visible in `execute_reviewer_attempt` via bash dynamic scoping (sole call site; same pattern as `emit_reviewer_substate`).
- `scripts/review_run_reviewers.sh` — pre-launch guard: an unexpectedly empty effective prompt is restored from the base prompt (or flagged with `::warning::`) before codex launches, so any residual empty-stdin condition fails loudly instead of silently killing the slot.
- `tests/test_review_reviewer_attempt_prompt_isolation.py` — new contract test pinning both halves.
- `changelog.d/review-autofix-per-slot-attempt-prompts.md` — §20 fragment (`fixed`).

## Verification

- `bash -n scripts/review_run_reviewers.sh` clean.
- `pytest tests/test_review_reviewer_attempt_prompt_isolation.py tests/test_changelog_fragment_contract.py tests/test_review_autofix_review_pipeline_contract.py` — **114 passed**.
- Broader `-k "review or reviewer or codex"` sweep: 44 failures, all reproduced **identically on pristine `stable`** (pre-existing, environment-dependent) — none introduced by this change.
- Race repro above (41/1200 → 0/1200).

## Port-to-main caveat

This lands on `stable` (the consumer pin). The same defective line exists on `main` (`912b386`) — the stable→main diff of the touched scripts is comment-only — so **this fix must be ported to `main` before the next main → stable promotion**, or the promotion silently reverts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lz6pb9sWMfHbL7146MfApB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lz6pb9sWMfHbL7146MfApB)_