### PR TITLE
chore: register shubhodeep1/drhyg_ecommerce_automation as consumer repo

### DIFF
--- a/.github/ai/consumer_repos.json
+++ b/.github/ai/consumer_repos.json
@@ -10,5 +10,6 @@
   "shubhodeep1/fbc_shutdown",
   "shubhodeep1/bitsafe.io",
   "shubhodeep1/hylifegroup.com",
-  "shubhodeep1/radateeree-resort.com"
+  "shubhodeep1/radateeree-resort.com",
+  "shubhodeep1/drhyg_ecommerce_automation"
 ]

--- a/changelog.d/3809-register-drhyg-ecommerce-automation.md
+++ b/changelog.d/3809-register-drhyg-ecommerce-automation.md
@@ -1,0 +1,12 @@
+<!-- changelog: added -->
+- **`shubhodeep1/drhyg_ecommerce_automation` is now a registered consumer repo.** It receives the `@stable` `repository_dispatch` on every release.
+
+The repo was seeded with the standard profile from `@stable` in its seed PR (`drhyg_ecommerce_automation#1`): 12 standard-profile wrapper workflows plus `ai-update-workflows.yml`, the `.claude/` command and hook assets, and the root `CLAUDE.md`. This registration adds it to `.github/ai/consumer_repos.json`, so tagging a new `@stable` release dispatches an immediate sync to it instead of leaving it to the daily 04:00 UTC cron.
+
+| The numbers that matter | Value |
+| --- | --- |
+| Consumer repos registered | 13 (was 12) |
+| Wrapper workflows seeded | 13 (standard profile + self-updater) |
+| Seed source ref | `stable` (`f7b0aa59`) |
+
+What this means for operators: the release `GH_PAT` must hold `repo` scope on `shubhodeep1/drhyg_ecommerce_automation`, and that repo needs `GH_PAT` and `OPENROUTER_API_KEY` secrets plus `WORKFLOW_PROFILE=standard` set before its wrappers can run.


### PR DESCRIPTION
Registers `shubhodeep1/drhyg_ecommerce_automation` in `.github/ai/consumer_repos.json` per CLAUDE.md §14. The repo was seeded with the **standard** profile from `@stable` (`f7b0aa5979a539d7105979b074e6faffaba5c05e`) in [drhyg_ecommerce_automation#1](https://github.com/shubhodeep1/drhyg_ecommerce_automation/pull/1); this entry makes it receive the `repository_dispatch` sent when a new `@stable` release is tagged, so its wrapper workflows update immediately instead of waiting for the daily 04:00 UTC cron.

Operational note: the `GH_PAT` used by the release workflows must have `repo` scope on `shubhodeep1/drhyg_ecommerce_automation` for the dispatch to succeed.

A changelog fragment for this registration follows in a second commit on this branch (named after this PR's number, per §20.B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JC5d7mfRRwbUjY4qdH4MhX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JC5d7mfRRwbUjY4qdH4MhX)_