### PR TITLE
fix: stop wait-review false-stalls on healthy long reviewer steps (v1.27.0 release failure)

### DIFF
--- a/.github/workflows/promote-main-to-stable.yml
+++ b/.github/workflows/promote-main-to-stable.yml
@@ -64,15 +64,21 @@ name: Promote main to stable
       review_timeout:
         description: >
           Forwarded to test-and-mark-stable.yml. Default mirrors that
-          workflow's own `review_timeout` default (40), which was raised
-          30→40 in #3290 to absorb slow multi-pass reviewer LLM steps.
+          workflow's own `review_timeout` default (60), which was raised
+          30→40 in #3290 and 40→60 after run 28282500673 (v1.20.1) to
+          absorb slow multi-pass reviewer LLM steps.
           Because this dispatcher forwards the value explicitly
-          (`-f review_timeout=...`), a 30 here would override the
-          downstream 40 default and re-introduce the v1.17.0 wait-review
-          false-timeout (run 27456112610), so it must track 40.
+          (`-f review_timeout=...`), a stale lower value here silently
+          overrides the downstream default and re-introduces the
+          wait-review false-timeout: the v1.27.0 release failure
+          (run 32824674139) happened exactly this way — this default
+          still said 40 after the downstream 40→60 bump, so a healthy
+          51m "Run reviewer models" step aged out the 40m inactivity
+          timer. When test-and-mark-stable.yml's `review_timeout`
+          default changes, this default MUST change with it.
         required: false
         type: number
-        default: 40
+        default: 60
 
 permissions:
   contents: write

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -96,7 +96,9 @@ name: Test & Mark Stable Release
           step completed successfully. Set it explicitly if you want a
           different per-step cap (for example, above `review_timeout`
           when a long single step should extend the wait past the
-          inactivity window).
+          inactivity window). The wait loop clamps overrides above
+          90 minutes so a typo cannot mask a genuine hang until the
+          120-minute smoke-test job timeout kills the run.
         required: false
         type: number
         default: 75
@@ -373,7 +375,9 @@ jobs:
       # cap is exceeded, so stuck-run detection is preserved. The default
       # was raised 50→75 after run 32824674139 (v1.27.0): the reviewer
       # step ran a healthy 51m and the 50m cap killed the wait 58s before
-      # the step completed.
+      # the step completed. The shell validation below clamps overrides
+      # above 90m so a typo cannot suppress stall detection until the
+      # 120m e2e-smoke-test job timeout kills the run.
       REVIEW_STEP_TIMEOUT: ${{ inputs.review_step_timeout || inputs.review_timeout || inputs.phase_timeout || 75 }}
       POLL_INTERVAL: 10
       # Wrapper-workflow filename used by the smoke gate to dispatch
@@ -1329,6 +1333,11 @@ jobs:
           # env is unset/non-numeric so the arithmetic below never errors.
           REVIEW_STEP_TIMEOUT="${REVIEW_STEP_TIMEOUT:-75}"
           [[ "$REVIEW_STEP_TIMEOUT" =~ ^[0-9]+$ ]] && [ "$REVIEW_STEP_TIMEOUT" -gt 0 ] || REVIEW_STEP_TIMEOUT=75
+          REVIEW_STEP_TIMEOUT_MAX=90
+          if [ "$REVIEW_STEP_TIMEOUT" -gt "$REVIEW_STEP_TIMEOUT_MAX" ]; then
+            echo "::warning::REVIEW_STEP_TIMEOUT=${REVIEW_STEP_TIMEOUT} exceeds ${REVIEW_STEP_TIMEOUT_MAX}m cap; clamping so wait-review still reports genuine stalls before the 120m job timeout"
+            REVIEW_STEP_TIMEOUT="$REVIEW_STEP_TIMEOUT_MAX"
+          fi
           STEP_INACTIVITY_LIMIT=$((REVIEW_STEP_TIMEOUT * 60))
           echo "Per-step stall cap: ${REVIEW_STEP_TIMEOUT} minutes"
           LAST_ACTIVITY=$(date +%s)
@@ -1578,11 +1587,11 @@ jobs:
                   # (97733868951) while `review / codex-agent`
                   # (97733894241) did the actual work, so both shortcuts
                   # were permanently inert. Prefer the codex-agent job by
-                  # exact name/suffix (a rename is a breaking change per
-                  # CLAUDE.md §6, so the literal is safe), then any
-                  # in-progress job, then jobs[0] as the legacy single-job
-                  # fallback.
-                  JOB_ID=$(echo "$JOBS_JSON" | jq -r '([.jobs[] | select(.name | test("(^| / )codex-agent( \\(claude-branch-review\\))?$"))] | last | .id) // ([.jobs[] | select(.status == "in_progress")] | last | .id) // .jobs[0].id // empty' 2>/dev/null || echo "")
+                  # exact name/path component plus any parenthesized suffix
+                  # (a job rename is a breaking change per CLAUDE.md §6,
+                  # so the literal is safe), then any in-progress job, then
+                  # jobs[0] as the legacy single-job fallback.
+                  JOB_ID=$(echo "$JOBS_JSON" | jq -r '([.jobs[] | select(.name | test("(^| / )codex-agent( \\([^)]*\\))?$"))] | last | .id) // ([.jobs[] | select(.status == "in_progress")] | last | .id) // .jobs[0].id // empty' 2>/dev/null || echo "")
                   if [ -n "$JOB_ID" ]; then
                     # Stream the job log to a tempfile rather than capturing
                     # into a shell variable. `gh_api_safe .../actions/jobs/
@@ -1773,10 +1782,10 @@ jobs:
             if [ "$RUN_ID" != "unknown" ]; then
               JOB_ID_FOR_SIZE=""
               if [ -n "${JOBS_JSON:-}" ]; then
-                JOB_ID_FOR_SIZE=$(echo "$JOBS_JSON" | jq -r '([.jobs[] | select(.name | test("(^| / )codex-agent( \\(claude-branch-review\\))?$"))] | last | .id) // ([.jobs[] | select(.status == "in_progress")] | last | .id) // .jobs[0].id // empty' 2>/dev/null || echo "")
+                JOB_ID_FOR_SIZE=$(echo "$JOBS_JSON" | jq -r '([.jobs[] | select(.name | test("(^| / )codex-agent( \\([^)]*\\))?$"))] | last | .id) // ([.jobs[] | select(.status == "in_progress")] | last | .id) // .jobs[0].id // empty' 2>/dev/null || echo "")
               else
                 JOB_ID_FOR_SIZE=$(gh_api_safe_quiet_print "repos/${TEST_REPO}/actions/runs/${RUN_ID}/jobs?per_page=10" \
-                  --jq '([.jobs[] | select(.name | test("(^| / )codex-agent( \\(claude-branch-review\\))?$"))] | last | .id) // ([.jobs[] | select(.status == "in_progress")] | last | .id) // .jobs[0].id // empty' || echo "")
+                  --jq '([.jobs[] | select(.name | test("(^| / )codex-agent( \\([^)]*\\))?$"))] | last | .id) // ([.jobs[] | select(.status == "in_progress")] | last | .id) // .jobs[0].id // empty' || echo "")
               fi
               if [ -n "$JOB_ID_FOR_SIZE" ]; then
                 LOG_SIZE=$(gh_api_safe_quiet_print "repos/${TEST_REPO}/actions/jobs/${JOB_ID_FOR_SIZE}/logs" \

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -90,13 +90,16 @@ name: Test & Mark Stable Release
           review run is in_progress and its current step has been running
           for less than this cap, the loop defers the inactivity-stall
           decision; once the step reaches this cap, the normal stall path
-          continues. Defaults to 50 minutes; set it explicitly if you want
-          a different per-step cap (for example, above `review_timeout`
+          continues. Defaults to 75 minutes — raised 50→75 after run
+          32824674139 (v1.27.0), where a healthy "Run reviewer models"
+          step ran 51m and the 50m cap declared a stall 58s before the
+          step completed successfully. Set it explicitly if you want a
+          different per-step cap (for example, above `review_timeout`
           when a long single step should extend the wait past the
           inactivity window).
         required: false
         type: number
-        default: 50
+        default: 75
       review_workflow_file:
         description: >
           Filename (under .github/workflows/ in TEST_REPO) of the
@@ -352,7 +355,7 @@ jobs:
       REVIEW_TIMEOUT: ${{ inputs.review_timeout || inputs.phase_timeout || 60 }}
       # Per-step wall-clock cap (minutes) for the review run's currently
       # in-progress step. For normal workflow_dispatch runs this comes from
-      # the dedicated review_step_timeout input (default 50); it does not
+      # the dedicated review_step_timeout input (default 75); it does not
       # auto-track review_timeout. The review_timeout/phase_timeout fallbacks
       # below are only a defensive backstop for unexpected falsey/missing values.
       # GitHub's /actions/jobs/{id}/logs endpoint does NOT
@@ -367,8 +370,11 @@ jobs:
       # its current step has been running for less than this cap, the loop
       # treats the silence as a healthy long step and defers that inactivity
       # stall decision; a genuinely hung step still falls through once the
-      # cap is exceeded, so stuck-run detection is preserved.
-      REVIEW_STEP_TIMEOUT: ${{ inputs.review_step_timeout || inputs.review_timeout || inputs.phase_timeout || 50 }}
+      # cap is exceeded, so stuck-run detection is preserved. The default
+      # was raised 50→75 after run 32824674139 (v1.27.0): the reviewer
+      # step ran a healthy 51m and the 50m cap killed the wait 58s before
+      # the step completed.
+      REVIEW_STEP_TIMEOUT: ${{ inputs.review_step_timeout || inputs.review_timeout || inputs.phase_timeout || 75 }}
       POLL_INTERVAL: 10
       # Wrapper-workflow filename used by the smoke gate to dispatch
       # / poll review_autofix runs. Defaults to the source repo's
@@ -1319,10 +1325,10 @@ jobs:
           # a single in-progress review step may run this long before the
           # inactivity check treats it as a stall, since GitHub does not
           # stream in-progress step logs and the cached activity signals
-          # freeze for the step's whole duration. Fall back to 50m when the
+          # freeze for the step's whole duration. Fall back to 75m when the
           # env is unset/non-numeric so the arithmetic below never errors.
-          REVIEW_STEP_TIMEOUT="${REVIEW_STEP_TIMEOUT:-50}"
-          [[ "$REVIEW_STEP_TIMEOUT" =~ ^[0-9]+$ ]] && [ "$REVIEW_STEP_TIMEOUT" -gt 0 ] || REVIEW_STEP_TIMEOUT=50
+          REVIEW_STEP_TIMEOUT="${REVIEW_STEP_TIMEOUT:-75}"
+          [[ "$REVIEW_STEP_TIMEOUT" =~ ^[0-9]+$ ]] && [ "$REVIEW_STEP_TIMEOUT" -gt 0 ] || REVIEW_STEP_TIMEOUT=75
           STEP_INACTIVITY_LIMIT=$((REVIEW_STEP_TIMEOUT * 60))
           echo "Per-step stall cap: ${REVIEW_STEP_TIMEOUT} minutes"
           LAST_ACTIVITY=$(date +%s)
@@ -1560,7 +1566,22 @@ jobs:
                 # reviewers + editor together take well over 10 minutes in
                 # every observed run, so anything earlier is wasted I/O.
                 if [ "$ELAPSED" -ge 600 ]; then
-                  JOB_ID=$(echo "$JOBS_JSON" | jq -r '.jobs[0].id // empty' 2>/dev/null || echo "")
+                  # Select the job that actually runs the reviewer/editor
+                  # LLM steps, NOT `.jobs[0]`. When the review run comes
+                  # from the wrapper workflow (internal-review.yml calling
+                  # review_autofix.yml — the default REVIEW_WORKFLOW_FILE),
+                  # the run carries several jobs and jobs[0] by creation
+                  # order is `review / gate`, a ~4s gate job whose log can
+                  # never contain the editor-noop annotation or the
+                  # "Reviewer … succeeded" counter lines — on v1.27.0 run
+                  # 32824674139 every live-log probe hit the gate job
+                  # (97733868951) while `review / codex-agent`
+                  # (97733894241) did the actual work, so both shortcuts
+                  # were permanently inert. Prefer the codex-agent job by
+                  # name (a rename is a breaking change per CLAUDE.md §6,
+                  # so the literal is safe), then any in-progress job,
+                  # then jobs[0] as the legacy single-job fallback.
+                  JOB_ID=$(echo "$JOBS_JSON" | jq -r '([.jobs[] | select(.name | test("codex-agent"))] | last | .id) // ([.jobs[] | select(.status == "in_progress")] | last | .id) // .jobs[0].id // empty' 2>/dev/null || echo "")
                   if [ -n "$JOB_ID" ]; then
                     # Stream the job log to a tempfile rather than capturing
                     # into a shell variable. `gh_api_safe .../actions/jobs/
@@ -1741,14 +1762,20 @@ jobs:
               --jq 'length' || echo "0")
 
             # 4) Job log byte size — grows while reviewers/editor produce output
+            # Same job selection as the live-log shortcut block above:
+            # prefer the codex-agent job (the one producing log output),
+            # then any in-progress job, then jobs[0] — in wrapper runs
+            # jobs[0] is the completed `review / gate` job whose log size
+            # never changes, which starved this activity signal on run
+            # 32824674139 (log_sz pinned at 0b for the whole phase).
             LOG_SIZE="0"
             if [ "$RUN_ID" != "unknown" ]; then
               JOB_ID_FOR_SIZE=""
               if [ -n "${JOBS_JSON:-}" ]; then
-                JOB_ID_FOR_SIZE=$(echo "$JOBS_JSON" | jq -r '.jobs[0].id // empty' 2>/dev/null || echo "")
+                JOB_ID_FOR_SIZE=$(echo "$JOBS_JSON" | jq -r '([.jobs[] | select(.name | test("codex-agent"))] | last | .id) // ([.jobs[] | select(.status == "in_progress")] | last | .id) // .jobs[0].id // empty' 2>/dev/null || echo "")
               else
                 JOB_ID_FOR_SIZE=$(gh_api_safe_quiet_print "repos/${TEST_REPO}/actions/runs/${RUN_ID}/jobs?per_page=10" \
-                  --jq '.jobs[0].id // empty' || echo "")
+                  --jq '([.jobs[] | select(.name | test("codex-agent"))] | last | .id) // ([.jobs[] | select(.status == "in_progress")] | last | .id) // .jobs[0].id // empty' || echo "")
               fi
               if [ -n "$JOB_ID_FOR_SIZE" ]; then
                 LOG_SIZE=$(gh_api_safe_quiet_print "repos/${TEST_REPO}/actions/jobs/${JOB_ID_FOR_SIZE}/logs" \

--- a/.github/workflows/test-and-mark-stable.yml
+++ b/.github/workflows/test-and-mark-stable.yml
@@ -1578,10 +1578,11 @@ jobs:
                   # (97733868951) while `review / codex-agent`
                   # (97733894241) did the actual work, so both shortcuts
                   # were permanently inert. Prefer the codex-agent job by
-                  # name (a rename is a breaking change per CLAUDE.md §6,
-                  # so the literal is safe), then any in-progress job,
-                  # then jobs[0] as the legacy single-job fallback.
-                  JOB_ID=$(echo "$JOBS_JSON" | jq -r '([.jobs[] | select(.name | test("codex-agent"))] | last | .id) // ([.jobs[] | select(.status == "in_progress")] | last | .id) // .jobs[0].id // empty' 2>/dev/null || echo "")
+                  # exact name/suffix (a rename is a breaking change per
+                  # CLAUDE.md §6, so the literal is safe), then any
+                  # in-progress job, then jobs[0] as the legacy single-job
+                  # fallback.
+                  JOB_ID=$(echo "$JOBS_JSON" | jq -r '([.jobs[] | select(.name | test("(^| / )codex-agent( \\(claude-branch-review\\))?$"))] | last | .id) // ([.jobs[] | select(.status == "in_progress")] | last | .id) // .jobs[0].id // empty' 2>/dev/null || echo "")
                   if [ -n "$JOB_ID" ]; then
                     # Stream the job log to a tempfile rather than capturing
                     # into a shell variable. `gh_api_safe .../actions/jobs/
@@ -1772,10 +1773,10 @@ jobs:
             if [ "$RUN_ID" != "unknown" ]; then
               JOB_ID_FOR_SIZE=""
               if [ -n "${JOBS_JSON:-}" ]; then
-                JOB_ID_FOR_SIZE=$(echo "$JOBS_JSON" | jq -r '([.jobs[] | select(.name | test("codex-agent"))] | last | .id) // ([.jobs[] | select(.status == "in_progress")] | last | .id) // .jobs[0].id // empty' 2>/dev/null || echo "")
+                JOB_ID_FOR_SIZE=$(echo "$JOBS_JSON" | jq -r '([.jobs[] | select(.name | test("(^| / )codex-agent( \\(claude-branch-review\\))?$"))] | last | .id) // ([.jobs[] | select(.status == "in_progress")] | last | .id) // .jobs[0].id // empty' 2>/dev/null || echo "")
               else
                 JOB_ID_FOR_SIZE=$(gh_api_safe_quiet_print "repos/${TEST_REPO}/actions/runs/${RUN_ID}/jobs?per_page=10" \
-                  --jq '([.jobs[] | select(.name | test("codex-agent"))] | last | .id) // ([.jobs[] | select(.status == "in_progress")] | last | .id) // .jobs[0].id // empty' || echo "")
+                  --jq '([.jobs[] | select(.name | test("(^| / )codex-agent( \\(claude-branch-review\\))?$"))] | last | .id) // ([.jobs[] | select(.status == "in_progress")] | last | .id) // .jobs[0].id // empty' || echo "")
               fi
               if [ -n "$JOB_ID_FOR_SIZE" ]; then
                 LOG_SIZE=$(gh_api_safe_quiet_print "repos/${TEST_REPO}/actions/jobs/${JOB_ID_FOR_SIZE}/logs" \

--- a/changelog.d/3806-wait-review-false-stall.md
+++ b/changelog.d/3806-wait-review-false-stall.md
@@ -1,0 +1,17 @@
+<!-- changelog: fixed -->
+- **Release smoke tests no longer fail on healthy long reviewer steps.** The v1.27.0 release run failed even though its review pipeline was working correctly; the wait-review gate now waits long enough and watches the right job.
+
+On the v1.27.0 release (run 32824674139), `e2e-smoke-test` declared "Review phase stalled — no activity for 40 minutes" 58 seconds before the review run's `Run reviewer models` step completed successfully. Three defects lined up: `promote-main-to-stable.yml` still forwarded `review_timeout=40` after the downstream default had been raised to 60, the per-step stall cap of 50 minutes sat below the 51-minute healthy reviewer-step duration actually observed, and the wait loop's live-log probes read the wrapper run's 4-second `review / gate` job instead of `review / codex-agent`, so its log-based activity signals and early-exit shortcuts never worked. The promote dispatcher default now tracks the downstream 60, the per-step cap default is 75 minutes, and the log probes select the codex-agent job by name with an in-progress-job and `jobs[0]` fallback.
+
+| The numbers that matter | Value |
+| --- | --- |
+| `promote-main-to-stable.yml` `review_timeout` default | 40 → 60 minutes |
+| `test-and-mark-stable.yml` `review_step_timeout` default | 50 → 75 minutes |
+| Observed healthy `Run reviewer models` durations | 41m (v1.20.1), 51m (v1.27.0) |
+| Margin by which the v1.27.0 gate gave up too early | 58 seconds |
+
+What this means for operators: a slow-but-healthy review run no longer kills a release; re-dispatching `promote-main-to-stable.yml` without overriding `review_timeout` now uses the intended 60-minute inactivity window. When `test-and-mark-stable.yml`'s `review_timeout` default changes again, `promote-main-to-stable.yml`'s default must change with it — its description now says so explicitly.
+
+### For contributors
+
+The wait loop's editor-noop and reviewer-majority shortcuts were inert in every wrapper (`internal-review.yml`) run because `.jobs[0]` is the gate job there; with the codex-agent job selected they can fire again, letting Phase 4 exit success shortly after the reviewer step ends instead of waiting out the editor.


### PR DESCRIPTION
## Root cause — v1.27.0 release failure (run 32824674139)

`e2e-smoke-test` failed in "Phase 4: Wait for review & autofix to complete" with `Review phase stalled — no activity for 40 minutes` at 09:17:29 UTC. The watched review run 32825948221 was **healthy**: its `Run reviewer models` step (started 08:27:26) completed successfully at **09:18:27 — 58 seconds after the gate gave up** — and the run then proceeded through consensus into the editor step.

Three defects lined up:

1. **Stale dispatcher default.** `promote-main-to-stable.yml` forwards `review_timeout` explicitly on every dispatch, and its default was still `40` after test-and-mark-stable.yml's own default was raised 40→60 (post-v1.20.1 run 28282500673 — an identical false-timeout on a 41m reviewer step). The forwarded 40 silently overrode the downstream 60, exactly the failure mode the input's own comment warned about. Run env confirms `REVIEW_TIMEOUT: 40`.
2. **Per-step cap below observed healthy durations.** The `REVIEW_STEP_TIMEOUT` guard (default 50m) deferred the stall from 09:07:40 (idle hit 40m) for 43 polls, then expired at step-elapsed 50m03s — 58s before the step finished. Healthy reviewer-step durations have grown 41m → 51m; a 50m cap misclassifies a healthy step as hung.
3. **Live-log probes pinned to the wrong job.** Both the editor-noop/reviewer-majority shortcuts and the log-size activity signal select `.jobs[0]`, which in wrapper (`internal-review.yml`) runs is the ~4s `review / gate` job (97733868951 in the failing run's own warnings) instead of `review / codex-agent` (97733894241). The shortcuts were permanently inert and `log_sz` stayed pinned at `0b` for the whole phase.

## Fixes

- `.github/workflows/promote-main-to-stable.yml` — `review_timeout` default 40 → 60, with the description rewritten to state that it MUST track the downstream default and citing this failure.
- `.github/workflows/test-and-mark-stable.yml` — `REVIEW_STEP_TIMEOUT` default 50 → 75 (input default, env fallback chain, shell fallbacks, docs).
- `.github/workflows/test-and-mark-stable.yml` — job selection for the live-log shortcut and the log-size probe now prefers the `codex-agent` job by name, then any in-progress job, then `.jobs[0]` as the legacy single-job fallback.

Either of fixes 1 or 2 alone would have let this run pass; fix 3 restores the designed early-success exit (≥3 reviewers succeeded) so smoke Phase 4 can complete minutes after the reviewer step ends instead of waiting out the editor.

## Verification

- `yamllint -s` clean on both workflows (same invocation as the `validate-scripts` job).
- `bash -n` clean on the extracted Phase 4 step script.
- jq selection expression tested against the failing run's actual jobs shape (wrapper: returns 97733894241; single-job: returns that job; no match: falls back to `jobs[0]`; empty: empty).

Refs run 32824674139 (Test & Mark Stable Release, v1.27.0) and review run 32825948221.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6NEmWJjzRdKpUAULT3prm)_