### PR TITLE
fix: pin GET on the branch-scoped list-runs probes so editor-changes-lost re-dispatch works

### DIFF
--- a/changelog.d/3763-changes-lost-redispatch-get-method.md
+++ b/changelog.d/3763-changes-lost-redispatch-get-method.md
@@ -1,0 +1,21 @@
+<!-- changelog: fixed -->
+- **The editor-changes-lost re-dispatch works again.** Both branch-scoped list-runs probes in `scripts/gh_helpers.sh` now pin `-X GET`, so they stop 404ing and the automated retry is no longer reported as budget-exhausted on a head SHA that was never retried.
+
+`autofix_retrigger_has_inflight_peer` and `autofix_changes_lost_head_retry_consumed` query `/repos/{repo}/actions/runs` with `-f branch=` and `-f per_page=`. `gh api` infers its HTTP method from its arguments: GET by default, but POST as soon as any `-f` / `-F` parameter is present and no method is given. There is no `POST /repos/{repo}/actions/runs` route, so every call 404'd, `_is_gh_permanent_failure` classified the 404 as non-retryable, and both probes returned `reason=api_error` on their first attempt. The peer probe fails open, so its breakage was silent. The budget probe fails closed, so the same 404 reported the per-head-SHA retry budget as consumed and suppressed the `Re-dispatch review on editor-changes-lost` step every single time it was reachable.
+
+The visible effect in consumer repos was a PR that went quiet: the run finished green, posted the CRITICAL `⚠️ Editor changes lost (retry unavailable)` alert and the "retry budget is unavailable or exhausted" comment, blocked auto-merge, and then waited for the orchestrator's generic stall recovery to re-trigger the review roughly two hours later.
+
+| The numbers that matter | Value |
+| --- | --- |
+| Probes fixed | 2 (`autofix_retrigger_has_inflight_peer`, `autofix_changes_lost_head_retry_consumed`) |
+| Automated changes-lost retries previously dispatched | 0 of every occurrence |
+| Retry attempts before the fail-closed skip | 1 (404 is non-retryable) |
+| Observed stall before generic recovery | 123–137 min, up to attempt 3 (`tele-funtoken-msg-scoring` #3763/#3764, #3761/#3765) |
+| Reference run | `tele-funtoken-msg-scoring` 32732281452 |
+| New regression tests | 4 in `tests/test_gh_helpers_list_runs_method.py` |
+
+What this means for operators: an editor-changes-lost iteration now re-dispatches its own review immediately instead of dead-ending on a CRITICAL alert and waiting on stall recovery, which removes the two-hour idle window and the repeated stall-recovery escalations on affected PRs. The one-retry-per-head-SHA bound is unchanged — a head that genuinely already consumed its retry still skips, and the probe still fails closed when the API is truly unreachable.
+
+### For contributors
+
+The pre-existing suite could not catch this: its `gh` stub ignores the arguments it is passed, so the method the helper actually requests was never asserted. The new tests add a stub that reproduces gh's method inference, plus a static assertion that both call sites pin GET, so removing the flag fails the suite. `review_autofix_sweep.yml` already used `-X GET` on the same endpoint family; these two helpers were the only REST GETs in `gh_helpers.sh` passing `-f` without a pinned method.

--- a/scripts/gh_helpers.sh
+++ b/scripts/gh_helpers.sh
@@ -1196,7 +1196,15 @@ autofix_retrigger_has_inflight_peer()
 	fi
 
 	local response
+	# -X GET is REQUIRED, not decorative: `gh api` infers POST whenever
+	# any -f/-F parameter is supplied and no method is given, and
+	# POST /repos/{repo}/actions/runs is not a route — it 404s, which
+	# _is_gh_permanent_failure classifies as non-retryable, so the
+	# probe dies instantly with reason=api_error.  Dropping this flag
+	# silently breaks the probe (tele-funtoken-msg-scoring#3763,
+	# review run 32732281452).
 	if ! response=$(gh_retry gh api \
+		-X GET \
 		-H "Accept: application/vnd.github+json" \
 		"/repos/${GITHUB_REPOSITORY}/actions/runs" \
 		-f "branch=${head_branch}" \
@@ -1308,7 +1316,15 @@ autofix_changes_lost_head_retry_consumed()
 	fi
 
 	local response
+	# -X GET is REQUIRED, not decorative: `gh api` infers POST whenever
+	# any -f/-F parameter is supplied and no method is given, and
+	# POST /repos/{repo}/actions/runs is not a route — it 404s, which
+	# _is_gh_permanent_failure classifies as non-retryable, so the
+	# probe dies instantly with reason=api_error.  Dropping this flag
+	# silently breaks the probe (tele-funtoken-msg-scoring#3763,
+	# review run 32732281452).
 	if ! response=$(gh_retry gh api \
+		-X GET \
 		-H "Accept: application/vnd.github+json" \
 		"/repos/${GITHUB_REPOSITORY}/actions/runs" \
 		-f "branch=${head_branch}" \

--- a/tests/test_gh_helpers_list_runs_method.py
+++ b/tests/test_gh_helpers_list_runs_method.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Tests that the branch-scoped list-runs probes issue a real GET.
+
+Background (tele-funtoken-msg-scoring#3763, review run 32732281452):
+``autofix_retrigger_has_inflight_peer`` and
+``autofix_changes_lost_head_retry_consumed`` (scripts/gh_helpers.sh) both
+query ``/repos/{repo}/actions/runs`` with ``-f branch=`` and
+``-f per_page=``.  ``gh api`` infers the HTTP method from its arguments:
+the default is GET, but it switches to **POST** as soon as any ``-f`` /
+``-F`` parameter is supplied and no ``--method`` is given.  There is no
+``POST /repos/{repo}/actions/runs`` route, so every invocation 404'd.
+``_is_gh_permanent_failure`` matches HTTP 404, so ``gh_retry`` did not
+retry and both probes returned ``reason=api_error`` immediately::
+
+    AUTOFIX_PEER_QUERY_FAILED pr=3764 branch=ai/issue-3763 reason=api_error
+    AUTOFIX_CHANGES_LOST_BUDGET_QUERY_FAILED pr=3764 ... reason=api_error
+
+The peer probe fails OPEN, so its breakage was invisible.  The budget
+probe fails CLOSED, so the identical failure reported the per-head-SHA
+retry budget as consumed on a head that had never been retried,
+permanently suppressing the editor-changes-lost re-dispatch: every
+occurrence dead-ended on the CRITICAL "retry unavailable" alert with
+auto-merge blocked, until the orchestrator's generic stall recovery
+re-triggered the review hours later.
+
+The pre-existing suite could not catch this because its ``gh`` stub
+ignores its arguments.  The stub below emulates gh's method inference,
+so a future removal of ``-X GET`` fails these tests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GH_HELPERS = REPO_ROOT / "scripts" / "gh_helpers.sh"
+
+PROBES = (
+	"autofix_retrigger_has_inflight_peer",
+	"autofix_changes_lost_head_retry_consumed",
+)
+
+HEAD = "789e2f8a036f2236a5f10dcffab31019d328d77c"
+CURRENT_RUN = "32732281452"
+BRANCH = "ai/issue-3763"
+
+
+def _helpers_text() -> str:
+	return GH_HELPERS.read_text(encoding="utf-8")
+
+
+def _probe_body(text: str, fn: str) -> str:
+	m = re.search(r"^%s\(\)\n\{\n(.*?)\n\}$" % re.escape(fn), text, re.DOTALL | re.MULTILINE)
+	assert m, "Failed to locate %s in gh_helpers.sh" % fn
+	return m.group(0)
+
+
+def test_list_runs_probes_pin_the_get_method() -> None:
+	text = _helpers_text()
+	for fn in PROBES:
+		body = _probe_body(text, fn)
+		assert "/actions/runs" in body, fn
+		# gh api infers POST from the -f parameters unless the method is
+		# pinned; POST /actions/runs is not a route and 404s.
+		assert re.search(r"-X GET|--method GET", body), (
+			"%s must pin GET on the list-runs call — without it `gh api` "
+			"POSTs and the probe 404s" % fn
+		)
+
+
+# ---------------------------------------------------------------------------
+# Functional tests against a gh stub that emulates gh's method inference
+# ---------------------------------------------------------------------------
+
+_RUNNER = r"""
+extract_fn() {
+	awk -v fn="__FN__" '
+		BEGIN { in_fn=0 }
+		$0 ~ "^"fn"\\(\\)" { in_fn=1 }
+		in_fn { print }
+		in_fn && /^\}$/ { exit }
+	' "__HELPERS__"
+}
+
+gh_retry() { "$@"; }
+emit_event() { :; }
+
+# Emulate `gh api` method inference: default GET, but POST as soon as any
+# -f/-F parameter is present and no -X/--method is supplied. POST against
+# the list-runs endpoint is not a route, so gh prints a 404 and fails.
+gh() {
+	[ "${1:-}" = "api" ] || return 1
+	shift
+	method=""
+	has_field=0
+	for arg in "$@"; do
+		case "$arg" in
+			-X|--method) method="PENDING" ;;
+			-f|-F|--field|--raw-field) has_field=1 ;;
+			*)
+				if [ "$method" = "PENDING" ]; then method="$arg"; fi
+				;;
+		esac
+	done
+	if [ -z "$method" ]; then
+		if [ "$has_field" = "1" ]; then method="POST"; else method="GET"; fi
+	fi
+	if [ "$method" != "GET" ]; then
+		echo "gh: Not Found (HTTP 404)" >&2
+		return 1
+	fi
+	cat "${RUNS_FIXTURE}"
+}
+
+eval "$(extract_fn)"
+__FN__ "$@"
+"""
+
+
+def _run_probe(fn: str, runs_json: str, *args: str) -> subprocess.CompletedProcess:
+	with tempfile.TemporaryDirectory() as tmp:
+		fixture = Path(tmp) / "runs.json"
+		fixture.write_text(runs_json, encoding="utf-8")
+		env = dict(os.environ)
+		env["GITHUB_REPOSITORY"] = "owner/repo"
+		env["RUNS_FIXTURE"] = str(fixture)
+		script = _RUNNER.replace("__HELPERS__", str(GH_HELPERS)).replace("__FN__", fn)
+		return subprocess.run(
+			["bash", "-c", script, "bash", *args],
+			capture_output=True,
+			text=True,
+			env=env,
+		)
+
+
+def _runs(*entries: dict) -> str:
+	return json.dumps({"workflow_runs": list(entries)})
+
+
+def test_budget_probe_reaches_the_api_and_reports_budget_available() -> None:
+	# A head SHA no prior run has reviewed: the budget is available, so
+	# the caller may dispatch exactly one automated retry. This is the
+	# real #3763 shape — head 789e2f8a appears on no other run.
+	proc = _run_probe(
+		"autofix_changes_lost_head_retry_consumed",
+		_runs(
+			{
+				"id": 32720851044,
+				"status": "completed",
+				"conclusion": "success",
+				"head_sha": "549d94dd0f80955e0cf28e55be2152378e5e2937",
+				"path": ".github/workflows/ai-review.yml",
+			}
+		),
+		"3764",
+		BRANCH,
+		CURRENT_RUN,
+		HEAD,
+	)
+	assert "reason=api_error" not in proc.stderr, proc.stderr
+	assert "prior_completed=0" in proc.stdout, proc.stdout
+	# rc=1 means budget available; rc=0 would suppress the re-dispatch.
+	assert proc.returncode == 1, (proc.returncode, proc.stdout, proc.stderr)
+
+
+def test_budget_probe_still_fails_closed_when_the_head_was_already_retried() -> None:
+	proc = _run_probe(
+		"autofix_changes_lost_head_retry_consumed",
+		_runs(
+			{
+				"id": 32700000000,
+				"status": "completed",
+				"conclusion": "success",
+				"head_sha": HEAD,
+				"path": ".github/workflows/ai-review.yml",
+			}
+		),
+		"3764",
+		BRANCH,
+		CURRENT_RUN,
+		HEAD,
+	)
+	assert "prior_completed=1" in proc.stdout, proc.stdout
+	assert proc.returncode == 0, (proc.returncode, proc.stdout, proc.stderr)
+
+
+def test_peer_probe_reaches_the_api_and_detects_an_inflight_peer() -> None:
+	proc = _run_probe(
+		"autofix_retrigger_has_inflight_peer",
+		_runs(
+			{
+				"id": 32799999999,
+				"status": "in_progress",
+				"conclusion": None,
+				"head_sha": HEAD,
+				"path": ".github/workflows/ai-review.yml",
+			}
+		),
+		"3764",
+		BRANCH,
+		CURRENT_RUN,
+	)
+	assert "reason=api_error" not in proc.stderr, proc.stderr
+	assert "peer_count=1" in proc.stdout, proc.stdout
+	assert proc.returncode == 0, (proc.returncode, proc.stdout, proc.stderr)

--- a/tests/test_gh_helpers_list_runs_method.py
+++ b/tests/test_gh_helpers_list_runs_method.py
@@ -61,14 +61,25 @@ def _probe_body(text: str, fn: str) -> str:
 	return m.group(0)
 
 
+def _list_runs_call(body: str, fn: str) -> str:
+	uncommented_body = "\n".join(
+		line for line in body.splitlines()
+		if not line.lstrip().startswith("#")
+	)
+	m = re.search(r"gh_retry gh api \\\n(?P<call>.*?\n\s+2>/dev/null)", uncommented_body, re.DOTALL)
+	assert m, "Failed to locate %s list-runs gh api call" % fn
+	return m.group("call")
+
+
 def test_list_runs_probes_pin_the_get_method() -> None:
 	text = _helpers_text()
 	for fn in PROBES:
 		body = _probe_body(text, fn)
-		assert "/actions/runs" in body, fn
+		list_runs_call = _list_runs_call(body, fn)
+		assert "/actions/runs" in list_runs_call, fn
 		# gh api infers POST from the -f parameters unless the method is
-		# pinned; POST /actions/runs is not a route and 404s.
-		assert re.search(r"-X GET|--method GET", body), (
+		# pinned on the actual command; POST /actions/runs is not a route and 404s.
+		assert re.search(r"^\s+(?:-X GET|--method GET)\s*\\$", list_runs_call, re.MULTILINE), (
 			"%s must pin GET on the list-runs call — without it `gh api` "
 			"POSTs and the probe 404s" % fn
 		)
@@ -100,14 +111,18 @@ gh() {
 	method=""
 	has_field=0
 	for arg in "$@"; do
+		if [ "$method" = "PENDING" ]; then method="$arg"; continue; fi
 		case "$arg" in
 			-X|--method) method="PENDING" ;;
+			-X*) method="${arg#-X}" ;;
+			--method=*) method="${arg#--method=}" ;;
 			-f|-F|--field|--raw-field) has_field=1 ;;
-			*)
-				if [ "$method" = "PENDING" ]; then method="$arg"; fi
-				;;
 		esac
 	done
+	if [ "$method" = "PENDING" ]; then
+		echo "gh: flag needs an argument: -X" >&2
+		return 1
+	fi
 	if [ -z "$method" ]; then
 		if [ "$has_field" = "1" ]; then method="POST"; else method="GET"; fi
 	fi


### PR DESCRIPTION
## Summary

The `Re-dispatch review on editor-changes-lost` step in `review_autofix.yml` has never dispatched. Both branch-scoped list-runs probes in `scripts/gh_helpers.sh` sent the wrong HTTP method and 404'd on every invocation; the one that fails closed then reported the retry budget as exhausted on a head SHA that had never been retried, blocking auto-merge and leaving the PR idle until the orchestrator's generic stall recovery re-triggered the review ~2 hours later.

This PR adds `-X GET` to both calls, annotates the call sites so the flag is not removed again, and adds a regression test that reproduces the production failure.

## Root cause

`autofix_retrigger_has_inflight_peer` (`scripts/gh_helpers.sh:1199`) and `autofix_changes_lost_head_retry_consumed` (`scripts/gh_helpers.sh:1311`) both query `/repos/{repo}/actions/runs` with `-f branch=` and `-f per_page=`.

`gh api` infers the HTTP method from its arguments: GET by default, **POST as soon as any `-f` / `-F` parameter is supplied and no `--method` is given**. There is no `POST /repos/{repo}/actions/runs` route, so both calls returned 404. `_is_gh_permanent_failure` (`scripts/gh_helpers.sh:90`) matches `HTTP 404`, so `gh_retry` classified it as non-retryable and gave up on the first attempt.

The two probes then diverged by fail direction:

| Probe | Fails | Effect of the 404 |
|---|---|---|
| `autofix_retrigger_has_inflight_peer` | open (`return 1`) | silent — reports "no peer", dedup protection quietly lost |
| `autofix_changes_lost_head_retry_consumed` | closed (`return 0`) | reports the per-head-SHA retry budget as consumed, suppressing the re-dispatch |

Both docstrings already describe the call as `gh api GET /repos/{repo}/actions/runs` — the intent was GET; only the implementation disagreed. `review_autofix_sweep.yml:122` queries the same endpoint family and already passes `-X GET`. These two helpers were the only REST GETs in `gh_helpers.sh` passing `-f` without a pinned method (the other two `-f` uses are `gh api graphql`, where POST is correct).

## Evidence

From `tele-funtoken-msg-scoring` review run [32732281452](https://github.com/shubhodeep1/tele-funtoken-msg-scoring/actions/runs/32732281452) (PR #3764, issue #3763), job `review / codex-agent`:

```
13:37:56.5481977Z AUTOFIX_PEER_QUERY_FAILED pr=3764 branch=ai/issue-3763 reason=api_error
13:37:56.6968381Z AUTOFIX_CHANGES_LOST_BUDGET_QUERY_FAILED pr=3764 branch=ai/issue-3763 reason=api_error
13:37:56.6969800Z AUTOFIX_DISPATCH_SKIPPED reason=changes_lost_budget_unavailable_or_exhausted pr=3764 head_sha=789e2f8a036f2236a5f10dcffab31019d328d77c current_run=32732281452 source=editor_changes_lost_retrigger
```

Three details confirm the diagnosis rather than a transient or a legitimately consumed budget:

- **The budget was genuinely available.** Head `789e2f8a` appears on exactly one run across all 8 `ai-review` runs on branch `ai/issue-3763`, so `prior_completed` would have been `0` had the query succeeded.
- **It was not a transient failure.** The two probes failed 149 ms apart with no retry backoff, matching the non-retryable 404 path rather than a 5xx or rate limit.
- **The time budget was not the constraint.** The same run reported `budget_remaining_secs: 11843` of `12600` — the "budget" in the skip reason is the per-head-SHA retry bound, not wall clock.

The run still concluded `success`, so this failed silently apart from the CRITICAL alert.

## Impact

Deterministic, and it affected every consumer repo on `@stable`. Every editor-changes-lost iteration posted `⚠️ Editor changes lost (retry unavailable)` plus the "retry budget is unavailable or exhausted" PR comment, blocked auto-merge, and stalled. The observed consequence was repeated stall-recovery escalations: `#3763`/`#3764` stuck 127 min at attempt 2, `#3761`/`#3765` stuck 137 min at attempt 3.

## Changes

- `scripts/gh_helpers.sh:1199-1210` — `autofix_retrigger_has_inflight_peer`: add `-X GET`, plus a comment explaining why the flag is load-bearing.
- `scripts/gh_helpers.sh:1319-1330` — `autofix_changes_lost_head_retry_consumed`: same.
- `tests/test_gh_helpers_list_runs_method.py` — new, 4 tests.
- `changelog.d/3763-changes-lost-redispatch-get-method.md` — new fragment (§20).

No behaviour is changed beyond making the probes reach the API. The one-retry-per-head-SHA bound, the fail-closed contract, and every log line are unchanged.

## Verification

The pre-existing suite could not catch this: its `gh` stub ignores the arguments it receives, so the method the helper actually requests was never asserted. The new stub reproduces gh's method inference.

```
# against the fixed helper
4 passed in 0.08s

# against the pre-fix helper (git stash)
4 failed — including the production signature:
  assert 'reason=api_error' not in 'AUTOFIX_PEER_QUERY_FAILED ... reason=api_error'
```

Existing related suites: `test_editor_changes_lost_redispatch_budget.py`, `test_retrigger_inflight_direct_fallback.py`, `test_detect_editor_changes_lost.py` — 38 passed. Broader `gh_helpers`-touching suites pass, except one pre-existing failure in `test_implement_post_codex_recovery.py` (`gawk: command not found`, a sandbox tooling gap) that reproduces identically with and without this change. `bash -n scripts/gh_helpers.sh` clean.

## Note on the base branch

Opened against `main`, not `stable`, even though the reporting consumer pins `@stable`. `promote-main-to-stable.yml:125` refuses to promote when `stable` carries commits not present on `main`, and pushes main's HEAD to `refs/heads/stable` — so a stable-only commit would both block the next promotion and be overwritten by it. `stable` (`37e0180`) is currently an ancestor of `main`, and the defect is present identically on both. Landing on `main` is therefore the durable fix; it reaches consumers at the next promotion.

Refs shubhodeep1/tele-funtoken-msg-scoring#3763
Refs shubhodeep1/tele-funtoken-msg-scoring#3761

---
_Generated by [Claude Code](https://claude.ai/code/session_018Bzx7iru1Avy66CjpwAnUN)_