### PR TITLE
fix: preserve editor-created changelog fragments in the consumer commit path

### DIFF
--- a/changelog.d/3764-preserve-editor-changelog-fragments.md
+++ b/changelog.d/3764-preserve-editor-changelog-fragments.md
@@ -1,12 +1,12 @@
 <!-- changelog: fixed -->
-- **The review editor's changelog fragments now survive to commit.** The consumer-repo new-file cleanup in `scripts/review_commit_changes.sh` exempts `changelog.d/*.md`, so a review round whose fix is creating the required fragment commits normally instead of dead-ending on a false "Editor changes lost" alert.
+- **The review editor's changelog fragments now survive to commit.** The consumer-repo new-file cleanup in `scripts/review_commit_changes.sh` exempts top-level `changelog.d/*.md` fragments, so a review round whose fix is creating the required fragment commits normally instead of dead-ending on a false "Editor changes lost" alert.
 
 Reviewers flag a missing changelog fragment per the §20 convention, and the editor's usual fix is creating one new file under `changelog.d/`. The commit step's consumer-repo cleanup deleted every editor-created untracked file before staging ("editor may not create new files"), which erased the fragment, left the tree with nothing to commit, and fired `EDITOR_CHANGES_LOST` — blocking auto-merge on a round that had actually produced the requested fix. The failure was deterministic: a retried round recreated the fragment and hit the same deletion. Observed on `tele-funtoken-msg-scoring` PR #3764 (review run 32732281452), where the editor's only claimed change was `changelog.d/3763-uniswap-comp-admin-stats-aggregator.md` and the run's own log shows the cleanup removing that exact path two steps before the changes-lost error.
 
 | The numbers that matter | Value |
 | --- | --- |
-| Paths exempted | `changelog.d/*.md` |
-| Other new-file cleanup behaviour | unchanged (strays still removed, incl. non-`.md` files in `changelog.d/`) |
+| Paths exempted | top-level `changelog.d/*.md` fragments |
+| Other new-file cleanup behaviour | unchanged (strays still removed, incl. non-`.md` files and nested Markdown under `changelog.d/`) |
 | Reference run | `tele-funtoken-msg-scoring` 32732281452 |
 | New tests | 5 in `tests/test_review_commit_changelog_fragment_preserved.py` |
 

--- a/changelog.d/3764-preserve-editor-changelog-fragments.md
+++ b/changelog.d/3764-preserve-editor-changelog-fragments.md
@@ -1,0 +1,17 @@
+<!-- changelog: fixed -->
+- **The review editor's changelog fragments now survive to commit.** The consumer-repo new-file cleanup in `scripts/review_commit_changes.sh` exempts `changelog.d/*.md`, so a review round whose fix is creating the required fragment commits normally instead of dead-ending on a false "Editor changes lost" alert.
+
+Reviewers flag a missing changelog fragment per the §20 convention, and the editor's usual fix is creating one new file under `changelog.d/`. The commit step's consumer-repo cleanup deleted every editor-created untracked file before staging ("editor may not create new files"), which erased the fragment, left the tree with nothing to commit, and fired `EDITOR_CHANGES_LOST` — blocking auto-merge on a round that had actually produced the requested fix. The failure was deterministic: a retried round recreated the fragment and hit the same deletion. Observed on `tele-funtoken-msg-scoring` PR #3764 (review run 32732281452), where the editor's only claimed change was `changelog.d/3763-uniswap-comp-admin-stats-aggregator.md` and the run's own log shows the cleanup removing that exact path two steps before the changes-lost error.
+
+| The numbers that matter | Value |
+| --- | --- |
+| Paths exempted | `changelog.d/*.md` |
+| Other new-file cleanup behaviour | unchanged (strays still removed, incl. non-`.md` files in `changelog.d/`) |
+| Reference run | `tele-funtoken-msg-scoring` 32732281452 |
+| New tests | 5 in `tests/test_review_commit_changelog_fragment_preserved.py` |
+
+What this means for operators: fragment-only review rounds in consumer repos now commit and push like any other fix, so the "Editor changes lost (retry unavailable)" alert no longer fires for this case and auto-merge is not blocked on it. The workflow-source repo path is untouched — it already preserved editor-created files.
+
+### For contributors
+
+The exemption sits in the existing removal-loop `case` statement beside `.serena` / `scripts/` / `prompts/`, and the surviving fragment is staged by the existing consumer untracked-files `git add` pass — no new staging logic. This pairs with the `-X GET` probe fix (fragment `3763-changes-lost-redispatch-get-method.md`): that PR repaired the retry after a changes-lost event; this one removes the pipeline-inflicted cause of the event for fragment-only rounds.

--- a/scripts/review_commit_changes.sh
+++ b/scripts/review_commit_changes.sh
@@ -172,6 +172,19 @@ if [ -s "${NEW_FILES_BEFORE_COMMIT_FILE}" ]; then
       case "${created_file}" in
         .serena|.serena/*) continue ;;
         scripts/*|prompts/*) continue ;;
+        changelog.d/*.md)
+          # Editor-created changelog fragments are a legitimate review
+          # fix, not a stray artifact: CLAUDE.md §20 requires one
+          # fragment per behaviour-changing PR, reviewers flag its
+          # absence, and nothing in the pipeline machinery writes into
+          # changelog.d/.  Deleting the fragment here left the tree
+          # clean at commit time and fired a false EDITOR_CHANGES_LOST
+          # dead end on every fragment-only review round
+          # (tele-funtoken-msg-scoring#3763, review run 32732281452).
+          # The consumer-repo staging below picks the file up via its
+          # untracked-files `git add` pass.
+          echo "Preserving editor-created changelog fragment: ${created_file}"
+          continue ;;
       esac
       echo "- ${created_file}"
       if ! rm -rf -- "${created_file}"; then

--- a/scripts/review_commit_changes.sh
+++ b/scripts/review_commit_changes.sh
@@ -173,18 +173,20 @@ if [ -s "${NEW_FILES_BEFORE_COMMIT_FILE}" ]; then
         .serena|.serena/*) continue ;;
         scripts/*|prompts/*) continue ;;
         changelog.d/*.md)
-          # Editor-created changelog fragments are a legitimate review
-          # fix, not a stray artifact: CLAUDE.md §20 requires one
-          # fragment per behaviour-changing PR, reviewers flag its
-          # absence, and nothing in the pipeline machinery writes into
-          # changelog.d/.  Deleting the fragment here left the tree
-          # clean at commit time and fired a false EDITOR_CHANGES_LOST
-          # dead end on every fragment-only review round
-          # (tele-funtoken-msg-scoring#3763, review run 32732281452).
-          # The consumer-repo staging below picks the file up via its
-          # untracked-files `git add` pass.
-          echo "Preserving editor-created changelog fragment: ${created_file}"
-          continue ;;
+          if [[ "${created_file#changelog.d/}" != */* ]]; then
+            # Editor-created changelog fragments are a legitimate review
+            # fix, not a stray artifact: CLAUDE.md §20 requires one
+            # top-level fragment per behaviour-changing PR, reviewers flag its
+            # absence, and nothing in the pipeline machinery writes into
+            # changelog.d/.  Deleting the fragment here left the tree
+            # clean at commit time and fired a false EDITOR_CHANGES_LOST
+            # dead end on every fragment-only review round
+            # (tele-funtoken-msg-scoring#3763, review run 32732281452).
+            # The consumer-repo staging below picks the file up via its
+            # untracked-files `git add` pass.
+            echo "Preserving editor-created changelog fragment: ${created_file}"
+            continue
+          fi ;;
       esac
       echo "- ${created_file}"
       if ! rm -rf -- "${created_file}"; then

--- a/tests/test_review_commit_changelog_fragment_preserved.py
+++ b/tests/test_review_commit_changelog_fragment_preserved.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Tests that the consumer-repo new-file cleanup preserves changelog fragments.
+
+Background (tele-funtoken-msg-scoring#3763, review run 32732281452): the
+reviewer consensus asked for the CLAUDE.md §20 changelog fragment the PR
+was missing, and the editor created exactly one file —
+``changelog.d/3763-uniswap-comp-admin-stats-aggregator.md``.  The write
+persisted (``git status`` showed the untracked file), but the
+consumer-repo branch of ``scripts/review_commit_changes.sh`` deletes
+every newly created untracked path before staging ("editor may not
+create new files"), so the fragment was removed, the tree was clean at
+commit time, and the run fired a false ``EDITOR_CHANGES_LOST`` dead end
+that blocked auto-merge.  Any review round whose entire fix is creating
+a fragment reproduced this deterministically.
+
+The fix exempts ``changelog.d/*.md`` from the cleanup, alongside the
+existing ``.serena`` / ``scripts/`` / ``prompts/`` exemptions.  The
+consumer staging pass (``git ls-files --others ... | xargs git add``)
+then stages the surviving fragment, so the round commits normally.
+
+These tests extract the cleanup block from the script and run it in a
+throwaway git repo, mirroring the extraction style of the other
+``review_commit_changes`` contract tests.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "review_commit_changes.sh"
+
+
+def _script_text() -> str:
+	return SCRIPT.read_text(encoding="utf-8")
+
+
+def _cleanup_block(text: str) -> str:
+	m = re.search(
+		r'NEW_FILES_BEFORE_COMMIT_FILE="\$\(mktemp\)"\n.*?\nfi\nrm -f "\$\{NEW_FILES_BEFORE_COMMIT_FILE\}"\n',
+		text,
+		re.DOTALL,
+	)
+	assert m, "Failed to locate the new-file cleanup block in review_commit_changes.sh"
+	return m.group(0)
+
+
+def test_cleanup_block_exempts_changelog_fragments() -> None:
+	block = _cleanup_block(_script_text())
+	assert "changelog.d/*.md)" in block, (
+		"The consumer-repo new-file cleanup must exempt changelog.d/*.md — "
+		"deleting editor-created fragments makes every fragment-only review "
+		"round a false EDITOR_CHANGES_LOST dead end"
+	)
+	# The exemption must sit inside the removal case statement, before the rm.
+	assert block.index("changelog.d/*.md)") < block.index('rm -rf -- "${created_file}"')
+
+
+def test_consumer_staging_does_not_exclude_changelog_fragments() -> None:
+	# The exemption only helps if the untracked-files staging pass picks
+	# the fragment up afterwards; assert no pathspec exclusion covers it.
+	text = _script_text()
+	m = re.search(r"git ls-files --others --exclude-standard -z -- (.*)\| xargs -0 -r git add --", text)
+	assert m, "Failed to locate the consumer untracked-files staging pass"
+	assert "changelog.d" not in m.group(1)
+
+
+def _run_cleanup(tmp: Path, *, source_repo: bool) -> subprocess.CompletedProcess:
+	block = _cleanup_block(_script_text())
+	repo = tmp / "repo"
+	repo.mkdir()
+	subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+	(repo / "changelog.d").mkdir()
+	(repo / "changelog.d" / "3763-example-fragment.md").write_text(
+		"<!-- changelog: added -->\n- Example.\n", encoding="utf-8"
+	)
+	(repo / "stray_artifact.txt").write_text("leftover\n", encoding="utf-8")
+	(repo / "scripts").mkdir()
+	(repo / "scripts" / "helper.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+	script = "set -euo pipefail\n" + block
+	return subprocess.run(
+		["bash", "-c", script],
+		cwd=repo,
+		capture_output=True,
+		text=True,
+		env={
+			"PATH": "/usr/bin:/bin:/usr/local/bin",
+			"IS_WORKFLOW_SOURCE_REPO": "true" if source_repo else "false",
+			"HOME": str(tmp),
+		},
+	)
+
+
+def test_consumer_cleanup_preserves_fragment_and_removes_strays() -> None:
+	with tempfile.TemporaryDirectory() as tmpdir:
+		tmp = Path(tmpdir)
+		proc = _run_cleanup(tmp, source_repo=False)
+		assert proc.returncode == 0, (proc.stdout, proc.stderr)
+		repo = tmp / "repo"
+		assert (repo / "changelog.d" / "3763-example-fragment.md").exists(), proc.stdout
+		assert not (repo / "stray_artifact.txt").exists(), proc.stdout
+		assert (repo / "scripts" / "helper.sh").exists(), proc.stdout
+		assert "Preserving editor-created changelog fragment: changelog.d/3763-example-fragment.md" in proc.stdout
+		assert "- stray_artifact.txt" in proc.stdout
+
+
+def test_consumer_cleanup_still_removes_non_fragment_files_in_changelog_dir() -> None:
+	with tempfile.TemporaryDirectory() as tmpdir:
+		tmp = Path(tmpdir)
+		repo = tmp / "repo"
+		repo.mkdir()
+		subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+		(repo / "changelog.d").mkdir()
+		(repo / "changelog.d" / "notes.txt").write_text("not a fragment\n", encoding="utf-8")
+		block = _cleanup_block(_script_text())
+		proc = subprocess.run(
+			["bash", "-c", "set -euo pipefail\n" + block],
+			cwd=repo,
+			capture_output=True,
+			text=True,
+			env={
+				"PATH": "/usr/bin:/bin:/usr/local/bin",
+				"IS_WORKFLOW_SOURCE_REPO": "false",
+				"HOME": str(tmp),
+			},
+		)
+		assert proc.returncode == 0, (proc.stdout, proc.stderr)
+		assert not (repo / "changelog.d" / "notes.txt").exists(), proc.stdout
+
+
+def test_source_repo_cleanup_still_preserves_everything() -> None:
+	with tempfile.TemporaryDirectory() as tmpdir:
+		tmp = Path(tmpdir)
+		proc = _run_cleanup(tmp, source_repo=True)
+		assert proc.returncode == 0, (proc.stdout, proc.stderr)
+		repo = tmp / "repo"
+		assert (repo / "changelog.d" / "3763-example-fragment.md").exists()
+		assert (repo / "stray_artifact.txt").exists()
+		assert "Preserving newly created files in workflow source repo:" in proc.stdout

--- a/tests/test_review_commit_changelog_fragment_preserved.py
+++ b/tests/test_review_commit_changelog_fragment_preserved.py
@@ -13,10 +13,11 @@ commit time, and the run fired a false ``EDITOR_CHANGES_LOST`` dead end
 that blocked auto-merge.  Any review round whose entire fix is creating
 a fragment reproduced this deterministically.
 
-The fix exempts ``changelog.d/*.md`` from the cleanup, alongside the
-existing ``.serena`` / ``scripts/`` / ``prompts/`` exemptions.  The
-consumer staging pass (``git ls-files --others ... | xargs git add``)
-then stages the surviving fragment, so the round commits normally.
+The fix exempts top-level ``changelog.d/*.md`` fragments from the
+cleanup, alongside the existing ``.serena`` / ``scripts/`` / ``prompts/``
+exemptions.  The consumer staging pass (``git ls-files --others ... |
+xargs git add``) then stages the surviving fragment, so the round commits
+normally.
 
 These tests extract the cleanup block from the script and run it in a
 throwaway git repo, mirroring the extraction style of the other
@@ -33,6 +34,10 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = REPO_ROOT / "scripts" / "review_commit_changes.sh"
+
+
+def _git_test_env(home: Path | str) -> dict[str, str]:
+	return {"PATH": "/usr/bin:/bin:/usr/local/bin", "HOME": str(home)}
 
 
 def _script_text() -> str:
@@ -62,18 +67,41 @@ def test_cleanup_block_exempts_changelog_fragments() -> None:
 
 def test_consumer_staging_does_not_exclude_changelog_fragments() -> None:
 	# The exemption only helps if the untracked-files staging pass picks
-	# the fragment up afterwards; assert no pathspec exclusion covers it.
+	# the fragment up afterwards; exercise the real pathspec so a generic
+	# exclusion such as :!*.md would fail this contract.
 	text = _script_text()
-	m = re.search(r"git ls-files --others --exclude-standard -z -- (.*)\| xargs -0 -r git add --", text)
+	m = re.search(
+		r"^  (git ls-files --others --exclude-standard -z -- .*\| xargs -0 -r git add --)$",
+		text,
+		re.MULTILINE,
+	)
 	assert m, "Failed to locate the consumer untracked-files staging pass"
-	assert "changelog.d" not in m.group(1)
+	with tempfile.TemporaryDirectory() as tmpdir:
+		repo = Path(tmpdir) / "repo"
+		repo.mkdir()
+		test_env = _git_test_env(tmpdir)
+		subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=test_env)
+		(repo / "changelog.d").mkdir()
+		fragment_path = repo / "changelog.d" / "3763-example-fragment.md"
+		fragment_path.write_text("<!-- changelog: added -->\n- Example.\n", encoding="utf-8")
+		proc = subprocess.run(
+			["bash", "-c", "set -euo pipefail\n_ra_script_excludes=()\n" + m.group(1)],
+			cwd=repo,
+			capture_output=True,
+			text=True,
+			env=test_env,
+		)
+		assert proc.returncode == 0, (proc.stdout, proc.stderr)
+		staged = subprocess.check_output(["git", "diff", "--cached", "--name-only"], cwd=repo, text=True, env=test_env)
+		assert "changelog.d/3763-example-fragment.md" in staged.splitlines()
 
 
 def _run_cleanup(tmp: Path, *, source_repo: bool) -> subprocess.CompletedProcess:
 	block = _cleanup_block(_script_text())
 	repo = tmp / "repo"
 	repo.mkdir()
-	subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+	test_env = _git_test_env(tmp)
+	subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=test_env)
 	(repo / "changelog.d").mkdir()
 	(repo / "changelog.d" / "3763-example-fragment.md").write_text(
 		"<!-- changelog: added -->\n- Example.\n", encoding="utf-8"
@@ -88,9 +116,8 @@ def _run_cleanup(tmp: Path, *, source_repo: bool) -> subprocess.CompletedProcess
 		capture_output=True,
 		text=True,
 		env={
-			"PATH": "/usr/bin:/bin:/usr/local/bin",
+			**test_env,
 			"IS_WORKFLOW_SOURCE_REPO": "true" if source_repo else "false",
-			"HOME": str(tmp),
 		},
 	)
 
@@ -113,9 +140,12 @@ def test_consumer_cleanup_still_removes_non_fragment_files_in_changelog_dir() ->
 		tmp = Path(tmpdir)
 		repo = tmp / "repo"
 		repo.mkdir()
-		subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+		test_env = _git_test_env(tmp)
+		subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=test_env)
 		(repo / "changelog.d").mkdir()
 		(repo / "changelog.d" / "notes.txt").write_text("not a fragment\n", encoding="utf-8")
+		(repo / "changelog.d" / "nested").mkdir()
+		(repo / "changelog.d" / "nested" / "notes.md").write_text("not a top-level fragment\n", encoding="utf-8")
 		block = _cleanup_block(_script_text())
 		proc = subprocess.run(
 			["bash", "-c", "set -euo pipefail\n" + block],
@@ -123,13 +153,13 @@ def test_consumer_cleanup_still_removes_non_fragment_files_in_changelog_dir() ->
 			capture_output=True,
 			text=True,
 			env={
-				"PATH": "/usr/bin:/bin:/usr/local/bin",
+				**test_env,
 				"IS_WORKFLOW_SOURCE_REPO": "false",
-				"HOME": str(tmp),
 			},
 		)
 		assert proc.returncode == 0, (proc.stdout, proc.stderr)
 		assert not (repo / "changelog.d" / "notes.txt").exists(), proc.stdout
+		assert not (repo / "changelog.d" / "nested" / "notes.md").exists(), proc.stdout
 
 
 def test_source_repo_cleanup_still_preserves_everything() -> None:


### PR DESCRIPTION
## Summary

A review round whose entire fix is creating the §20 changelog fragment is deterministically un-committable in consumer repos: the editor writes `changelog.d/<slug>.md`, the commit step's new-file cleanup deletes it ("editor may not create new files"), the tree is clean at commit time, and the run fires a false `EDITOR_CHANGES_LOST` that blocks auto-merge. A retried round recreates the fragment and hits the same deletion.

This PR exempts `changelog.d/*.md` from that cleanup, in the existing removal-loop `case` statement beside `.serena` / `scripts/` / `prompts/` (`scripts/review_commit_changes.sh:173`). The surviving fragment is staged by the existing consumer untracked-files `git add` pass — no new staging logic.

**Companion to #3796**, which repairs the automated retry *after* a changes-lost event. This PR removes the pipeline-inflicted *cause* of the event for fragment-only rounds. Split into its own PR per the maintainer's choice so #3796 stays a pure transport fix.

## The defect, from the reference run

`tele-funtoken-msg-scoring` review run [32732281452](https://github.com/shubhodeep1/tele-funtoken-msg-scoring/actions/runs/32732281452) (PR #3764, issue #3763). Reviewers asked for the missing changelog fragment; the editor created exactly one file, and the write persisted:

```
?? changelog.d/3763-uniswap-comp-admin-stats-aggregator.md
```

Two steps later the commit script deleted it:

```
Removing newly created files before commit (editor may not create new files):
- changelog.d/3763-uniswap-comp-admin-stats-aggregator.md
...
No repository changes to commit.
```

Then the changes-lost detector compared the editor's summary ("Added `changelog.d/…`") against the now-clean tree:

```
##[error]Editor claimed changes but no commit was produced. This indicates a mismatch
between the editor summary and final git state (changes may have failed to persist,
or may have been discarded during commit validation).
```

It was the latter — the pipeline discarded its own requested fix, then alarmed on the discrepancy it created. The script's header comment for the source-repo branch already records the same failure shape from PR #1330; this is the consumer-repo twin of it, triggered by the §20 fragment convention that makes new-file creation a *routine* review fix rather than an anomaly.

## Why the exemption is safe

- **Nothing else writes there.** The runtime artifacts the cleanup exists for (`pre_assembled_static.txt`, `.ai/review_runtime/…`, fetched `scripts/`/`prompts/`) never land in `changelog.d/`; only the editor creates files there.
- **Scope is tight.** Only `*.md` under `changelog.d/` survives; any other new file — including a non-`.md` stray inside `changelog.d/` — is still removed (covered by a test).
- **Staging and guards already permit it.** The consumer staging pass stages untracked files with no `changelog.d` exclusion, and the `review_editor` write guard allows `**`.
- **Source-repo path untouched.** `IS_WORKFLOW_SOURCE_REPO=true` already preserves all editor-created files.

## Changes

- `scripts/review_commit_changes.sh:173-187` — `changelog.d/*.md` exemption in the removal loop, with a "Preserving editor-created changelog fragment" log line.
- `tests/test_review_commit_changelog_fragment_preserved.py` — new, 5 tests: block extraction + real-git-repo runs covering fragment preserved, strays removed, non-`.md` in `changelog.d/` removed, source-repo behaviour unchanged, and a staging-pathspec assertion.
- `changelog.d/3764-preserve-editor-changelog-fragments.md` — §20 fragment.

## Verification

- New tests: 5 passed against the fixed script; the two exemption tests **fail against the pre-fix script** (the functional one reproduces the deletion of the fragment).
- Related suites: `test_review_semble_contract.py`, `test_review_autofix_editor_noop_cascade_contract.py`, `test_detect_editor_changes_lost.py`, `test_editor_changes_lost_redispatch_budget.py`, `test_review_autofix_review_pipeline_contract.py` — 161 passed.
- `bash -n scripts/review_commit_changes.sh` clean.

Base is `main` for the same reason as #3796: `promote-main-to-stable.yml` refuses to promote over stable-only commits and overwrites `stable` with main's HEAD, so `main` is the durable landing spot; the fix reaches consumers at the next promotion.

Refs shubhodeep1/tele-funtoken-msg-scoring#3763

---
_Generated by [Claude Code](https://claude.ai/code/session_018Bzx7iru1Avy66CjpwAnUN)_